### PR TITLE
feat(widgets): move uniswap protocol branding from header to bottom of output

### DIFF
--- a/src/lib/components/BrandedFooter.tsx
+++ b/src/lib/components/BrandedFooter.tsx
@@ -1,17 +1,13 @@
 import { Trans } from '@lingui/macro'
 import Row from 'lib/components/Row'
 import { Logo } from 'lib/icons'
-import styled from 'lib/theme'
+import styled, { ThemedText } from 'lib/theme'
 
 import ExternalLink from './ExternalLink'
 
 const UniswapA = styled(ExternalLink)`
   color: ${({ theme }) => theme.secondary};
   cursor: pointer;
-  display: flex;
-  font-size: 0.75em;
-  justify-content: center;
-  line-height: 1.35em;
   text-decoration: none;
 
   ${Logo} {
@@ -28,12 +24,14 @@ const UniswapA = styled(ExternalLink)`
   }
 `
 
-export default function BrandingFooter() {
+export default function BrandedFooter() {
   return (
     <UniswapA href={`https://app.uniswap.org/`}>
-      <Row gap={0.4}>
+      <Row gap={0.4} justify="center">
         <Logo />
-        <Trans>Powered by the Uniswap protocol</Trans>
+        <ThemedText.Caption color="secondary">
+          <Trans>Powered by the Uniswap protocol</Trans>
+        </ThemedText.Caption>
       </Row>
     </UniswapA>
   )

--- a/src/lib/components/BrandingFooter.tsx
+++ b/src/lib/components/BrandingFooter.tsx
@@ -1,0 +1,40 @@
+import { Trans } from '@lingui/macro'
+import Row from 'lib/components/Row'
+import { Logo } from 'lib/icons'
+import styled from 'lib/theme'
+
+import ExternalLink from './ExternalLink'
+
+const UniswapA = styled(ExternalLink)`
+  color: ${({ theme }) => theme.secondary};
+  cursor: pointer;
+  display: flex;
+  font-size: 0.75em;
+  justify-content: center;
+  line-height: 1.35em;
+  text-decoration: none;
+
+  ${Logo} {
+    fill: ${({ theme }) => theme.secondary};
+    height: 1em;
+    transition: transform 0.25s ease;
+    width: 1em;
+    will-change: transform;
+
+    :hover {
+      fill: ${({ theme }) => theme.onHover(theme.secondary)};
+      transform: rotate(-5deg);
+    }
+  }
+`
+
+export default function BrandingFooter() {
+  return (
+    <UniswapA href={`https://app.uniswap.org/`}>
+      <Row gap={0.4}>
+        <Logo />
+        <Trans>Powered by the Uniswap protocol</Trans>
+      </Row>
+    </UniswapA>
+  )
+}

--- a/src/lib/components/ExternalLink.tsx
+++ b/src/lib/components/ExternalLink.tsx
@@ -1,0 +1,17 @@
+import { HTMLProps } from 'react'
+
+/**
+ * Outbound link
+ */
+export default function ExternalLink({
+  target = '_blank',
+  href,
+  rel = 'noopener noreferrer',
+  ...rest
+}: Omit<HTMLProps<HTMLAnchorElement>, 'as' | 'ref' | 'onClick'> & { href: string }) {
+  return (
+    <a target={target} rel={rel} href={href} {...rest}>
+      {rest.children}
+    </a>
+  )
+}

--- a/src/lib/components/Header.tsx
+++ b/src/lib/components/Header.tsx
@@ -1,25 +1,8 @@
-import { largeIconCss, Logo } from 'lib/icons'
+import { largeIconCss } from 'lib/icons'
 import styled, { ThemedText } from 'lib/theme'
 import { ReactElement, ReactNode } from 'react'
 
 import Row from './Row'
-
-const UniswapA = styled.a`
-  cursor: pointer;
-
-  ${Logo} {
-    fill: ${({ theme }) => theme.secondary};
-    height: 1.5em;
-    transition: transform 0.25s ease;
-    width: 1.5em;
-    will-change: transform;
-
-    :hover {
-      fill: ${({ theme }) => theme.onHover(theme.secondary)};
-      transform: rotate(-5deg);
-    }
-  }
-`
 
 const HeaderRow = styled(Row)`
   height: 1.75em;
@@ -30,21 +13,13 @@ const HeaderRow = styled(Row)`
 
 export interface HeaderProps {
   title?: ReactElement
-  logo?: boolean
   children: ReactNode
 }
 
-export default function Header({ title, logo, children }: HeaderProps) {
+export default function Header({ title, children }: HeaderProps) {
   return (
     <HeaderRow iconSize={1.2}>
-      <Row gap={0.5}>
-        {logo && (
-          <UniswapA href={`https://app.uniswap.org/`}>
-            <Logo />
-          </UniswapA>
-        )}
-        {title && <ThemedText.Subhead1>{title}</ThemedText.Subhead1>}
-      </Row>
+      <Row gap={0.5}>{title && <ThemedText.Subhead1>{title}</ThemedText.Subhead1>}</Row>
       <Row gap={1}>{children}</Row>
     </HeaderRow>
   )

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { atom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
-import BrandingFooter from 'lib/components/BrandingFooter'
+import BrandedFooter from 'lib/components/BrandedFooter'
 import { useSwapAmount, useSwapCurrency, useSwapInfo } from 'lib/hooks/swap'
 import useCurrencyColor from 'lib/hooks/useCurrencyColor'
 import { Field } from 'lib/state/swap'
@@ -102,7 +102,7 @@ export default function Output({ disabled, children }: OutputProps) {
           </ThemedText.Body2>
         </TokenInput>
         {children}
-        <BrandingFooter />
+        <BrandedFooter />
       </OutputColumn>
     </DynamicThemeProvider>
   )

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -4,6 +4,7 @@ import { atom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
 import { useSwapAmount, useSwapCurrency, useSwapInfo } from 'lib/hooks/swap'
 import useCurrencyColor from 'lib/hooks/useCurrencyColor'
+import { Logo } from 'lib/icons'
 import { Field } from 'lib/state/swap'
 import styled, { DynamicThemeProvider, ThemedText } from 'lib/theme'
 import { ReactNode, useCallback, useMemo } from 'react'
@@ -28,6 +29,30 @@ const OutputColumn = styled(Column)<{ hasColor: boolean | null }>`
   * {
     // When color is loading, delay the color/stroke so that it seems to transition from the last state.
     transition: ${({ hasColor }) => (hasColor === null ? 'color 0.25s ease-in, stroke 0.25s ease-in' : undefined)};
+  }
+`
+
+const UniswapA = styled.a`
+  align-items: center;
+  color: ${({ theme }) => theme.secondary};
+  cursor: pointer;
+  display: flex;
+  font-size: 0.75em;
+  justify-content: center;
+  line-height: 1.25em;
+  text-decoration: none;
+
+  ${Logo} {
+    fill: ${({ theme }) => theme.secondary};
+    height: 1em;
+    transition: transform 0.25s ease;
+    width: 1em;
+    will-change: transform;
+
+    :hover {
+      fill: ${({ theme }) => theme.onHover(theme.secondary)};
+      transform: rotate(-5deg);
+    }
   }
 `
 
@@ -101,6 +126,11 @@ export default function Output({ disabled, children }: OutputProps) {
           </ThemedText.Body2>
         </TokenInput>
         {children}
+        <UniswapA href={`https://app.uniswap.org/`}>
+          <Logo />
+          &nbsp;
+          <Trans>Powered by the Uniswap protocol</Trans>
+        </UniswapA>
       </OutputColumn>
     </DynamicThemeProvider>
   )

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -2,9 +2,9 @@ import { Trans } from '@lingui/macro'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { atom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
+import BrandingFooter from 'lib/components/BrandingFooter'
 import { useSwapAmount, useSwapCurrency, useSwapInfo } from 'lib/hooks/swap'
 import useCurrencyColor from 'lib/hooks/useCurrencyColor'
-import { Logo } from 'lib/icons'
 import { Field } from 'lib/state/swap'
 import styled, { DynamicThemeProvider, ThemedText } from 'lib/theme'
 import { ReactNode, useCallback, useMemo } from 'react'
@@ -29,30 +29,6 @@ const OutputColumn = styled(Column)<{ hasColor: boolean | null }>`
   * {
     // When color is loading, delay the color/stroke so that it seems to transition from the last state.
     transition: ${({ hasColor }) => (hasColor === null ? 'color 0.25s ease-in, stroke 0.25s ease-in' : undefined)};
-  }
-`
-
-const UniswapA = styled.a`
-  align-items: center;
-  color: ${({ theme }) => theme.secondary};
-  cursor: pointer;
-  display: flex;
-  font-size: 0.75em;
-  justify-content: center;
-  line-height: 1.25em;
-  text-decoration: none;
-
-  ${Logo} {
-    fill: ${({ theme }) => theme.secondary};
-    height: 1em;
-    transition: transform 0.25s ease;
-    width: 1em;
-    will-change: transform;
-
-    :hover {
-      fill: ${({ theme }) => theme.onHover(theme.secondary)};
-      transform: rotate(-5deg);
-    }
   }
 `
 
@@ -126,11 +102,7 @@ export default function Output({ disabled, children }: OutputProps) {
           </ThemedText.Body2>
         </TokenInput>
         {children}
-        <UniswapA href={`https://app.uniswap.org/`}>
-          <Logo />
-          &nbsp;
-          <Trans>Powered by the Uniswap protocol</Trans>
-        </UniswapA>
+        <BrandingFooter />
       </OutputColumn>
     </DynamicThemeProvider>
   )

--- a/src/lib/components/Swap/index.tsx
+++ b/src/lib/components/Swap/index.tsx
@@ -59,7 +59,7 @@ export default function Swap(props: SwapProps) {
   return (
     <SwapPropValidator {...props}>
       <SwapInfoUpdater />
-      <Header logo title={<Trans>Swap</Trans>}>
+      <Header title={<Trans>Swap</Trans>}>
         {active && <Wallet disabled={!account} />}
         <Settings disabled={!active} />
       </Header>

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -39,7 +39,6 @@ const WidgetWrapper = styled.div<{ width?: number | string }>`
   font-size: 16px;
   font-smooth: always;
   font-variant: none;
-  height: 348px;
   min-width: 300px;
   overflow-y: hidden;
   padding: 0.25em;

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -39,6 +39,7 @@ const WidgetWrapper = styled.div<{ width?: number | string }>`
   font-size: 16px;
   font-smooth: always;
   font-variant: none;
+  height: 376px;
   min-width: 300px;
   overflow-y: hidden;
   padding: 0.25em;


### PR DESCRIPTION
<img width="613" alt="image" src="https://user-images.githubusercontent.com/5773490/151291823-21de9320-051e-47d6-95eb-c365dfdfd9d4.png">
