### PR TITLE
feat: ETH2x-FLI to BTC2X pair routing

### DIFF
--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -67,6 +67,7 @@ export const ADDITIONAL_BASES: { [chainId: number]: { [tokenAddress: string]: To
   [1]: {
     ...mAssetsAdditionalBases,
     '0xF16E4d813f4DcfDe4c5b44f305c908742De84eF0': [ETH2X_FLI],
+    '0x882b454e9152d1c35c77f9d79399d7dbf07e1b1d': [ETH2X_FLI],
     '0xA948E86885e12Fb09AfEF8C52142EBDbDf73cD18': [UNI[1]],
     '0x561a4717537ff4AF5c687328c0f7E90a319705C0': [UNI[1]],
     '0xE0360A9e2cdd7d03B9408c7D3001E017BAc2EcD5': [UNI[1]],


### PR DESCRIPTION
This is the same as #1644 with an addition of BTC2X. This allows direct routing between leveraged tokenset to tokenset pair particularly between ETH2x-FLI and the BTC2X pair, a leveraged BTC token.

The BTC2X token can already be found here: [https://www.tokensets.com/v2/set/0x882B454E9152D1c35C77F9d79399d7DBf07E1b1D](url)

The liquidity between BTC2X and ETH2X-FLI can be found here: [https://info.uniswap.org/#/pools/0x4004d94a4e6a6ca2b745b9b2e9fd262f3c3bdd98](url)