### PR TITLE
fix: Italian translation

### DIFF
--- a/src/locales/it-IT.po
+++ b/src/locales/it-IT.po
@@ -302,7 +302,7 @@ msgstr "Disponibile per il deposito: {0}"
 
 #: src/components/CurrencyInputPanel/index.tsx
 msgid "Balance: {0}"
-msgstr "Bilanciamento: {0}"
+msgstr "Disponibili: {0}"
 
 #: src/components/FeeSelector/shared.tsx
 msgid "Best for exotic pairs."


### PR DESCRIPTION
the translation "Balance" was wrong
"Bilanciamento" was used which means "balancing".

Changed to "Disponibile" which means "Available" and is much more appropriate