### PR TITLE
feat(perf): cache usdc prices per block

### DIFF
--- a/src/lib/hooks/useBlockCache.ts
+++ b/src/lib/hooks/useBlockCache.ts
@@ -1,40 +1,44 @@
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { useCallback, useEffect, useState } from 'react'
 
+export const ShouldUpdateCache = Symbol()
+
 /**
- * Configures leader/followers for a block-scoped cache (ie the cache clears every block).
+ * Configures leader/followers for a block-scoped cache (ie a cache that clears every block).
  * This is useful for data-fetching hooks which are called throughout the component tree with the
- * same data, allowing the data to be shared across the tree without being re-fetched (because
- * useMemo only works within a component).
+ * same data, allowing the data to be shared across the tree without being re-fetched. This is
+ * important because useMemo only works within a component, so a cache is necessary for
+ * performance.
  *
- * Returns [isCacheLeader, updateCache], where
- * - isLeader is true if this hook should actually fetch data, and false if it should not.
- * - updateCache should be called with any retrieved data, and will return the latest data.
- *   Thus, updateCache should be called by both the leader and followers.
+ * Returns [value, setValue]. value may be either the cached value or ShouldUpdateCache.
+ * iff value === ShouldUpdateCache, the caller is the leader, and should fetch data and update via
+ * setValue. If value !== ShouldUpdateCache, the caller should _not_ fetch data, and return value.
  *
  *     const cache = new Map<string, object>()
  *
  *     function useFetchData() {
  *       const key = useGetDataKey()
- *       const [isCacheLeader, updateCache] = useBlockCache(cache, key)
+ *       const [value, setValue] = useBlockCache(cache, key)
  *
- *       // Followers should prevent data from being fetched.
- *       const data = useFetchData(isCacheLeader ? key : undefined)
+ *       // The leader fetches data. Followers should short-circuit (usually passing undefined).
+ *       const data = useFetchData(value === ShouldUpdateCache ? key : undefined)
  *
- *       // updateCache both updates the cache (for the leader) and returns the most recent data
- *       // (for both the leader and followers).
- *       return updateCache(data)
+ *       if (value === ShouldUpdateCache) {
+ *         setValue(data)
+ *         return data
+ *       }
+ *       return value
  *     }
  */
 export default function useBlockCache<K, V>(
-  cache: Map<K, V | undefined>,
+  cache: Map<K, V | null>,
   key?: K
-): [boolean, (update?: V) => V | undefined] {
+): [V | null | typeof ShouldUpdateCache, (update: V) => void] {
   // This hooks should only take "lead" (ie not use the cache) if the cache has not yet been set.
   // This avoids having multiple hooks taking "lead".
   const [lead, setLead] = useState(key ? !cache.has(key) : false)
   if (key && !cache.has(key)) {
-    cache.set(key, undefined)
+    cache.set(key, null)
     setLead(true)
   }
 
@@ -44,7 +48,7 @@ export default function useBlockCache<K, V>(
     cache.clear()
     // Immediately set the cache to keep the "lead".
     if (lead && key) {
-      cache.set(key, undefined)
+      cache.set(key, null)
     }
   }, [block, cache, key, lead])
 
@@ -58,20 +62,17 @@ export default function useBlockCache<K, V>(
   })
 
   // Grab the value outside of a hook to force followers to re-render when it is updated.
-  const value = key && cache.get(key)
+  const value = (key && cache.get(key)) ?? null
 
-  const updateCache = useCallback(
-    (update?: V) => {
+  const setValue = useCallback(
+    (update: V) => {
       if (key) {
         if (lead && value !== update) {
           cache.set(key, update)
-          return update
         }
-        return value
       }
-      return
     },
     [cache, key, lead, value]
   )
-  return [lead, updateCache]
+  return [lead ? ShouldUpdateCache : value, setValue]
 }

--- a/src/lib/hooks/useBlockCache.ts
+++ b/src/lib/hooks/useBlockCache.ts
@@ -1,0 +1,77 @@
+import useBlockNumber from 'lib/hooks/useBlockNumber'
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Configures leader/followers for a block-scoped cache (ie the cache clears every block).
+ * This is useful for data-fetching hooks which are called throughout the component tree with the
+ * same data, allowing the data to be shared across the tree without being re-fetched (because
+ * useMemo only works within a component).
+ *
+ * Returns [isCacheLeader, updateCache], where
+ * - isLeader is true if this hook should actually fetch data, and false if it should not.
+ * - updateCache should be called with any retrieved data, and will return the latest data.
+ *   Thus, updateCache should be called by both the leader and followers.
+ *
+ *     const cache = new Map<string, object>()
+ *
+ *     function useFetchData() {
+ *       const key = useGetDataKey()
+ *       const [isCacheLeader, updateCache] = useBlockCache(cache, key)
+ *
+ *       // Followers should prevent data from being fetched.
+ *       const data = useFetchData(isCacheLeader ? key : undefined)
+ *
+ *       // updateCache both updates the cache (for the leader) and returns the most recent data
+ *       // (for both the leader and followers).
+ *       return updateCache(data)
+ *     }
+ */
+export default function useBlockCache<K, V>(
+  cache: Map<K, V | undefined>,
+  key?: K
+): [boolean, (update?: V) => V | undefined] {
+  // This hooks should only take "lead" (ie not use the cache) if the cache has not yet been set.
+  // This avoids having multiple hooks taking "lead".
+  const [lead, setLead] = useState(key ? !cache.has(key) : false)
+  if (key && !cache.has(key)) {
+    cache.set(key, undefined)
+    setLead(true)
+  }
+
+  // Clears the cache every block.
+  const block = useBlockNumber()
+  useEffect(() => {
+    cache.clear()
+    // Immediately set the cache to keep the "lead".
+    if (lead && key) {
+      cache.set(key, undefined)
+    }
+  }, [block, cache, key, lead])
+
+  useEffect(() => {
+    return () => {
+      // If there is not yet a cached value when unmounting, give up the "lead".
+      if (lead && key && !cache.get(key)) {
+        cache.delete(key)
+      }
+    }
+  })
+
+  // Grab the value outside of a hook to force followers to re-render when it is updated.
+  const value = key && cache.get(key)
+
+  const updateCache = useCallback(
+    (update?: V) => {
+      if (key) {
+        if (lead && value !== update) {
+          cache.set(key, update)
+          return update
+        }
+        return value
+      }
+      return
+    },
+    [cache, key, lead, value]
+  )
+  return [lead, updateCache]
+}


### PR DESCRIPTION
The `useUSDCPrice` hook is used throughout both the app and widgets, and nested within other hooks. It is computationally expensive, because it computes a best route to USDC.
Rather than try to move it to a top level (so that `useMemo` would appropriately cache), I implemented a cache external to React for the `useUSDCPrice` hook.

This significantly speeds up rendering when multiple prices are displayed on the screen (as they all call into this hook), and also improves re-rendering an already known pair (eg if you hit the "switch" button twice).