### PR TITLE
fix: update widget loading state detection

### DIFF
--- a/src/lib/components/Swap/Toolbar/index.tsx
+++ b/src/lib/components/Swap/Toolbar/index.tsx
@@ -1,5 +1,5 @@
 import { ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
-import { useSwapAmount, useSwapInfo } from 'lib/hooks/swap'
+import { useIsAmountPopulated, useSwapInfo } from 'lib/hooks/swap'
 import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
 import { largeIconCss } from 'lib/icons'
 import { Field } from 'lib/state/swap'
@@ -29,8 +29,7 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
     [state, trade?.swaps]
   )
 
-  const [swapInputAmount] = useSwapAmount(Field.INPUT)
-  const [swapOutputAmount] = useSwapAmount(Field.OUTPUT)
+  const isAmountPopulated = useIsAmountPopulated()
 
   const caption = useMemo(() => {
     if (disabled) {
@@ -45,7 +44,7 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
       return <Caption.InsufficientBalance currency={trade.inputAmount.currency} />
     }
 
-    if (inputCurrency && outputCurrency && (swapInputAmount || swapOutputAmount)) {
+    if (inputCurrency && outputCurrency && isAmountPopulated) {
       if (!trade || routeIsLoading) {
         return <Caption.LoadingTrade />
       }
@@ -58,18 +57,7 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
     }
 
     return <Caption.Empty />
-  }, [
-    balance,
-    chainId,
-    disabled,
-    inputCurrency,
-    outputCurrency,
-    routeFound,
-    routeIsLoading,
-    swapInputAmount,
-    swapOutputAmount,
-    trade,
-  ])
+  }, [balance, chainId, disabled, inputCurrency, isAmountPopulated, outputCurrency, routeFound, routeIsLoading, trade])
 
   return (
     <>

--- a/src/lib/components/Swap/Toolbar/index.tsx
+++ b/src/lib/components/Swap/Toolbar/index.tsx
@@ -1,5 +1,5 @@
 import { ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
-import { useSwapInfo } from 'lib/hooks/swap'
+import { useSwapAmount, useSwapInfo } from 'lib/hooks/swap'
 import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
 import { largeIconCss } from 'lib/icons'
 import { Field } from 'lib/state/swap'
@@ -29,6 +29,9 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
     [state, trade?.swaps]
   )
 
+  const [swapInputAmount] = useSwapAmount(Field.INPUT)
+  const [swapOutputAmount] = useSwapAmount(Field.OUTPUT)
+
   const caption = useMemo(() => {
     if (disabled) {
       return <Caption.ConnectWallet />
@@ -42,11 +45,10 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
       return <Caption.InsufficientBalance currency={trade.inputAmount.currency} />
     }
 
-    if (inputCurrency && outputCurrency) {
+    if (inputCurrency && outputCurrency && (swapInputAmount || swapOutputAmount)) {
       if (!trade || routeIsLoading) {
         return <Caption.LoadingTrade />
       }
-
       if (!routeFound) {
         return <Caption.InsufficientLiquidity />
       }
@@ -56,7 +58,18 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
     }
 
     return <Caption.Empty />
-  }, [balance, chainId, disabled, inputCurrency, outputCurrency, routeFound, routeIsLoading, trade])
+  }, [
+    balance,
+    chainId,
+    disabled,
+    inputCurrency,
+    outputCurrency,
+    routeFound,
+    routeIsLoading,
+    swapInputAmount,
+    swapOutputAmount,
+    trade,
+  ])
 
   return (
     <>

--- a/src/lib/hooks/swap/index.ts
+++ b/src/lib/hooks/swap/index.ts
@@ -72,3 +72,8 @@ export function useSwapAmount(field: Field): [string | undefined, (amount: strin
   )
   return [value, updateAmount]
 }
+
+// check if any amount has been entered by user
+export function useIsAmountPopulated() {
+  return Boolean(useAtomValue(amountAtom))
+}


### PR DESCRIPTION
- only show loading status, insufficient liquidity, or trade info if the user has typed in an amount 