### PR TITLE
fix: token img overflow

### DIFF
--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -24,7 +24,12 @@ const TokenButtonRow = styled(Row)<{ collapsed: boolean }>`
   height: 1.2em;
   // max-width must have an absolute value in order to transition.
   max-width: ${({ collapsed }) => (collapsed ? '1.2em' : '12em')};
+  overflow: hidden;
   transition: max-width 0.25s linear;
+
+  img {
+    min-width: 1.2em;
+  }
 `
 
 interface TokenButtonProps {


### PR DESCRIPTION
- reverts #3504, with the addition of overflow-x to avoid token button overflow
- adds a min-width to TokenButtonRow img so that the image will not be collapsed when the row shrinks

Fixes https://www.notion.so/uniswaplabs/Fix-token-icon-when-max-is-shown-see-x-roll-0df8f9152db048c1a852cd8af75dceeb