### PR TITLE
fix: display network message on vote page if not mainnet

### DIFF
--- a/src/components/vote/ProposalEmptyState.tsx
+++ b/src/components/vote/ProposalEmptyState.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { L2_CHAIN_IDS } from 'constants/chains'
+import { SupportedChainId } from 'constants/chains'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -38,7 +38,7 @@ const EmptyState = ({ HeaderContent, SubHeaderContent }: EmptyStateProps) => (
 
 export default function ProposalEmptyState() {
   const { chainId } = useActiveWeb3React()
-  if (chainId && L2_CHAIN_IDS.includes(chainId)) {
+  if (chainId && chainId !== SupportedChainId.MAINNET) {
     return (
       <EmptyState
         HeaderContent={() => <Trans>Please connect to Layer 1 Ethereum</Trans>}


### PR DESCRIPTION
Current behavior:  if you visit the /vote page while connected to Polygon, Rinkeby, Ropsten, etc,  you see an empty page with no explanation.

Expected behavior:  you should see a message 
<img width="667" alt="Screen Shot 2022-01-18 at 11 00 16 PM" src="https://user-images.githubusercontent.com/5455577/150061583-c460f897-2a85-4e3e-8c4d-d29643c05d94.png">

We already have this on optimism and arbitrum, but the conditional was overlooking Polygon, Rinkeby, etc

This was made more noticeable by Tina's PR for chain ID URL param https://github.com/Uniswap/interface/pull/3057