### PR TITLE
chore: add focus-visible for menu links

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -127,6 +127,11 @@ const MenuItem = styled(ExternalLink)`
     cursor: pointer;
     text-decoration: none;
   }
+  :focus-visible {
+    border-radius: 0.5rem;
+    text-decoration: none;
+    outline: 1px solid ${({ theme }) => theme.bg3};
+  }
 `
 
 const InternalMenuItem = styled(Link)`
@@ -175,6 +180,10 @@ const ToggleMenuItem = styled.button`
     color: ${({ theme }) => theme.text1};
     cursor: pointer;
     text-decoration: none;
+  }
+  :focus-visible {
+    border-radius: 0.5rem;
+    outline: 1px solid ${({ theme }) => theme.bg3};
   }
 `
 


### PR DESCRIPTION
This PR will increase a11y for users

Will pass this w3c criterion https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html

This only work for keyboard users ⌨️ 

https://user-images.githubusercontent.com/69431456/148234913-db5df2b9-a5a4-49bd-8f88-67d5d353758b.mov

![image](https://user-images.githubusercontent.com/69431456/148234979-88229976-d3cd-4345-9ba7-f2689ab537d4.png)

![image](https://user-images.githubusercontent.com/69431456/148235016-76acb407-980a-4ddf-a3ce-3609a1f2e4d8.png)
