### PR TITLE
refactor: add reducer path to routing api

### DIFF
--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -5,6 +5,7 @@ import qs from 'qs'
 import { GetQuoteResult } from './types'
 
 export const routingApi = createApi({
+  reducerPath: 'routingApi',
   baseQuery: fetchBaseQuery({
     baseUrl: 'https://api.uniswap.org/v1/',
   }),


### PR DESCRIPTION
`reducerPath` needed to avoid conficts with future apis