### PR TITLE
fix: add check for undefined slot0 and liquidity call results

### DIFF
--- a/src/hooks/usePools.ts
+++ b/src/hooks/usePools.ts
@@ -106,9 +106,9 @@ export function usePools(
       const [token0, token1, fee] = tokens
 
       if (!slot0s[index]) return [PoolState.INVALID, null]
-      if (!liquidities[index]) return [PoolState.INVALID, null]
-
       const { result: slot0, loading: slot0Loading, valid: slot0Valid } = slot0s[index]
+
+      if (!liquidities[index]) return [PoolState.INVALID, null]
       const { result: liquidity, loading: liquidityLoading, valid: liquidityValid } = liquidities[index]
 
       if (!tokens || !slot0Valid || !liquidityValid) return [PoolState.INVALID, null]

--- a/src/hooks/usePools.ts
+++ b/src/hooks/usePools.ts
@@ -105,17 +105,11 @@ export function usePools(
       if (!tokens) return [PoolState.INVALID, null]
       const [token0, token1, fee] = tokens
 
-      const {
-        result: slot0,
-        loading: slot0Loading,
-        valid: slot0Valid,
-      } = slot0s[index] ?? { result: undefined, loading: false, valid: false }
+      if (!slot0s[index]) return [PoolState.INVALID, null]
+      if (!liquidities[index]) return [PoolState.INVALID, null]
 
-      const {
-        result: liquidity,
-        loading: liquidityLoading,
-        valid: liquidityValid,
-      } = liquidities[index] ?? { result: undefined, loading: false, valid: false }
+      const { result: slot0, loading: slot0Loading, valid: slot0Valid } = slot0s[index]
+      const { result: liquidity, loading: liquidityLoading, valid: liquidityValid } = liquidities[index]
 
       if (!tokens || !slot0Valid || !liquidityValid) return [PoolState.INVALID, null]
       if (slot0Loading || liquidityLoading) return [PoolState.LOADING, null]

--- a/src/hooks/usePools.ts
+++ b/src/hooks/usePools.ts
@@ -105,8 +105,18 @@ export function usePools(
       if (!tokens) return [PoolState.INVALID, null]
       const [token0, token1, fee] = tokens
 
-      const { result: slot0, loading: slot0Loading, valid: slot0Valid } = slot0s[index]
-      const { result: liquidity, loading: liquidityLoading, valid: liquidityValid } = liquidities[index]
+      const {
+        result: slot0,
+        loading: slot0Loading,
+        valid: slot0Valid,
+      } = slot0s[index] ?? { result: undefined, loading: false, valid: false }
+
+      const {
+        result: liquidity,
+        loading: liquidityLoading,
+        valid: liquidityValid,
+      } = liquidities[index] ?? { result: undefined, loading: false, valid: false }
+
       if (!tokens || !slot0Valid || !liquidityValid) return [PoolState.INVALID, null]
       if (slot0Loading || liquidityLoading) return [PoolState.LOADING, null]
       if (!slot0 || !liquidity) return [PoolState.NOT_EXISTS, null]


### PR DESCRIPTION
- in `usePools` an error can surface when network is changed to an unsupported network 
- in the widget, on unsupported networks `slot0s` and `liquidities` will be empty arrays
- this fix adds a check that the element in the result array exists before attempting to reference it

- may fix notion issue [here ](https://www.notion.so/uniswaplabs/Widgets-UI-Polish-a7c6d4ece6124d4cb96e9be926e9e67f?p=7f1c80a961fd4e19a528ed46fc6afc8a)