### PR TITLE
fix: app crash on coinbase wallet + polygon network

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -70,4 +70,5 @@ export const walletlink = new WalletLinkConnector({
   url: NETWORK_URLS[SupportedChainId.MAINNET],
   appName: 'Uniswap',
   appLogoUrl: UNISWAP_LOGO_URL,
+  supportedChainIds: [SupportedChainId.MAINNET],
 })


### PR DESCRIPTION
fixes https://github.com/Uniswap/interface/issues/2477

walletlink/coinbase wallet used to only support mainnet but added other networks along the way
so we need to let `react-web3` know to only support certain chains

to reproduce the bug on main:
- disconnect your metamask/existing wallet connection
- connect to coinbase wallet using the QR code scanner
- on the coinbase wallet app, change your default network to any unsupported network (like polygon)

(thank you @NoahZinsmeister for your help!!)