### PR TITLE
fix: the logic of display injected connectors on mobile app.

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -250,7 +250,10 @@ export default function WalletModal({
             />
           )
         }
-        return null
+
+        if (option.mobileOnly) {
+          return null
+        }
       }
 
       // overwrite injected when needed
@@ -284,25 +287,23 @@ export default function WalletModal({
       }
 
       // return rest of options
-      return (
-        !isMobile &&
-        !option.mobileOnly && (
-          <Option
-            id={`connect-${key}`}
-            onClick={() => {
-              option.connector === connector
-                ? setWalletView(WALLET_VIEWS.ACCOUNT)
-                : !option.href && tryActivation(option.connector)
-            }}
-            key={key}
-            active={option.connector === connector}
-            color={option.color}
-            link={option.href}
-            header={option.name}
-            subheader={null} //use option.descriptio to bring back multi-line
-            icon={option.iconURL}
-          />
-        )
+      return
+      (
+        <Option
+          id={`connect-${key}`}
+          onClick={() => {
+            option.connector === connector
+              ? setWalletView(WALLET_VIEWS.ACCOUNT)
+              : !option.href && tryActivation(option.connector)
+          }}
+          key={key}
+          active={option.connector === connector}
+          color={option.color}
+          link={option.href}
+          header={option.name}
+          subheader={null} //use option.descriptio to bring back multi-line
+          icon={option.iconURL}
+        />
       )
     })
   }
@@ -337,7 +338,7 @@ export default function WalletModal({
               onClick={() => {
                 setWalletView(
                   (previousWalletView === WALLET_VIEWS.LEGAL ? WALLET_VIEWS.ACCOUNT : previousWalletView) ??
-                    WALLET_VIEWS.ACCOUNT
+                  WALLET_VIEWS.ACCOUNT
                 )
               }}
             >

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -287,8 +287,7 @@ export default function WalletModal({
       }
 
       // return rest of options
-      return
-      (
+      return (
         <Option
           id={`connect-${key}`}
           onClick={() => {
@@ -338,7 +337,7 @@ export default function WalletModal({
               onClick={() => {
                 setWalletView(
                   (previousWalletView === WALLET_VIEWS.LEGAL ? WALLET_VIEWS.ACCOUNT : previousWalletView) ??
-                  WALLET_VIEWS.ACCOUNT
+                    WALLET_VIEWS.ACCOUNT
                 )
               }}
             >


### PR DESCRIPTION
In the old logic, the return on line 253 would cause wallet apps like TokenPocket and BitizenWallet (built by our team) that provide injected connectors to display an empty list of wallets.

![image](https://user-images.githubusercontent.com/29243953/157153585-d495296c-c132-4f80-ac80-8ecdcf993f22.png)


So I moved the logic to check for non-mobile and non-mobile exclusive on line 288 inside `isMobile` so that the mobile injected connector can be displayed in the wallet list properly.

Now:

![image](https://user-images.githubusercontent.com/29243953/157158549-fcdccba4-3eff-40f3-868d-85459ebb7212.png)
