### PR TITLE
feat: update slippage tolerance to use auto or custom

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -29,12 +29,11 @@ const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 1000) // 0.5%
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(25, 100) // 25%
 
 /**
- * @param trade
- * @returns slippage tolerance based on values from current trade, gas estimates from api, and active network
+ * returns slippage tolerance based on values from current trade, gas estimates from api, and active network
  */
-export default function useSlippageToleranceFromTrade(
+export default function useAutoSlippageTolerance(
   trade: InterfaceTrade<Currency, Currency, TradeType> | undefined
-) {
+): Percent {
   const { chainId } = useActiveWeb3React()
   const onL2 = chainId && L2_CHAIN_IDS.includes(chainId)
   const outputDollarValue = useUSDCValue(trade?.outputAmount)

--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -29,7 +29,7 @@ const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 1000) // 0.5%
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(25, 100) // 25%
 
 /**
- * returns slippage tolerance based on values from current trade, gas estimates from api, and active network
+ * Returns slippage tolerance based on values from current trade, gas estimates from api, and active network.
  */
 export default function useAutoSlippageTolerance(
   trade: InterfaceTrade<Currency, Currency, TradeType> | undefined

--- a/src/hooks/useSlippageToleranceFromTrade.ts
+++ b/src/hooks/useSlippageToleranceFromTrade.ts
@@ -8,7 +8,6 @@ import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 import { useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 
-import { useUserSlippageToleranceWithDefault } from '../state/user/hooks'
 import useGasPrice from './useGasPrice'
 import useUSDCPrice, { useUSDCValue } from './useUSDCPrice'
 
@@ -29,9 +28,13 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
 const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 1000) // 0.5%
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(25, 100) // 25%
 
-export default function useSwapSlippageTolerance(
+/**
+ * @param trade
+ * @returns slippage tolerance based on values from current trade, gas estimates from api, and active network
+ */
+export default function useSlippageToleranceFromTrade(
   trade: InterfaceTrade<Currency, Currency, TradeType> | undefined
-): Percent {
+) {
   const { chainId } = useActiveWeb3React()
   const onL2 = chainId && L2_CHAIN_IDS.includes(chainId)
   const outputDollarValue = useUSDCValue(trade?.outputAmount)
@@ -41,7 +44,7 @@ export default function useSwapSlippageTolerance(
   const nativeCurrency = useNativeCurrency()
   const nativeCurrencyPrice = useUSDCPrice(nativeCurrency ?? undefined)
 
-  const defaultSlippageTolerance = useMemo(() => {
+  return useMemo(() => {
     if (!trade || onL2) return ONE_TENTHS_PERCENT
 
     const nativeGasCost =
@@ -73,6 +76,4 @@ export default function useSwapSlippageTolerance(
 
     return V3_SWAP_DEFAULT_SLIPPAGE
   }, [trade, onL2, nativeGasPrice, gasEstimate, nativeCurrency, nativeCurrencyPrice, chainId, outputDollarValue])
-
-  return useUserSlippageToleranceWithDefault(defaultSlippageTolerance)
 }

--- a/src/lib/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/lib/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -48,13 +48,12 @@ export default function MaxSlippageSelect() {
   const { allowedSlippage } = useSwapInfo()
 
   const [slippageInput, setSlippageInput] = useState('')
-  const [slippageError, setSlippageError] = useState<boolean>(false)
+  const [, setSlippageError] = useState<boolean>(false)
 
   function parseSlippageInput(value: string) {
     // populate what the user typed and clear the error
     setSlippageInput(value)
     setSlippageError(false)
-
     if (value.length === 0) {
       setMaxSlippage('auto')
     } else {
@@ -70,9 +69,6 @@ export default function MaxSlippageSelect() {
       }
     }
   }
-
-  const tooLow = maxSlippage !== 'auto' && maxSlippage.lessThan(new Percent(5, 10_000))
-  const tooHigh = maxSlippage !== 'auto' && maxSlippage.greaterThan(new Percent(1, 100))
 
   return (
     <Column gap={0.75}>
@@ -99,19 +95,6 @@ export default function MaxSlippageSelect() {
           %
         </InputOption>
       </Row>
-      {slippageError || tooLow || tooHigh ? (
-        <Row>
-          <ThemedText.Caption color={slippageError ? 'error' : 'warning'}>
-            {slippageError ? (
-              <Trans>Enter a valid slippage percentage</Trans>
-            ) : tooLow ? (
-              <Trans>Your transaction may fail</Trans>
-            ) : (
-              <Trans>Your transaction may be frontrun</Trans>
-            )}
-          </ThemedText.Caption>
-        </Row>
-      ) : null}
     </Column>
   )
 }

--- a/src/lib/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/lib/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -6,7 +6,7 @@ import { maxSlippageAtom } from 'lib/state/settings'
 import styled, { ThemedText } from 'lib/theme'
 import { ReactNode, useState } from 'react'
 
-import { BaseButton } from '../../Button'
+import { BaseButton, TextButton } from '../../Button'
 import Column from '../../Column'
 import { DecimalInput, inputCss } from '../../Input'
 import Row from '../../Row'
@@ -16,22 +16,15 @@ const tooltip = (
   <Trans>Your transaction will revert if the price changes unfavorably by more than this percentage.</Trans>
 )
 
+const StyledOption = styled(TextButton)<{ selected: boolean }>`
+  ${({ selected }) => optionCss(selected)}
+`
+
 const StyledInputOption = styled(BaseButton)<{ selected: boolean }>`
   ${({ selected }) => optionCss(selected)}
   ${inputCss}
   border-color: ${({ selected, theme }) => (selected ? theme.active : 'transparent')} !important;
   padding: calc(0.5em - 1px) 0.625em;
-`
-
-const Option = styled(BaseButton)<{ selected: boolean }>`
-  ${({ selected }) => optionCss(selected)}
-  background-color: ${({ selected, theme }) => (selected ? theme.active : theme.container)};
-  border-radius: ${({ theme }) => theme.borderRadius}em;
-  :hover {
-    cursor: pointer;
-  }
-  color: ${({ theme, selected }) => (selected ? theme.dialog : theme.secondary)} !important;
-  margin-right: 8px;
 `
 
 interface OptionProps<T> {
@@ -85,14 +78,14 @@ export default function MaxSlippageSelect() {
     <Column gap={0.75}>
       <Label name={<Trans>Max slippage</Trans>} tooltip={tooltip} />
       <Row gap={0.5} grow>
-        <Option
+        <StyledOption
           onClick={() => {
             parseSlippageInput('')
           }}
           selected={maxSlippage === 'auto'}
         >
           <Trans>Auto</Trans>
-        </Option>
+        </StyledOption>
         <InputOption value={slippageInput} selected={maxSlippage !== 'auto'}>
           <DecimalInput
             value={slippageInput.length > 0 ? slippageInput : maxSlippage === 'auto' ? '' : maxSlippage.toFixed(2)}

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -88,15 +88,15 @@ function useComputeSwapInfo(): SwapInfo {
     [trade.trade?.inputAmount, trade.trade?.outputAmount]
   )
 
-  /**
-    If user has enabled 'auto' slippage, use the default best slippage calculated 
-    based on the trade. If user has entered custom slippage, use that instead. 
+  /*
+   * If user has enabled 'auto' slippage, use the default best slippage calculated
+   * based on the trade. If user has entered custom slippage, use that instead.
    */
-  const auotSlippageTolerance = useAutoSlippageTolerance(trade.trade)
+  const autoSlippageTolerance = useAutoSlippageTolerance(trade.trade)
   const maxSlippage = useAtomValue(maxSlippageAtom)
   const allowedSlippage = useMemo(
-    () => (maxSlippage === 'auto' ? auotSlippageTolerance : maxSlippage),
-    [auotSlippageTolerance, maxSlippage]
+    () => (maxSlippage === 'auto' ? autoSlippageTolerance : maxSlippage),
+    [autoSlippageTolerance, maxSlippage]
   )
 
   const inputError = useMemo(() => {
@@ -163,7 +163,7 @@ export function SwapInfoUpdater() {
   return null
 }
 
-/** Requires that SwapInfoUpdater be installed in the DOM tree. */
+/* Requires that SwapInfoUpdater be installed in the DOM tree. */
 export default function useSwapInfo(): SwapInfo {
   return useAtomValue(swapInfoAtom)
 }

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -163,7 +163,7 @@ export function SwapInfoUpdater() {
   return null
 }
 
-/* Requires that SwapInfoUpdater be installed in the DOM tree. */
+/** Requires that SwapInfoUpdater be installed in the DOM tree. **/
 export default function useSwapInfo(): SwapInfo {
   return useAtomValue(swapInfoAtom)
 }

--- a/src/lib/state/atoms.ts
+++ b/src/lib/state/atoms.ts
@@ -34,43 +34,6 @@ export function pickAtom<Value, Key extends keyof Value & keyof Draft<Value>, Up
   )
 }
 
-/**
- * Typing for a customizable enum; see setCustomizable.
- * This is not exported because an enum may not extend another interface.
- */
-interface CustomizableEnum<T extends number> {
-  CUSTOM: -1
-  DEFAULT: T
-}
-
-/**
- * Typing for a customizable enum; see setCustomizable.
- * The first value is used, unless it is CUSTOM, in which case the second is used.
- */
-export type Customizable<T> = { value: T; custom?: number }
-
-/** Sets a customizable enum, validating the tuple and falling back to the default. */
-export function setCustomizable<T extends number, Enum extends CustomizableEnum<T>>(customizable: Enum) {
-  return (draft: Customizable<T>, update: T | Customizable<T>) => {
-    // normalize the update
-    if (typeof update === 'number') {
-      update = { value: update }
-    }
-
-    draft.value = update.value
-    if (draft.value === customizable.CUSTOM) {
-      draft.custom = update.custom
-
-      // prevent invalid state
-      if (draft.custom === undefined) {
-        draft.value = customizable.DEFAULT
-      }
-    }
-
-    return draft
-  }
-}
-
 /** Sets a togglable atom to invert its state at the next render. */
 export function setTogglable(draft: boolean) {
   return !draft

--- a/src/lib/state/settings.ts
+++ b/src/lib/state/settings.ts
@@ -1,34 +1,26 @@
+import { Percent } from '@uniswap/sdk-core'
 import { atomWithReset } from 'jotai/utils'
 
-import { Customizable, pickAtom, setCustomizable, setTogglable } from './atoms'
-
-/** Max slippage, as a percentage. */
-export enum MaxSlippage {
-  P01 = 0.1,
-  P05 = 0.5,
-  // Members to satisfy CustomizableEnum; see setCustomizable
-  CUSTOM = -1,
-  DEFAULT = P05,
-}
+import { pickAtom, setTogglable } from './atoms'
 
 export const TRANSACTION_TTL_DEFAULT = 40
 
 interface Settings {
-  maxSlippage: Customizable<MaxSlippage>
+  maxSlippage: Percent | 'auto' // auto will cause slippage to resort to default calculation
   transactionTtl: number | undefined
   mockTogglable: boolean
   clientSideRouter: boolean // wether to use
 }
 
 const initialSettings: Settings = {
-  maxSlippage: { value: MaxSlippage.DEFAULT },
+  maxSlippage: 'auto',
   transactionTtl: undefined,
   mockTogglable: true,
   clientSideRouter: false,
 }
 
 export const settingsAtom = atomWithReset(initialSettings)
-export const maxSlippageAtom = pickAtom(settingsAtom, 'maxSlippage', setCustomizable(MaxSlippage))
+export const maxSlippageAtom = pickAtom(settingsAtom, 'maxSlippage')
 export const transactionTtlAtom = pickAtom(settingsAtom, 'transactionTtl')
 export const mockTogglableAtom = pickAtom(settingsAtom, 'mockTogglable', setTogglable)
 export const clientSideRouterAtom = pickAtom(settingsAtom, 'clientSideRouter')

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import useAutoSlippageTolerance from 'hooks/useAutoSlippageTolerance'
 import { useBestTrade } from 'hooks/useBestTrade'
-import useSlippageToleranceFromTrade from 'hooks/useSlippageToleranceFromTrade'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ParsedQs } from 'qs'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
@@ -135,8 +135,8 @@ export function useDerivedSwapInfo(): {
   )
 
   // allowed slippage is either auto slippage, or custom user defined slippage if auto slippage disabled
-  const slippageToleranceFromTrade = useSlippageToleranceFromTrade(trade.trade)
-  const allowedSlippage = useUserSlippageToleranceWithDefault(slippageToleranceFromTrade)
+  const autoSlippageTolerance = useAutoSlippageTolerance(trade.trade)
+  const allowedSlippage = useUserSlippageToleranceWithDefault(autoSlippageTolerance)
 
   const inputError = useMemo(() => {
     let inputError: ReactNode | undefined

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -2,16 +2,17 @@ import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useBestTrade } from 'hooks/useBestTrade'
+import useSlippageToleranceFromTrade from 'hooks/useSlippageToleranceFromTrade'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ParsedQs } from 'qs'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { InterfaceTrade, TradeState } from 'state/routing/types'
+import { useUserSlippageToleranceWithDefault } from 'state/user/hooks'
 
 import { useCurrency } from '../../hooks/Tokens'
 import useENS from '../../hooks/useENS'
 import useParsedQueryString from '../../hooks/useParsedQueryString'
-import useSwapSlippageTolerance from '../../hooks/useSwapSlippageTolerance'
 import { isAddress } from '../../utils'
 import { AppState } from '../index'
 import { useCurrencyBalances } from '../wallet/hooks'
@@ -133,7 +134,10 @@ export function useDerivedSwapInfo(): {
     [inputCurrency, outputCurrency]
   )
 
-  const allowedSlippage = useSwapSlippageTolerance(trade.trade ?? undefined)
+  // allowed slippage is either auto slippage, or custom user defined slippage if auto slippage disabled
+  const slippageToleranceFromTrade = useSlippageToleranceFromTrade(trade.trade)
+  const allowedSlippage = useUserSlippageToleranceWithDefault(slippageToleranceFromTrade)
+
   const inputError = useMemo(() => {
     let inputError: ReactNode | undefined
 


### PR DESCRIPTION
- change slippage type to `Percent | auto` to support auto slippage calculations based on trade details 

NB: This is a functional change - design/UI updates will be made in a separate PR.