### PR TITLE
fix: routing tooltip sizing

### DIFF
--- a/src/lib/components/Button.tsx
+++ b/src/lib/components/Button.tsx
@@ -10,6 +10,7 @@ export const BaseButton = styled.button`
   cursor: pointer;
   font-size: inherit;
   font-weight: inherit;
+  height: inherit;
   line-height: inherit;
   margin: 0;
   padding: 0;

--- a/src/lib/components/Popover.tsx
+++ b/src/lib/components/Popover.tsx
@@ -21,7 +21,9 @@ const PopoverContainer = styled.div<{ show: boolean }>`
 `
 
 const Reference = styled.div`
+  align-self: flex-start;
   display: inline-block;
+  height: 1em;
 `
 
 const Arrow = styled.div`


### PR DESCRIPTION
Fixes routing tooltip height, which overflows the widget in third-party integrations.
This does not manifest in cosmos.