### PR TITLE
fix: upgrade @davatar/react to 1.6.2, minor fix for ERC token URIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": ".",
   "private": true,
   "devDependencies": {
-    "@davatar/react": "1.6.0",
+    "@davatar/react": "1.6.2",
     "@ethersproject/experimental": "^5.4.0",
     "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
     "@graphql-codegen/cli": "1.21.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,10 +1384,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@davatar/react@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.6.0.tgz#5bcff32ae4cf79398e86bc58a1596301f72c8e9f"
-  integrity sha512-C0AM4NWkE6lNAtc2ItD4yApnumj8WzpViIpr58ofDqv7dSBf9CPiZY42OrwZkIGN+UC+k2tNtUEmbneF2L2LaA==
+"@davatar/react@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.6.2.tgz#27ccb5e653dae1a525368daf82d801812f44b240"
+  integrity sha512-BQIP6fg8xoUgTleLUk91kItpDYpyXAkFYl04W+86LfYBahr1zBe4lvWZqVypMR36YASa4qn2yIyaaVHLgDOeqQ==
   dependencies:
     "@ethersproject/providers" "^5.4.5"
     "@types/react-blockies" "^1.4.1"


### PR DESCRIPTION
There was a small bug identified in the library when ERC721/1155 token URIs were provided in uppercase, while The Graph expects lowercase contract IDs. This patch version fixes that bug and ensures IDs are all in lowercase.