### PR TITLE
fix: missing token balance

### DIFF
--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -47,7 +47,7 @@ export function useNativeCurrencyBalances(uncheckedAddresses?: (string | undefin
 }
 
 const ERC20Interface = new Interface(ERC20ABI) as Erc20Interface
-const tokenBalancesGasRequirement = { gasRequired: 200_000 }
+const tokenBalancesGasRequirement = { gasRequired: 185_000 }
 
 /**
  * Returns a map of token addresses to their eventually consistent token balances for a single account.

--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -47,7 +47,7 @@ export function useNativeCurrencyBalances(uncheckedAddresses?: (string | undefin
 }
 
 const ERC20Interface = new Interface(ERC20ABI) as Erc20Interface
-const tokenBalancesGasRequirement = { gasRequired: 125_000 }
+const tokenBalancesGasRequirement = { gasRequired: 200_000 }
 
 /**
  * Returns a map of token addresses to their eventually consistent token balances for a single account.


### PR DESCRIPTION
Increases the gas requirement to 200,000 when calling the `balanceOf` function on a token.
Ensures that the token balance and "MAX" button appear in the Swap input component.

Tested on token 0xab167E816E4d76089119900e941BEfdfA37d6b32 which requires ~173k gas to read `balanceOf` with multicall.