### PR TITLE
fix: respond to updated amounts immediately

### DIFF
--- a/src/lib/components/Swap/Toolbar/index.tsx
+++ b/src/lib/components/Swap/Toolbar/index.tsx
@@ -40,16 +40,15 @@ export default function Toolbar({ disabled }: { disabled?: boolean }) {
       return <Caption.UnsupportedNetwork />
     }
 
-    if (balance && trade?.inputAmount.greaterThan(balance)) {
-      return <Caption.InsufficientBalance currency={trade.inputAmount.currency} />
-    }
-
     if (inputCurrency && outputCurrency && isAmountPopulated) {
       if (!trade || routeIsLoading) {
         return <Caption.LoadingTrade />
       }
       if (!routeFound) {
         return <Caption.InsufficientLiquidity />
+      }
+      if (balance && trade?.inputAmount.greaterThan(balance)) {
+        return <Caption.InsufficientBalance currency={trade.inputAmount.currency} />
       }
       if (trade.inputAmount && trade.outputAmount) {
         return <Caption.Trade trade={trade} />

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -57,6 +57,8 @@ function useComputeSwapInfo(): SwapInfo {
     () => tryParseCurrencyAmount(amount, (isExactIn ? inputCurrency : outputCurrency) ?? undefined),
     [inputCurrency, isExactIn, outputCurrency, amount]
   )
+  const parsedAmountIn = isExactIn ? parsedAmount : undefined
+  const parsedAmountOut = isExactIn ? undefined : parsedAmount
 
   //@TODO(ianlapham): this would eventually be replaced with routing api logic.
   const trade = useBestTrade(
@@ -83,10 +85,10 @@ function useComputeSwapInfo(): SwapInfo {
 
   const currencyAmounts = useMemo(
     () => ({
-      [Field.INPUT]: trade.trade?.inputAmount,
-      [Field.OUTPUT]: trade.trade?.outputAmount,
+      [Field.INPUT]: parsedAmountIn || trade.trade?.inputAmount,
+      [Field.OUTPUT]: parsedAmountOut || trade.trade?.outputAmount,
     }),
-    [trade.trade?.inputAmount, trade.trade?.outputAmount]
+    [parsedAmountIn, parsedAmountOut, trade.trade?.inputAmount, trade.trade?.outputAmount]
   )
 
   const allowedSlippage = useAllowedSlippage(trade.trade)


### PR DESCRIPTION
Allows the UI to respond to updated amounts immediately, instead of waiting for a trade to load.
eg as you type an input amount larger than your balance, this allows it to flag the insufficient funds.