### PR TITLE
fix: support 0.01% fee tier in client side router

### DIFF
--- a/src/hooks/useV3SwapPools.ts
+++ b/src/hooks/useV3SwapPools.ts
@@ -23,6 +23,7 @@ export function useV3SwapPools(
     () =>
       allCurrencyCombinations.reduce<[Token, Token, FeeAmount][]>((list, [tokenA, tokenB]) => {
         return list.concat([
+          [tokenA, tokenB, FeeAmount.LOWEST],
           [tokenA, tokenB, FeeAmount.LOW],
           [tokenA, tokenB, FeeAmount.MEDIUM],
           [tokenA, tokenB, FeeAmount.HIGH],


### PR DESCRIPTION
- chore: add support for 0.01% tier
- only show 1bps on mainnet
- rename VERY_LOW to LOWEST
- upgrade to v3-sdk 3.7.0
- consider 0.01% tier in pool
