### PR TITLE
feat: add chainId (network) as url parameter

### DIFF
--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -286,7 +286,7 @@ export default function NetworkSelector() {
     if (chainId && chainId !== prevChainId) {
       history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
       // otherwise assume network change originates from URL
-    } else if (urlChainId) {
+    } else if (urlChainId && urlChainId !== chainId) {
       handleChainSwitch(urlChainId, true)
     }
   }, [chainId, urlChainId, prevChainId, handleChainSwitch, history])

--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -225,7 +225,7 @@ const getParsedChainId = (parsedQs?: ParsedQs) => {
 export default function NetworkSelector() {
   const { chainId, library } = useActiveWeb3React()
   const parsedQs = useParsedQueryString()
-  const [promptedNetworkChange, setPromptedNetworkChange] = useState(false)
+  const [lastNetworkChange, setLastNetworkChange] = useState<number | null>(null)
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.NETWORK_SELECTOR)
   const toggle = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
@@ -250,14 +250,14 @@ export default function NetworkSelector() {
   )
 
   useEffect(() => {
-    if (!chainId || promptedNetworkChange) return
+    if (!chainId || lastNetworkChange === chainId) return
     const newChainId = getParsedChainId(parsedQs)
 
     if (newChainId && chainId !== newChainId) {
       handleChainSwitch(newChainId, true)
-      setPromptedNetworkChange(true)
+      setLastNetworkChange(chainId)
     }
-  }, [handleChainSwitch, promptedNetworkChange, chainId, parsedQs])
+  }, [handleChainSwitch, lastNetworkChange, chainId, parsedQs])
 
   if (!chainId || !info || !library) {
     return null

--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -236,10 +236,10 @@ export default function NetworkSelector() {
   const dispatch = useAppDispatch()
 
   const handleChainSwitch = useCallback(
-    (targetChain: number) => {
+    (targetChain: number, skipToggle?: boolean) => {
       if (!library) return
       switchToNetwork({ library, chainId: targetChain })
-        .then(() => toggle())
+        .then(() => !skipToggle && toggle())
         .catch((error) => {
           console.error('Failed to switch networks', error)
           toggle()
@@ -254,7 +254,7 @@ export default function NetworkSelector() {
     const newChainId = getParsedChainId(parsedQs)
 
     if (newChainId && chainId !== newChainId) {
-      handleChainSwitch(newChainId)
+      handleChainSwitch(newChainId, true)
       setPromptedNetworkChange(true)
     }
   }, [handleChainSwitch, promptedNetworkChange, chainId, parsedQs])

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -18,6 +18,20 @@ export enum SupportedChainId {
   POLYGON_MUMBAI = 80001,
 }
 
+export const CHAIN_IDS_TO_NAMES = {
+  [SupportedChainId.MAINNET]: 'mainnet',
+  [SupportedChainId.ROPSTEN]: 'ropsten',
+  [SupportedChainId.RINKEBY]: 'rinkeby',
+  [SupportedChainId.GOERLI]: 'goerli',
+  [SupportedChainId.KOVAN]: 'kovan',
+  [SupportedChainId.POLYGON]: 'polygon',
+  [SupportedChainId.POLYGON_MUMBAI]: 'polygon_mumbai',
+  [SupportedChainId.ARBITRUM_ONE]: 'arbitrum',
+  [SupportedChainId.ARBITRUM_RINKEBY]: 'arbitrum_rinkeby',
+  [SupportedChainId.OPTIMISM]: 'optimism',
+  [SupportedChainId.OPTIMISTIC_KOVAN]: 'optimistic_kovan',
+}
+
 /**
  * Array of all the supported chain IDs
  */

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,0 +1,5 @@
+export const replaceURLParam = (search: string, param: string, newValue: string) => {
+  const searchParams = new URLSearchParams(search)
+  searchParams.set(param, newValue)
+  return searchParams.toString()
+}


### PR DESCRIPTION
fixes https://github.com/Uniswap/interface/issues/1893 https://github.com/Uniswap/interface/issues/3032

This allows users to add `chainId` to the URL to prompt the user to switch their wallet network if necessary.

Some considerations/assumptions here:
- By default (no `chainId` parameter), the network should be the wallet's network
- When no wallet is connected, the behavior should match that of switching the network option with no wallet that is currently in the app
- if `chainId` parameter exists, and is a supported chain id and is not the wallet current network, then fire a request to prompt network change
- We consider the wallet's network as the source of truth -> if the user rejects the network change request, remain on the current network
- When we switch networks on the app, should we update the URL too? ~I'm thinking no, since not changing it would be consistent with the behavior of `inputCurrency` and `outputCurrency` parameters, where the url param acts as one-directional data flow~

~to try it out: append `swap?inputCurrency=0x8e915a77e301ad12ad1f62012734cf7557eee81a&&chainId=137` to the URL~


edit: 
- when we switch networks on the app, we *should* update the URL and vice versa
- we're using `chain` name instead of `chainId`. alternate URL: `swap?inputCurrency=0x8e915a77e301ad12ad1f62012734cf7557eee81a&&chain=polygon`