### PR TITLE
fix: token img jank

### DIFF
--- a/src/lib/components/TokenImg.tsx
+++ b/src/lib/components/TokenImg.tsx
@@ -3,7 +3,7 @@ import { useToken } from 'lib/hooks/useCurrency'
 import useCurrencyLogoURIs from 'lib/hooks/useCurrencyLogoURIs'
 import { MissingToken } from 'lib/icons'
 import styled from 'lib/theme'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 const badSrcs = new Set<string>()
 
@@ -18,19 +18,23 @@ function TokenImg({ token, ...rest }: TokenImgProps) {
   const tokenInfo = useToken(token.isToken ? token.wrapped.address : undefined) ?? token
 
   const srcs = useCurrencyLogoURIs(tokenInfo)
-  const [src, setSrc] = useState<string | undefined>()
-  useEffect(() => {
-    setSrc(srcs.find((src) => !badSrcs.has(src)))
-  }, [srcs])
-  const onError = useCallback(() => {
-    if (src) badSrcs.add(src)
-    setSrc(srcs.find((src) => !badSrcs.has(src)))
-  }, [src, srcs])
 
-  if (src) {
-    return <img src={src} alt={tokenInfo.name || tokenInfo.symbol} onError={onError} {...rest} />
-  }
-  return <MissingToken color="secondary" {...rest} />
+  const [attempt, setAttempt] = useState(0)
+  const onError = useCallback((e) => {
+    if (e.target.src) badSrcs.add(e.target.src)
+    setAttempt((attempt) => ++attempt)
+  }, [])
+
+  return useMemo(() => {
+    // Trigger a re-render when an error occurs.
+    void attempt
+
+    const src = srcs.find((src) => !badSrcs.has(src))
+    if (!src) return <MissingToken color="secondary" {...rest} />
+
+    const alt = tokenInfo.name || tokenInfo.symbol
+    return <img src={src} alt={alt} key={alt} onError={onError} {...rest} />
+  }, [attempt, onError, rest, srcs, tokenInfo.name, tokenInfo.symbol])
 }
 
 export default styled(TokenImg)<{ size?: number }>`


### PR DESCRIPTION
Re-render the token image when it changes by setting the alt as a key. This prevents rendering the stale image for a frame while the new image loads.

Alternatively, the currencyId could be used as a key, but it likely should not be re-rendered across chains with different addresses for the same currency name, so alt seems more appropriate.

The issue can be seen in this screencap. This can be reproduced by opening DevTools and disabling the cache.

https://user-images.githubusercontent.com/5403956/159192131-79f9bba9-9cb3-4baf-ae34-ac82143c9f8b.mov