### PR TITLE
fix: typo in arweave URI recognition

### DIFF
--- a/src/utils/uriToHttp.ts
+++ b/src/utils/uriToHttp.ts
@@ -18,7 +18,7 @@ export default function uriToHttp(uri: string): string[] {
       const name = uri.match(/^ipns:(\/\/)?(.*)$/i)?.[2]
       return [`https://cloudflare-ipfs.com/ipns/${name}/`, `https://ipfs.io/ipns/${name}/`]
     case 'ar':
-      const tx = uri.match(/^ipns:(\/\/)?(.*)$/i)?.[2]
+      const tx = uri.match(/^ar:(\/\/)?(.*)$/i)?.[2]
       return [`https://arweave.net/${tx}`]
     default:
       return []


### PR DESCRIPTION
There was a typo left from a copy pasta when adding arweave support in URI resolution. I've received reports the ENS avatar implementation isn't working properly on a few avatar types, such as brantley.eth's avatar.

When we implemented `@davatar/react`, we went through a lot of trial and error covering edge cases @zzmp that you're going to need to re-discover now 😅 I would recommend testing with all of the ENS team member's avatars, as they each use very quirky NFT sets that push the edges of the spec and provide good coverage.