### PR TITLE
feat: integrate with ledger dappsBrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@graphql-codegen/typescript": "1.22.3",
     "@graphql-codegen/typescript-operations": "^1.18.2",
     "@graphql-codegen/typescript-rtk-query": "^1.1.1",
+    "@ledgerhq/iframe-provider": "^0.4.2",
     "@lingui/cli": "^3.9.0",
     "@lingui/macro": "^3.9.0",
     "@lingui/react": "^3.9.0",

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -7,6 +7,8 @@ import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 
 import UNISWAP_LOGO_URL from '../assets/svg/logo.svg'
 import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from '../constants/chains'
+import { IS_IN_IFRAME } from '../constants/misc'
+import { parsedQueryString } from '../hooks/useParsedQueryString'
 import getLibrary from '../utils/getLibrary'
 import { FortmaticConnector } from './Fortmatic'
 import { NetworkConnector } from './NetworkConnector'
@@ -17,6 +19,16 @@ const PORTIS_ID = process.env.REACT_APP_PORTIS_ID
 
 if (typeof INFURA_KEY === 'undefined') {
   throw new Error(`REACT_APP_INFURA_KEY must be a defined environment variable`)
+}
+
+const isInsideLedgerDappBrowser = () => {
+  const queryParams = parsedQueryString(window.location.search)
+  return IS_IN_IFRAME && queryParams.embed === 'ledgerdappbrowser'
+}
+if (isInsideLedgerDappBrowser()) {
+  import('@ledgerhq/iframe-provider').then(({ IFrameEthereumProvider }) => {
+    window.ethereum = new IFrameEthereumProvider()
+  })
 }
 
 const NETWORK_URLS: { [key in SupportedChainId]: string } = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,6 +2936,13 @@
     "@json-rpc-tools/types" "^1.7.6"
     "@pedrouid/environment" "^1.0.1"
 
+"@ledgerhq/iframe-provider@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/iframe-provider/-/iframe-provider-0.4.2.tgz#2b63892bb3ab9a0719d2b00488be18b176ad6b7e"
+  integrity sha512-RbdwvQow/ITLk0TLb6c3M7y8IyjopIGXhhuUEMjqTU6PZhAL9Gl7TzH8INit9x9cOeG2WCuV+ZbHQ2oWsLfJ+A==
+  dependencies:
+    eventemitter3 "^4.0.0"
+
 "@lingui/babel-plugin-extract-messages@^3.9.0":
   version "3.9.0"
   resolved "https://registry.npmjs.org/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-3.9.0.tgz"


### PR DESCRIPTION
This makes uniswap interface compatible with ledger DappsBrowser by injecting `@ledger/iframe-provider` into `window.ethereum` when the  interface is run inside an iframe, **and** the url contains `?embed=ledgerdappbrowser`

Please note this PR is done in the context of [Ledger Vault](https://enterprise.ledger.com/products/vault/), the B2B solution and not directly ledger-live. The vault code reuse the [DappsBrowser](https://github.com/LedgerHQ/eth-dapp-browser) but in order to be visible in Ledger-Live, other steps are needed, described in the [doc](https://developers.ledger.com/docs/dapp/introduction/)

I'm fairly new to ethereum world, so feel free to give me any feedbacks on this.

I have tested this by running the code locally, running an iframe with the url `https://localhost:3000?embed=ledgerdappbrowser`.

Also let met know, if you feel like the code injecting the iframe-provider should be done elsewhere in the code base.

