### PR TITLE
feat: improved warning ux

### DIFF
--- a/src/lib/components/Swap/Input.tsx
+++ b/src/lib/components/Swap/Input.tsx
@@ -16,7 +16,7 @@ import Row from '../Row'
 import TokenImg from '../TokenImg'
 import TokenInput from './TokenInput'
 
-export const LoadingSpan = styled.span<{ $loading: boolean }>`
+export const LoadingRow = styled(Row)<{ $loading: boolean }>`
   ${loadingOpacityCss};
 `
 
@@ -88,7 +88,7 @@ export default function Input({ disabled, focused }: InputProps) {
       >
         <ThemedText.Body2 color="secondary">
           <Row>
-            <LoadingSpan $loading={isLoading}>{inputUSDC ? `$${inputUSDC.toFixed(2)}` : '-'}</LoadingSpan>
+            <LoadingRow $loading={isLoading}>{inputUSDC ? `$${inputUSDC.toFixed(2)}` : '-'}</LoadingRow>
             {balance && (
               <Balance color={inputCurrencyAmount?.greaterThan(balance) ? 'error' : undefined} focused={focused}>
                 Balance: <span style={{ userSelect: 'text' }}>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -74,7 +74,7 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
 
   const usdc = useMemo(() => {
     if (outputUSDC) {
-      return `$${outputUSDC.toFixed(2)} (${priceImpact && priceImpact > 0 ? '+' : ''}${priceImpact}%)`
+      return `$${outputUSDC.toFixed(2)} (${priceImpact && priceImpact > 0 ? `+${priceImpact}%` : ''})`
     }
     return ''
   }, [priceImpact, outputUSDC])

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -12,10 +12,11 @@ import { PropsWithChildren, useMemo } from 'react'
 import { TradeState } from 'state/routing/types'
 import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
+import { getPriceImpactWarning } from 'utils/prices'
 
 import Column from '../Column'
 import Row from '../Row'
-import { Balance, InputProps, LoadingSpan } from './Input'
+import { Balance, InputProps, LoadingRow } from './Input'
 import TokenInput from './TokenInput'
 
 export const colorAtom = atom<string | undefined>(undefined)
@@ -68,16 +69,19 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
   const outputUSDC = useUSDCValue(outputCurrencyAmount)
 
   const priceImpact = useMemo(() => {
-    const computedChange = computeFiatValuePriceImpact(inputUSDC, outputUSDC)
-    return computedChange ? parseFloat(computedChange.multiply(-1)?.toSignificant(3)) : undefined
-  }, [inputUSDC, outputUSDC])
+    const fiatValuePriceImpact = computeFiatValuePriceImpact(inputUSDC, outputUSDC)
+    if (!fiatValuePriceImpact) return null
 
-  const usdc = useMemo(() => {
-    if (outputUSDC) {
-      return `$${outputUSDC.toFixed(2)} (${priceImpact && priceImpact > 0 ? `+${priceImpact}%` : ''})`
-    }
-    return ''
-  }, [priceImpact, outputUSDC])
+    const color = getPriceImpactWarning(fiatValuePriceImpact)
+    const sign = fiatValuePriceImpact.lessThan(0) ? '+' : ''
+    const displayedPriceImpact = parseFloat(fiatValuePriceImpact.multiply(-1)?.toSignificant(3))
+    return (
+      <ThemedText.Body2 color={color}>
+        ({sign}
+        {displayedPriceImpact}%)
+      </ThemedText.Body2>
+    )
+  }, [inputUSDC, outputUSDC])
 
   return (
     <DynamicThemeProvider color={color}>
@@ -97,7 +101,9 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
         >
           <ThemedText.Body2 color="secondary">
             <Row>
-              <LoadingSpan $loading={isLoading}>{usdc}</LoadingSpan>
+              <LoadingRow gap={0.5} $loading={isLoading}>
+                {outputUSDC?.toFixed(2)} {priceImpact}
+              </LoadingRow>
               {balance && (
                 <Balance focused={focused}>
                   Balance: <span style={{ userSelect: 'text' }}>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>

--- a/src/lib/components/Swap/Summary/Details.tsx
+++ b/src/lib/components/Swap/Summary/Details.tsx
@@ -2,7 +2,6 @@ import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
-import { ALLOWED_PRICE_IMPACT_HIGH, ALLOWED_PRICE_IMPACT_MEDIUM } from 'constants/misc'
 import { useAtomValue } from 'jotai/utils'
 import { getSlippageWarning } from 'lib/hooks/useAllowedSlippage'
 import { feeOptionsAtom } from 'lib/state/swap'
@@ -10,7 +9,7 @@ import styled, { Color, ThemedText } from 'lib/theme'
 import { useMemo } from 'react'
 import { currencyId } from 'utils/currencyId'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
-import { computeRealizedLPFeeAmount, computeRealizedPriceImpact } from 'utils/prices'
+import { computeRealizedLPFeeAmount, computeRealizedPriceImpact, getPriceImpactWarning } from 'utils/prices'
 
 import Row from '../../Row'
 
@@ -63,13 +62,7 @@ export default function Details({ trade, allowedSlippage }: DetailsProps) {
       }
     }
 
-    let priceImpactColor: Color | undefined
-    if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) {
-      priceImpactColor = 'error'
-    } else if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) {
-      priceImpactColor = 'warning'
-    }
-    rows.push([t`Price impact`, `${priceImpact.toFixed(2)}%`, priceImpactColor])
+    rows.push([t`Price impact`, `${priceImpact.toFixed(2)}%`, getPriceImpactWarning(priceImpact)])
 
     if (lpFeeAmount) {
       const parsedLpFee = formatCurrencyAmount(lpFeeAmount, 6, i18n.locale)

--- a/src/lib/components/Swap/Summary/index.tsx
+++ b/src/lib/components/Swap/Summary/index.tsx
@@ -5,9 +5,9 @@ import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { ALLOWED_PRICE_IMPACT_HIGH, ALLOWED_PRICE_IMPACT_MEDIUM } from 'constants/misc'
 import { useAtomValue } from 'jotai/utils'
 import { IconButton } from 'lib/components/Button'
+import { getSlippageWarning } from 'lib/hooks/useAllowedSlippage'
 import useScrollbar from 'lib/hooks/useScrollbar'
 import { AlertTriangle, BarChart, Expando, Info } from 'lib/icons'
-import { MIN_HIGH_SLIPPAGE } from 'lib/state/settings'
 import { Field, independentFieldAtom } from 'lib/state/swap'
 import styled, { ThemedText } from 'lib/theme'
 import formatLocaleNumber from 'lib/utils/formatLocaleNumber'
@@ -100,8 +100,7 @@ export function SummaryDialog({ trade, allowedSlippage, onConfirm }: SummaryDial
   const warning = useMemo(() => {
     if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) return 'error'
     if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) return 'warning'
-    if (allowedSlippage.greaterThan(MIN_HIGH_SLIPPAGE)) return 'warning'
-    return
+    return getSlippageWarning(allowedSlippage)
   }, [allowedSlippage, priceImpact])
 
   const [ackPriceImpact, setAckPriceImpact] = useState(false)

--- a/src/lib/components/Swap/Summary/index.tsx
+++ b/src/lib/components/Swap/Summary/index.tsx
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
-import { ALLOWED_PRICE_IMPACT_HIGH, ALLOWED_PRICE_IMPACT_MEDIUM } from 'constants/misc'
 import { useAtomValue } from 'jotai/utils'
 import { IconButton } from 'lib/components/Button'
 import { getSlippageWarning } from 'lib/hooks/useAllowedSlippage'
@@ -13,7 +12,7 @@ import styled, { ThemedText } from 'lib/theme'
 import formatLocaleNumber from 'lib/utils/formatLocaleNumber'
 import { useMemo, useState } from 'react'
 import { formatCurrencyAmount, formatPrice } from 'utils/formatCurrencyAmount'
-import { computeRealizedPriceImpact } from 'utils/prices'
+import { computeRealizedPriceImpact, getPriceImpactWarning } from 'utils/prices'
 import { tradeMeaningfullyDiffers } from 'utils/tradeMeaningFullyDiffer'
 
 import ActionButton, { Action } from '../../ActionButton'
@@ -98,9 +97,7 @@ export function SummaryDialog({ trade, allowedSlippage, onConfirm }: SummaryDial
   const scrollbar = useScrollbar(details)
 
   const warning = useMemo(() => {
-    if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) return 'error'
-    if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) return 'warning'
-    return getSlippageWarning(allowedSlippage)
+    return getPriceImpactWarning(priceImpact) || getSlippageWarning(allowedSlippage)
   }, [allowedSlippage, priceImpact])
 
   const [ackPriceImpact, setAckPriceImpact] = useState(false)
@@ -119,7 +116,7 @@ export function SummaryDialog({ trade, allowedSlippage, onConfirm }: SummaryDial
         onClick: () => setConfirmedTrade(trade),
         children: <Trans>Accept</Trans>,
       }
-    } else if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH) && !ackPriceImpact) {
+    } else if (getPriceImpactWarning(priceImpact) === 'error' && !ackPriceImpact) {
       return {
         message: <Trans>High price impact</Trans>,
         onClick: () => setAckPriceImpact(true),

--- a/src/lib/hooks/useAllowedSlippage.ts
+++ b/src/lib/hooks/useAllowedSlippage.ts
@@ -16,3 +16,12 @@ export default function useAllowedSlippage(trade: InterfaceTrade<Currency, Curre
   const maxSlippage = toPercent(useAtomValue(maxSlippageAtom))
   return useAtomValue(autoSlippageAtom) ? autoSlippage : maxSlippage ?? autoSlippage
 }
+
+export const MAX_VALID_SLIPPAGE = new Percent(1, 2)
+export const MIN_HIGH_SLIPPAGE = new Percent(1, 100)
+
+export function getSlippageWarning(slippage?: Percent): 'warning' | 'error' | undefined {
+  if (slippage?.greaterThan(MAX_VALID_SLIPPAGE)) return 'error'
+  if (slippage?.greaterThan(MIN_HIGH_SLIPPAGE)) return 'warning'
+  return
+}

--- a/src/lib/hooks/useAllowedSlippage.ts
+++ b/src/lib/hooks/useAllowedSlippage.ts
@@ -11,7 +11,7 @@ export function toPercent(maxSlippage: number | undefined): Percent | undefined 
 }
 
 /** Returns the user-inputted max slippage. */
-export default function useMaxSlippage(trade: InterfaceTrade<Currency, Currency, TradeType> | undefined): Percent {
+export default function useAllowedSlippage(trade: InterfaceTrade<Currency, Currency, TradeType> | undefined): Percent {
   const autoSlippage = useAutoSlippageTolerance(trade)
   const maxSlippage = toPercent(useAtomValue(maxSlippageAtom))
   return useAtomValue(autoSlippageAtom) ? autoSlippage : maxSlippage ?? autoSlippage

--- a/src/lib/state/settings.ts
+++ b/src/lib/state/settings.ts
@@ -1,10 +1,6 @@
-import { Percent } from '@uniswap/sdk-core'
 import { atomWithReset } from 'jotai/utils'
 
 import { pickAtom, setTogglable } from './atoms'
-
-export const MAX_VALID_SLIPPAGE = new Percent(1, 2)
-export const MIN_HIGH_SLIPPAGE = new Percent(1, 100)
 
 interface Settings {
   autoSlippage: boolean // if true, slippage will use the default calculation

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -21,6 +21,12 @@ export function computeRealizedPriceImpact(trade: Trade<Currency, Currency, Trad
   return trade.priceImpact.subtract(realizedLpFeePercent)
 }
 
+export function getPriceImpactWarning(priceImpact: Percent): 'warning' | 'error' | undefined {
+  if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) return 'error'
+  if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) return 'warning'
+  return
+}
+
 // computes realized lp fee as a percent
 export function computeRealizedLPFeePercent(trade: Trade<Currency, Currency, TradeType>): Percent {
   let percent: Percent

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -21,9 +21,9 @@ export function computeRealizedPriceImpact(trade: Trade<Currency, Currency, Trad
   return trade.priceImpact.subtract(realizedLpFeePercent)
 }
 
-export function getPriceImpactWarning(priceImpact: Percent): 'warning' | 'error' | undefined {
-  if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) return 'error'
-  if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) return 'warning'
+export function getPriceImpactWarning(priceImpact?: Percent): 'warning' | 'error' | undefined {
+  if (priceImpact?.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) return 'error'
+  if (priceImpact?.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) return 'warning'
   return
 }
 


### PR DESCRIPTION
- move price impact and slippage warning logic so that there is only one shared definition
- color price impact on the swap screen