### PR TITLE
feat: accept {provider, signer} as ethers provider

### DIFF
--- a/src/lib/components/Web3Provider.tsx
+++ b/src/lib/components/Web3Provider.tsx
@@ -1,6 +1,9 @@
+import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
+import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
+import { Eip1193Bridge } from '@ethersproject/experimental'
 import { initializeConnector, Web3ReactHooks } from '@web3-react/core'
 import { EIP1193 } from '@web3-react/eip1193'
-import { Actions, Connector, Provider as EthProvider } from '@web3-react/types'
+import { Actions, Connector, Provider as Eip1193Provider } from '@web3-react/types'
 import { Url } from '@web3-react/url'
 import { SetStateAction } from 'jotai'
 import { RESET, useUpdateAtom } from 'jotai/utils'
@@ -9,7 +12,7 @@ import { ReactNode, useEffect } from 'react'
 
 interface Web3ProviderProps {
   jsonRpcEndpoint?: string
-  provider?: EthProvider
+  provider?: Eip1193Provider | { provider: EthersProvider; signer: EthersSigner }
   children: ReactNode
 }
 
@@ -33,7 +36,13 @@ export default function Web3Provider({ jsonRpcEndpoint, provider, children }: We
   useConnector(Url, jsonRpcEndpoint, setUrl)
 
   const setInjected = useUpdateAtom(injectedAtom)
-  useConnector(EIP1193, provider, setInjected)
+  let eip1193: Eip1193Provider | undefined
+  if (provider && 'provider' in provider && 'signer' in provider) {
+    eip1193 = new Eip1193Bridge(provider.signer, provider.provider)
+  } else {
+    eip1193 = provider
+  }
+  useConnector(EIP1193, eip1193, setInjected)
 
   return <>{children}</>
 }

--- a/src/lib/components/Web3Provider.tsx
+++ b/src/lib/components/Web3Provider.tsx
@@ -1,6 +1,3 @@
-import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
-import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
-import { Eip1193Bridge } from '@ethersproject/experimental'
 import { initializeConnector, Web3ReactHooks } from '@web3-react/core'
 import { EIP1193 } from '@web3-react/eip1193'
 import { Actions, Connector, Provider as Eip1193Provider } from '@web3-react/types'
@@ -12,7 +9,7 @@ import { ReactNode, useEffect } from 'react'
 
 interface Web3ProviderProps {
   jsonRpcEndpoint?: string
-  provider?: Eip1193Provider | { provider: EthersProvider; signer: EthersSigner }
+  provider?: Eip1193Provider
   children: ReactNode
 }
 
@@ -36,13 +33,7 @@ export default function Web3Provider({ jsonRpcEndpoint, provider, children }: We
   useConnector(Url, jsonRpcEndpoint, setUrl)
 
   const setInjected = useUpdateAtom(injectedAtom)
-  let eip1193: Eip1193Provider | undefined
-  if (provider && 'provider' in provider && 'signer' in provider) {
-    eip1193 = new Eip1193Bridge(provider.signer, provider.provider)
-  } else {
-    eip1193 = provider
-  }
-  useConnector(EIP1193, eip1193, setInjected)
+  useConnector(EIP1193, provider, setInjected)
 
   return <>{children}</>
 }

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -1,6 +1,7 @@
 import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
 import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
 import { Eip1193Bridge } from '@ethersproject/experimental'
+import { ExternalProvider } from '@ethersproject/providers'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Provider as Eip1193Provider } from '@web3-react/types'
 import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
@@ -95,7 +96,7 @@ function Updaters() {
 export type WidgetProps = {
   theme?: Theme
   locale?: SupportedLocale
-  provider?: Eip1193Provider | JsonRpcProvider | { provider: EthersProvider; signer: EthersSigner }
+  provider?: Eip1193Provider | ExternalProvider | JsonRpcProvider | { provider: EthersProvider; signer: EthersSigner }
   jsonRpcEndpoint?: string
   width?: string | number
   dialog?: HTMLElement | null
@@ -121,8 +122,8 @@ export default function Widget(props: PropsWithChildren<WidgetProps>) {
     eip1193 = new Eip1193Bridge(provider.signer, provider.provider)
   } else if (provider instanceof JsonRpcProvider) {
     eip1193 = new Eip1193Bridge(provider.getSigner(), provider)
-  } else {
-    eip1193 = provider
+  } else if (provider) {
+    eip1193 = provider as Eip1193Provider
   }
 
   const [dialog, setDialog] = useState<HTMLDivElement | null>(null)

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -1,7 +1,7 @@
 import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
 import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
 import { Eip1193Bridge } from '@ethersproject/experimental'
-import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
+import { JsonRpcProvider } from '@ethersproject/providers'
 import { Provider as Eip1193Provider } from '@web3-react/types'
 import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
 import { Provider as AtomProvider } from 'jotai'

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -1,5 +1,6 @@
 import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
 import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
+import { Eip1193Bridge } from '@ethersproject/experimental'
 import { Provider as Eip1193Provider } from '@web3-react/types'
 import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
 import { Provider as AtomProvider } from 'jotai'
@@ -114,6 +115,13 @@ export default function Widget(props: PropsWithChildren<WidgetProps>) {
     onError,
   } = props
 
+  let eip1193: Eip1193Provider | undefined
+  if (provider && 'provider' in provider && 'signer' in provider) {
+    eip1193 = new Eip1193Bridge(provider.signer, provider.provider)
+  } else {
+    eip1193 = provider
+  }
+
   const [dialog, setDialog] = useState<HTMLDivElement | null>(null)
   return (
     <StrictMode>
@@ -126,7 +134,7 @@ export default function Widget(props: PropsWithChildren<WidgetProps>) {
                 <WidgetPropValidator {...props}>
                   <ReduxProvider store={multicallStore}>
                     <AtomProvider>
-                      <Web3Provider provider={provider} jsonRpcEndpoint={jsonRpcEndpoint}>
+                      <Web3Provider provider={eip1193} jsonRpcEndpoint={jsonRpcEndpoint}>
                         <Updaters />
                         {children}
                       </Web3Provider>

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -1,4 +1,6 @@
-import { Provider as EthProvider } from '@web3-react/types'
+import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
+import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
+import { Provider as Eip1193Provider } from '@web3-react/types'
 import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
 import { Provider as AtomProvider } from 'jotai'
 import { TransactionsUpdater } from 'lib/hooks/transactions'
@@ -91,7 +93,7 @@ function Updaters() {
 export type WidgetProps = {
   theme?: Theme
   locale?: SupportedLocale
-  provider?: EthProvider
+  provider?: Eip1193Provider | { provider: EthersProvider; signer: EthersSigner }
   jsonRpcEndpoint?: string
   width?: string | number
   dialog?: HTMLElement | null

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -1,6 +1,7 @@
 import { Provider as EthersProvider } from '@ethersproject/abstract-provider'
 import { Signer as EthersSigner } from '@ethersproject/abstract-signer'
 import { Eip1193Bridge } from '@ethersproject/experimental'
+import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 import { Provider as Eip1193Provider } from '@web3-react/types'
 import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
 import { Provider as AtomProvider } from 'jotai'
@@ -94,7 +95,7 @@ function Updaters() {
 export type WidgetProps = {
   theme?: Theme
   locale?: SupportedLocale
-  provider?: Eip1193Provider | { provider: EthersProvider; signer: EthersSigner }
+  provider?: Eip1193Provider | JsonRpcProvider | { provider: EthersProvider; signer: EthersSigner }
   jsonRpcEndpoint?: string
   width?: string | number
   dialog?: HTMLElement | null
@@ -118,6 +119,8 @@ export default function Widget(props: PropsWithChildren<WidgetProps>) {
   let eip1193: Eip1193Provider | undefined
   if (provider && 'provider' in provider && 'signer' in provider) {
     eip1193 = new Eip1193Bridge(provider.signer, provider.provider)
+  } else if (provider instanceof JsonRpcProvider) {
+    eip1193 = new Eip1193Bridge(provider.getSigner(), provider)
   } else {
     eip1193 = provider
   }


### PR DESCRIPTION
Allows ethers provider/signer to be passed instead of an EIP1193 provider.
The ethers provider/signer is bridged to an EIP1193 using require('@ethersproject/experiment').Eip1193Bridge.