### PR TITLE
fix: show hide closed position option in mobile view

### DIFF
--- a/src/components/PositionList/index.tsx
+++ b/src/components/PositionList/index.tsx
@@ -57,6 +57,9 @@ export default function PositionList({
       </DesktopHeader>
       <MobileHeader>
         <Trans>Your positions</Trans>
+        <ButtonText style={{ opacity: 0.6 }} onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}>
+          <Trans>Hide closed positions</Trans>
+        </ButtonText>
       </MobileHeader>
       {positions.map((p) => {
         return <PositionListItem key={p.tokenId.toString()} positionDetails={p} />


### PR DESCRIPTION
<img width="325" alt="image" src="https://user-images.githubusercontent.com/51886388/156164660-f4fa6a45-68f6-418f-95e9-c9ed7d889a2e.png">
