### PR TITLE
fix: upgrade @web3-react/eip1193 usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "@uniswap/v2-sdk": "^3.0.1",
     "@uniswap/v3-sdk": "^3.8.2",
     "@web3-react/core": "8.0.17-beta.0",
-    "@web3-react/eip1193": "8.0.12-beta.0",
+    "@web3-react/eip1193": "8.0.15-beta.0",
     "@web3-react/empty": "8.0.10-beta.0",
     "@web3-react/types": "8.0.10-beta.0",
     "@web3-react/url": "8.0.12-beta.0",

--- a/src/lib/hooks/useEip1193Provider.ts
+++ b/src/lib/hooks/useEip1193Provider.ts
@@ -16,12 +16,6 @@ class Eip1193Bridge extends ExperimentalEip1193Bridge {
         const result = await this.provider.getNetwork()
         return '0x' + result.chainId.toString(16)
       }
-      case 'eth_requestAccounts':
-        try {
-          return await super.send(method, params)
-        } catch (e) {
-          return this.send('eth_accounts')
-        }
       case 'eth_sendTransaction': {
         if (!this.signer) break
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5348,10 +5348,10 @@
   optionalDependencies:
     "@ethersproject/providers" "^5.5.1"
 
-"@web3-react/eip1193@8.0.12-beta.0":
-  version "8.0.12-beta.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/eip1193/-/eip1193-8.0.12-beta.0.tgz#07aae52dd1b10870b29889499d9854b7e81322ee"
-  integrity sha512-Euj/JL3S3V4BuBI9qe/DdcviQ3VK+PItcdmyn/cdieaejiRUfgGj7Nqa3uhvlD98zvzeoGKBX5mzU10gvx7PGQ==
+"@web3-react/eip1193@8.0.15-beta.0":
+  version "8.0.15-beta.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/eip1193/-/eip1193-8.0.15-beta.0.tgz#38fa4fa1cf61231d043a77db8151bc01c075931f"
+  integrity sha512-Ch69TGwJgyGTXr/nepCSLhd9Ime1cCaPmz+1oBQMn109NzOCWn8wOFbFwNojyh+e80zWq2WiaIs2NqiZVzUJPA==
   dependencies:
     "@web3-react/types" "^8.0.10-beta.0"
 


### PR DESCRIPTION
Upgrades @web3-react/eip1193 to a version that only requires an EIP1193 provider. Prior versions relied on eth_requestAccounts, specified in EIP1102.

For more context, see [the web3-react issue](https://github.com/NoahZinsmeister/web3-react/issues/469), [our past workaround](https://github.com/Uniswap/interface/pull/3516), or the [issue tracking notion card](https://www.notion.so/uniswaplabs/WalletConnect-rainbow-unable-to-connect-to-widget-5f0bcad9a1b442248890af336a9c51d9).