### PR TITLE
fix: expando icon direction

### DIFF
--- a/src/lib/icons/index.tsx
+++ b/src/lib/icons/index.tsx
@@ -109,17 +109,18 @@ export const Check = styled(icon(CheckIcon))`
 `
 
 export const Expando = styled(icon(ExpandoIcon))<{ open: boolean }>`
-  path {
+  .left,
+  .right {
     transition: transform 0.25s ease-in-out;
     will-change: transform;
+  }
 
-    &:first-child {
-      transform: ${({ open }) => open && 'translateX(-25%)'};
-    }
+  .left {
+    transform: ${({ open }) => (open ? undefined : 'translateX(-25%)')};
+  }
 
-    &:last-child {
-      transform: ${({ open }) => open && 'translateX(25%)'};
-    }
+  .right {
+    transform: ${({ open }) => (open ? undefined : 'translateX(25%)')};
   }
 `
 


### PR DESCRIPTION
See [notion](https://www.notion.so/uniswaplabs/Flip-review-carrot-direction-should-indicate-the-result-of-your-click-not-the-state-42d15f0f7eb447509ee44e9f0590c5cd)