### PR TITLE
feat: display "no results found" message

### DIFF
--- a/src/lib/components/TokenSelect/index.tsx
+++ b/src/lib/components/TokenSelect/index.tsx
@@ -97,7 +97,21 @@ export function TokenSelectDialog({ value, onSelect }: TokenSelectDialogProps) {
         )}
         <Rule padded />
       </Column>
-      {isLoaded ? <TokenOptions tokens={tokens} onSelect={onSelect} ref={setOptions} /> : <TokenOptionsSkeleton />}
+      {isLoaded ? (
+        tokens.length ? (
+          <TokenOptions tokens={tokens} onSelect={onSelect} ref={setOptions} />
+        ) : (
+          <Column padded>
+            <Row justify="center">
+              <ThemedText.Subhead2 color="secondary">
+                <Trans>No results found.</Trans>
+              </ThemedText.Subhead2>
+            </Row>
+          </Column>
+        )
+      ) : (
+        <TokenOptionsSkeleton />
+      )}
     </>
   )
 }

--- a/src/lib/components/TokenSelect/index.tsx
+++ b/src/lib/components/TokenSelect/index.tsx
@@ -103,9 +103,9 @@ export function TokenSelectDialog({ value, onSelect }: TokenSelectDialogProps) {
         ) : (
           <Column padded>
             <Row justify="center">
-              <ThemedText.Subhead2 color="secondary">
+              <ThemedText.Body1 color="secondary">
                 <Trans>No results found.</Trans>
-              </ThemedText.Subhead2>
+              </ThemedText.Body1>
             </Row>
           </Column>
         )


### PR DESCRIPTION
Displays a "No results found" message in TokenSelect when appropriate:

<img width="366" alt="image" src="https://user-images.githubusercontent.com/5403956/157714943-00727870-328e-42f4-a3be-6e426e91c1a9.png">
