### PR TITLE
perf: lazy load routes to reduce initial bundle size

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -25,7 +25,6 @@ const MigrateV2Pair = lazy(() => import('./MigrateV2/MigrateV2Pair'))
 const OpenClaimAddressModalAndRedirectToSwap = lazy(() =>
   import('./Swap/redirects').then((module) => ({ default: module.OpenClaimAddressModalAndRedirectToSwap }))
 )
-const RedirectToSwap = lazy(() => import('./Swap/redirects').then((module) => ({ default: module.RedirectToSwap })))
 const Pool = lazy(() => import('./Pool'))
 const PoolFinder = lazy(() => import('./PoolFinder'))
 const PoolV2 = lazy(() => import('./Pool/v2'))
@@ -39,6 +38,7 @@ const RedirectDuplicateTokenIdsV2 = lazy(() =>
 const RedirectPathToSwapOnly = lazy(() =>
   import('./Swap/redirects').then((module) => ({ default: module.RedirectPathToSwapOnly }))
 )
+const RedirectToSwap = lazy(() => import('./Swap/redirects').then((module) => ({ default: module.RedirectToSwap })))
 const RemoveLiquidity = lazy(() => import('./RemoveLiquidity'))
 const RemoveLiquidityV3 = lazy(() => import('./RemoveLiquidity/V3'))
 const Vote = lazy(() => import('./Vote'))

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import ApeModeQueryParamReader from 'hooks/useApeModeQueryParamReader'
 import { Route, Switch } from 'react-router-dom'
 import styled from 'styled-components/macro'
@@ -11,24 +12,37 @@ import Web3ReactManager from '../components/Web3ReactManager'
 import { ApplicationModal } from '../state/application/actions'
 import { useModalOpen, useToggleModal } from '../state/application/hooks'
 import DarkModeQueryParamReader from '../theme/DarkModeQueryParamReader'
-import AddLiquidity from './AddLiquidity'
-import { RedirectDuplicateTokenIds } from './AddLiquidity/redirects'
-import { RedirectDuplicateTokenIdsV2 } from './AddLiquidityV2/redirects'
-import CreateProposal from './CreateProposal'
-import Earn from './Earn'
-import Manage from './Earn/Manage'
-import MigrateV2 from './MigrateV2'
-import MigrateV2Pair from './MigrateV2/MigrateV2Pair'
-import Pool from './Pool'
-import { PositionPage } from './Pool/PositionPage'
-import PoolV2 from './Pool/v2'
-import PoolFinder from './PoolFinder'
-import RemoveLiquidity from './RemoveLiquidity'
-import RemoveLiquidityV3 from './RemoveLiquidity/V3'
 import Swap from './Swap'
-import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly, RedirectToSwap } from './Swap/redirects'
-import Vote from './Vote'
-import VotePage from './Vote/VotePage'
+
+const { lazy, Suspense } = React
+
+const AddLiquidity = lazy(() => import('./AddLiquidity'))
+const CreateProposal = lazy(() => import('./CreateProposal'))
+const Earn = lazy(() => import('./Earn'))
+const Manage = lazy(() => import('./Earn/Manage'))
+const MigrateV2 = lazy(() => import('./MigrateV2'))
+const MigrateV2Pair = lazy(() => import('./MigrateV2/MigrateV2Pair'))
+const OpenClaimAddressModalAndRedirectToSwap = lazy(() =>
+  import('./Swap/redirects').then((module) => ({ default: module.OpenClaimAddressModalAndRedirectToSwap }))
+)
+const RedirectToSwap = lazy(() => import('./Swap/redirects').then((module) => ({ default: module.RedirectToSwap })))
+const Pool = lazy(() => import('./Pool'))
+const PoolFinder = lazy(() => import('./PoolFinder'))
+const PoolV2 = lazy(() => import('./Pool/v2'))
+const PositionPage = lazy(() => import('./Pool/PositionPage').then((module) => ({ default: module.PositionPage })))
+const RedirectDuplicateTokenIds = lazy(() =>
+  import('./AddLiquidity/redirects').then((module) => ({ default: module.RedirectDuplicateTokenIds }))
+)
+const RedirectDuplicateTokenIdsV2 = lazy(() =>
+  import('./AddLiquidityV2/redirects').then((module) => ({ default: module.RedirectDuplicateTokenIdsV2 }))
+)
+const RedirectPathToSwapOnly = lazy(() =>
+  import('./Swap/redirects').then((module) => ({ default: module.RedirectPathToSwapOnly }))
+)
+const RemoveLiquidity = lazy(() => import('./RemoveLiquidity'))
+const RemoveLiquidityV3 = lazy(() => import('./RemoveLiquidity/V3'))
+const Vote = lazy(() => import('./Vote'))
+const VotePage = lazy(() => import('./Vote/VotePage'))
 
 const AppWrapper = styled.div`
   display: flex;
@@ -84,46 +98,51 @@ export default function App() {
             <Popups />
             <Polling />
             <TopLevelModals />
-            <Switch>
-              <Route exact strict path="/vote" component={Vote} />
-              <Route exact strict path="/vote/:governorIndex/:id" component={VotePage} />
-              <Route exact strict path="/claim" component={OpenClaimAddressModalAndRedirectToSwap} />
-              <Route exact strict path="/uni" component={Earn} />
-              <Route exact strict path="/uni/:currencyIdA/:currencyIdB" component={Manage} />
+            <Suspense fallback={<div>loading...</div>}>
+              <Switch>
+                <Route exact strict path="/vote" component={Vote} />
+                <Route exact strict path="/vote/:governorIndex/:id" component={VotePage} />
+                <Route exact strict path="/claim" component={OpenClaimAddressModalAndRedirectToSwap} />
+                <Route exact strict path="/uni" component={Earn} />
+                <Route exact strict path="/uni/:currencyIdA/:currencyIdB" component={Manage} />
 
-              <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-              <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
-              <Route exact strict path="/swap" component={Swap} />
+                <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
+                <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
+                <Route exact strict path="/swap" component={Swap} />
+                <Route exact strict path="/pool/v2/find" component={PoolFinder} />
+                <Route exact strict path="/pool/v2" component={PoolV2} />
+                <Route exact strict path="/pool" component={Pool} />
+                <Route exact strict path="/pool/:tokenId" component={PositionPage} />
+                <Route
+                  exact
+                  strict
+                  path="/add/v2/:currencyIdA?/:currencyIdB?"
+                  component={RedirectDuplicateTokenIdsV2}
+                />
+                <Route
+                  exact
+                  strict
+                  path="/add/:currencyIdA?/:currencyIdB?/:feeAmount?"
+                  component={RedirectDuplicateTokenIds}
+                />
 
-              <Route exact strict path="/pool/v2/find" component={PoolFinder} />
-              <Route exact strict path="/pool/v2" component={PoolV2} />
-              <Route exact strict path="/pool" component={Pool} />
-              <Route exact strict path="/pool/:tokenId" component={PositionPage} />
+                <Route
+                  exact
+                  strict
+                  path="/increase/:currencyIdA?/:currencyIdB?/:feeAmount?/:tokenId?"
+                  component={AddLiquidity}
+                />
 
-              <Route exact strict path="/add/v2/:currencyIdA?/:currencyIdB?" component={RedirectDuplicateTokenIdsV2} />
-              <Route
-                exact
-                strict
-                path="/add/:currencyIdA?/:currencyIdB?/:feeAmount?"
-                component={RedirectDuplicateTokenIds}
-              />
+                <Route exact strict path="/remove/v2/:currencyIdA/:currencyIdB" component={RemoveLiquidity} />
+                <Route exact strict path="/remove/:tokenId" component={RemoveLiquidityV3} />
 
-              <Route
-                exact
-                strict
-                path="/increase/:currencyIdA?/:currencyIdB?/:feeAmount?/:tokenId?"
-                component={AddLiquidity}
-              />
+                <Route exact strict path="/migrate/v2" component={MigrateV2} />
+                <Route exact strict path="/migrate/v2/:address" component={MigrateV2Pair} />
 
-              <Route exact strict path="/remove/v2/:currencyIdA/:currencyIdB" component={RemoveLiquidity} />
-              <Route exact strict path="/remove/:tokenId" component={RemoveLiquidityV3} />
-
-              <Route exact strict path="/migrate/v2" component={MigrateV2} />
-              <Route exact strict path="/migrate/v2/:address" component={MigrateV2Pair} />
-
-              <Route exact strict path="/create-proposal" component={CreateProposal} />
-              <Route component={RedirectPathToSwapOnly} />
-            </Switch>
+                <Route exact strict path="/create-proposal" component={CreateProposal} />
+                <Route component={RedirectPathToSwapOnly} />
+              </Switch>
+            </Suspense>
             <Marginer />
           </BodyWrapper>
         </AppWrapper>

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react'
+import { lazy, Suspense } from 'react'
 import ApeModeQueryParamReader from 'hooks/useApeModeQueryParamReader'
 import { Route, Switch } from 'react-router-dom'
+import { Trans } from '@lingui/macro'
 import styled from 'styled-components/macro'
 import GoogleAnalyticsReporter from '../components/analytics/GoogleAnalyticsReporter'
 import AddressClaimModal from '../components/claim/AddressClaimModal'
@@ -13,8 +14,7 @@ import { ApplicationModal } from '../state/application/actions'
 import { useModalOpen, useToggleModal } from '../state/application/hooks'
 import DarkModeQueryParamReader from '../theme/DarkModeQueryParamReader'
 import Swap from './Swap'
-
-const { lazy, Suspense } = React
+import { Dots } from 'components/swap/styleds'
 
 const AddLiquidity = lazy(() => import('./AddLiquidity'))
 const CreateProposal = lazy(() => import('./CreateProposal'))
@@ -98,7 +98,14 @@ export default function App() {
             <Popups />
             <Polling />
             <TopLevelModals />
-            <Suspense fallback={<div>loading...</div>}>
+            <Suspense
+              fallback={
+                <div>
+                  <Trans>loading</Trans>
+                  <Dots />
+                </div>
+              }
+            >
               <Switch>
                 <Route exact strict path="/vote" component={Vote} />
                 <Route exact strict path="/vote/:governorIndex/:id" component={VotePage} />


### PR DESCRIPTION
I noticed there was [a pull request](https://github.com/Uniswap/interface/pull/1597) doing what this pull request want to do, but it was reverted later in https://github.com/Uniswap/interface/pull/1611.

This pull request does almost the same thing like the initial pull request, however with a suspense.

Currently the loading indicator is simply a `loading...`, I think it can be improved to conform to the uniswap's theme.