### PR TITLE
fix: add formatting to USDC values

### DIFF
--- a/src/lib/components/Swap/Input.tsx
+++ b/src/lib/components/Swap/Input.tsx
@@ -122,7 +122,9 @@ export default function Input({ disabled, focused }: InputProps) {
       >
         <ThemedText.Body2 color="secondary" userSelect>
           <Row>
-            <USDC isLoading={isRouteLoading}>{inputUSDC ? `$${inputUSDC.toFixed(2)}` : '-'}</USDC>
+            <USDC isLoading={isRouteLoading}>
+              {inputUSDC ? `$${formatCurrencyAmount(inputUSDC, 6, i18n.locale, 2)}` : '-'}
+            </USDC>
             {balance && (
               <Balance color={balanceColor} focused={focused}>
                 Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -87,7 +87,7 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
           <ThemedText.Body2 color="secondary" userSelect>
             <Row>
               <USDC gap={0.5} isLoading={isRouteLoading}>
-                {outputUSDC ? `$${outputUSDC.toFixed(2)}` : '-'}{' '}
+                {outputUSDC ? `$${formatCurrencyAmount(outputUSDC, 6, i18n.locale, 2)}` : '-'}{' '}
                 {priceImpact && (
                   <ThemedText.Body2 color={priceImpactWarning}>
                     ({toHumanReadablePriceImpact(priceImpact)})

--- a/src/lib/components/Swap/Toolbar/Caption.tsx
+++ b/src/lib/components/Swap/Toolbar/Caption.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
 import { Currency, TradeType } from '@uniswap/sdk-core'
 import Column from 'lib/components/Column'
 import Rule from 'lib/components/Rule'
@@ -10,6 +11,7 @@ import { AlertTriangle, Icon, Info, InlineSpinner } from 'lib/icons'
 import styled, { ThemedText } from 'lib/theme'
 import { ReactNode, useCallback, useMemo, useState } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
+import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { getPriceImpactWarning } from 'utils/prices'
 
 import { TextButton } from '../../Button'
@@ -80,6 +82,7 @@ export function WrapCurrency({ loading, wrapType }: { loading: boolean; wrapType
 }
 
 export function Trade({ trade }: { trade: InterfaceTrade<Currency, Currency, TradeType> }) {
+  const { i18n } = useLingui()
   const [flip, setFlip] = useState(true)
   const { inputAmount: input, outputAmount: output, executionPrice } = trade
   const { inputUSDC, outputUSDC, priceImpact } = useUSDCPriceImpact(input, output)
@@ -92,10 +95,10 @@ export function Trade({ trade }: { trade: InterfaceTrade<Currency, Currency, Tra
     const ratio = `1 ${a.currency.symbol} = ${priceString} ${b.currency.symbol}`
     const usdc = !flip
       ? inputUSDC
-        ? ` ($${inputUSDC.toSignificant(6)})`
+        ? ` ($${formatCurrencyAmount(inputUSDC, 6, i18n.locale, 2)})`
         : null
       : outputUSDC
-      ? ` ($${outputUSDC.toSignificant(6)})`
+      ? ` ($${formatCurrencyAmount(outputUSDC, 6, i18n.locale, 2)})`
       : null
 
     return (
@@ -106,7 +109,7 @@ export function Trade({ trade }: { trade: InterfaceTrade<Currency, Currency, Tra
         </Row>
       </ThemedText.Caption>
     )
-  }, [executionPrice, inputUSDC, outputUSDC, flip, input, output])
+  }, [flip, output, input, executionPrice, inputUSDC, i18n.locale, outputUSDC])
 
   return (
     <>

--- a/src/lib/utils/formatLocaleNumber.ts
+++ b/src/lib/utils/formatLocaleNumber.ts
@@ -6,9 +6,16 @@ interface FormatLocaleNumberArgs {
   locale: string | null | undefined
   options?: Intl.NumberFormatOptions
   sigFigs?: number
+  fixedDecimals?: number
 }
 
-export default function formatLocaleNumber({ number, locale, sigFigs, options = {} }: FormatLocaleNumberArgs): string {
+export default function formatLocaleNumber({
+  number,
+  locale,
+  sigFigs,
+  fixedDecimals,
+  options = {},
+}: FormatLocaleNumberArgs): string {
   let localeArg: string | string[]
   if (!locale || (locale && !SUPPORTED_LOCALES.includes(locale))) {
     localeArg = DEFAULT_LOCALE
@@ -16,9 +23,14 @@ export default function formatLocaleNumber({ number, locale, sigFigs, options = 
     localeArg = [locale, DEFAULT_LOCALE]
   }
   options.maximumSignificantDigits = options.maximumSignificantDigits || sigFigs
+
+  let numberString: number
   if (typeof number === 'number') {
-    return number.toLocaleString(localeArg, options)
+    numberString = fixedDecimals ? parseFloat(number.toFixed(fixedDecimals)) : number
   } else {
-    return parseFloat(number.toSignificant(sigFigs)).toLocaleString(localeArg, options)
+    const baseString = parseFloat(number.toSignificant(sigFigs))
+    numberString = fixedDecimals ? parseFloat(baseString.toFixed(fixedDecimals)) : baseString
   }
+
+  return numberString.toLocaleString(localeArg, options)
 }

--- a/src/utils/formatCurrencyAmount.ts
+++ b/src/utils/formatCurrencyAmount.ts
@@ -6,7 +6,8 @@ import formatLocaleNumber from 'lib/utils/formatLocaleNumber'
 export function formatCurrencyAmount(
   amount: CurrencyAmount<Currency> | undefined,
   sigFigs: number,
-  locale: SupportedLocale = DEFAULT_LOCALE
+  locale: SupportedLocale = DEFAULT_LOCALE,
+  fixedDecimals?: number
 ): string {
   if (!amount) {
     return '-'
@@ -17,10 +18,10 @@ export function formatCurrencyAmount(
   }
 
   if (amount.divide(amount.decimalScale).lessThan(new Fraction(1, 100000))) {
-    return `<${formatLocaleNumber({ number: 0.00001, locale })}`
+    return `<${formatLocaleNumber({ number: 0.00001, locale, fixedDecimals })}`
   }
 
-  return formatLocaleNumber({ number: amount, locale, sigFigs })
+  return formatLocaleNumber({ number: amount, locale, sigFigs, fixedDecimals })
 }
 
 export function formatPrice(


### PR DESCRIPTION
- add formatting to input and output USDC values on widget 
- update formatting util to accept fixed decimal cutoff (used to cutoff decimals at 2 for USD prices)