### PR TITLE
fix: introduce safeNamehash

### DIFF
--- a/src/hooks/useENSAddress.ts
+++ b/src/hooks/useENSAddress.ts
@@ -1,5 +1,5 @@
-import { namehash } from '@ethersproject/hash'
 import { useMemo } from 'react'
+import { safeNamehash } from 'utils/safeNamehash'
 
 import { useSingleCallResult } from '../state/multicall/hooks'
 import isZero from '../utils/isZero'
@@ -12,12 +12,8 @@ import useDebounce from './useDebounce'
 export default function useENSAddress(ensName?: string | null): { loading: boolean; address: string | null } {
   const debouncedName = useDebounce(ensName, 200)
   const ensNodeArgument = useMemo(() => {
-    if (!debouncedName) return [undefined]
-    try {
-      return debouncedName ? [namehash(debouncedName)] : [undefined]
-    } catch (error) {
-      return [undefined]
-    }
+    if (debouncedName === null) return [undefined]
+    return [safeNamehash(debouncedName)]
   }, [debouncedName])
   const registrarContract = useENSRegistrarContract(false)
   const resolverAddress = useSingleCallResult(registrarContract, 'resolver', ensNodeArgument)

--- a/src/hooks/useENSAddress.ts
+++ b/src/hooks/useENSAddress.ts
@@ -11,10 +11,10 @@ import useDebounce from './useDebounce'
  */
 export default function useENSAddress(ensName?: string | null): { loading: boolean; address: string | null } {
   const debouncedName = useDebounce(ensName, 200)
-  const ensNodeArgument = useMemo(() => {
-    if (debouncedName === null) return [undefined]
-    return [safeNamehash(debouncedName)]
-  }, [debouncedName])
+  const ensNodeArgument = useMemo(
+    () => [debouncedName === null ? undefined : safeNamehash(debouncedName)],
+    [debouncedName]
+  )
   const registrarContract = useENSRegistrarContract(false)
   const resolverAddress = useSingleCallResult(registrarContract, 'resolver', ensNodeArgument)
   const resolverAddressResult = resolverAddress.result?.[0]

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -1,5 +1,5 @@
-import { namehash } from '@ethersproject/hash'
 import { useEffect, useMemo, useState } from 'react'
+import { safeNamehash } from 'utils/safeNamehash'
 import uriToHttp from 'utils/uriToHttp'
 
 import { useSingleCallResult } from '../state/multicall/hooks'
@@ -21,15 +21,12 @@ export default function useENSAvatar(
   const debouncedAddress = useDebounce(address, 200)
   const node = useMemo(() => {
     if (!debouncedAddress || !isAddress(debouncedAddress)) return undefined
-    try {
-      return debouncedAddress ? namehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`) : undefined
-    } catch (error) {
-      return undefined
-    }
+    return safeNamehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)
   }, [debouncedAddress])
 
   const addressAvatar = useAvatarFromNode(node)
-  const nameAvatar = useAvatarFromNode(namehash(useENSName(address).ENSName ?? ''))
+  const ENSName = useENSName(address).ENSName
+  const nameAvatar = useAvatarFromNode(ENSName ? safeNamehash(ENSName) : undefined)
   let avatar = addressAvatar.avatar || nameAvatar.avatar
 
   const nftAvatar = useAvatarFromNFT(avatar, enforceOwnership)

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -1,3 +1,4 @@
+import { namehash } from '@ethersproject/hash'
 import { useEffect, useMemo, useState } from 'react'
 import { safeNamehash } from 'utils/safeNamehash'
 import uriToHttp from 'utils/uriToHttp'
@@ -21,12 +22,12 @@ export default function useENSAvatar(
   const debouncedAddress = useDebounce(address, 200)
   const node = useMemo(() => {
     if (!debouncedAddress || !isAddress(debouncedAddress)) return undefined
-    return safeNamehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)
+    return namehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)
   }, [debouncedAddress])
 
   const addressAvatar = useAvatarFromNode(node)
   const ENSName = useENSName(address).ENSName
-  const nameAvatar = useAvatarFromNode(ENSName ? safeNamehash(ENSName) : undefined)
+  const nameAvatar = useAvatarFromNode(ENSName === null ? undefined : safeNamehash(ENSName))
   let avatar = addressAvatar.avatar || nameAvatar.avatar
 
   const nftAvatar = useAvatarFromNFT(avatar, enforceOwnership)

--- a/src/hooks/useENSContentHash.ts
+++ b/src/hooks/useENSContentHash.ts
@@ -1,5 +1,5 @@
-import { namehash } from '@ethersproject/hash'
 import { useMemo } from 'react'
+import { safeNamehash } from 'utils/safeNamehash'
 
 import { useSingleCallResult } from '../state/multicall/hooks'
 import isZero from '../utils/isZero'
@@ -10,12 +10,8 @@ import { useENSRegistrarContract, useENSResolverContract } from './useContract'
  */
 export default function useENSContentHash(ensName?: string | null): { loading: boolean; contenthash: string | null } {
   const ensNodeArgument = useMemo(() => {
-    if (!ensName) return [undefined]
-    try {
-      return ensName ? [namehash(ensName)] : [undefined]
-    } catch (error) {
-      return [undefined]
-    }
+    if (ensName === null) return [undefined]
+    return [safeNamehash(ensName)]
   }, [ensName])
   const registrarContract = useENSRegistrarContract(false)
   const resolverAddressResult = useSingleCallResult(registrarContract, 'resolver', ensNodeArgument)

--- a/src/hooks/useENSContentHash.ts
+++ b/src/hooks/useENSContentHash.ts
@@ -9,10 +9,7 @@ import { useENSRegistrarContract, useENSResolverContract } from './useContract'
  * Does a lookup for an ENS name to find its contenthash.
  */
 export default function useENSContentHash(ensName?: string | null): { loading: boolean; contenthash: string | null } {
-  const ensNodeArgument = useMemo(() => {
-    if (ensName === null) return [undefined]
-    return [safeNamehash(ensName)]
-  }, [ensName])
+  const ensNodeArgument = useMemo(() => [ensName === null ? undefined : safeNamehash(ensName)], [ensName])
   const registrarContract = useENSRegistrarContract(false)
   const resolverAddressResult = useSingleCallResult(registrarContract, 'resolver', ensNodeArgument)
   const resolverAddress = resolverAddressResult.result?.[0]

--- a/src/hooks/useENSName.ts
+++ b/src/hooks/useENSName.ts
@@ -1,5 +1,5 @@
+import { namehash } from '@ethersproject/hash'
 import { useMemo } from 'react'
-import { safeNamehash } from 'utils/safeNamehash'
 
 import { useSingleCallResult } from '../state/multicall/hooks'
 import { isAddress } from '../utils'
@@ -15,7 +15,7 @@ export default function useENSName(address?: string): { ENSName: string | null; 
   const debouncedAddress = useDebounce(address, 200)
   const ensNodeArgument = useMemo(() => {
     if (!debouncedAddress || !isAddress(debouncedAddress)) return [undefined]
-    return [safeNamehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)]
+    return [namehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)]
   }, [debouncedAddress])
   const registrarContract = useENSRegistrarContract(false)
   const resolverAddress = useSingleCallResult(registrarContract, 'resolver', ensNodeArgument)

--- a/src/hooks/useENSName.ts
+++ b/src/hooks/useENSName.ts
@@ -1,5 +1,5 @@
-import { namehash } from '@ethersproject/hash'
 import { useMemo } from 'react'
+import { safeNamehash } from 'utils/safeNamehash'
 
 import { useSingleCallResult } from '../state/multicall/hooks'
 import { isAddress } from '../utils'
@@ -15,11 +15,7 @@ export default function useENSName(address?: string): { ENSName: string | null; 
   const debouncedAddress = useDebounce(address, 200)
   const ensNodeArgument = useMemo(() => {
     if (!debouncedAddress || !isAddress(debouncedAddress)) return [undefined]
-    try {
-      return debouncedAddress ? [namehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)] : [undefined]
-    } catch (error) {
-      return [undefined]
-    }
+    return [safeNamehash(`${debouncedAddress.toLowerCase().substr(2)}.addr.reverse`)]
   }, [debouncedAddress])
   const registrarContract = useENSRegistrarContract(false)
   const resolverAddress = useSingleCallResult(registrarContract, 'resolver', ensNodeArgument)

--- a/src/utils/safeNamehash.test.ts
+++ b/src/utils/safeNamehash.test.ts
@@ -2,17 +2,20 @@ import { namehash } from '@ethersproject/hash'
 
 import { safeNamehash } from './safeNamehash'
 
-describe.only('#safeNamehash', () => {
+describe('#safeNamehash', () => {
+  const emoji = '🤔'
+
   it('#namehash fails', () => {
-    expect(() => namehash('🤔')).toThrow('STRINGPREP_CONTAINS_UNASSIGNED')
+    expect(() => namehash(emoji)).toThrow('STRINGPREP_CONTAINS_UNASSIGNED')
   })
 
+  // suppress console.debug for the next test
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     jest.spyOn(console, 'debug').mockImplementation(() => {})
   })
 
   it('works', () => {
-    expect(safeNamehash('🤔')).toEqual(undefined)
+    expect(safeNamehash(emoji)).toEqual(undefined)
   })
 })

--- a/src/utils/safeNamehash.test.ts
+++ b/src/utils/safeNamehash.test.ts
@@ -1,0 +1,18 @@
+import { namehash } from '@ethersproject/hash'
+
+import { safeNamehash } from './safeNamehash'
+
+describe.only('#safeNamehash', () => {
+  it('#namehash fails', () => {
+    expect(() => namehash('🤔')).toThrow('STRINGPREP_CONTAINS_UNASSIGNED')
+  })
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  it('works', () => {
+    expect(safeNamehash('🤔')).toEqual(undefined)
+  })
+})

--- a/src/utils/safeNamehash.ts
+++ b/src/utils/safeNamehash.ts
@@ -1,7 +1,7 @@
 import { namehash } from '@ethersproject/hash'
 
 export function safeNamehash(name?: string): string | undefined {
-  if (typeof name === 'undefined') return undefined
+  if (name === undefined) return undefined
 
   try {
     return namehash(name)

--- a/src/utils/safeNamehash.ts
+++ b/src/utils/safeNamehash.ts
@@ -1,0 +1,12 @@
+import { namehash } from '@ethersproject/hash'
+
+export function safeNamehash(name?: string): string | undefined {
+  if (typeof name === 'undefined') return undefined
+
+  try {
+    return namehash(name)
+  } catch (error) {
+    console.debug(error)
+    return undefined
+  }
+}


### PR DESCRIPTION
closes #2876 

seems like there's probably some deeper unicode issue going on here, but this at least fixes the immediate problem for those with emojis in their ENS names