### PR TITLE
fix: add web3 debug log

### DIFF
--- a/src/lib/hooks/useActiveWeb3React.tsx
+++ b/src/lib/hooks/useActiveWeb3React.tsx
@@ -59,5 +59,13 @@ export function Web3Provider({ provider, jsonRpcEndpoint, children }: PropsWithC
     setWeb3(priorityWeb3React)
   }, [priorityWeb3React, setWeb3])
 
+  // Log web3 errors to facilitate debugging.
+  const error = priorityConnector.usePriorityError()
+  useEffect(() => {
+    if (error) {
+      console.error('web3 error:', error)
+    }
+  }, [error])
+
   return <>{children}</>
 }


### PR DESCRIPTION
Logs any web3-react errors to the console. These errors were silent before, and made it difficult to debug EIP-1193 incompatibilities.