### PR TITLE
fix: bug where user cannot burn lp position if fetching fee values fails.

### DIFF
--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
-import { Percent } from '@uniswap/sdk-core'
+import { CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { NonfungiblePositionManager } from '@uniswap/v3-sdk'
 import RangeBadge from 'components/Badge/RangeBadge'
 import { ButtonConfirmed, ButtonPrimary } from 'components/Button'
@@ -109,8 +109,6 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       !deadline ||
       !account ||
       !chainId ||
-      !feeValue0 ||
-      !feeValue1 ||
       !positionSDK ||
       !liquidityPercentage ||
       !library
@@ -118,14 +116,16 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       return
     }
 
+    // we fall back to expecting 0 fees in case the fetch fails, which is safe in the
+    // vast majority of cases
     const { calldata, value } = NonfungiblePositionManager.removeCallParameters(positionSDK, {
       tokenId: tokenId.toString(),
       liquidityPercentage,
       slippageTolerance: allowedSlippage,
       deadline: deadline.toString(),
       collectOptions: {
-        expectedCurrencyOwed0: feeValue0,
-        expectedCurrencyOwed1: feeValue1,
+        expectedCurrencyOwed0: feeValue0 ?? CurrencyAmount.fromRawAmount(liquidityValue0.currency, 0),
+        expectedCurrencyOwed1: feeValue1 ?? CurrencyAmount.fromRawAmount(liquidityValue1.currency, 0),
         recipient: account,
       },
     })

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -109,6 +109,8 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       !deadline ||
       !account ||
       !chainId ||
+      !feeValue0 ||
+      !feeValue1 ||
       !positionSDK ||
       !liquidityPercentage ||
       !library
@@ -122,8 +124,8 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       slippageTolerance: allowedSlippage,
       deadline: deadline.toString(),
       collectOptions: {
-        expectedCurrencyOwed0: liquidityValue0,
-        expectedCurrencyOwed1: liquidityValue1,
+        expectedCurrencyOwed0: feeValue0,
+        expectedCurrencyOwed1: feeValue1,
         recipient: account,
       },
     })

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -109,8 +109,6 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       !deadline ||
       !account ||
       !chainId ||
-      !feeValue0 ||
-      !feeValue1 ||
       !positionSDK ||
       !liquidityPercentage ||
       !library
@@ -124,8 +122,8 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       slippageTolerance: allowedSlippage,
       deadline: deadline.toString(),
       collectOptions: {
-        expectedCurrencyOwed0: feeValue0,
-        expectedCurrencyOwed1: feeValue1,
+        expectedCurrencyOwed0: liquidityValue0,
+        expectedCurrencyOwed1: liquidityValue1,
         recipient: account,
       },
     })


### PR DESCRIPTION
Sometimes the `positionManager.callStatic.collect()` call fails in hooks/useV3PositionFees.ts. 

When this happens, the `useDerivedV3BurnInfo(position, receiveWETH)` function on line `87` of pages/RemoveLiquidity/V3.tsx returns `undefined` for `feeValue0` and `feeValue1` 

If `feeValue0` and `feeValue1` is `undefined`, then the `burn = useCallback` function on line 103  fails because `!feeValue0` and `!feeValue0` return `True`. So LPs cannot burn their position if the `collect()` call fails (which happens quite frequently for me)

To solve this, I removed the `!feeValue0` and `!feeValue1` conditions lines on 112+113, and also replaced `feeValue0`+`feeValue1` with `liquidityValue0`+`liquidityValue1` for `expectedCurrencyOwed0`+`expectedCurrencyOwed1` on lines 127 and 128. 

Maybe the `expectedCurrencyOwed0` and `expectedCurrencyOwed1` could be set to 0 as in https://docs.uniswap.org/sdk/guides/liquidity/removing#removing-liquidity-from-a-position (?)