### PR TITLE
fix: allow input selection in WebKit

### DIFF
--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -35,12 +35,12 @@ const WidgetWrapper = styled.div<{ width?: number | string }>`
   min-width: 300px;
   padding: 0.25em;
   position: relative;
+  user-select: none;
   width: ${({ width }) => width && (isNaN(Number(width)) ? width : `${width}px`)};
 
   * {
     box-sizing: border-box;
     font-family: ${({ theme }) => theme.fontFamily};
-    user-select: none;
 
     @supports (font-variation-settings: normal) {
       font-family: ${({ theme }) => theme.fontFamilyVariable};


### PR DESCRIPTION
Applying user-select to the widget element, and not its constituents, stops WebKit from preventing <input>s from receiving user focus.

NB: Defaulting to `user-select: none` is intentional. An audit is scheduled to go over which elements should have `user-select`. This PR is only meant to address a WebKit issue.