### PR TITLE
feat(widgets): ensure passed locale is supported

### DIFF
--- a/src/lib/components/Error/WidgetsPropsValidator.tsx
+++ b/src/lib/components/Error/WidgetsPropsValidator.tsx
@@ -22,7 +22,7 @@ export default function WidgetsPropsValidator(props: PropsWithChildren<WidgetPro
   const { locale } = props
   useEffect(() => {
     if (locale && locale !== 'pseudo' && !SUPPORTED_LOCALES.includes(locale)) {
-      throw new IntegrationError(`${locale} is not a supported locale.`)
+      console.warn('Unsupported locale: ', locale)
     }
   }, [locale])
 

--- a/src/lib/components/Error/WidgetsPropsValidator.tsx
+++ b/src/lib/components/Error/WidgetsPropsValidator.tsx
@@ -1,3 +1,4 @@
+import { SUPPORTED_LOCALES } from 'constants/locales'
 import { WidgetProps } from 'lib/components/Widget'
 import { IntegrationError } from 'lib/errors'
 import { PropsWithChildren, useEffect } from 'react'
@@ -17,6 +18,13 @@ export default function WidgetsPropsValidator(props: PropsWithChildren<WidgetPro
       throw new IntegrationError(`Set widget width to at least 300px. (You set it to ${width}.)`)
     }
   }, [width])
+
+  const { locale } = props
+  useEffect(() => {
+    if (locale && locale !== 'pseudo' && !SUPPORTED_LOCALES.includes(locale)) {
+      throw new IntegrationError(`${locale} is not a supported locale.`)
+    }
+  }, [locale])
 
   return <>{props.children}</>
 }

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,5 +1,6 @@
 import Swap, { SwapProps } from './components/Swap'
 import Widget, { WidgetProps } from './components/Widget'
+export { SUPPORTED_LOCALES } from 'constants/locales'
 
 type SwapWidgetProps = SwapProps & WidgetProps
 

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,6 +1,5 @@
 import Swap, { SwapProps } from './components/Swap'
 import Widget, { WidgetProps } from './components/Widget'
-export { SUPPORTED_LOCALES } from 'constants/locales'
 
 type SwapWidgetProps = SwapProps & WidgetProps
 


### PR DESCRIPTION
ensures the integrator passes only supported locales

exports `SUPPORTED_LOCALES`