### PR TITLE
feat: block cache

### DIFF
--- a/src/hooks/useUSDCPrice.ts
+++ b/src/hooks/useUSDCPrice.ts
@@ -1,7 +1,9 @@
 import { Currency, CurrencyAmount, Price, Token, TradeType } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import useBlockCache, { ShouldUpdate } from 'lib/hooks/useBlockCache'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useMemo } from 'react'
+import { currencyId } from 'utils/currencyId'
 
 import { SupportedChainId } from '../constants/chains'
 import { DAI_OPTIMISM, USDC_ARBITRUM, USDC_MAINNET, USDC_POLYGON } from '../constants/tokens'
@@ -18,42 +20,58 @@ export const STABLECOIN_AMOUNT_OUT: { [chainId: number]: CurrencyAmount<Token> }
 }
 
 /**
+ * Caches USDC prices so that they are only fetched once per currency per block.
+ * This prevents multiple calls to determine a currency's USDC price, an expensive operation.
+ *
+ * useUSDCPrice is used throughout the component tree, and is thus called multiple times and not
+ * memoized between them, which can lead to 100+ms blocking delays when prices update.
+ *
+ * Rather than try to move all usage to a top level (so that useMemo would appropriately cache), a
+ * cache external to React allows each currency to be fetched exactly once per block, and limits
+ * blocking time to the first call.
+ */
+const usdcPriceCache = new Map<string, Price<Currency, Token>>()
+
+/**
  * Returns the price in USDC of the input currency
  * @param currency currency to compute the USDC price of
  */
 export default function useUSDCPrice(currency?: Currency): Price<Currency, Token> | undefined {
-  const chainId = currency?.chainId
+  const amountSpecified = currency?.chainId ? STABLECOIN_AMOUNT_OUT[currency.chainId] : undefined
+  const stablecoin = amountSpecified?.currency
 
-  const amountOut = chainId ? STABLECOIN_AMOUNT_OUT[chainId] : undefined
-  const stablecoin = amountOut?.currency
+  const key = currency && currencyId(currency)
+  const [cachedPrice, setCachedPrice] = useBlockCache(usdcPriceCache, key)
+  const otherCurrency = useMemo(() => (cachedPrice === ShouldUpdate ? currency : undefined), [cachedPrice, currency])
 
-  // TODO(#2808): remove dependency on useBestV2Trade
-  const v2USDCTrade = useBestV2Trade(TradeType.EXACT_OUTPUT, amountOut, currency, {
-    maxHops: 2,
-  })
-  const v3USDCTrade = useClientSideV3Trade(TradeType.EXACT_OUTPUT, amountOut, currency)
+  const v2Trade = useBestV2Trade(TradeType.EXACT_OUTPUT, amountSpecified, otherCurrency, { maxHops: 2 })
+  const { trade: v3Trade } = useClientSideV3Trade(TradeType.EXACT_OUTPUT, amountSpecified, otherCurrency)
 
   return useMemo(() => {
-    if (!currency || !stablecoin) {
-      return undefined
+    if (cachedPrice === ShouldUpdate) {
+      const price = computePrice()
+      if (price) setCachedPrice(price)
+      return price
     }
+    return cachedPrice
 
-    // handle usdc
-    if (currency?.wrapped.equals(stablecoin)) {
-      return new Price(stablecoin, stablecoin, '1', '1')
+    function computePrice(): Price<Currency, Token> | undefined {
+      if (!currency || !stablecoin) return
+
+      // If currency is the stablecoin, return the stable price.
+      if (currency.wrapped.equals(stablecoin)) return new Price(stablecoin, stablecoin, '1', '1')
+
+      // Use v2 price if available, and fallback to v3.
+      const route = v2Trade?.route || v3Trade?.routes[0]
+      if (route) {
+        const { numerator, denominator } = route.midPrice
+        const price = new Price(currency, stablecoin, denominator, numerator)
+        return price
+      }
+
+      return
     }
-
-    // use v2 price if available, v3 as fallback
-    if (v2USDCTrade) {
-      const { numerator, denominator } = v2USDCTrade.route.midPrice
-      return new Price(currency, stablecoin, denominator, numerator)
-    } else if (v3USDCTrade.trade) {
-      const { numerator, denominator } = v3USDCTrade.trade.routes[0].midPrice
-      return new Price(currency, stablecoin, denominator, numerator)
-    }
-
-    return undefined
-  }, [currency, stablecoin, v2USDCTrade, v3USDCTrade.trade])
+  }, [cachedPrice, currency, setCachedPrice, stablecoin, v2Trade?.route, v3Trade?.routes])
 }
 
 export function useUSDCValue(currencyAmount: CurrencyAmount<Currency> | undefined | null) {

--- a/src/lib/hooks/useBlockCache.ts
+++ b/src/lib/hooks/useBlockCache.ts
@@ -1,0 +1,94 @@
+import useBlockNumber from 'lib/hooks/useBlockNumber'
+import { useCallback, useEffect, useState } from 'react'
+
+export const ShouldUpdate = Symbol()
+
+// Denotes a cache entry that is pending data, so that other nodes do not re-fetch the same data.
+const Pending = Symbol()
+
+// The current block being cached by subscribers to useBlockCache.
+let cacheBlock: number | undefined = undefined
+
+/**
+ * Configures leader/followers for a block-scoped cache (ie a cache that clears every block).
+ *
+ * This is useful for data-fetching hooks which are called multiple times or are called throughout
+ * the component tree with the same key. It enforces that data is fetched only once, and can be
+ * shared across the component tree without being re-fetched. This can be seen as a lightweight,
+ * web3-specific alternative to eg rtk-query, or an analog to useMemo (as it memoizes across the
+ * component tree, whereas useMemo works within a single component).
+ *
+ * Returns [cachedValue, setCachedValue]. If (cachedValue === ShouldUpdate), the caller should fetch
+ * data, update the cache using setCachedValue, and return the fetched data. Otherwise, the caller
+ * should _not_ fetch data, and just return the cachedValue.
+ *
+ * NB: setCachedValue may only be called once per block, so do not set intermediate values.
+ *
+ *     const cache = new Map<string, object>()
+ *
+ *     function useFetchData() {
+ *       const key = useGetDataKey()
+ *       const [cachedValue, setCachedValue] = useBlockCache(cache, key)
+ *
+ *       // Only fetch data if (cachedValue === ShouldUpdate).
+ *       const data = useFetchData(cachedValue === ShouldUpdate ? key : undefined)
+ *       return useMemo(() => {
+ *         if (cachedValue === ShouldUpdate) {
+ *           setCachedValue(data)
+ *           return data
+ *         }
+ *         return cachedValue
+ *       })
+ *     }
+ */
+export default function useBlockCache<V>(
+  cache?: Map<string, V | typeof Pending>,
+  key?: string
+): [V | undefined | typeof ShouldUpdate, (update: V) => void] {
+  const block = useBlockNumber()
+  const [updatingBlock, setUpdatingBlock] = useState<number | false>(false)
+
+  useEffect(() => {
+    // Clears the cache with every new block.
+    if (block !== cacheBlock) {
+      cacheBlock = block
+      cache?.clear()
+    }
+    // At this point, block is synced with cacheBlock.
+
+    // Claims a key to update. cache.has(key) tracks whether this key is already owned.
+    if (block && key && cache && !cache.has(key)) {
+      cache?.set(key, Pending)
+      setUpdatingBlock(block)
+    }
+
+    // Unclaims a key (when switching keys or unmounting) if it has not yet been written this block.
+    return () => {
+      if (updatingBlock === cacheBlock && key && !cache?.get(key)) {
+        cache?.delete(key)
+        setUpdatingBlock(false)
+      }
+    }
+  }, [block, cache, key, updatingBlock])
+
+  // Grab the value outside of a hook to force a re-render when it is updated.
+  const cacheValue = key ? cache?.get(key) : undefined
+  const isPending = cacheValue === Pending
+  const value = isPending ? undefined : cacheValue
+
+  // Only return ShouldUpdate if a this hook has claimed the key this block, and it is still pending.
+  const shouldUpdate = updatingBlock === cacheBlock && isPending
+
+  const setValue = useCallback(
+    (update: V) => {
+      if (!shouldUpdate) {
+        throw new Error('The block cache value may only be set if ShouldUpdate is returned')
+      }
+      if (key) {
+        cache?.set(key, update)
+      }
+    },
+    [cache, key, shouldUpdate]
+  )
+  return [shouldUpdate ? ShouldUpdate : value, setValue]
+}

--- a/src/lib/hooks/useBlockCache.ts
+++ b/src/lib/hooks/useBlockCache.ts
@@ -1,3 +1,4 @@
+import useCurrentBlockTimestamp from 'hooks/useCurrentBlockTimestamp'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -6,8 +7,21 @@ export const ShouldUpdate = Symbol()
 // Denotes a cache entry that is pending data, so that other nodes do not re-fetch the same data.
 const Pending = Symbol()
 
-// The current block being cached by subscribers to useBlockCache.
-let cacheBlock: number | undefined = undefined
+// The current block being cached by subscribers to useBlockCache, for a specific cache.
+const blockCache =
+  typeof WeakMap !== 'undefined'
+    ? new WeakMap<
+        Map<string, unknown>,
+        {
+          block: number
+          timestamp: number
+        }
+      >()
+    : null
+
+// The TTL between blocks, in seconds.
+// This is necessary for L2, where the cache would otherwise clear too frequently to be usable.
+const BLOCK_CACHE_TTL = 30
 
 /**
  * Configures leader/followers for a block-scoped cache (ie a cache that clears every block).
@@ -45,39 +59,44 @@ export default function useBlockCache<V>(
   cache?: Map<string, V | typeof Pending>,
   key?: string
 ): [V | undefined | typeof ShouldUpdate, (update: V) => void] {
-  const block = useBlockNumber()
-  const [updatingBlock, setUpdatingBlock] = useState<number | false>(false)
+  const block = useBlockNumber() ?? 0
+  const timestamp = useCurrentBlockTimestamp()?.toNumber() ?? 0
+  const [cachingBlock, setCachingBlock] = useState<number | false>(false)
 
   useEffect(() => {
-    // Clears the cache with every new block.
-    if (block !== cacheBlock) {
-      cacheBlock = block
-      cache?.clear()
-    }
-    // At this point, block is synced with cacheBlock.
+    const { block: cacheBlock = 0, timestamp: cacheTimestamp = 0 } = (cache && blockCache?.get(cache)) ?? {}
 
-    // Claims a key to update. cache.has(key) tracks whether this key is already owned.
-    if (block && key && cache && !cache.has(key)) {
+    // Clears the cache if there is a new block at least 15s fresher for this cache
+    // (uses Math.abs to compute the difference in case we are on a different chain).
+    if (cache && block !== cacheBlock && Math.abs(timestamp - cacheTimestamp) > BLOCK_CACHE_TTL) {
+      blockCache?.set(cache, { block, timestamp })
+      cache?.clear()
+      return
+    }
+
+    // Claims a key to update. cache.has(key) tracks whether this key is already owned for this block.
+    if (cacheBlock && key && cache && !cache.has(key)) {
       cache?.set(key, Pending)
-      setUpdatingBlock(block)
+      setCachingBlock(cacheBlock)
     }
 
     // Unclaims a key (when switching keys or unmounting) if it has not yet been written this block.
     return () => {
-      if (updatingBlock === cacheBlock && key && !cache?.get(key)) {
+      if (cachingBlock === cacheBlock && key && cache?.get(key) === Pending) {
         cache?.delete(key)
-        setUpdatingBlock(false)
+        setCachingBlock(false)
       }
     }
-  }, [block, cache, key, updatingBlock])
+  }, [block, cache, key, cachingBlock, timestamp])
 
-  // Grab the value outside of a hook to force a re-render when it is updated.
   const cacheValue = key ? cache?.get(key) : undefined
   const isPending = cacheValue === Pending
   const value = isPending ? undefined : cacheValue
 
   // Only return ShouldUpdate if a this hook has claimed the key this block, and it is still pending.
-  const shouldUpdate = updatingBlock === cacheBlock && isPending
+  // NB: If WeakMap is not supported, this becomes a nop by setting shouldUpdate = true.
+  const { block: cacheBlock = 0 } = (cache && blockCache?.get(cache)) ?? {}
+  const shouldUpdate = !blockCache || (cachingBlock === cacheBlock && isPending)
 
   const setValue = useCallback(
     (update: V) => {
@@ -90,5 +109,6 @@ export default function useBlockCache<V>(
     },
     [cache, key, shouldUpdate]
   )
+
   return [shouldUpdate ? ShouldUpdate : value, setValue]
 }


### PR DESCRIPTION
Adds a hook for block-level cache coordination. This allows expensive data fetches to be performed only once per block (using an arbitrary key).

In code, this allows useUSDCPrice to return cached values, and getClientSideQuote (a network call) to re-use the same response, instead of re-fetching every render loop until resolved.

Practically, this means that requests that are abandoned will still be cached, so a user can go to previously seen screens with little to no latency. Eg a user can click the "reverse button" and both trades will remain populated, instead of refetching; or a user can type in "1", "12", "123", and as they delete, the results for "12", "1" will still be available.