### PR TITLE
fix: summary expando height

### DIFF
--- a/src/lib/components/Swap/Summary/index.tsx
+++ b/src/lib/components/Swap/Summary/index.tsx
@@ -161,7 +161,7 @@ export function SummaryDialog({ trade, slippage, inputUSDC, outputUSDC, impact, 
             title={<Subhead priceImpact={impact} slippage={slippage} />}
             open={open}
             onExpand={onExpand}
-            height={7.25}
+            height={7}
           >
             <Details trade={trade} slippage={slippage} priceImpact={impact} />
           </Expando>


### PR DESCRIPTION
Fixes [grey bar at bottom of expando](https://www.notion.so/uniswaplabs/Grey-bar-appears-at-bottom-of-scrollable-expando-on-Safari-1b4f2d065fd0423f98ab798fdc02fe7a).

Reviewer: please verify that you can see the grey bar on main, and that this PR actually fixes it.