### PR TITLE
fix: disable swap button if trade not populated

### DIFF
--- a/src/lib/components/Swap/SwapButton.tsx
+++ b/src/lib/components/Swap/SwapButton.tsx
@@ -94,13 +94,24 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
   const disableSwap = useMemo(
     () =>
       disabled ||
+      !optimizedTrade ||
       !chainId ||
       wrapLoading ||
       (wrapType !== WrapType.NOT_APPLICABLE && wrapError) ||
       approvalState === ApproveOrPermitState.PENDING_SIGNATURE ||
       !(inputTradeCurrencyAmount && inputCurrencyBalance) ||
       inputCurrencyBalance.lessThan(inputTradeCurrencyAmount),
-    [disabled, chainId, wrapLoading, wrapType, wrapError, approvalState, inputTradeCurrencyAmount, inputCurrencyBalance]
+    [
+      disabled,
+      optimizedTrade,
+      chainId,
+      wrapLoading,
+      wrapType,
+      wrapError,
+      approvalState,
+      inputTradeCurrencyAmount,
+      inputCurrencyBalance,
+    ]
   )
 
   const actionProps = useMemo((): Partial<ActionButtonProps> | undefined => {


### PR DESCRIPTION
- Fixes [this](https://www.notion.so/uniswaplabs/Widgets-UI-Polish-a7c6d4ece6124d4cb96e9be926e9e67f?p=a5ff30539c2844d6b4fa46f67f6a64ef)
- currenlty the swap button is enabled even if `trade`is undefined