### PR TITLE
fix: override Rule width

### DIFF
--- a/src/lib/components/Rule.tsx
+++ b/src/lib/components/Rule.tsx
@@ -6,6 +6,9 @@ const Rule = styled.hr<{ padded?: true; scrollingEdge?: 'top' | 'bottom' }>`
   margin: 0 ${({ padded }) => (padded ? '0.75em' : 0)};
   margin-bottom: ${({ scrollingEdge }) => (scrollingEdge === 'bottom' ? -1 : 0)}px;
   margin-top: ${({ scrollingEdge }) => (scrollingEdge !== 'bottom' ? -1 : 0)}px;
+
+  // Integrators will commonly modify hr width - this overrides any modifications within the widget.
+  width: auto;
 `
 
 export default Rule

--- a/src/lib/components/Rule.tsx
+++ b/src/lib/components/Rule.tsx
@@ -8,6 +8,7 @@ const Rule = styled.hr<{ padded?: true; scrollingEdge?: 'top' | 'bottom' }>`
   margin-top: ${({ scrollingEdge }) => (scrollingEdge !== 'bottom' ? -1 : 0)}px;
 
   // Integrators will commonly modify hr width - this overrides any modifications within the widget.
+  max-width: auto;
   width: auto;
 `
 


### PR DESCRIPTION
Allows hr to extend to full width, despite any integrator hr-specific width styles.