### PR TITLE
fix: prevent scroll on token select focus

### DIFF
--- a/src/lib/components/TokenSelect/index.tsx
+++ b/src/lib/components/TokenSelect/index.tsx
@@ -68,7 +68,7 @@ export function TokenSelectDialog({ value, onSelect }: TokenSelectDialogProps) {
   const baseTokens: Currency[] = [] // TODO(zzmp): Add base tokens to token list functionality
 
   const input = useRef<HTMLInputElement>(null)
-  useEffect(() => input.current?.focus(), [input])
+  useEffect(() => input.current?.focus({ preventScroll: true }), [input])
 
   const [options, setOptions] = useState<ElementRef<typeof TokenOptions> | null>(null)
 


### PR DESCRIPTION
Fixes [jank when mounting TokenSelect](https://www.notion.so/uniswaplabs/safari-Token-selector-animation-wonky-551d5757740d42d990eec081b4ae7cdf) caused by WebKit scrolling the focused element (the search bar) into view during the Dialog mounting animation.