### PR TITLE
fix: typeError: Cannot read properties of undefined (reading 'split')

### DIFF
--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -269,7 +269,7 @@ export function useAllProposalData(): { data: ProposalData[]; loading: boolean }
       data: proposalsCallData.map((proposal, i) => {
         const startBlock = parseInt(proposal?.result?.startBlock?.toString())
 
-        let description = formattedLogs.length ? formattedLogs[i]?.description : ''
+        let description = formattedLogs[i]?.description ?? ''
         if (startBlock === UNISWAP_GRANTS_START_BLOCK) {
           description = UNISWAP_GRANTS_PROPOSAL_DESCRIPTION
         }

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -269,7 +269,7 @@ export function useAllProposalData(): { data: ProposalData[]; loading: boolean }
       data: proposalsCallData.map((proposal, i) => {
         const startBlock = parseInt(proposal?.result?.startBlock?.toString())
 
-        let description = formattedLogs[i]?.description
+        let description = formattedLogs.length ? formattedLogs[i]?.description : ''
         if (startBlock === UNISWAP_GRANTS_START_BLOCK) {
           description = UNISWAP_GRANTS_PROPOSAL_DESCRIPTION
         }


### PR DESCRIPTION
fixes #3506 
fixes #3501 
fixes #3494 
fixes #3490 
fixes #3489 
fixes #3473 
fixes #3521 
fixes #3522 
fixes #3533 
fixes #3534 