### PR TITLE
fix: update default tokens on unsupported networks

### DIFF
--- a/src/lib/hooks/swap/useSyncTokenDefaults.ts
+++ b/src/lib/hooks/swap/useSyncTokenDefaults.ts
@@ -47,12 +47,13 @@ export default function useSyncTokenDefaults({
 }: TokenDefaults) {
   const updateSwap = useUpdateAtom(swapAtom)
   const { chainId } = useActiveWeb3React()
+  const onSupportedNetwork = useOnSupportedNetwork()
   const nativeCurrency = useNativeCurrency()
   const defaultOutputToken = useDefaultToken(defaultOutputTokenAddress, chainId)
   const defaultInputToken =
     useDefaultToken(defaultInputTokenAddress, chainId) ??
     // Default the input token to the native currency if it is not the output token.
-    (defaultOutputToken === nativeCurrency ? nativeCurrency : undefined)
+    (defaultOutputToken === nativeCurrency && onSupportedNetwork ? nativeCurrency : undefined)
 
   const setToDefaults = useCallback(() => {
     const defaultSwapState: Swap = {

--- a/src/lib/hooks/swap/useSyncTokenDefaults.ts
+++ b/src/lib/hooks/swap/useSyncTokenDefaults.ts
@@ -53,7 +53,7 @@ export default function useSyncTokenDefaults({
   const defaultInputToken =
     useDefaultToken(defaultInputTokenAddress, chainId) ??
     // Default the input token to the native currency if it is not the output token.
-    (defaultOutputToken === nativeCurrency && onSupportedNetwork ? nativeCurrency : undefined)
+    (defaultOutputToken !== nativeCurrency && onSupportedNetwork ? nativeCurrency : undefined)
 
   const setToDefaults = useCallback(() => {
     const defaultSwapState: Swap = {

--- a/src/lib/hooks/swap/useSyncTokenDefaults.ts
+++ b/src/lib/hooks/swap/useSyncTokenDefaults.ts
@@ -1,11 +1,12 @@
 import { Currency } from '@uniswap/sdk-core'
-import { SupportedChainId } from 'constants/chains'
 import { nativeOnChain } from 'constants/tokens'
 import { useUpdateAtom } from 'jotai/utils'
 import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
 import { useToken } from 'lib/hooks/useCurrency'
 import { Field, Swap, swapAtom } from 'lib/state/swap'
 import { useCallback, useLayoutEffect, useState } from 'react'
+
+import useOnSupportedNetwork from '../useOnSupportedNetwork'
 
 export type DefaultAddress = string | { [chainId: number]: string | 'NATIVE' } | 'NATIVE'
 
@@ -27,8 +28,11 @@ function useDefaultToken(
     address = defaultAddress[chainId]
   }
   const token = useToken(address)
+
+  const onSupportedNetwork = useOnSupportedNetwork()
+
   // Only use native currency if chain ID is in supported chains. ExtendedEther will error otherwise.
-  if (chainId && address === 'NATIVE' && chainId in SupportedChainId) {
+  if (chainId && address === 'NATIVE' && onSupportedNetwork) {
     return nativeOnChain(chainId)
   }
   return token

--- a/src/lib/hooks/swap/useSyncTokenDefaults.ts
+++ b/src/lib/hooks/swap/useSyncTokenDefaults.ts
@@ -1,4 +1,5 @@
 import { Currency } from '@uniswap/sdk-core'
+import { SupportedChainId } from 'constants/chains'
 import { nativeOnChain } from 'constants/tokens'
 import { useUpdateAtom } from 'jotai/utils'
 import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
@@ -26,7 +27,8 @@ function useDefaultToken(
     address = defaultAddress[chainId]
   }
   const token = useToken(address)
-  if (chainId && address === 'NATIVE') {
+  // Only use native currency if chain ID is in supported chains. ExtendedEther will error otherwise.
+  if (chainId && address === 'NATIVE' && chainId in SupportedChainId) {
     return nativeOnChain(chainId)
   }
   return token


### PR DESCRIPTION
- currentlty the widget will crash when `ExtendedEther` is use as a token input on a network that has no native currency 
- this issue is only exposed through network switching (as we disable token select on those networks)
- when switching from unsupported to supported, a race condition causes ExtendedEther to be used on a network where there is no native currency 

-  to avoid this we should only use "NATIVE" as a token default if we have instantiated the native currency to be used within `ExtendedEther`