### PR TITLE
fix: token input height

### DIFF
--- a/src/lib/components/Swap/TokenInput.tsx
+++ b/src/lib/components/Swap/TokenInput.tsx
@@ -18,7 +18,8 @@ const TokenInputRow = styled(Row)`
 
 const ValueInput = styled(DecimalInput)`
   color: ${({ theme }) => theme.primary};
-  height: 1em;
+  height: 1.5em;
+  margin: -0.25em 0;
 
   :hover:not(:focus-within) {
     color: ${({ theme }) => theme.onHover(theme.primary)};


### PR DESCRIPTION
WebKit always renders inputs at >1em height, which results in a 1em container having the input content cut off [1].
This is apparent (but subtle) with `font-family: Inter`, but more so with `font-family: Popper`:
<img width="356" alt="Screen Shot 2022-04-06 at 12 00 46 PM" src="https://user-images.githubusercontent.com/5403956/162049027-ba15eecf-2373-467a-a508-40304d7597a2.png">

This updates the TokenInput to use a height of 1.5em, with margin offsets to vertically center the content, in order to avoid cutting off the input content.


[1]: This is partially explained in https://www.456bereastreet.com/archive/201108/line-height_in_input_fields/