### PR TITLE
fix: modal border radius

### DIFF
--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -60,7 +60,7 @@ const slideOut = keyframes`
 `
 
 const DialogWrapper = styled.div`
-  border-radius: ${({ theme }) => theme.borderRadius}em;
+  border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   height: calc(100% - 0.5em);
   left: 0;
   margin: 0.25em;


### PR DESCRIPTION
Fixes the border radius on the Dialog wrapper, which was cutting of modals on top of it.