### PR TITLE
fix: do not fetch wrap price

### DIFF
--- a/src/lib/components/Swap/Toolbar/index.tsx
+++ b/src/lib/components/Swap/Toolbar/index.tsx
@@ -37,7 +37,7 @@ export default memo(function Toolbar({ disabled }: { disabled?: boolean }) {
     }
 
     if (inputCurrency && outputCurrency && isAmountPopulated) {
-      if (wrapType === WrapType.NONE && (state === TradeState.SYNCING || state === TradeState.LOADING)) {
+      if (state === TradeState.SYNCING || state === TradeState.LOADING) {
         return <Caption.LoadingTrade />
       }
       if (inputBalance && inputAmount?.greaterThan(inputBalance)) {

--- a/src/lib/components/Swap/Toolbar/index.tsx
+++ b/src/lib/components/Swap/Toolbar/index.tsx
@@ -37,7 +37,7 @@ export default memo(function Toolbar({ disabled }: { disabled?: boolean }) {
     }
 
     if (inputCurrency && outputCurrency && isAmountPopulated) {
-      if (state === TradeState.SYNCING || state === TradeState.LOADING) {
+      if (wrapType === WrapType.NONE && (state === TradeState.SYNCING || state === TradeState.LOADING)) {
         return <Caption.LoadingTrade />
       }
       if (inputBalance && inputAmount?.greaterThan(inputBalance)) {

--- a/src/lib/hooks/swap/useSwapInfo.tsx
+++ b/src/lib/hooks/swap/useSwapInfo.tsx
@@ -43,7 +43,7 @@ function useComputeSwapInfo(): SwapInfo {
     () => tryParseCurrencyAmount(amount, (isExactIn ? currencyIn : currencyOut) ?? undefined),
     [amount, isExactIn, currencyIn, currencyOut]
   )
-  const hasAmounts = currencyIn && currencyOut && parsedAmount
+  const hasAmounts = currencyIn && currencyOut && parsedAmount && !isWrapping
   const trade = useBestTrade(
     isExactIn ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT,
     hasAmounts ? parsedAmount : undefined,


### PR DESCRIPTION
- Prevents the toolbar from showing "Fetching best price" when the "swap" is just a "wrap", as the price in this case is fixed.