### PR TITLE
feat: Added lido steth wrap/unwrap functionality

### DIFF
--- a/src/abis/wsteth.json
+++ b/src/abis/wsteth.json
@@ -1,0 +1,202 @@
+[
+  {
+    "inputs": [{ "internalType": "contract IStETH", "name": "_stETH", "type": "address" }],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_wstETHAmount", "type": "uint256" }],
+    "name": "getStETHByWstETH",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_stETHAmount", "type": "uint256" }],
+    "name": "getWstETHByStETH",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "nonces",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stETH",
+    "outputs": [{ "internalType": "contract IStETH", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stEthPerToken",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokensPerStEth",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_wstETHAmount", "type": "uint256" }],
+    "name": "unwrap",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_stETHAmount", "type": "uint256" }],
+    "name": "wrap",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/src/components/AccountDetails/TransactionSummary.tsx
+++ b/src/components/AccountDetails/TransactionSummary.tsx
@@ -131,7 +131,11 @@ function DelegateSummary({ info: { delegatee } }: { info: DelegateTransactionInf
   return <Trans>Delegate voting power to {ENSName ?? delegatee}</Trans>
 }
 
-function WrapSummary({ info: { chainId, currencyAmountRaw, unwrapped } }: { info: WrapTransactionInfo }) {
+function WrapSummary({
+  info: { chainId, currencyAmountRaw, unwrapped, unwrappedTokenSymbol, wrappedTokenSymbol },
+}: {
+  info: WrapTransactionInfo
+}) {
   const native = chainId ? nativeOnChain(chainId) : undefined
 
   if (unwrapped) {
@@ -140,11 +144,11 @@ function WrapSummary({ info: { chainId, currencyAmountRaw, unwrapped } }: { info
         Unwrap{' '}
         <FormattedCurrencyAmount
           rawAmount={currencyAmountRaw}
-          symbol={native?.wrapped?.symbol ?? 'WETH'}
+          symbol={wrappedTokenSymbol ?? native?.wrapped?.symbol ?? 'WETH'}
           decimals={18}
           sigFigs={6}
         />{' '}
-        to {native?.symbol ?? 'ETH'}
+        to {unwrappedTokenSymbol ?? native?.symbol ?? 'ETH'}
       </Trans>
     )
   } else {
@@ -153,11 +157,11 @@ function WrapSummary({ info: { chainId, currencyAmountRaw, unwrapped } }: { info
         Wrap{' '}
         <FormattedCurrencyAmount
           rawAmount={currencyAmountRaw}
-          symbol={native?.symbol ?? 'ETH'}
+          symbol={unwrappedTokenSymbol ?? native?.symbol ?? 'ETH'}
           decimals={18}
           sigFigs={6}
         />{' '}
-        to {native?.wrapped?.symbol ?? 'WETH'}
+        to {wrappedTokenSymbol ?? native?.wrapped?.symbol ?? 'WETH'}
       </Trans>
     )
   }

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -201,6 +201,41 @@ export const WETH_POLYGON = new Token(
   'WETH',
   'Wrapped Ether'
 )
+
+export const STETH: { [chainId: number]: Token } = {
+  [SupportedChainId.MAINNET]: new Token(
+    SupportedChainId.MAINNET,
+    '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+    18,
+    'stETH',
+    'Lido Liquid Staked Ether 2.0'
+  ),
+  [SupportedChainId.GOERLI]: new Token(
+    SupportedChainId.GOERLI,
+    '0x1643E812aE58766192Cf7D2Cf9567dF2C37e9B7F',
+    18,
+    'stETH',
+    'Lido Liquid Staked Ether 2.0'
+  ),
+}
+
+export const WSTETH: { [chainId: number]: Token } = {
+  [SupportedChainId.MAINNET]: new Token(
+    SupportedChainId.MAINNET,
+    '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+    18,
+    'wstETH',
+    'Lido Wrapped Liquid Staked Ether 2.0'
+  ),
+  [SupportedChainId.GOERLI]: new Token(
+    SupportedChainId.GOERLI,
+    '0x1643e812ae58766192cf7d2cf9567df2c37e9b7f',
+    18,
+    'wstETH',
+    'Lido Wrapped Liquid Staked Ether 2.0'
+  ),
+}
+
 export const UNI: { [chainId: number]: Token } = {
   [SupportedChainId.MAINNET]: new Token(SupportedChainId.MAINNET, UNI_ADDRESS[1], 18, 'UNI', 'Uniswap'),
   [SupportedChainId.RINKEBY]: new Token(SupportedChainId.RINKEBY, UNI_ADDRESS[4], 18, 'UNI', 'Uniswap'),

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -14,8 +14,9 @@ import ERC20_ABI from 'abis/erc20.json'
 import ERC20_BYTES32_ABI from 'abis/erc20_bytes32.json'
 import ERC721_ABI from 'abis/erc721.json'
 import ERC1155_ABI from 'abis/erc1155.json'
-import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Erc721, Erc1155, Weth } from 'abis/types'
+import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Erc721, Erc1155, Weth, Wsteth } from 'abis/types'
 import WETH_ABI from 'abis/weth.json'
+import WSTETH_ABI from 'abis/wsteth.json'
 import {
   ARGENT_WALLET_DETECTOR_ADDRESS,
   ENS_REGISTRAR_ADDRESSES,
@@ -26,7 +27,7 @@ import {
   V2_ROUTER_ADDRESS,
   V3_MIGRATOR_ADDRESSES,
 } from 'constants/addresses'
-import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
+import { WRAPPED_NATIVE_CURRENCY, WSTETH } from 'constants/tokens'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useMemo } from 'react'
 import { NonfungiblePositionManager, Quoter, TickLens, UniswapInterfaceMulticall } from 'types/v3'
@@ -80,6 +81,11 @@ export function useWETHContract(withSignerIfPossible?: boolean) {
     WETH_ABI,
     withSignerIfPossible
   )
+}
+
+export function useWSTETHContract(withSignerIfPossible?: boolean) {
+  const { chainId } = useActiveWeb3React()
+  return useContract<Wsteth>(chainId ? WSTETH[chainId]?.address : undefined, WSTETH_ABI, withSignerIfPossible)
 }
 
 export function useERC721Contract(nftAddress?: string) {

--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -14,7 +14,6 @@ import { useWETHContract, useWSTETHContract } from './useContract'
 
 export enum WrapType {
   NOT_APPLICABLE,
-  PENDING_APPROVAL,
   WRAP,
   UNWRAP,
 }
@@ -79,6 +78,7 @@ export default function useWrapCallback(
   inputError?: WrapInputError
   approvalCallback?: () => Promise<void>
   approvalState?: ApprovalState
+  needsApproval?: boolean
 } {
   const { chainId, account } = useActiveWeb3React()
   const wethContract = useWETHContract()
@@ -160,9 +160,10 @@ export default function useWrapCallback(
       if (steth.equals(inputCurrency) && wsteth.equals(outputCurrency)) {
         if (stethApproval === ApprovalState.NOT_APPROVED) {
           return {
-            wrapType: WrapType.PENDING_APPROVAL,
+            wrapType: WrapType.WRAP,
             approvalCallback: getStethApproval,
             approvalState: stethApproval,
+            needsApproval: true,
           }
         }
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -127,6 +127,7 @@ export default function Swap({ history }: RouteComponentProps) {
     inputError: wrapInputError,
     approvalCallback: wrapApprovalCallback,
     approvalState: wrapApprovalState,
+    needsApproval: wrapNeedsApproval,
   } = useWrapCallback(currencies[Field.INPUT], currencies[Field.OUTPUT], typedValue)
   const showWrap: boolean = wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
@@ -390,7 +391,7 @@ export default function Swap({ history }: RouteComponentProps) {
 
   const priceImpactTooHigh = priceImpactSeverity > 3 && !isExpertMode
 
-  function getApprovalButton({
+  const getApprovalButton = ({
     approveCallback,
     tokenApprovalState,
     tokenSignatureState,
@@ -404,7 +405,7 @@ export default function Swap({ history }: RouteComponentProps) {
     approvedMessage: JSX.Element
     pendingApprovalMessage: JSX.Element
     tooltipMessage: JSX.Element
-  }) {
+  }) => {
     return (
       <ButtonConfirmed
         onClick={approveCallback}
@@ -547,29 +548,35 @@ export default function Swap({ history }: RouteComponentProps) {
                 <ButtonLight onClick={toggleWalletModal}>
                   <Trans>Connect Wallet</Trans>
                 </ButtonLight>
-              ) : showWrap && wrapType !== WrapType.PENDING_APPROVAL ? (
-                <ButtonPrimary disabled={Boolean(wrapInputError)} onClick={onWrap}>
-                  {wrapInputError ? (
-                    <WrapErrorText wrapInputError={wrapInputError} />
-                  ) : wrapType === WrapType.WRAP ? (
-                    <Trans>Wrap</Trans>
-                  ) : wrapType === WrapType.UNWRAP ? (
-                    <Trans>Unwrap</Trans>
-                  ) : null}
-                </ButtonPrimary>
-              ) : showWrap && wrapType === WrapType.PENDING_APPROVAL ? (
-                getApprovalButton({
-                  tokenApprovalState: wrapApprovalState,
-                  approveCallback: wrapApprovalCallback,
-                  approvedMessage: <Trans>You can now wrap {currencies[Field.INPUT]?.symbol}</Trans>,
-                  pendingApprovalMessage: <Trans>Approve your {currencies[Field.INPUT]?.symbol} for wrapping</Trans>,
-                  tooltipMessage: (
-                    <Trans>
-                      You must give the Lido {currencies[Field.OUTPUT]?.symbol} contract permission to use your{' '}
-                      {currencies[Field.INPUT]?.symbol}.
-                    </Trans>
-                  ),
-                })
+              ) : showWrap ? (
+                <AutoRow style={{ flexWrap: 'nowrap', width: '100%' }}>
+                  <AutoColumn style={{ width: '100%' }} gap="12px">
+                    {wrapNeedsApproval &&
+                      getApprovalButton({
+                        tokenApprovalState: wrapApprovalState,
+                        approveCallback: wrapApprovalCallback,
+                        approvedMessage: <Trans>You can now wrap {currencies[Field.INPUT]?.symbol}</Trans>,
+                        pendingApprovalMessage: (
+                          <Trans>Approve your {currencies[Field.INPUT]?.symbol} for wrapping</Trans>
+                        ),
+                        tooltipMessage: (
+                          <Trans>
+                            You must give the Lido {currencies[Field.OUTPUT]?.symbol} contract permission to use your{' '}
+                            {currencies[Field.INPUT]?.symbol}.
+                          </Trans>
+                        ),
+                      })}
+                    <ButtonPrimary disabled={Boolean(wrapInputError) || wrapNeedsApproval} onClick={onWrap}>
+                      {wrapInputError ? (
+                        <WrapErrorText wrapInputError={wrapInputError} />
+                      ) : wrapType === WrapType.WRAP ? (
+                        <Trans>Wrap</Trans>
+                      ) : wrapType === WrapType.UNWRAP ? (
+                        <Trans>Unwrap</Trans>
+                      ) : null}
+                    </ButtonPrimary>
+                  </AutoColumn>
+                </AutoRow>
               ) : routeNotFound && userHasSpecifiedInputOutput && !routeIsLoading && !routeIsSyncing ? (
                 <GreyCard style={{ textAlign: 'center' }}>
                   <ThemedText.Main mb="4px">

--- a/src/state/transactions/actions.ts
+++ b/src/state/transactions/actions.ts
@@ -96,6 +96,8 @@ export interface WrapTransactionInfo {
   unwrapped: boolean
   currencyAmountRaw: string
   chainId?: number
+  unwrappedTokenSymbol?: string
+  wrappedTokenSymbol?: string
 }
 
 export interface ClaimTransactionInfo {


### PR DESCRIPTION
Added wrap/unwrap functionality for Lido stETH.

Certain code could be modularized in the future to more easily support wrap/unwrap of additional tokens though given this may be an uncommon use case and in an effort to keep complexity low for my first contribution I opted not to do this. If it is predicted to be a common future use case I would be happy to abstract some of the hard coded instances of weth/steth contracts and naming.

Wrap token approval is handled in the useWrapCallback hook since the approval hooks in Swap/index.tsx are focused on SwapRouter approval. In the event of adding wrap support for other tokens, the wrap approval complexity can remain encapsulated in the useWrapCallback hook without adding any code to Swap/index.tsx.

I did not add swap functionality in the widget components as it did not seem in scope of the ticket.