### PR TITLE
fix: fully specify locales

### DIFF
--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -81,7 +81,7 @@ export async function dynamicActivate(locale: SupportedLocale) {
   // There are no default messages in production; instead, bundle the default to save a network request:
   // see https://github.com/lingui/js-lingui/issues/388#issuecomment-497779030
   const catalog =
-    locale === DEFAULT_LOCALE ? DEFAULT_CATALOG : await import(`${process.env.REACT_APP_LOCALES}/${locale}`)
+    locale === DEFAULT_LOCALE ? DEFAULT_CATALOG : await import(`${process.env.REACT_APP_LOCALES}/${locale}.js`)
   // Bundlers will either export it as default or as a named export named default.
   i18n.load(locale, catalog.messages || catalog.default.messages)
   i18n.activate(locale)


### PR DESCRIPTION
CRAv5 requires that locales be fully specified (including the `.js` suffix) in order to load them. Doing so adds support for CRAv5 to the widgets lib.