### PR TITLE
fix: Use eth_chainId for requesting chainId w/i switchToNetwork

### DIFF
--- a/src/utils/switchToNetwork.ts
+++ b/src/utils/switchToNetwork.ts
@@ -16,8 +16,8 @@ export async function switchToNetwork({ library, chainId }: SwitchNetworkArgumen
   if (!library?.provider?.request) {
     return
   }
-  if (!chainId && library?.getNetwork) {
-    ;({ chainId } = await library.getNetwork())
+  if (!chainId) {
+    ;({ chainId } = await library.provider.request({ method: 'eth_chainId' }))
   }
   const formattedChainId = hexStripZeros(BigNumber.from(chainId).toHexString())
   try {


### PR DESCRIPTION
https://github.com/Uniswap/interface/pull/2824 broke 3085 support for CB Wallet. `switchToNetwork.ts` assumes the implementation of a `getNetwork()` method I haven't seen spec'd (https://github.com/Uniswap/interface/blob/main/src/utils/switchToNetwork.ts#L19). I believe the correct way to request the chainId from a wallet is via `ethereum.request({ method: 'eth_chainId' })`