### PR TITLE
fix: input amount lag

### DIFF
--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -60,8 +60,8 @@ function useComputeSwapInfo(): SwapInfo {
   const tradeCurrencyAmounts = useMemo(
     () => ({
       // Use same amount for input and output if user is wrapping.
-      [Field.INPUT]: isWrapping ? parsedAmount : trade.trade?.inputAmount,
-      [Field.OUTPUT]: isWrapping ? parsedAmount : trade.trade?.outputAmount,
+      [Field.INPUT]: isWrapping || isExactIn ? parsedAmount : trade.trade?.inputAmount,
+      [Field.OUTPUT]: isWrapping || !isExactIn ? parsedAmount : trade.trade?.outputAmount,
     }),
     [isWrapping, parsedAmount, trade.trade?.inputAmount, trade.trade?.outputAmount]
   )


### PR DESCRIPTION
Propagates the exact amount to the trade currency amount without waiting for the trade to be computed. This allows things like insufficient balance or approval to be reflected in the UI while typing, instead of having a lag.

This screencap shows the issue that is being fixed:
https://user-images.githubusercontent.com/5403956/157987706-dbdbaa6f-8027-4bf6-aeac-ec9330be7cb1.mov


