### PR TITLE
fix: use group separator to add commas to USD values 

### DIFF
--- a/src/lib/components/Swap/Input.tsx
+++ b/src/lib/components/Swap/Input.tsx
@@ -122,7 +122,9 @@ export default function Input({ disabled, focused }: InputProps) {
       >
         <ThemedText.Body2 color="secondary" userSelect>
           <Row>
-            <USDC isLoading={isRouteLoading}>{inputUSDC ? `$${inputUSDC.toFixed(2)}` : '-'}</USDC>
+            <USDC isLoading={isRouteLoading}>
+              {inputUSDC ? `$${inputUSDC.toFixed(2, { groupSeparator: ',' })}` : '-'}
+            </USDC>
             {balance && (
               <Balance color={balanceColor} focused={focused}>
                 Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -87,7 +87,7 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
           <ThemedText.Body2 color="secondary" userSelect>
             <Row>
               <USDC gap={0.5} isLoading={isRouteLoading}>
-                {outputUSDC ? `$${outputUSDC.toFixed(2)}` : '-'}{' '}
+                {outputUSDC ? `$${outputUSDC.toFixed(2, { groupSeparator: ',' })}` : '-'}{' '}
                 {priceImpact && (
                   <ThemedText.Body2 color={priceImpactWarning}>
                     ({toHumanReadablePriceImpact(priceImpact)})

--- a/src/lib/components/Swap/Toolbar/Caption.tsx
+++ b/src/lib/components/Swap/Toolbar/Caption.tsx
@@ -92,10 +92,10 @@ export function Trade({ trade }: { trade: InterfaceTrade<Currency, Currency, Tra
     const ratio = `1 ${a.currency.symbol} = ${priceString} ${b.currency.symbol}`
     const usdc = !flip
       ? inputUSDC
-        ? ` ($${inputUSDC.toSignificant(6)})`
+        ? ` ($${inputUSDC.toFixed(2, { groupSeparator: ',' })})`
         : null
       : outputUSDC
-      ? ` ($${outputUSDC.toSignificant(6)})`
+      ? ` ($${outputUSDC.toFixed(2, { groupSeparator: ',' })})`
       : null
 
     return (


### PR DESCRIPTION
- this is an alternative solution to #3478 
- uses group separator to add commas without incorporating local formatting 