### PR TITLE
fix: action button jank

### DIFF
--- a/src/lib/components/ActionButton.tsx
+++ b/src/lib/components/ActionButton.tsx
@@ -6,9 +6,9 @@ import Button from './Button'
 import Row from './Row'
 
 const StyledButton = styled(Button)`
-  border-radius: ${({ theme }) => theme.borderRadius}em;
+  border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   flex-grow: 1;
-  transition: background-color 0.25s ease-out, flex-grow 0.25s ease-out, padding 0.25s ease-out;
+  transition: background-color 0.25s ease-out, border-radius 0.25s ease-out, flex-grow 0.25s ease-out;
 
   :disabled {
     margin: -1px;
@@ -39,7 +39,7 @@ const actionCss = css`
   }
 
   ${StyledButton} {
-    border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
+    border-radius: ${({ theme }) => theme.borderRadius}em;
     flex-grow: 0;
     padding: 1em;
   }


### PR DESCRIPTION
Fixes the whole-widget height change when the action button's action transitions away, eg:

https://user-images.githubusercontent.com/5403956/159618009-bda33dae-0f05-4acc-87ef-0abcc0a413a5.mov

(See [notion](https://www.notion.so/uniswaplabs/Approvals-still-have-jank-d25a2f4dfe884d7fade2d2346f89fb0e) for more context.)