### PR TITLE
fix(widgets): fix broken unsupported network message

### DIFF
--- a/src/lib/components/Swap/Toolbar/Caption.tsx
+++ b/src/lib/components/Swap/Toolbar/Caption.tsx
@@ -28,7 +28,7 @@ export function ConnectWallet() {
   return <Caption caption={<Trans>Connect wallet to swap</Trans>} />
 }
 export function UnsupportedNetwork() {
-  return <Caption caption={<Trans>Unsupported network - switch to another network to swap</Trans>} />
+  return <Caption caption={<Trans>Unsupported network - switch to another to trade.</Trans>} />
 }
 export function InsufficientBalance({ currency }: { currency: Currency }) {
   return <Caption caption={<Trans>Insufficient {currency?.symbol} balance</Trans>} />

--- a/src/lib/components/Swap/index.tsx
+++ b/src/lib/components/Swap/index.tsx
@@ -9,7 +9,7 @@ import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
 import useTokenList from 'lib/hooks/useTokenList'
 import { displayTxHashAtom } from 'lib/state/swap'
 import { SwapTransactionInfo, Transaction, TransactionType } from 'lib/state/transactions'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import Dialog from '../Dialog'
 import Header from '../Header'
@@ -47,20 +47,25 @@ export interface SwapProps {
 }
 
 export default function Swap(props: SwapProps) {
-  useTokenList(props.tokenList)
+  const list = useTokenList(props.tokenList)
   useSyncSwapDefaults(props)
   useSyncConvenienceFee(props)
 
-  const { active, account } = useActiveWeb3React()
+  const { active, account, chainId } = useActiveWeb3React()
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
 
   const [displayTxHash, setDisplayTxHash] = useAtom(displayTxHashAtom)
   const pendingTxs = usePendingTransactions()
   const displayTx = getSwapTx(pendingTxs, displayTxHash)
 
+  const onSupportedChain = useMemo(
+    () => list.reduce((acc, cur) => acc || cur.chainId === chainId, false),
+    [chainId, list]
+  )
+
   return (
     <SwapPropValidator {...props}>
-      <SwapInfoUpdater />
+      {onSupportedChain && <SwapInfoUpdater />}
       <Header title={<Trans>Swap</Trans>}>
         {active && <Wallet disabled={!account} />}
         <Settings disabled={!active} />

--- a/src/lib/components/Swap/index.tsx
+++ b/src/lib/components/Swap/index.tsx
@@ -60,10 +60,7 @@ export default function Swap(props: SwapProps) {
   const displayTx = getSwapTx(pendingTxs, displayTxHash)
 
   const onSupportedChain = useMemo(
-    () =>
-      chainId &&
-      ALL_SUPPORTED_CHAIN_IDS.includes(chainId) &&
-      list.reduce((acc, cur) => acc || cur.chainId === chainId, false),
+    () => chainId && ALL_SUPPORTED_CHAIN_IDS.includes(chainId) && list.some((token) => token.chainId === chainId),
     [chainId, list]
   )
 

--- a/src/lib/components/Swap/index.tsx
+++ b/src/lib/components/Swap/index.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { TokenInfo } from '@uniswap/token-lists'
+import { ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
 import { useAtom } from 'jotai'
 import { SwapInfoUpdater } from 'lib/hooks/swap/useSwapInfo'
 import useSyncConvenienceFee from 'lib/hooks/swap/useSyncConvenienceFee'
@@ -59,7 +60,10 @@ export default function Swap(props: SwapProps) {
   const displayTx = getSwapTx(pendingTxs, displayTxHash)
 
   const onSupportedChain = useMemo(
-    () => list.reduce((acc, cur) => acc || cur.chainId === chainId, false),
+    () =>
+      chainId &&
+      ALL_SUPPORTED_CHAIN_IDS.includes(chainId) &&
+      list.reduce((acc, cur) => acc || cur.chainId === chainId, false),
     [chainId, list]
   )
 


### PR DESCRIPTION
Stops rendering the swap info updater on chains we don't support

![image](https://user-images.githubusercontent.com/5773490/153044800-7f06c214-8c1b-4861-9051-084cd71444a6.png)
