### PR TITLE
feat: add @davatar/react for robust avatar support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": ".",
   "private": true,
   "devDependencies": {
+    "@davatar/react": "^1.0.2",
     "@ethersproject/experimental": "^5.4.0",
     "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
     "@graphql-codegen/cli": "1.21.5",
@@ -154,7 +155,5 @@
     ]
   },
   "license": "GPL-3.0-or-later",
-  "dependencies": {
-    "@davatar/react": "^1.0.2"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -155,5 +155,7 @@
     ]
   },
   "license": "GPL-3.0-or-later",
-  "dependencies": {}
+  "dependencies": {
+    "@davatar/react": "^1.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": ".",
   "private": true,
   "devDependencies": {
-    "@davatar/react": "^1.0.2",
+    "@davatar/react": "1.1.0",
     "@ethersproject/experimental": "^5.4.0",
     "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
     "@graphql-codegen/cli": "1.21.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@lingui/loader": "^3.9.0",
     "@lingui/macro": "^3.9.0",
     "@lingui/react": "^3.9.0",
-    "@metamask/jazzicon": "^2.0.0",
     "@popperjs/core": "^2.4.4",
     "@reach/dialog": "^0.10.3",
     "@reach/portal": "^0.10.3",

--- a/src/components/Identicon/index.tsx
+++ b/src/components/Identicon/index.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useRef } from 'react'
-
 import styled from 'styled-components/macro'
 
 import { useActiveWeb3React } from '../../hooks/web3'
-import Jazzicon from '@metamask/jazzicon'
+import Davatar from '@davatar/react'
 
 const StyledIdenticonContainer = styled.div`
   height: 1rem;
@@ -13,17 +11,12 @@ const StyledIdenticonContainer = styled.div`
 `
 
 export default function Identicon() {
-  const ref = useRef<HTMLDivElement>()
-
-  const { account } = useActiveWeb3React()
-
-  useEffect(() => {
-    if (account && ref.current) {
-      ref.current.innerHTML = ''
-      ref.current.appendChild(Jazzicon(16, parseInt(account.slice(2, 10), 16)))
-    }
-  }, [account])
+  const { account, library } = useActiveWeb3React()
 
   // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
-  return <StyledIdenticonContainer ref={ref as any} />
+  return (
+    <StyledIdenticonContainer>
+      {account && library?.provider && <Davatar address={account} size={16} provider={library.provider} />}
+    </StyledIdenticonContainer>
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,10 +1384,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@davatar/react@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.0.2.tgz#eee9abb53dd38cb460f130ed9652e5b3375f856e"
-  integrity sha512-dnXr1o5bSIPeEMpEmFLYvUMYMkFQyzm0Ry3+HaYOi+nlSBGV1125LGrPEHCLss+KLWfoOQl1BC+enfYVPeHouw==
+"@davatar/react@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.1.0.tgz#8fdeee6ebecd8da3e7c7d1de0df5db60919517c6"
+  integrity sha512-TYgLp3xDl5+jPRK9HO7viegl9o98MKquJK0HRP3iUycePEMag/z5nSQKiwtQaUh+dJZtuPkq2FjkHdIyw8qAPQ==
   dependencies:
     color "^3.2.1"
     ethers "^5.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,14 +2912,6 @@
     "@babel/runtime" "^7.11.2"
     "@lingui/core" "^3.9.0"
 
-"@metamask/jazzicon@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@metamask/jazzicon/-/jazzicon-2.0.0.tgz"
-  integrity sha512-7M+WSZWKcQAo0LEhErKf1z+D3YX0tEDAcGvcKbDyvDg34uvgeKR00mFNIYwAhdAS9t8YXxhxZgsrRBBg6X8UQg==
-  dependencies:
-    color "^0.11.3"
-    mersenne-twister "^1.1.0"
-
 "@metamask/safe-event-emitter@2.0.0", "@metamask/safe-event-emitter@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz"
@@ -7249,7 +7241,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -7273,13 +7265,6 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
-  integrity sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=
-  dependencies:
-    color-name "^1.0.0"
-
 color-string@^1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
@@ -7295,15 +7280,6 @@ color-string@^1.6.0:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
-
-color@^0.11.3:
-  version "0.11.4"
-  resolved "https://registry.npmjs.org/color/-/color-0.11.4.tgz"
-  integrity sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=
-  dependencies:
-    clone "^1.0.2"
-    color-convert "^1.3.0"
-    color-string "^0.3.0"
 
 color@^3.0.0:
   version "3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,6 +1384,15 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@davatar/react@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.0.2.tgz#eee9abb53dd38cb460f130ed9652e5b3375f856e"
+  integrity sha512-dnXr1o5bSIPeEMpEmFLYvUMYMkFQyzm0Ry3+HaYOi+nlSBGV1125LGrPEHCLss+KLWfoOQl1BC+enfYVPeHouw==
+  dependencies:
+    color "^3.2.1"
+    ethers "^5.4.6"
+    mersenne-twister "^1.1.0"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz"
@@ -7240,7 +7249,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -7279,6 +7288,14 @@ color-string@^1.5.4:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color-string@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
+  integrity sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@^0.11.3:
   version "0.11.4"
   resolved "https://registry.npmjs.org/color/-/color-0.11.4.tgz"
@@ -7295,6 +7312,14 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.4"
+
+color@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## Description

This PR adds robust avatar image lookup support for ENS `avatar` text record lookup for the logged in user's avatar, using the [@davatar/react](https://github.com/TBDAO/davatar-helpers/tree/master/packages/react) package, which seeks to fulfill the spec outlined in [avatars.md](https://gist.github.com/Arachnid/9db60bd75277969ee1689c8742b75182).

Presently, we support all URI types except the NFT-metadata reference type, although that one is planned in a future package release. Our goal is to push forward usage of decentralized avatars using ENS, and this PR works toward making sure as people do so, they see their chosen avatar in the Uniswap app!

The component defaults to a Jazzicon, exactly as Uniswap currently behaves today, so if no avatar has been set by the user on their ENS reverse record, they see exactly the same thing as they always have in the app.

## Security / Supply Chain risk consideration
The `@davatar/react` library uses minimal dependencies (just the `color` package and the `merssene-twister` package, which the `@metamask/jazzicon` package that this one replaces already used, and `ethers`). This adds no extra third-party dependencies to the project, other than the `@davatar/react` package itself, which aims to be very small.

## List of features added/changed

- Add `@davatar/react` dependency (small, 7kb)
- Remove `@metamask/jazzicon` (no longer needed)
- Replace the jazzicon SVG component for rendering avatars with the `<Davatar />` component from `@davatar/react`, which supports several decentralized URI protocols (in addition to Jazzicon default)

## How Has This Been Tested?

Connected my wallet in the local dev environment and checked that it rendered my avatar correctly.

## Screenshots (if appropriate):
![Screen Shot 2021-09-10 at 2 24 08 PM](https://user-images.githubusercontent.com/198739/132900754-048cc9f0-23e0-41d0-8e35-2279eb6ea42c.png)
