### PR TITLE
fix: summary expando height

### DIFF
--- a/src/lib/components/Swap/Summary/index.tsx
+++ b/src/lib/components/Swap/Summary/index.tsx
@@ -161,7 +161,7 @@ export function SummaryDialog({ trade, slippage, inputUSDC, outputUSDC, impact, 
             title={<Subhead priceImpact={impact} slippage={slippage} />}
             open={open}
             onExpand={onExpand}
-            height={7.25}
+            height={7}
           >
             <Details trade={trade} slippage={slippage} priceImpact={impact} />
           </Expando>


### PR DESCRIPTION
Update the expando absolute height to not overflow the dialog, fixing the [grey bar](https://www.notion.so/uniswaplabs/safari-seeing-the-bottom-gray-bar-again-c9a8a5931db741ed8edc80f50ce71b82).

This will not work until https://github.com/Uniswap/interface/pull/3553 is merged, as rendering the price impact currently crashes the widget.