### PR TITLE
fix: keep price impact in place when swap amount changes

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -60,7 +60,6 @@ import {
 } from '../../state/swap/hooks'
 import { useExpertModeManager } from '../../state/user/hooks'
 import { LinkStyledButton, TYPE } from '../../theme'
-import { computeFiatValuePriceImpact } from '../../utils/computeFiatValuePriceImpact'
 import { getTradeVersion } from '../../utils/getTradeVersion'
 import { maxAmountSpend } from '../../utils/maxAmountSpend'
 import { warningSeverity } from '../../utils/prices'
@@ -123,6 +122,7 @@ export default function Swap({ history }: RouteComponentProps) {
     parsedAmount,
     currencies,
     inputError: swapInputError,
+    priceImpact,
   } = useDerivedSwapInfo(toggledVersion)
 
   const {
@@ -132,7 +132,6 @@ export default function Swap({ history }: RouteComponentProps) {
   } = useWrapCallback(currencies[Field.INPUT], currencies[Field.OUTPUT], typedValue)
   const showWrap: boolean = wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
-
   const parsedAmounts = useMemo(
     () =>
       showWrap
@@ -158,7 +157,6 @@ export default function Swap({ history }: RouteComponentProps) {
 
   const fiatValueInput = useUSDCValue(parsedAmounts[Field.INPUT])
   const fiatValueOutput = useUSDCValue(parsedAmounts[Field.OUTPUT])
-  const priceImpact = routeIsSyncing ? undefined : computeFiatValuePriceImpact(fiatValueInput, fiatValueOutput)
 
   const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useSwapActionHandlers()
   const isValid = !swapInputError


### PR DESCRIPTION
fixes https://github.com/Uniswap/interface/issues/2456
1. Move priceImpact calculation from swap/index to useDerivedSwapState

Evidence -

https://www.loom.com/share/e6d110affc81484886a70cbd3216a65b

It goes through
1. The case where there is a change in the trade amount, where the currencies are not wrapped eth.
2. The case where there is a change in the trade amount, where one of the currencies is wrapped eth (not sure why wrapped eth is special cased)

Questions -
1. Right now we will be calling `useWrapCallback` twice - is that fine?
2. Suppose - a. You click on ETH. b. Enter amount. c. Click on UNI. d. Enter amount. e. Go back to ETH amount, and update. Note that the priceImpact that is in gray is the impact of the previous ETH value and the current Uni value, because the request to get the trade has not returned. What do I do here?


