### PR TITLE
style: Clarify "Remove send" button in v2 interface

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -435,7 +435,7 @@ export default function Swap({ history }: RouteComponentProps) {
                     <ArrowDown size="16" color={theme.text2} />
                   </ArrowWrapper>
                   <LinkStyledButton id="remove-recipient-button" onClick={() => onChangeRecipient(null)}>
-                    <Trans>- Remove send</Trans>
+                    <Trans>- Remove recipient</Trans>
                   </LinkStyledButton>
                 </AutoRow>
                 <AddressInputPanel id="recipient" value={recipient} onChange={onChangeRecipient} />


### PR DESCRIPTION
Changed "Remove send" to "Remove recipient" for clarification purposes. This also aligns better with the language used in the code itself. I guess it's also a good preparation for the future in case this feature is [re-added in v3](https://github.com/Uniswap/interface/issues/1440).
![image](https://user-images.githubusercontent.com/11910229/134802086-dc10bcfd-6723-492d-976b-ed2c647f1212.png)
