### PR TITLE
fix: update wrap fail state callback and input values

### DIFF
--- a/src/lib/components/Swap/SwapButton.tsx
+++ b/src/lib/components/Swap/SwapButton.tsx
@@ -184,7 +184,7 @@ export default function SwapButton({ disabled }: SwapButtonProps) {
   }, [addTransaction, inputTradeCurrencyAmount, outputTradeCurrencyAmount, setDisplayTxHash, swapCallback, tradeType])
 
   const ButtonText = useCallback(() => {
-    if (wrapError !== WrapError.NO_ERROR) {
+    if (wrapError !== WrapError.NO_ERROR && (wrapType === WrapType.WRAP || wrapType === WrapType.UNWRAP)) {
       return <WrapErrorText wrapError={wrapError} />
     }
     switch (wrapType) {

--- a/src/lib/components/Swap/SwapButton.tsx
+++ b/src/lib/components/Swap/SwapButton.tsx
@@ -207,14 +207,16 @@ export default function SwapButton({ disabled }: SwapButtonProps) {
       setActiveTrade(trade.trade)
     } else {
       const transaction = await wrapCallback()
-      addTransaction({
-        response: transaction,
-        type: TransactionType.WRAP,
-        unwrapped: wrapType === WrapType.UNWRAP,
-        currencyAmountRaw: transaction.value?.toString() ?? '0',
-        chainId,
-      })
-      setDisplayTxHash(transaction.hash)
+      if (transaction) {
+        addTransaction({
+          response: transaction,
+          type: TransactionType.WRAP,
+          unwrapped: wrapType === WrapType.UNWRAP,
+          currencyAmountRaw: transaction.value?.toString() ?? '0',
+          chainId,
+        })
+        setDisplayTxHash(transaction.hash)
+      }
     }
   }, [addTransaction, chainId, setDisplayTxHash, trade.trade, wrapCallback, wrapType])
 

--- a/src/lib/components/Swap/SwapButton.tsx
+++ b/src/lib/components/Swap/SwapButton.tsx
@@ -184,7 +184,7 @@ export default function SwapButton({ disabled }: SwapButtonProps) {
   }, [addTransaction, inputTradeCurrencyAmount, outputTradeCurrencyAmount, setDisplayTxHash, swapCallback, tradeType])
 
   const ButtonText = useCallback(() => {
-    if (wrapError !== WrapError.NO_ERROR && (wrapType === WrapType.WRAP || wrapType === WrapType.UNWRAP)) {
+    if ((wrapType === WrapType.WRAP || wrapType === WrapType.UNWRAP) && wrapError !== WrapError.NO_ERROR) {
       return <WrapErrorText wrapError={wrapError} />
     }
     switch (wrapType) {
@@ -207,16 +207,14 @@ export default function SwapButton({ disabled }: SwapButtonProps) {
       setActiveTrade(trade.trade)
     } else {
       const transaction = await wrapCallback()
-      if (transaction) {
-        addTransaction({
-          response: transaction,
-          type: TransactionType.WRAP,
-          unwrapped: wrapType === WrapType.UNWRAP,
-          currencyAmountRaw: transaction.value?.toString() ?? '0',
-          chainId,
-        })
-        setDisplayTxHash(transaction.hash)
-      }
+      addTransaction({
+        response: transaction,
+        type: TransactionType.WRAP,
+        unwrapped: wrapType === WrapType.UNWRAP,
+        currencyAmountRaw: transaction.value?.toString() ?? '0',
+        chainId,
+      })
+      setDisplayTxHash(transaction.hash)
     }
   }, [addTransaction, chainId, setDisplayTxHash, trade.trade, wrapCallback, wrapType])
 

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -53,10 +53,6 @@ function useComputeSwapInfo(): SwapInfo {
     useMemo(() => [inputCurrency ?? undefined, outputCurrency ?? undefined], [inputCurrency, outputCurrency])
   )
 
-  // Short circuit trade fetching and amount parsing if wrapping or unwrapping.
-  const { type: wrapType } = useWrapCallback()
-  const isWrapping = wrapType === WrapType.WRAP || wrapType === WrapType.UNWRAP
-
   const isExactIn = independentField === Field.INPUT
   const parsedAmount = useMemo(
     () => tryParseCurrencyAmount(amount, (isExactIn ? inputCurrency : outputCurrency) ?? undefined),
@@ -85,6 +81,10 @@ function useComputeSwapInfo(): SwapInfo {
     }),
     [relevantTokenBalances]
   )
+
+  // Use same amount for input and output if user is wrapping.
+  const { type: wrapType } = useWrapCallback()
+  const isWrapping = wrapType === WrapType.WRAP || wrapType === WrapType.UNWRAP
 
   const tradeCurrencyAmounts = useMemo(
     () => ({

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -66,7 +66,7 @@ function useComputeSwapInfo(): SwapInfo {
   //@TODO(ianlapham): this would eventually be replaced with routing api logic.
   const trade = useBestTrade(
     isExactIn ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT,
-    isWrapping ? undefined : parsedAmount,
+    parsedAmount,
     (isExactIn ? outputCurrency : inputCurrency) ?? undefined
   )
 

--- a/src/lib/hooks/swap/useWrapCallback.tsx
+++ b/src/lib/hooks/swap/useWrapCallback.tsx
@@ -16,7 +16,7 @@ export enum WrapType {
   UNWRAP,
 }
 interface UseWrapCallbackReturns {
-  callback: () => Promise<ContractTransaction>
+  callback: () => Promise<ContractTransaction | void>
   error: WrapError
   loading: boolean
   type: WrapType
@@ -44,12 +44,7 @@ export default function useWrapCallback(): UseWrapCallbackReturns {
   const { account, chainId } = useActiveWeb3React()
   const [{ loading, error }, setWrapState] = useAtom(wrapState)
   const wrappedNativeCurrencyContract = useWETHContract()
-  const {
-    amount,
-    independentField,
-    [Field.INPUT]: inputCurrency,
-    [Field.OUTPUT]: outputCurrency,
-  } = useAtomValue(swapAtom)
+  const { amount, [Field.INPUT]: inputCurrency, [Field.OUTPUT]: outputCurrency } = useAtomValue(swapAtom)
 
   const wrapType = useMemo(() => {
     if (!inputCurrency || !outputCurrency || !chainId) {
@@ -64,12 +59,10 @@ export default function useWrapCallback(): UseWrapCallbackReturns {
     return WrapType.NOT_APPLICABLE
   }, [chainId, inputCurrency, outputCurrency])
 
-  const isExactIn = independentField === Field.INPUT
-  const parsedAmount = useMemo(
-    () => tryParseCurrencyAmount(amount, (isExactIn ? inputCurrency : outputCurrency) ?? undefined),
-    [inputCurrency, isExactIn, outputCurrency, amount]
+  const parsedAmountIn = useMemo(
+    () => tryParseCurrencyAmount(amount, inputCurrency ?? undefined),
+    [inputCurrency, amount]
   )
-  const parsedAmountIn = isExactIn ? parsedAmount : undefined
 
   const relevantTokenBalances = useCurrencyBalances(
     account,
@@ -83,7 +76,7 @@ export default function useWrapCallback(): UseWrapCallbackReturns {
     [relevantTokenBalances]
   )
 
-  const hasInputAmount = Boolean(parsedAmount?.greaterThan('0'))
+  const hasInputAmount = Boolean(parsedAmountIn?.greaterThan('0'))
   const sufficientBalance = parsedAmountIn && !currencyBalances[Field.INPUT]?.lessThan(parsedAmountIn)
 
   useEffect(() => {
@@ -118,7 +111,11 @@ export default function useWrapCallback(): UseWrapCallbackReturns {
     setWrapState((state) => ({ ...state, loading: true }))
     const result = await (wrapType === WrapType.WRAP
       ? wrappedNativeCurrencyContract.deposit({ value: `0x${parsedAmountIn.quotient.toString(16)}` })
-      : wrappedNativeCurrencyContract.withdraw(`0x${parsedAmountIn.quotient.toString(16)}`))
+      : wrappedNativeCurrencyContract.withdraw(`0x${parsedAmountIn.quotient.toString(16)}`)
+    ).catch(() => {
+      setWrapState((state) => ({ ...state, loading: false }))
+      return Promise.reject('User denied wallet transaction.')
+    })
     // resolve loading state after one confirmation
     result.wait(1).finally(() => setWrapState((state) => ({ ...state, loading: false })))
     return Promise.resolve(result)

--- a/src/lib/hooks/swap/useWrapCallback.tsx
+++ b/src/lib/hooks/swap/useWrapCallback.tsx
@@ -16,7 +16,7 @@ export enum WrapType {
   UNWRAP,
 }
 interface UseWrapCallbackReturns {
-  callback: () => Promise<ContractTransaction | void>
+  callback: () => Promise<ContractTransaction>
   error: WrapError
   loading: boolean
   type: WrapType

--- a/src/lib/hooks/swap/useWrapCallback.tsx
+++ b/src/lib/hooks/swap/useWrapCallback.tsx
@@ -112,9 +112,9 @@ export default function useWrapCallback(): UseWrapCallbackReturns {
     const result = await (wrapType === WrapType.WRAP
       ? wrappedNativeCurrencyContract.deposit({ value: `0x${parsedAmountIn.quotient.toString(16)}` })
       : wrappedNativeCurrencyContract.withdraw(`0x${parsedAmountIn.quotient.toString(16)}`)
-    ).catch(() => {
+    ).catch((e: unknown) => {
       setWrapState((state) => ({ ...state, loading: false }))
-      return Promise.reject('User denied wallet transaction.')
+      throw e
     })
     // resolve loading state after one confirmation
     result.wait(1).finally(() => setWrapState((state) => ({ ...state, loading: false })))


### PR DESCRIPTION
This PR contains 4 changes. 

1. Add error catching to the `wrapCallback`. Before, if a user rejected the transaction in their wallet the `WrapState` would not reset the value for `loading`, which causes button to be disabled until page relod. Fix is to catch error within the callback and reset loading state if detected. 

2. Update amount parsing when wrapping and disable trade fetching. When a user is wrapping or unwrapping, we dont want to fetch an ETH <-> WETH trade, and we dont want to show the input/output amounts from that trade. Instead, force input/output amounts to be the typed value from user. 

3. Fix logic for detecting balance in wrapCallback. Currently we are only checking balance if the user has typed in the input field. This leads to an error when users type in the output field, as `sufficientBalance` in `useWrapCallback` is always false if they type in output field. 

4. Dont show wrapping errors if user is not wrapping or unwrapping (in swap button)