### PR TITLE
fix(SafariSquareDots): fixed by using border-top-with instead of bord…

### DIFF
--- a/src/components/RoutingDiagram/RoutingDiagram.tsx
+++ b/src/components/RoutingDiagram/RoutingDiagram.tsx
@@ -42,7 +42,7 @@ const PoolBadge = styled(Badge)`
 const DottedLine = styled.div`
   border-color: ${({ theme }) => theme.bg4};
   border-top-style: dotted;
-  border-width: 4px;
+  border-top-width: 5px;
   height: 0px;
   position: absolute;
   width: calc(100%);


### PR DESCRIPTION
The problem is not Safari browser. The problem is that the screen size is small and it affective with style "border-width". It's bordered on four sides. 

So I fixed by using "border-top-width" instead of "border-width"

Browser Test and Dev
Google Chrome : Version 93.0.4577.82 (Official Build) (x86_64)

Before  Fix
<img width="1439" alt="beforeFix" src="https://user-images.githubusercontent.com/77143416/135392866-340d59b9-516b-4092-a2ff-edd20ffd9984.png">

After Fix

<img width="1440" alt="afterFix" src="https://user-images.githubusercontent.com/77143416/135392881-190e98da-0af0-4b64-a044-7ff5ded0f463.png">

