### PR TITLE
fix: fallback from davatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@lingui/cli": "^3.9.0",
     "@lingui/macro": "^3.9.0",
     "@lingui/react": "^3.9.0",
+    "@metamask/jazzicon": "^2.0.0",
     "@popperjs/core": "^2.4.4",
     "@reach/dialog": "^0.10.3",
     "@reach/portal": "^0.10.3",

--- a/src/components/Identicon/index.tsx
+++ b/src/components/Identicon/index.tsx
@@ -1,5 +1,7 @@
-import Davatar, { Image } from '@davatar/react'
-import { useMemo } from 'react'
+import Davatar from '@davatar/react'
+import { Web3Provider } from '@ethersproject/providers'
+import jazzicon from '@metamask/jazzicon'
+import { Component, createRef, useMemo } from 'react'
 import styled from 'styled-components/macro'
 
 import { useActiveWeb3React } from '../../hooks/web3'
@@ -11,6 +13,46 @@ const StyledIdenticonContainer = styled.div`
   background-color: ${({ theme }) => theme.bg4};
 `
 
+interface IdenticonInnerProps {
+  address?: string
+  provider?: Web3Provider
+}
+
+class IdenticonInner extends Component<IdenticonInnerProps> {
+  state: { fallback: boolean } = { fallback: false }
+  ref = createRef<HTMLDivElement>()
+
+  static getDerivedStateFromError() {
+    // use Jazzicon if Davatar throws; Davatar throws when localStorage is blocked (eg on iframes)
+    // see https://github.com/metaphor-xyz/davatar-helpers/issues/19
+    return { fallback: true }
+  }
+
+  renderDavatar(address: string, provider: Web3Provider) {
+    return <Davatar address={address} size={16} provider={provider} />
+  }
+
+  renderJazzicon(address?: string) {
+    if (this.ref.current) {
+      this.ref.current.innerHTML = ''
+      if (address) {
+        this.ref.current.appendChild(jazzicon(16, parseInt(address.slice(2, 10), 16)))
+      }
+    }
+    return null
+  }
+
+  render() {
+    return (
+      <StyledIdenticonContainer ref={this.ref}>
+        {this.props.address && this.props.provider && !this.state.fallback
+          ? this.renderDavatar(this.props.address, this.props.provider)
+          : this.renderJazzicon(this.props.address)}
+      </StyledIdenticonContainer>
+    )
+  }
+}
+
 export default function Identicon() {
   const { account, library } = useActiveWeb3React()
 
@@ -20,13 +62,5 @@ export default function Identicon() {
     return ([1, 3, 4, 5] as Array<number | undefined>).includes(library?.network?.chainId)
   }, [library])
 
-  return (
-    <StyledIdenticonContainer>
-      {account && supportsENS ? (
-        <Davatar address={account} size={16} provider={library} />
-      ) : (
-        <Image address={account} size={16} />
-      )}
-    </StyledIdenticonContainer>
-  )
+  return <IdenticonInner address={account ?? undefined} provider={(supportsENS && library) || undefined} />
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,6 +3034,14 @@
     "@babel/runtime" "^7.11.2"
     "@lingui/core" "^3.9.0"
 
+"@metamask/jazzicon@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/jazzicon/-/jazzicon-2.0.0.tgz#5615528e91c0fc5c9d79202d1f0954a7922525a0"
+  integrity sha512-7M+WSZWKcQAo0LEhErKf1z+D3YX0tEDAcGvcKbDyvDg34uvgeKR00mFNIYwAhdAS9t8YXxhxZgsrRBBg6X8UQg==
+  dependencies:
+    color "^0.11.3"
+    mersenne-twister "^1.1.0"
+
 "@metamask/safe-event-emitter@2.0.0", "@metamask/safe-event-emitter@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz"
@@ -7645,7 +7653,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.3:
+color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -7669,6 +7677,13 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+color-string@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
+  integrity sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=
+  dependencies:
+    color-name "^1.0.0"
+
 color-string@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
@@ -7676,6 +7691,15 @@ color-string@^1.6.0:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color@^0.11.3:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
+  integrity sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=
+  dependencies:
+    clone "^1.0.2"
+    color-convert "^1.3.0"
+    color-string "^0.3.0"
 
 color@^3.0.0, color@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Renders <Davatar> in an error boundary so that localStorage errors can be recovered. Falls back to rendering the MetaMask Jazzicon.

Due to React's developement environment behavior, this will still display an error in development environments. It will swallow the error (correctly) in production environments. To reproduce, block third-party cookies on the site:
- In Chrome, go to chrome://settings
- Search for "third"
- Click on "Cookies and other site data"
- At the bottom, add the site to "Sites that can never use cookies"
- Next time you reload, the site should log an exception, but recover and still display a Jazzicon; note that this can also be achieved by loading the site in an iframe

This _should_ be temporary until https://github.com/metaphor-xyz/davatar-helpers/issues/19 is fixed.

Fixes #2801, which causes the site to crash when it is iframed and a wallet is connected.