### PR TITLE
feat: focus and hover hooks

### DIFF
--- a/src/lib/components/Button.tsx
+++ b/src/lib/components/Button.tsx
@@ -1,6 +1,6 @@
 import { Icon } from 'lib/icons'
 import styled, { Color } from 'lib/theme'
-import { ComponentProps } from 'react'
+import { ComponentProps, forwardRef } from 'react'
 
 export const BaseButton = styled.button`
   background-color: transparent;
@@ -55,10 +55,12 @@ interface IconButtonProps {
   iconProps?: ComponentProps<Icon>
 }
 
-export function IconButton({ icon: Icon, iconProps, ...props }: IconButtonProps & ComponentProps<typeof BaseButton>) {
-  return (
-    <SecondaryButton {...props}>
-      <Icon {...iconProps} />
-    </SecondaryButton>
-  )
-}
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps & ComponentProps<typeof BaseButton>>(
+  function IconButton({ icon: Icon, iconProps, ...props }: IconButtonProps & ComponentProps<typeof BaseButton>, ref) {
+    return (
+      <SecondaryButton {...props} ref={ref}>
+        <Icon {...iconProps} />
+      </SecondaryButton>
+    )
+  }
+)

--- a/src/lib/components/Swap/index.tsx
+++ b/src/lib/components/Swap/index.tsx
@@ -7,6 +7,7 @@ import useSyncConvenienceFee from 'lib/hooks/swap/useSyncConvenienceFee'
 import useSyncSwapDefaults from 'lib/hooks/swap/useSyncSwapDefaults'
 import { usePendingTransactions } from 'lib/hooks/transactions'
 import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
+import useHasFocus from 'lib/hooks/useHasFocus'
 import useTokenList from 'lib/hooks/useTokenList'
 import { displayTxHashAtom } from 'lib/state/swap'
 import { SwapTransactionInfo, Transaction, TransactionType } from 'lib/state/transactions'
@@ -54,7 +55,7 @@ export default function Swap(props: SwapProps) {
   useSyncConvenienceFee(props)
 
   const { active, account, chainId } = useActiveWeb3React()
-  const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
+  const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
 
   const [displayTxHash, setDisplayTxHash] = useAtom(displayTxHashAtom)
   const pendingTxs = usePendingTransactions()
@@ -65,7 +66,7 @@ export default function Swap(props: SwapProps) {
     [chainId, list]
   )
 
-  const [focused, setFocused] = useState(false)
+  const focused = useHasFocus(wrapper)
 
   return (
     <SwapPropValidator {...props}>
@@ -74,8 +75,8 @@ export default function Swap(props: SwapProps) {
         {active && <Wallet disabled={!account} onClick={props.onConnectWallet} />}
         <Settings disabled={!active} />
       </Header>
-      <div onFocus={() => setFocused(true)} onBlur={() => setFocused(false)} ref={setBoundary}>
-        <BoundaryProvider value={boundary}>
+      <div ref={setWrapper}>
+        <BoundaryProvider value={wrapper}>
           <Input disabled={!active} focused={focused} />
           <ReverseButton disabled={!active} />
           <Output disabled={!active} focused={focused}>

--- a/src/lib/components/Tooltip.tsx
+++ b/src/lib/components/Tooltip.tsx
@@ -1,23 +1,17 @@
 import { Placement } from '@popperjs/core'
+import useHasFocus from 'lib/hooks/useHasFocus'
+import useHasHover from 'lib/hooks/useHasHover'
 import { HelpCircle, Icon } from 'lib/icons'
 import styled from 'lib/theme'
-import { ComponentProps, ReactNode, useCallback, useState } from 'react'
+import { ComponentProps, ReactNode, useRef } from 'react'
 
 import { IconButton } from './Button'
 import Popover from './Popover'
 
-export interface TooltipHandlers {
-  onMouseEnter: () => void
-  onMouseLeave: () => void
-  onFocus: () => void
-  onBlur: () => void
-}
-
-export function useTooltip(showOnMount = false): [boolean, (show: boolean) => void, TooltipHandlers] {
-  const [show, setShow] = useState(showOnMount)
-  const enable = useCallback(() => setShow(true), [])
-  const disable = useCallback(() => setShow(false), [])
-  return [show, setShow, { onMouseEnter: enable, onMouseLeave: disable, onFocus: enable, onBlur: disable }]
+export function useTooltip(tooltip: Node | null | undefined): boolean {
+  const hover = useHasHover(tooltip)
+  const focus = useHasFocus(tooltip)
+  return hover || focus
 }
 
 const IconTooltip = styled(IconButton)`
@@ -41,10 +35,11 @@ export default function Tooltip({
   offset,
   contained,
 }: TooltipProps) {
-  const [showTooltip, , tooltipProps] = useTooltip()
+  const tooltip = useRef<HTMLDivElement>(null)
+  const showTooltip = useTooltip(tooltip.current)
   return (
     <Popover content={children} show={showTooltip} placement={placement} offset={offset} contained={contained}>
-      <IconTooltip icon={Icon} iconProps={iconProps} {...tooltipProps} />
+      <IconTooltip icon={Icon} iconProps={iconProps} ref={tooltip} />
     </Popover>
   )
 }

--- a/src/lib/hooks/useHasFocus.ts
+++ b/src/lib/hooks/useHasFocus.ts
@@ -1,0 +1,16 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export default function useHasFocus(node: Node | null | undefined): boolean {
+  const [hasFocus, setHasFocus] = useState(node?.contains(document.activeElement) ?? false)
+  const onFocus = useCallback(() => setHasFocus(true), [])
+  const onBlur = useCallback((e) => setHasFocus(node?.contains(e.relatedTarget) ?? false), [node])
+  useEffect(() => {
+    node?.addEventListener('focusin', onFocus)
+    node?.addEventListener('focusout', onBlur)
+    return () => {
+      node?.removeEventListener('focusin', onFocus)
+      node?.removeEventListener('focusout', onBlur)
+    }
+  }, [node, onFocus, onBlur])
+  return hasFocus
+}

--- a/src/lib/hooks/useHasHover.ts
+++ b/src/lib/hooks/useHasHover.ts
@@ -1,0 +1,16 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export default function useHasHover(node: Node | null | undefined): boolean {
+  const [hasHover, setHasHover] = useState(false)
+  const onMouseEnter = useCallback(() => setHasHover(true), [])
+  const onMouseLeave = useCallback((e) => setHasHover(false), [])
+  useEffect(() => {
+    node?.addEventListener('mouseenter', onMouseEnter)
+    node?.addEventListener('mouseleave', onMouseLeave)
+    return () => {
+      node?.removeEventListener('mouseenter', onMouseEnter)
+      node?.removeEventListener('mouseleave', onMouseLeave)
+    }
+  }, [node, onMouseEnter, onMouseLeave])
+  return hasHover
+}


### PR DESCRIPTION
Uses native listeners for focus and hover instead of adding boilerplate for onFocus/onBlur/onMouseEnter/onMouseLeave. This implementation is slightly more complex, but the usages are significantly simpler.