### PR TITLE
chore: add focus-visible for nav links

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -214,6 +214,10 @@ const StyledNavLink = styled(NavLink).attrs({
   :focus {
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
+
+  :focus-visible {
+    outline: 1px solid ${({ theme }) => theme.bg3};
+  }
 `
 
 const StyledExternalLink = styled(ExternalLink).attrs({


### PR DESCRIPTION
This PR will increase a11y for users

Will pass this w3c criterion https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html

This only work for keyboard users ⌨️ 

https://user-images.githubusercontent.com/69431456/148232336-92b54b21-97bc-4194-a92b-983eb80f1050.mov

![Screenshot 2022-01-05 at 7 49 04 PM](https://user-images.githubusercontent.com/69431456/148232520-7d89aacf-cfab-4249-9421-92650b2eab5b.png)

![image](https://user-images.githubusercontent.com/69431456/148232633-15726ac0-9441-4c99-98bf-495b22387465.png)