### PR TITLE
fix: leave intermediate artifacts in watch

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -68,7 +68,7 @@ const type = {
   external: isAsset,
   plugins: [
     dts({ compilerOptions: { baseUrl: 'dist/dts' } }),
-    del({ hook: 'buildEnd', targets: ['dist/widgets.tsc', 'dist/dts'] }),
+    process.env.ROLLUP_WATCH ? undefined : del({ hook: 'buildEnd', targets: ['dist/widgets.tsc', 'dist/dts'] }),
   ],
 }
 


### PR DESCRIPTION
Without this change, `yarn widgets:build -w` will break on changes, because the intermediate files will have been deleted and are not marked for recreation. (idk why not.)