### PR TITLE
fix: trade UI latency

### DIFF
--- a/src/lib/components/Input.tsx
+++ b/src/lib/components/Input.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'lib/theme'
-import { forwardRef, HTMLProps, useCallback, useEffect, useState } from 'react'
+import { forwardRef, HTMLProps, useCallback } from 'react'
 
 const Input = styled.input`
   -webkit-appearance: textfield;
@@ -76,46 +76,23 @@ interface EnforcedNumericInputProps extends NumericInputProps {
   enforcer: (nextUserInput: string) => string | null
 }
 
-function isNumericallyEqual(a: string, b: string) {
-  const [aInteger, aDecimal] = toParts(a)
-  const [bInteger, bDecimal] = toParts(b)
-  return aInteger === bInteger && aDecimal === bDecimal
-
-  function toParts(num: string) {
-    let [integer, decimal] = num.split('.')
-    integer = integer?.match(/([1-9]\d*)/)?.[1] || ''
-    decimal = decimal?.match(/(\d*[1-9])/)?.[1] || ''
-    return [integer, decimal]
-  }
-}
-
 const NumericInput = forwardRef<HTMLInputElement, EnforcedNumericInputProps>(function NumericInput(
   { value, onChange, enforcer, pattern, ...props }: EnforcedNumericInputProps,
   ref
 ) {
-  const [state, setState] = useState(value ?? '')
-  useEffect(() => {
-    if (!isNumericallyEqual(state, value)) {
-      setState(value ?? '')
-    }
-  }, [value, state, setState])
-
   const validateChange = useCallback(
     (event) => {
       const nextInput = enforcer(event.target.value.replace(/,/g, '.'))
       if (nextInput !== null) {
-        setState(nextInput ?? '')
-        if (!isNumericallyEqual(nextInput, value)) {
-          onChange(nextInput)
-        }
+        onChange(nextInput)
       }
     },
-    [value, onChange, enforcer]
+    [onChange, enforcer]
   )
 
   return (
     <Input
-      value={state}
+      value={value}
       onChange={validateChange}
       // universal input options
       inputMode="decimal"

--- a/src/lib/hooks/routing/useClientSideSmartOrderRouterTrade.ts
+++ b/src/lib/hooks/routing/useClientSideSmartOrderRouterTrade.ts
@@ -92,20 +92,17 @@ export default function useClientSideSmartOrderRouterTrade<TTradeType extends Tr
     [currencyIn, currencyOut, quoteResult, tradeType]
   )
   const gasUseEstimateUSD = useStablecoinAmountFromFiatValue(quoteResult?.gasUseEstimateUSD) ?? null
-  const trade =
-    useLast(
-      useMemo(() => {
-        if (route) {
-          try {
-            return route && transformRoutesToTrade(route, tradeType, gasUseEstimateUSD)
-          } catch (e: unknown) {
-            console.debug('transformRoutesToTrade failed: ', e)
-          }
-        }
-        return
-      }, [gasUseEstimateUSD, route, tradeType]),
-      Boolean
-    ) ?? undefined
+  const trade = useMemo(() => {
+    if (route) {
+      try {
+        return route && transformRoutesToTrade(route, tradeType, gasUseEstimateUSD)
+      } catch (e: unknown) {
+        console.debug('transformRoutesToTrade failed: ', e)
+      }
+    }
+    return
+  }, [gasUseEstimateUSD, route, tradeType])
+  const lastTrade = useLast(trade, Boolean) ?? undefined
 
   // Dont return old trade if currencies dont match.
   const isStale =
@@ -122,9 +119,9 @@ export default function useClientSideSmartOrderRouterTrade<TTradeType extends Tr
       if (isStale) {
         return { state: TradeState.LOADING, trade: undefined }
       } else if (isDebouncing) {
-        return { state: TradeState.SYNCING, trade }
+        return { state: TradeState.SYNCING, trade: lastTrade }
       } else if (isLoading) {
-        return { state: TradeState.LOADING, trade }
+        return { state: TradeState.LOADING, trade: lastTrade }
       }
     }
 
@@ -151,14 +148,15 @@ export default function useClientSideSmartOrderRouterTrade<TTradeType extends Tr
   }, [
     currencyIn,
     currencyOut,
-    error,
     quoteResult,
+    error,
     route,
     queryArgs,
     trade,
     isStale,
     isDebouncing,
     isLoading,
+    lastTrade,
     tradeType,
   ])
 }


### PR DESCRIPTION
Fixes remaining latency on trade loading UI.

- Fixes useClientSideSmartOrderRouterTrade to return _the trade_, unless it is unavailable, and _then_ return the last trade
  - This fixes a bug where the trade amount took an extra frame to render (visible when reversing currencies on already-loaded trades), because the _last trade_ was always returned first, until it was updated.
- Fixes Input to immediately render any changed value. The validation is removed, so that it now only occurs when the Input changes, not on the initial value that is set.
  - This fixes a bug where the Input would take a frame to update (visible when reversing currencies to a trade that was already loaded, but is no longer, in which case it would flash the old trade then update to 0).