### PR TITLE
feat: create use best trade hook for widgets

### DIFF
--- a/src/lib/hooks/swap/useBestTrade.ts
+++ b/src/lib/hooks/swap/useBestTrade.ts
@@ -21,6 +21,7 @@ export function useBestTrade(
   trade: InterfaceTrade<Currency, Currency, TradeType> | undefined
 } {
   // debounce used to prevent excessive requests to SOR, as it is data intensive
+  // this helps provide a "syncing" state the UI can reference for loading animations
   const [debouncedAmount, debouncedOtherCurrency] = useDebounce(
     useMemo(() => [amountSpecified, otherCurrency], [amountSpecified, otherCurrency]),
     200

--- a/src/lib/hooks/swap/useBestTrade.ts
+++ b/src/lib/hooks/swap/useBestTrade.ts
@@ -1,0 +1,62 @@
+import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { useClientSideV3Trade } from 'hooks/useClientSideV3Trade'
+import useDebounce from 'hooks/useDebounce'
+import { useMemo } from 'react'
+import { InterfaceTrade, TradeState } from 'state/routing/types'
+
+import useClientSideSmartOrderRouterTrade from '../routing/useClientSideSmartOrderRouterTrade'
+
+/**
+ * Returns the best v2+v3 trade for a desired swap.
+ * @param tradeType whether the swap is an exact in/out
+ * @param amountSpecified the exact amount to swap in/out
+ * @param otherCurrency the desired output/payment currency
+ */
+export function useBestTrade(
+  tradeType: TradeType,
+  amountSpecified?: CurrencyAmount<Currency>,
+  otherCurrency?: Currency
+): {
+  state: TradeState
+  trade: InterfaceTrade<Currency, Currency, TradeType> | undefined
+} {
+  // debounce used to prevent excessive requests to SOR, as it is data intensive
+  const [debouncedAmount, debouncedOtherCurrency] = useDebounce(
+    useMemo(() => [amountSpecified, otherCurrency], [amountSpecified, otherCurrency]),
+    200
+  )
+
+  const routingAPITrade = useClientSideSmartOrderRouterTrade(tradeType, debouncedAmount, debouncedOtherCurrency)
+
+  const isLoading = amountSpecified !== undefined && debouncedAmount === undefined
+
+  // consider trade debouncing when inputs/outputs do not match
+  const debouncing =
+    routingAPITrade.trade &&
+    amountSpecified &&
+    (tradeType === TradeType.EXACT_INPUT
+      ? !routingAPITrade.trade.inputAmount.equalTo(amountSpecified) ||
+        !amountSpecified.currency.equals(routingAPITrade.trade.inputAmount.currency) ||
+        !debouncedOtherCurrency?.equals(routingAPITrade.trade.outputAmount.currency)
+      : !routingAPITrade.trade.outputAmount.equalTo(amountSpecified) ||
+        !amountSpecified.currency.equals(routingAPITrade.trade.outputAmount.currency) ||
+        !debouncedOtherCurrency?.equals(routingAPITrade.trade.inputAmount.currency))
+
+  const useFallback = !debouncing && routingAPITrade.state === TradeState.NO_ROUTE_FOUND
+
+  // use simple client side logic as backup if SOR is not available
+  const bestV3Trade = useClientSideV3Trade(
+    tradeType,
+    useFallback ? debouncedAmount : undefined,
+    useFallback ? debouncedOtherCurrency : undefined
+  )
+
+  return useMemo(
+    () => ({
+      ...(useFallback ? bestV3Trade : routingAPITrade),
+      ...(debouncing ? { state: TradeState.SYNCING } : {}),
+      ...(isLoading ? { state: TradeState.LOADING } : {}),
+    }),
+    [bestV3Trade, debouncing, isLoading, routingAPITrade, useFallback]
+  )
+}

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -11,8 +11,8 @@ import { ReactNode, useEffect, useMemo } from 'react'
 import { InterfaceTrade, TradeState } from 'state/routing/types'
 
 import { isAddress } from '../../../utils'
-import useClientSideSmartOrderRouterTrade from '../routing/useClientSideSmartOrderRouterTrade'
 import useActiveWeb3React from '../useActiveWeb3React'
+import { useBestTrade } from './useBestTrade'
 
 interface SwapInfo {
   currencies: { [field in Field]?: Currency }
@@ -56,7 +56,7 @@ function useComputeSwapInfo(): SwapInfo {
   )
 
   //@TODO(ianlapham): this would eventually be replaced with routing api logic.
-  const trade = useClientSideSmartOrderRouterTrade(
+  const trade = useBestTrade(
     isExactIn ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT,
     parsedAmount,
     (isExactIn ? outputCurrency : inputCurrency) ?? undefined


### PR DESCRIPTION
- create an intermediate hook for fetching the best trade based on current swap state 
- the new hook mimics the same behavior as app and is used for two purposes: 

 1. adds in logic to use the simple client side routing if the SOR package fails for any reason (this becomes extra helpful as we move from client side SOR to API, where API has potential downtime)
 
 2. helps debounce amount values so less calls are made to the SOR logic (as it is very data intensive). This is how we get an accurate "syncing" state which the UI components can reference for loading animations