### PR TITLE
fix: update gas quote for arbitrum and USDC address

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -40,7 +40,7 @@ export const USDC = new Token(
 )
 export const USDC_ARBITRUM = new Token(
   SupportedChainId.ARBITRUM_ONE,
-  '0xe865dF68133fcEd7c2285ff3896B406CAfAa2dB8',
+  '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
   6,
   'USDC',
   'USD//C'

--- a/src/hooks/useClientSideV3Trade.ts
+++ b/src/hooks/useClientSideV3Trade.ts
@@ -13,6 +13,7 @@ import { useActiveWeb3React } from './web3'
 const QUOTE_GAS_OVERRIDES: { [chainId: number]: number } = {
   [SupportedChainId.OPTIMISM]: 6_000_000,
   [SupportedChainId.OPTIMISTIC_KOVAN]: 6_000_000,
+  [SupportedChainId.ARBITRUM_ONE]: 16_000_000,
 }
 
 const DEFAULT_GAS_QUOTE = 2_000_000


### PR DESCRIPTION
- USDC address was incorrect 
- quoter default has value was causing multicall errors 
- this 16M number is fairly arbitrary - would be nice to get a real estimate