### PR TITLE
feat: prompt for interaction "in your wallet"

### DIFF
--- a/src/lib/components/ActionButton.tsx
+++ b/src/lib/components/ActionButton.tsx
@@ -5,10 +5,20 @@ import { ReactNode, useMemo } from 'react'
 import Button from './Button'
 import Row from './Row'
 
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`
+
 const StyledButton = styled(Button)`
+  animation: ${fadeIn} 0.25s ease-in;
   border-radius: ${({ theme }) => theme.borderRadius}em;
   flex-grow: 1;
-  transition: background-color 0.25s ease-out, flex-grow 0.25s ease-out, padding 0.25s ease-out;
+  transition: background-color 0.25s ease-out, flex-grow 0.25s ease-out, padding 0.25s ease-in;
 
   :disabled {
     margin: -1px;

--- a/src/lib/components/ActionButton.tsx
+++ b/src/lib/components/ActionButton.tsx
@@ -35,6 +35,8 @@ const actionCss = css`
 
   ${ActionRow} {
     animation: ${grow} 0.25s ease-in;
+    flex-grow: 1;
+    justify-content: flex-start;
     white-space: nowrap;
   }
 
@@ -58,7 +60,7 @@ export interface Action {
   message: ReactNode
   icon?: Icon
   onClick?: () => void
-  children: ReactNode
+  children?: ReactNode
 }
 
 export interface BaseProps {
@@ -72,11 +74,13 @@ export default function ActionButton({ color = 'accent', disabled, action, onCli
   const textColor = useMemo(() => (color === 'accent' && !disabled ? 'onAccent' : 'currentColor'), [color, disabled])
   return (
     <Overlay hasAction={Boolean(action)} flex align="stretch">
-      <StyledButton color={color} disabled={disabled} onClick={action ? action.onClick : onClick}>
-        <ThemedText.TransitionButton buttonSize={action ? 'medium' : 'large'} color={textColor}>
-          {action ? action.children : children}
-        </ThemedText.TransitionButton>
-      </StyledButton>
+      {(action ? action.onClick : true) && (
+        <StyledButton color={color} disabled={disabled} onClick={action?.onClick || onClick}>
+          <ThemedText.TransitionButton buttonSize={action ? 'medium' : 'large'} color={textColor}>
+            {action?.children || children}
+          </ThemedText.TransitionButton>
+        </StyledButton>
+      )}
       {action && (
         <ActionRow gap={0.5}>
           <LargeIcon color="currentColor" icon={action.icon || AlertTriangle} />

--- a/src/lib/components/Swap/Summary.fixture.tsx
+++ b/src/lib/components/Swap/Summary.fixture.tsx
@@ -41,7 +41,7 @@ function Fixture() {
   return trade ? (
     <Modal color="dialog">
       <SummaryDialog
-        onConfirm={() => void 0}
+        onConfirm={async () => void 0}
         trade={trade}
         slippage={slippage}
         inputUSDC={inputUSDC}

--- a/src/lib/components/Swap/Summary/index.tsx
+++ b/src/lib/components/Swap/Summary/index.tsx
@@ -11,7 +11,7 @@ import { Slippage } from 'lib/hooks/useSlippage'
 import { PriceImpact } from 'lib/hooks/useUSDCPriceImpact'
 import { AlertTriangle, BarChart, Info, Spinner } from 'lib/icons'
 import styled, { ThemedText } from 'lib/theme'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { tradeMeaningfullyDiffers } from 'utils/tradeMeaningFullyDiffer'
 
@@ -110,7 +110,6 @@ function ConfirmButton({
     await onConfirm()
     setIsPending(false)
   }, [onConfirm])
-  useEffect(() => setIsPending(false), [onClick])
 
   const action = useMemo((): Action | undefined => {
     if (isPending) {
@@ -133,7 +132,7 @@ function ConfirmButton({
   }, [ackPriceImpact, doesTradeDiffer, highPriceImpact, isPending, trade])
 
   return (
-    <ActionButton onClick={onConfirm} action={action}>
+    <ActionButton onClick={onClick} action={action}>
       <Trans>Confirm swap</Trans>
     </ActionButton>
   )

--- a/src/lib/components/Swap/SwapButton/index.tsx
+++ b/src/lib/components/Swap/SwapButton/index.tsx
@@ -8,6 +8,7 @@ import { useAddTransaction } from 'lib/hooks/transactions'
 import useActiveWeb3React from 'lib/hooks/useActiveWeb3React'
 import { useSetOldestValidBlock } from 'lib/hooks/useIsValidBlock'
 import useTransactionDeadline from 'lib/hooks/useTransactionDeadline'
+import { Spinner } from 'lib/icons'
 import { displayTxHashAtom, feeOptionsAtom, Field } from 'lib/state/swap'
 import { TransactionType } from 'lib/state/transactions'
 import { useTheme } from 'lib/theme'
@@ -66,7 +67,9 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
   const setDisplayTxHash = useUpdateAtom(displayTxHashAtom)
   const setOldestValidBlock = useSetOldestValidBlock()
 
+  const [isPending, setIsPending] = useState(false)
   const onWrap = useCallback(async () => {
+    setIsPending(true)
     try {
       const transaction = await wrapCallback?.()
       if (!transaction) return
@@ -82,7 +85,10 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       // TODO(zzmp): Surface errors from wrap.
       console.log(e)
     }
+    setIsPending(true)
   }, [addTransaction, chainId, setDisplayTxHash, wrapCallback, wrapType])
+  useEffect(() => setIsPending(false), [onWrap])
+
   const onSwap = useCallback(async () => {
     try {
       const transaction = await swapCallback?.()
@@ -124,9 +130,11 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
     } else if (wrapType === WrapType.NONE) {
       return approvalAction ? { action: approvalAction } : { onClick: () => setOpen(true) }
     } else {
-      return { onClick: onWrap }
+      return isPending
+        ? { action: { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner } }
+        : { onClick: onWrap }
     }
-  }, [approvalAction, disableSwap, onWrap, wrapType])
+  }, [approvalAction, disableSwap, isPending, onWrap, wrapType])
   const Label = useCallback(() => {
     switch (wrapType) {
       case WrapType.UNWRAP:

--- a/src/lib/components/Swap/SwapButton/index.tsx
+++ b/src/lib/components/Swap/SwapButton/index.tsx
@@ -46,7 +46,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
   const deadline = useTransactionDeadline()
 
   const { type: wrapType, callback: wrapCallback } = useWrapCallback()
-  const { approvalData, signatureData } = useApprovalData(optimizedTrade, slippage, inputCurrencyAmount)
+  const { approvalAction, signatureData } = useApprovalData(optimizedTrade, slippage, inputCurrencyAmount)
   const { callback: swapCallback } = useSwapCallback({
     trade: optimizedTrade,
     allowedSlippage: slippage.allowed,
@@ -122,11 +122,11 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
     if (disableSwap) {
       return { disabled: true }
     } else if (wrapType === WrapType.NONE) {
-      return approvalData || { onClick: () => setOpen(true) }
+      return approvalAction ? { action: approvalAction } : { onClick: () => setOpen(true) }
     } else {
       return { onClick: onWrap }
     }
-  }, [approvalData, disableSwap, onWrap, wrapType])
+  }, [approvalAction, disableSwap, onWrap, wrapType])
   const Label = useCallback(() => {
     switch (wrapType) {
       case WrapType.UNWRAP:

--- a/src/lib/components/Swap/SwapButton/useApprovalData.tsx
+++ b/src/lib/components/Swap/SwapButton/useApprovalData.tsx
@@ -42,7 +42,8 @@ export default function useApprovalData(
     }
     setIsPending(false)
   }, [addTransaction, handleApproveOrPermit])
-  useEffect(() => setIsPending(false), [onApprove])
+  // Reset the pending state if currency changes.
+  useEffect(() => setIsPending(false), [currency])
 
   const approvalHash = usePendingApproval(currency?.isToken ? currency : undefined, useSwapRouterAddress(trade))
   const approvalAction = useMemo((): Action | undefined => {

--- a/src/lib/components/Swap/SwapButton/useApprovalData.tsx
+++ b/src/lib/components/Swap/SwapButton/useApprovalData.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
-import { ActionButtonProps } from 'lib/components/ActionButton'
+import { Action } from 'lib/components/ActionButton'
 import EtherscanLink from 'lib/components/EtherscanLink'
 import {
   ApproveOrPermitState,
@@ -12,7 +12,7 @@ import { useAddTransaction, usePendingApproval } from 'lib/hooks/transactions'
 import { Slippage } from 'lib/hooks/useSlippage'
 import { Spinner } from 'lib/icons'
 import { TransactionType } from 'lib/state/transactions'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ExplorerDataType } from 'utils/getExplorerLink'
 
 export function useIsPendingApproval(token?: Token, spender?: string): boolean {
@@ -32,61 +32,56 @@ export default function useApprovalData(
     currencyAmount
   )
 
+  const [isPending, setIsPending] = useState(false)
   const addTransaction = useAddTransaction()
   const onApprove = useCallback(async () => {
+    setIsPending(true)
     const transaction = await handleApproveOrPermit()
     if (transaction) {
       addTransaction({ type: TransactionType.APPROVAL, ...transaction })
     }
+    setIsPending(false)
   }, [addTransaction, handleApproveOrPermit])
+  useEffect(() => setIsPending(false), [onApprove])
 
   const approvalHash = usePendingApproval(currency?.isToken ? currency : undefined, useSwapRouterAddress(trade))
-  const approvalData = useMemo((): Partial<ActionButtonProps> | undefined => {
+  const approvalAction = useMemo((): Action | undefined => {
     if (!trade || !currency) return
 
-    if (approvalState === ApproveOrPermitState.REQUIRES_APPROVAL) {
-      return {
-        action: {
+    switch (approvalState) {
+      case ApproveOrPermitState.REQUIRES_APPROVAL:
+        if (isPending) {
+          return { message: <Trans>Approve in your wallet</Trans>, icon: Spinner }
+        }
+        return {
           message: <Trans>Approve {currency.symbol} first</Trans>,
           onClick: onApprove,
           children: <Trans>Approve</Trans>,
-        },
-      }
-    } else if (approvalState === ApproveOrPermitState.REQUIRES_SIGNATURE) {
-      return {
-        action: {
+        }
+      case ApproveOrPermitState.REQUIRES_SIGNATURE:
+        if (isPending) {
+          return { message: <Trans>Allow in your wallet</Trans>, icon: Spinner }
+        }
+        return {
           message: <Trans>Allow {currency.symbol} first</Trans>,
           onClick: onApprove,
           children: <Trans>Allow</Trans>,
-        },
-      }
-    }
-    if (approvalState === ApproveOrPermitState.PENDING_APPROVAL) {
-      return {
-        disabled: true,
-        action: {
+        }
+      case ApproveOrPermitState.PENDING_APPROVAL:
+        return {
           message: (
             <EtherscanLink type={ExplorerDataType.TRANSACTION} data={approvalHash}>
               <Trans>Approval pending</Trans>
             </EtherscanLink>
           ),
           icon: Spinner,
-          children: <Trans>Approve</Trans>,
-        },
-      }
+        }
+      case ApproveOrPermitState.PENDING_SIGNATURE:
+        return { message: <Trans>Allowance pending</Trans>, icon: Spinner }
+      case ApproveOrPermitState.APPROVED:
+        return
     }
-    if (approvalState === ApproveOrPermitState.PENDING_SIGNATURE) {
-      return {
-        disabled: true,
-        action: {
-          message: <Trans>Allowance pending</Trans>,
-          icon: Spinner,
-          children: <Trans>Allow</Trans>,
-        },
-      }
-    }
-    return
-  }, [approvalHash, approvalState, currency, onApprove, trade])
+  }, [approvalHash, approvalState, currency, isPending, onApprove, trade])
 
-  return { approvalData, signatureData: signatureData ?? undefined }
+  return { approvalAction, signatureData: signatureData ?? undefined }
 }

--- a/src/lib/hooks/swap/useSwapApproval.ts
+++ b/src/lib/hooks/swap/useSwapApproval.ts
@@ -6,7 +6,7 @@ import { SWAP_ROUTER_ADDRESSES, V2_ROUTER_ADDRESS, V3_ROUTER_ADDRESS } from 'con
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useERC20PermitFromTrade, UseERC20PermitState } from 'hooks/useERC20Permit'
 import useTransactionDeadline from 'lib/hooks/useTransactionDeadline'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { getTxOptimizedSwapRouter, SwapRouterVersion } from 'utils/getTxOptimizedSwapRouter'
 
 import { ApprovalState, useApproval, useApprovalStateForSpender } from '../useApproval'
@@ -166,12 +166,8 @@ export const useApproveOrPermit = (
     gatherPermitSignature,
   } = useERC20PermitFromTrade(trade, allowedSlippage, deadline)
 
-  // Track when the interaction is blocked on a wallet so a PENDING state can be returned.
-  const [isPendingWallet, setIsPendingWallet] = useState(false)
-
   // If permit is supported, trigger a signature, if not create approval transaction.
   const handleApproveOrPermit = useCallback(async () => {
-    setIsPendingWallet(true)
     try {
       if (signatureState === UseERC20PermitState.NOT_SIGNED && gatherPermitSignature) {
         try {
@@ -187,8 +183,6 @@ export const useApproveOrPermit = (
       }
     } catch (e) {
       // Swallow approval errors - user rejections do not need to be displayed.
-    } finally {
-      setIsPendingWallet(false)
     }
   }, [signatureState, gatherPermitSignature, getApproval])
 
@@ -200,11 +194,11 @@ export const useApproveOrPermit = (
     } else if (approval !== ApprovalState.NOT_APPROVED || signatureState === UseERC20PermitState.SIGNED) {
       return ApproveOrPermitState.APPROVED
     } else if (gatherPermitSignature) {
-      return isPendingWallet ? ApproveOrPermitState.PENDING_SIGNATURE : ApproveOrPermitState.REQUIRES_SIGNATURE
+      return ApproveOrPermitState.REQUIRES_SIGNATURE
     } else {
-      return isPendingWallet ? ApproveOrPermitState.PENDING_APPROVAL : ApproveOrPermitState.REQUIRES_APPROVAL
+      return ApproveOrPermitState.REQUIRES_APPROVAL
     }
-  }, [approval, gatherPermitSignature, isPendingWallet, signatureState])
+  }, [approval, gatherPermitSignature, signatureState])
 
   return {
     approvalState,

--- a/src/lib/utils/animations.ts
+++ b/src/lib/utils/animations.ts
@@ -1,6 +1,6 @@
 import { RefObject } from 'react'
 
-export function isAnimating(node: HTMLElement) {
+export function isAnimating(node: Animatable | Document) {
   return (node.getAnimations().length ?? 0) > 0
 }
 


### PR DESCRIPTION
Prompts the user to complete an interaction (approve, permit, swap, wrap) "in your wallet". Spec'ed out in [notion](https://www.notion.so/uniswaplabs/Wallet-connect-signing-states-88e49d02eb934a4597c7902f3e232a43).

- Updates `ActionButton` to accomodate these prompting states.
- Updates logic for approval/swap/wrap to show these prompts.
  - Of note, adds `animationend` handlers in SwapButton/index.tsx for swap/wrap to avoid layout thrashing from `ActionButton` animations because of the large color difference between the prompt and the button. Specifically, delays the button from reappearing if it will then be immediately covered by a status dialog.