### PR TITLE
chore: rename web3-react-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,12 @@
     "@uniswap/v2-sdk": "^3.0.1",
     "@uniswap/v3-sdk": "^3.7.1",
     "@web3-react/core": "^6.0.9",
+    "@widgets/web3-react/core": "npm:@web3-react/core@8.0.16-alpha.0",
+    "@widgets/web3-react/eip1193": "npm:@web3-react/eip1193@8.0.16-alpha.0",
+    "@widgets/web3-react/empty": "npm:@web3-react/empty@8.0.17-alpha.0",
+    "@widgets/web3-react/metamask": "npm:@web3-react/metamask@8.0.16-alpha.0",
+    "@widgets/web3-react/types": "npm:@web3-react/types@8.0.16-alpha.0",
+    "@widgets/web3-react/url": "npm:@web3-react/url@8.0.17-alpha.0",
     "ajv": "^6.12.3",
     "cids": "^1.0.0",
     "immer": "^9.0.6",
@@ -204,12 +210,6 @@
     "styled-components": "^5.3.0",
     "tiny-invariant": "^1.2.0",
     "wcag-contrast": "^3.0.0",
-    "wicg-inert": "^3.1.1",
-    "widgets-web3-react/core": "npm:@web3-react/core@8.0.16-alpha.0",
-    "widgets-web3-react/eip1193": "npm:@web3-react/eip1193@8.0.16-alpha.0",
-    "widgets-web3-react/empty": "npm:@web3-react/empty@8.0.17-alpha.0",
-    "widgets-web3-react/metamask": "npm:@web3-react/metamask@8.0.16-alpha.0",
-    "widgets-web3-react/types": "npm:@web3-react/types@8.0.16-alpha.0",
-    "widgets-web3-react/url": "npm:@web3-react/url@8.0.17-alpha.0"
+    "wicg-inert": "^3.1.1"
   }
 }

--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -1,11 +1,11 @@
 import { Trans } from '@lingui/macro'
 import { AbstractConnector } from '@web3-react/abstract-connector'
+import { Connector } from '@widgets/web3-react/types'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useCallback, useContext } from 'react'
 import { ExternalLink as LinkIcon } from 'react-feather'
 import { useAppDispatch } from 'state/hooks'
 import styled, { ThemeContext } from 'styled-components/macro'
-import { Connector } from 'widgets-web3-react/types'
 
 import { ReactComponent as Close } from '../../assets/images/x.svg'
 import { injected, portis, walletlink } from '../../connectors'

--- a/src/components/Identicon/StatusIcon.tsx
+++ b/src/components/Identicon/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import { AbstractConnector } from '@web3-react/abstract-connector'
-import { Connector } from 'widgets-web3-react/types'
+import { Connector } from '@widgets/web3-react/types'
 
 import CoinbaseWalletIcon from '../../assets/images/coinbaseWalletIcon.svg'
 import FortmaticIcon from '../../assets/images/fortmaticIcon.png'

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -2,11 +2,11 @@
 import { t, Trans } from '@lingui/macro'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
+import { Connector } from '@widgets/web3-react/types'
 import { darken } from 'polished'
 import { useMemo } from 'react'
 import { Activity } from 'react-feather'
 import styled, { css } from 'styled-components/macro'
-import { Connector } from 'widgets-web3-react/types'
 
 import { NetworkContextName } from '../../constants/misc'
 import useENSName from '../../hooks/useENSName'

--- a/src/lib/components/Web3Provider.tsx
+++ b/src/lib/components/Web3Provider.tsx
@@ -1,11 +1,11 @@
+import { initializeConnector, Web3ReactHooks } from '@widgets/web3-react/core'
+import { EIP1193 } from '@widgets/web3-react/eip1193'
+import { Actions, Connector, Provider as EthProvider } from '@widgets/web3-react/types'
+import { Url } from '@widgets/web3-react/url'
 import { SetStateAction } from 'jotai'
 import { RESET, useUpdateAtom } from 'jotai/utils'
 import { injectedAtom, urlAtom } from 'lib/state/web3'
 import { ReactNode, useEffect } from 'react'
-import { initializeConnector, Web3ReactHooks } from 'widgets-web3-react/core'
-import { EIP1193 } from 'widgets-web3-react/eip1193'
-import { Actions, Connector, Provider as EthProvider } from 'widgets-web3-react/types'
-import { Url } from 'widgets-web3-react/url'
 
 interface Web3ProviderProps {
   jsonRpcEndpoint?: string

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -1,3 +1,4 @@
+import { Provider as EthProvider } from '@widgets/web3-react/types'
 import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
 import { Provider as AtomProvider } from 'jotai'
 import { TransactionsUpdater } from 'lib/hooks/transactions'
@@ -8,7 +9,6 @@ import { MulticallUpdater, store as multicallStore } from 'lib/state/multicall'
 import styled, { keyframes, Theme, ThemeProvider } from 'lib/theme'
 import { PropsWithChildren, StrictMode, useRef } from 'react'
 import { Provider as ReduxProvider } from 'react-redux'
-import { Provider as EthProvider } from 'widgets-web3-react/types'
 
 import { Provider as DialogProvider } from './Dialog'
 import ErrorBoundary, { ErrorHandler } from './Error/ErrorBoundary'

--- a/src/lib/cosmos/components/Widget.tsx
+++ b/src/lib/cosmos/components/Widget.tsx
@@ -1,3 +1,5 @@
+import { initializeConnector } from '@widgets/web3-react/core'
+import { MetaMask } from '@widgets/web3-react/metamask'
 import { INFURA_NETWORK_URLS } from 'constants/chainInfo'
 import { SupportedChainId } from 'constants/chains'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from 'constants/locales'
@@ -5,8 +7,6 @@ import Widget from 'lib/components/Widget'
 import { darkTheme, defaultTheme, lightTheme } from 'lib/theme'
 import { ReactNode, useEffect, useMemo } from 'react'
 import { useSelect, useValue } from 'react-cosmos/fixture'
-import { initializeConnector } from 'widgets-web3-react/core'
-import { MetaMask } from 'widgets-web3-react/metamask'
 
 export const [metaMask] = initializeConnector<MetaMask>((actions) => new MetaMask(actions))
 

--- a/src/lib/hooks/useActiveWeb3React.ts
+++ b/src/lib/hooks/useActiveWeb3React.ts
@@ -1,6 +1,6 @@
+import { Web3ReactHooks } from '@widgets/web3-react/core'
 import { useAtomValue } from 'jotai/utils'
 import { injectedAtom, urlAtom, Web3ReactState } from 'lib/state/web3'
-import { Web3ReactHooks } from 'widgets-web3-react/core'
 
 export function useActiveWeb3ReactState(): Web3ReactState {
   const injected = useAtomValue(injectedAtom)

--- a/src/lib/state/web3.ts
+++ b/src/lib/state/web3.ts
@@ -1,7 +1,7 @@
+import { initializeConnector, Web3ReactHooks } from '@widgets/web3-react/core'
+import { EMPTY } from '@widgets/web3-react/empty'
+import { Connector } from '@widgets/web3-react/types'
 import { atomWithDefault } from 'jotai/utils'
-import { initializeConnector, Web3ReactHooks } from 'widgets-web3-react/core'
-import { EMPTY } from 'widgets-web3-react/empty'
-import { Connector } from 'widgets-web3-react/types'
 
 const EMPTY_CONNECTOR = initializeConnector(() => EMPTY)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5621,7 +5621,7 @@
   resolved "https://registry.yarnpkg.com/@web3-react/types/-/types-6.0.7.tgz#34a6204224467eedc6123abaf55fbb6baeb2809f"
   integrity sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A==
 
-"@web3-react/types@^8.0.16-alpha.0", "widgets-web3-react/types@npm:@web3-react/types@8.0.16-alpha.0":
+"@web3-react/types@^8.0.16-alpha.0", "@widgets/web3-react/types@npm:@web3-react/types@8.0.16-alpha.0":
   version "8.0.16-alpha.0"
   resolved "https://registry.yarnpkg.com/@web3-react/types/-/types-8.0.16-alpha.0.tgz#bc9eeaf24d6a3e43cd262a90b4f48d1e4c95bfa4"
   integrity sha512-vVVUeV0xNaYpn+35nbU2qmfELU5c6nioSTp5esRX3qChIc9eHss9r43AopTMOGiS6keC/fjzuSXOxK33nRBIyA==
@@ -5791,6 +5791,46 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@widgets/web3-react/core@npm:@web3-react/core@8.0.16-alpha.0":
+  version "8.0.16-alpha.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/core/-/core-8.0.16-alpha.0.tgz#7e8a2e28ee492f40e482f609fd8c353b0bafa8c3"
+  integrity sha512-eRkZxSdOR4c0U0IpRnWf/5djWfmtLQ52RmpwwvAozxIEyM6UANsfvuyV3j8LSNIC0kWwZNl5fcOWTHQB6vetcg==
+  dependencies:
+    "@web3-react/store" "^8.0.16-alpha.0"
+    "@web3-react/types" "^8.0.16-alpha.0"
+    zustand "^4.0.0-beta.0"
+
+"@widgets/web3-react/eip1193@npm:@web3-react/eip1193@8.0.16-alpha.0":
+  version "8.0.16-alpha.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/eip1193/-/eip1193-8.0.16-alpha.0.tgz#d0c7703804edc40c393086e5c136824cebb0d3e3"
+  integrity sha512-prHcUj3Te8lqowZ0DQX81qL50uYVq7242B1IX5l+kgFxMlO1lwTH1JHpIm4T/sjxQce93Y4896eu1naNM55QtA==
+  dependencies:
+    "@web3-react/types" "^8.0.16-alpha.0"
+
+"@widgets/web3-react/empty@npm:@web3-react/empty@8.0.17-alpha.0":
+  version "8.0.17-alpha.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/empty/-/empty-8.0.17-alpha.0.tgz#79a3d42a01f59b00106acb055bf1be90cdc1b5ce"
+  integrity sha512-XpbN5It5+ajNFOP/9HVCc5fiMIYTJtqKrvWEeGwz2cRSP1TSFFlPFgpHU2T9gwffXjWXDfxPM2oRTE9v1gQu/Q==
+  dependencies:
+    "@web3-react/types" "^8.0.16-alpha.0"
+
+"@widgets/web3-react/metamask@npm:@web3-react/metamask@8.0.16-alpha.0":
+  version "8.0.16-alpha.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/metamask/-/metamask-8.0.16-alpha.0.tgz#7870580484ea0872b3b5713440f1858b9b6b03b8"
+  integrity sha512-KizXfLb2NPwlrSn7oJ/hbMTRsUoBmMbN1Wuur1oI1pxbDlqRMkfAZpfibSEgTLuTye1uNI8XmWCLIbWzU4oOSA==
+  dependencies:
+    "@metamask/detect-provider" "^1.2.0"
+    "@web3-react/types" "^8.0.16-alpha.0"
+
+"@widgets/web3-react/url@npm:@web3-react/url@8.0.17-alpha.0":
+  version "8.0.17-alpha.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/url/-/url-8.0.17-alpha.0.tgz#799082966ba8e3f752b9cdd1991c8b8037bd96c9"
+  integrity sha512-bcHtkUUhW8hrLDnx3Y1q88LK1i5qtQKWQQnYiCd8963ayAP/XuxoKiR56a/H5v5ofl9f3EM7GMO3WwFNabD6iQ==
+  dependencies:
+    "@ethersproject/experimental" "^5.4.0"
+    "@ethersproject/providers" "^5.4.5"
+    "@web3-react/types" "^8.0.16-alpha.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -21231,46 +21271,6 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
-
-"widgets-web3-react/core@npm:@web3-react/core@8.0.16-alpha.0":
-  version "8.0.16-alpha.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/core/-/core-8.0.16-alpha.0.tgz#7e8a2e28ee492f40e482f609fd8c353b0bafa8c3"
-  integrity sha512-eRkZxSdOR4c0U0IpRnWf/5djWfmtLQ52RmpwwvAozxIEyM6UANsfvuyV3j8LSNIC0kWwZNl5fcOWTHQB6vetcg==
-  dependencies:
-    "@web3-react/store" "^8.0.16-alpha.0"
-    "@web3-react/types" "^8.0.16-alpha.0"
-    zustand "^4.0.0-beta.0"
-
-"widgets-web3-react/eip1193@npm:@web3-react/eip1193@8.0.16-alpha.0":
-  version "8.0.16-alpha.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/eip1193/-/eip1193-8.0.16-alpha.0.tgz#d0c7703804edc40c393086e5c136824cebb0d3e3"
-  integrity sha512-prHcUj3Te8lqowZ0DQX81qL50uYVq7242B1IX5l+kgFxMlO1lwTH1JHpIm4T/sjxQce93Y4896eu1naNM55QtA==
-  dependencies:
-    "@web3-react/types" "^8.0.16-alpha.0"
-
-"widgets-web3-react/empty@npm:@web3-react/empty@8.0.17-alpha.0":
-  version "8.0.17-alpha.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/empty/-/empty-8.0.17-alpha.0.tgz#79a3d42a01f59b00106acb055bf1be90cdc1b5ce"
-  integrity sha512-XpbN5It5+ajNFOP/9HVCc5fiMIYTJtqKrvWEeGwz2cRSP1TSFFlPFgpHU2T9gwffXjWXDfxPM2oRTE9v1gQu/Q==
-  dependencies:
-    "@web3-react/types" "^8.0.16-alpha.0"
-
-"widgets-web3-react/metamask@npm:@web3-react/metamask@8.0.16-alpha.0":
-  version "8.0.16-alpha.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/metamask/-/metamask-8.0.16-alpha.0.tgz#7870580484ea0872b3b5713440f1858b9b6b03b8"
-  integrity sha512-KizXfLb2NPwlrSn7oJ/hbMTRsUoBmMbN1Wuur1oI1pxbDlqRMkfAZpfibSEgTLuTye1uNI8XmWCLIbWzU4oOSA==
-  dependencies:
-    "@metamask/detect-provider" "^1.2.0"
-    "@web3-react/types" "^8.0.16-alpha.0"
-
-"widgets-web3-react/url@npm:@web3-react/url@8.0.17-alpha.0":
-  version "8.0.17-alpha.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/url/-/url-8.0.17-alpha.0.tgz#799082966ba8e3f752b9cdd1991c8b8037bd96c9"
-  integrity sha512-bcHtkUUhW8hrLDnx3Y1q88LK1i5qtQKWQQnYiCd8963ayAP/XuxoKiR56a/H5v5ofl9f3EM7GMO3WwFNabD6iQ==
-  dependencies:
-    "@ethersproject/experimental" "^5.4.0"
-    "@ethersproject/providers" "^5.4.5"
-    "@web3-react/types" "^8.0.16-alpha.0"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Renames widgets-web3-react/* to @widgets/web3-react/*.
npm treats nested packages as scoped, and requires scoped packages to begin with @.