### PR TITLE
fix: set wallectconnect chainId explicitly to ethereum

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -34,6 +34,7 @@ export const walletconnect = new WalletConnectConnector({
   supportedChainIds: ALL_SUPPORTED_CHAIN_IDS,
   rpc: INFURA_NETWORK_URLS,
   qrcode: true,
+  chaiId: 1,
 })
 
 // mainnet only

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -34,7 +34,7 @@ export const walletconnect = new WalletConnectConnector({
   supportedChainIds: ALL_SUPPORTED_CHAIN_IDS,
   rpc: INFURA_NETWORK_URLS,
   qrcode: true,
-  chaiId: 1,
+  chainId: 1,
 })
 
 // mainnet only


### PR DESCRIPTION
Sets wallectconnect chainId explicitly to Ethereum, to make a point that it is only configured for Ethereum mainnet, which is the current state.

To support walletconnect on networks other than Ethereum this value needs to be set to the correct chainId!

When the network is changed before connecting via walletconnect (see https://github.com/Uniswap/interface/blob/main/src/components/Header/NetworkSelector.tsx#L227 ) the `chainId` value needs to be set to the correct `chainId`.