### PR TITLE
fix: token button overflow

### DIFF
--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -24,7 +24,6 @@ const TokenButtonRow = styled(Row)<{ collapsed: boolean }>`
   height: 1.2em;
   // max-width must have an absolute value in order to transition.
   max-width: ${({ collapsed }) => (collapsed ? '1.2em' : '12em')};
-  overflow-x: hidden;
   transition: max-width 0.25s linear;
 `
 


### PR DESCRIPTION
Removes the overflow property from TokenButton, which prevents the vertical scrollbar from rendering.

See https://www.notion.so/uniswaplabs/y-overflow-causing-scrollbar-on-token-in-output-d5aa67a355694c86b5d9530878a121c2