### PR TITLE
fix: increase quote gas overrides on arbitrum

### DIFF
--- a/src/hooks/useClientSideV3Trade.ts
+++ b/src/hooks/useClientSideV3Trade.ts
@@ -13,7 +13,7 @@ import { useActiveWeb3React } from './web3'
 const QUOTE_GAS_OVERRIDES: { [chainId: number]: number } = {
   [SupportedChainId.OPTIMISM]: 6_000_000,
   [SupportedChainId.OPTIMISTIC_KOVAN]: 6_000_000,
-  [SupportedChainId.ARBITRUM_ONE]: 16_000_000,
+  [SupportedChainId.ARBITRUM_ONE]: 26_000_000,
 }
 
 const DEFAULT_GAS_QUOTE = 2_000_000


### PR DESCRIPTION
tested locally, not getting `execution ran out of gas` anymore