### PR TITLE
feat: Menu update. Add help center & feature requests. Remove analytics & github.

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -13,6 +13,7 @@ import {
   Code,
   FileText,
   Globe,
+  HelpCircle,
   Info,
   MessageCircle,
   Moon,
@@ -252,6 +253,12 @@ export default function Menu() {
                       </div>
                       <Info opacity={0.6} size={16} />
                     </MenuItem>
+                    <MenuItem href="https://help.uniswap.org/">
+                      <div>
+                        <Trans>Help Center</Trans>
+                      </div>
+                      <HelpCircle opacity={0.6} size={16} />
+                    </MenuItem>
                     <MenuItem href="https://docs.uniswap.org/">
                       <div>
                         <Trans>Docs</Trans>
@@ -269,12 +276,6 @@ export default function Menu() {
                         <Trans>Discord</Trans>
                       </div>
                       <MessageCircle opacity={0.6} size={16} />
-                    </MenuItem>
-                    <MenuItem href={infoLink}>
-                      <div>
-                        <Trans>Analytics</Trans>
-                      </div>
-                      <PieChart opacity={0.6} size={16} />
                     </MenuItem>
                     <ToggleMenuItem onClick={() => setMenu('lang')}>
                       <div>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -10,14 +10,13 @@ import {
   BookOpen,
   Check,
   ChevronLeft,
-  Code,
   FileText,
   Globe,
   HelpCircle,
   Info,
   MessageCircle,
   Moon,
-  PieChart,
+  Send,
   Sun,
 } from 'react-feather'
 import { Link } from 'react-router-dom'
@@ -259,17 +258,11 @@ export default function Menu() {
                       </div>
                       <HelpCircle opacity={0.6} size={16} />
                     </MenuItem>
-                    <MenuItem href="https://docs.uniswap.org/">
+                    <MenuItem href="https://uniswap.canny.io/feature-requests">
                       <div>
-                        <Trans>Docs</Trans>
+                        <Trans>Request Features</Trans>
                       </div>
-                      <BookOpen opacity={0.6} size={16} />
-                    </MenuItem>
-                    <MenuItem href={CODE_LINK}>
-                      <div>
-                        <Trans>Code</Trans>
-                      </div>
-                      <Code opacity={0.6} size={16} />
+                      <Send opacity={0.6} size={16} />
                     </MenuItem>
                     <MenuItem href="https://discord.gg/FCfyBSbCU5">
                       <div>
@@ -287,6 +280,12 @@ export default function Menu() {
                       <div>{darkMode ? <Trans>Light Theme</Trans> : <Trans>Dark Theme</Trans>}</div>
                       {darkMode ? <Moon opacity={0.6} size={16} /> : <Sun opacity={0.6} size={16} />}
                     </ToggleMenuItem>
+                    <MenuItem href="https://docs.uniswap.org/">
+                      <div>
+                        <Trans>Docs</Trans>
+                      </div>
+                      <BookOpen opacity={0.6} size={16} />
+                    </MenuItem>
                     <ToggleMenuItem onClick={() => togglePrivacyPolicy()}>
                       <div>
                         <Trans>Legal & Privacy</Trans>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -10,13 +10,13 @@ import {
   BookOpen,
   Check,
   ChevronLeft,
+  Coffee,
   FileText,
   Globe,
   HelpCircle,
   Info,
   MessageCircle,
   Moon,
-  Send,
   Sun,
 } from 'react-feather'
 import { Link } from 'react-router-dom'
@@ -262,7 +262,7 @@ export default function Menu() {
                       <div>
                         <Trans>Request Features</Trans>
                       </div>
-                      <Send opacity={0.6} size={16} />
+                      <Coffee opacity={0.6} size={16} />
                     </MenuItem>
                     <MenuItem href="https://discord.gg/FCfyBSbCU5">
                       <div>


### PR DESCRIPTION
@callil ptal I added Help Center to the menu. It got so long that a scroll bar appeared (see screenshot), so I deleted Analytics because we have that in the Chart tab in the header. Wdyt?

Other options
- we could also extend the height of the menu with no scroll bar
- we could selectively hide the Claim UNI button, but that's a bit more complex

for a quick fix this seems optimal

https://github.com/Uniswap/interface/issues/2130