### PR TITLE
chore: restrict imports from dist

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,18 +39,26 @@
         "paths": [
           {
             "name": "lodash",
-            "message": "Please import lodash modules directly (lodash/module)."
+            "message": "Please import from 'lodash/module' directly to support tree-shaking."
+          },
+          {
+            "name": "ethers",
+            "message": "Please import from '@ethersproject/module' directly to support tree-shaking."
           },
           {
             "name": "styled-components",
             "message": "Please import from styled-components/macro."
-          },
-          {
-            "name": "ethers",
-            "message": "Please import from @ethersproject."
           }
         ],
-        "patterns": ["!styled-components/macro"]
+        "patterns": [
+          {
+            "group": ["**/dist"],
+            "message": "Do not import from dist/ - this is an implementation detail, and breaks tree-shaking."
+          },
+          {
+            "group": ["!styled-components/macro"]
+          }
+        ]
       }
     ]
   }

--- a/src/components/SearchModal/ImportToken.tsx
+++ b/src/components/SearchModal/ImportToken.tsx
@@ -1,6 +1,6 @@
 import { Plural, Trans } from '@lingui/macro'
 import { Currency, Token } from '@uniswap/sdk-core'
-import { TokenList } from '@uniswap/token-lists/dist/types'
+import { TokenList } from '@uniswap/token-lists'
 import { ButtonPrimary } from 'components/Button'
 import Card from 'components/Card'
 import { AutoColumn } from 'components/Column'

--- a/src/hooks/web3.ts
+++ b/src/hooks/web3.ts
@@ -1,13 +1,12 @@
 import { Web3Provider } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
-import { Web3ReactContextInterface } from '@web3-react/core/dist/types'
 import { useEffect, useState } from 'react'
 
 import { gnosisSafe, injected } from '../connectors'
 import { IS_IN_IFRAME, NetworkContextName } from '../constants/misc'
 import { isMobile } from '../utils/userAgent'
 
-export function useActiveWeb3React(): Web3ReactContextInterface<Web3Provider> {
+export function useActiveWeb3React() {
   const context = useWeb3React<Web3Provider>()
   const contextNetwork = useWeb3React<Web3Provider>(NetworkContextName)
   return context.active ? context : contextNetwork

--- a/src/state/data/slice.ts
+++ b/src/state/data/slice.ts
@@ -1,4 +1,4 @@
-import { BaseQueryApi, BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import { BaseQueryFn } from '@reduxjs/toolkit/query'
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { SupportedChainId } from 'constants/chains'
 import { DocumentNode } from 'graphql'
@@ -82,7 +82,7 @@ function graphqlRequestBaseQuery(): BaseQueryFn<
   Pick<ClientError, 'name' | 'message' | 'stack'>,
   Partial<Pick<ClientError, 'request' | 'response'>>
 > {
-  return async ({ document, variables }, { getState }: BaseQueryApi) => {
+  return async ({ document, variables }, { getState }) => {
     try {
       const chainId = (getState() as AppState).application.chainId
 

--- a/src/state/lists/reducer.ts
+++ b/src/state/lists/reducer.ts
@@ -1,6 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit'
-import { getVersionUpgrade, VersionUpgrade } from '@uniswap/token-lists'
-import { TokenList } from '@uniswap/token-lists/dist/types'
+import { getVersionUpgrade, TokenList, VersionUpgrade } from '@uniswap/token-lists'
 
 import { DEFAULT_ACTIVE_LIST_URLS } from '../../constants/lists'
 import { DEFAULT_LIST_OF_LISTS } from '../../constants/lists'

--- a/src/state/lists/wrappedTokenInfo.ts
+++ b/src/state/lists/wrappedTokenInfo.ts
@@ -1,6 +1,5 @@
 import { Currency, Token } from '@uniswap/sdk-core'
-import { Tags, TokenInfo } from '@uniswap/token-lists'
-import { TokenList } from '@uniswap/token-lists/dist/types'
+import { Tags, TokenInfo, TokenList } from '@uniswap/token-lists'
 
 import { isAddress } from '../../utils'
 

--- a/src/state/mint/v3/hooks.ts
+++ b/src/state/mint/v3/hooks.ts
@@ -10,7 +10,7 @@ import {
   TICK_SPACINGS,
   TickMath,
   tickToPrice,
-} from '@uniswap/v3-sdk/dist/'
+} from '@uniswap/v3-sdk'
 import { usePool } from 'hooks/usePools'
 import JSBI from 'jsbi'
 import { useCallback, useMemo } from 'react'

--- a/src/state/mint/v3/utils.ts
+++ b/src/state/mint/v3/utils.ts
@@ -6,7 +6,7 @@ import {
   priceToClosestTick,
   TICK_SPACINGS,
   TickMath,
-} from '@uniswap/v3-sdk/dist/'
+} from '@uniswap/v3-sdk'
 import JSBI from 'jsbi'
 
 export function tryParsePrice(baseToken?: Token, quoteToken?: Token, value?: string) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@ import { AddressZero } from '@ethersproject/constants'
 import { Contract } from '@ethersproject/contracts'
 import { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
 import { Token } from '@uniswap/sdk-core'
-import { FeeAmount } from '@uniswap/v3-sdk/dist/'
+import { FeeAmount } from '@uniswap/v3-sdk'
 
 import { TokenAddressMap } from '../state/lists/hooks'
 


### PR DESCRIPTION
Effectively removes a full (non-tree-shakeable) copy of @uniswap/v3-sdk from the bundle, reducing the uncompressed vendor bundle by 0.21 KB (11.9%).

Importing from `dist/` may bundle a library twice (as with @uniswap/v3-sdk) because it is pulled from the package.json-specified entry point, as an ES module; and again when imported from `dist/`, as CommonJS. `dist/` is an implementation detail, and should not be accessed directly. The CommonJS library is also not tree-shakeable, so importing from `dist/` is effectively a larger import.