### PR TITLE
feat: Add learn more link in TRM description

### DIFF
--- a/src/components/PrivacyPolicy/index.tsx
+++ b/src/components/PrivacyPolicy/index.tsx
@@ -62,7 +62,7 @@ const EXTERNAL_APIS = [
         <Trans>
           The app securely collects your wallet address and shares it with TRM Labs Inc. for risk and compliance
           reasons.
-        </Trans>
+        </Trans>{' '}
         <ExternalLink href="https://help.uniswap.org/en/articles/5675203-terms-of-service-faq">
           <Trans>Learn more</Trans>
         </ExternalLink>

--- a/src/components/PrivacyPolicy/index.tsx
+++ b/src/components/PrivacyPolicy/index.tsx
@@ -58,9 +58,15 @@ const EXTERNAL_APIS = [
   {
     name: 'TRM Labs',
     description: (
-      <Trans>
-        The app securely collects your wallet address and shares it with TRM Labs Inc. for risk and compliance reasons.
-      </Trans>
+      <>
+        <Trans>
+          The app securely collects your wallet address and shares it with TRM Labs Inc. for risk and compliance
+          reasons.
+        </Trans>
+        <ExternalLink href="https://help.uniswap.org/en/articles/5675203-terms-of-service-faq">
+          <Trans>Learn more</Trans>
+        </ExternalLink>
+      </>
     ),
   },
   {


### PR DESCRIPTION
One question:  how can I add a space between the period and the `ExternalLink`?