### PR TITLE
fix: avoid summary wrap

### DIFF
--- a/src/lib/components/Swap/Summary/Summary.tsx
+++ b/src/lib/components/Swap/Summary/Summary.tsx
@@ -26,12 +26,12 @@ function TokenValue({ input, usdc, children }: PropsWithChildren<TokenValueProps
         </ThemedText.Body2>
       </Row>
       {usdc && (
-        <Row justify="flex-start">
-          <ThemedText.Caption color="secondary" userSelect>
+        <ThemedText.Caption color="secondary" userSelect>
+          <Row justify="flex-start" gap={0.25}>
             ${formatCurrencyAmount(usdc, 6, 'en', 2)}
             {children}
-          </ThemedText.Caption>
-        </Row>
+          </Row>
+        </ThemedText.Caption>
       )}
     </Column>
   )


### PR DESCRIPTION
Fixes line wrapping in the Summary component. This was fixed, but inadvertently re-broken when resolving a merge conflict.

Before:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/5403956/157755998-4d8c2a60-c65d-4f11-8e1b-b7f160b41759.png">

After:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/5403956/157755834-4394a0ec-b26f-4af4-b53d-e90abf73b2dd.png">