### PR TITLE
fix: accomodate longer locales

### DIFF
--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -22,7 +22,8 @@ const StyledTokenButton = styled(Button)<{ empty?: boolean }>`
 
 const TokenButtonRow = styled(Row)<{ collapsed: boolean }>`
   height: 1.2em;
-  max-width: ${({ collapsed }) => (collapsed ? '1.2' : '8.2')}em;
+  // max-width must have an absolute value in order to transition.
+  max-width: ${({ collapsed }) => (collapsed ? '1.2em' : '12em')};
   overflow-x: hidden;
   transition: max-width 0.25s linear;
 `


### PR DESCRIPTION
Accomodates locales which have longer "Select a token" strings. In particular, the de-DE locale was overflowing and being cut off. See [notion](https://www.notion.so/uniswaplabs/German-token-selector-text-fit-ddd7bc94bb674b39959c0dd69b51668a).