### PR TITLE
fix: fallback to eth_accounts in eip1193 bridge

### DIFF
--- a/src/lib/hooks/useEip1193Provider.ts
+++ b/src/lib/hooks/useEip1193Provider.ts
@@ -16,6 +16,12 @@ class Eip1193Bridge extends ExperimentalEip1193Bridge {
         const result = await this.provider.getNetwork()
         return '0x' + result.chainId.toString(16)
       }
+      case 'eth_requestAccounts':
+        try {
+          return await super.send(method, params)
+        } catch (e) {
+          return this.send('eth_accounts')
+        }
       case 'eth_sendTransaction': {
         if (!this.signer) break
 


### PR DESCRIPTION
Allows providers to be passed that do not implement eth_requestAccounts, which is required to use web3-react [1].

An alternative solution would be to have web3-react fallback to using eth_accounts if eth_requestAccounts is not implemented. To be clear - I'm unsure if this is a failing of the provider for not supporting this, of the Eip1193Bridge for not polyfilling this, or of web3-react for not falling back to eth_accounts. @NoahZinsmeister - what would you advise?

This issue came up when trying to integrate a walletconnect provider through web3modal. It lacked eth_requestAccounts.

[1]: https://github.com/NoahZinsmeister/web3-react/blob/main/packages/eip1193/src/index.ts#L67