### PR TITLE
fix: use all_supported_chain_ids constant for walletlink

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -53,5 +53,5 @@ export const walletlink = new WalletLinkConnector({
   url: INFURA_NETWORK_URLS[SupportedChainId.MAINNET],
   appName: 'Uniswap',
   appLogoUrl: UNISWAP_LOGO_URL,
-  supportedChainIds: [SupportedChainId.MAINNET, SupportedChainId.POLYGON],
+  supportedChainIds: ALL_SUPPORTED_CHAIN_IDS,
 })


### PR DESCRIPTION
Walletlink and Coinbase Wallet have support for all chain id's supported by uniswap.