### PR TITLE
fix: set approval to pending on wallet request

### DIFF
--- a/src/lib/components/ActionButton.tsx
+++ b/src/lib/components/ActionButton.tsx
@@ -57,7 +57,7 @@ export const Overlay = styled(Row)<{ hasAction: boolean }>`
 export interface Action {
   message: ReactNode
   icon?: Icon
-  onClick: () => void
+  onClick?: () => void
   children: ReactNode
 }
 

--- a/src/lib/components/EtherscanLink.tsx
+++ b/src/lib/components/EtherscanLink.tsx
@@ -26,10 +26,12 @@ export default function EtherscanLink({ data, type, color = 'currentColor', chil
     () => data && getExplorerLink(chainId || SupportedChainId.MAINNET, data, type),
     [chainId, data, type]
   )
+
   return (
     <StyledExternalLink href={url} color={color} target="_blank">
       <Row gap={0.25}>
-        {children} <Link />
+        {children}
+        {url && <Link />}
       </Row>
     </StyledExternalLink>
   )

--- a/src/lib/components/Swap/SwapButton.tsx
+++ b/src/lib/components/Swap/SwapButton.tsx
@@ -86,12 +86,11 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
   )
 
   const addTransaction = useAddTransaction()
-  const onApprove = useCallback(() => {
-    handleApproveOrPermit().then((transaction) => {
-      if (transaction) {
-        addTransaction({ type: TransactionType.APPROVAL, ...transaction })
-      }
-    })
+  const onApprove = useCallback(async () => {
+    const transaction = await handleApproveOrPermit()
+    if (transaction) {
+      addTransaction({ type: TransactionType.APPROVAL, ...transaction })
+    }
   }, [addTransaction, handleApproveOrPermit])
 
   const { type: wrapType, callback: wrapCallback, error: wrapError, loading: wrapLoading } = useWrapCallback()
@@ -103,7 +102,6 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       !chainId ||
       wrapLoading ||
       (wrapType !== WrapType.NOT_APPLICABLE && wrapError) ||
-      approvalState === ApproveOrPermitState.PENDING_SIGNATURE ||
       !(inputTradeCurrencyAmount && inputCurrencyBalance) ||
       inputCurrencyBalance.lessThan(inputTradeCurrencyAmount),
     [
@@ -113,7 +111,6 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       wrapLoading,
       wrapType,
       wrapError,
-      approvalState,
       inputTradeCurrencyAmount,
       inputCurrencyBalance,
     ]
@@ -154,8 +151,17 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
             </EtherscanLink>
           ),
           icon: Spinner,
-          onClick: () => void 0, // @TODO: should not require an onclick
           children: <Trans>Approve</Trans>,
+        },
+      }
+    }
+    if (approvalState === ApproveOrPermitState.PENDING_SIGNATURE) {
+      return {
+        disabled: true,
+        action: {
+          message: <Trans>Allowance pending</Trans>,
+          icon: Spinner,
+          children: <Trans>Allow</Trans>,
         },
       }
     }


### PR DESCRIPTION
Flips ApprovalState to pending as soon as a wallet interaction is requested, so that the interface does not look hung if the request is going to a mobile wallet. See [notion](https://www.notion.so/uniswaplabs/Wallet-connect-signing-states-88e49d02eb934a4597c7902f3e232a43) for more context.