### PR TITLE
fix: polling memory leak

### DIFF
--- a/src/lib/hooks/routing/useClientSideSmartOrderRouterTrade.ts
+++ b/src/lib/hooks/routing/useClientSideSmartOrderRouterTrade.ts
@@ -92,7 +92,7 @@ export default function useClientSideSmartOrderRouterTrade<TTradeType extends Tr
   const getIsValidBlock = useGetIsValidBlock()
   const { data: quoteResult, error } = usePoll(getQuoteResult, JSON.stringify(queryArgs), {
     debounce: isDebouncing,
-    staleCallback: useCallback(({ data }) => !getIsValidBlock(Number(data?.blockNumber) || 0), [getIsValidBlock]),
+    isStale: useCallback(({ data }) => !getIsValidBlock(Number(data?.blockNumber) || 0), [getIsValidBlock]),
   }) ?? {
     error: undefined,
   }

--- a/src/lib/hooks/usePoll.ts
+++ b/src/lib/hooks/usePoll.ts
@@ -56,6 +56,7 @@ export default function usePoll<T>(
 
     return () => {
       clearTimeout(timeout)
+      timeout = 0
     }
 
     async function poll(ttl = Date.now() + pollingInterval) {
@@ -65,7 +66,7 @@ export default function usePoll<T>(
       // Always set the result in the cache, but only set it as data if the key is still being queried.
       const result = await fetch()
       cache.set(key, { ttl, result })
-      setData((data) => (data.key === key ? { key, result } : data))
+      if (timeout) setData((data) => (data.key === key ? { key, result } : data))
     }
   }, [cache, debounce, fetch, isStale, keepUnusedDataFor, key, pollingInterval])
 

--- a/src/lib/hooks/usePoll.ts
+++ b/src/lib/hooks/usePoll.ts
@@ -9,7 +9,7 @@ interface PollingOptions<T> {
   debounce?: boolean
 
   // If stale, any cached result will be returned, and a new fetch will be initiated.
-  staleCallback?: (value: T) => boolean
+  isStale?: (value: T) => boolean
 
   pollingInterval?: number
   keepUnusedDataFor?: number
@@ -25,7 +25,7 @@ export default function usePoll<T>(
   key = '',
   {
     debounce = false,
-    staleCallback,
+    isStale,
     pollingInterval = DEFAULT_POLLING_INTERVAL,
     keepUnusedDataFor = DEFAULT_KEEP_UNUSED_DATA_FOR,
   }: PollingOptions<T>
@@ -39,11 +39,10 @@ export default function usePoll<T>(
     let timeout: number
 
     const entry = cache.get(key)
-    const isStale = staleCallback && entry?.result !== undefined ? staleCallback(entry.result) : false
     if (entry) {
       // If there is not a pending fetch (and there should be), queue one.
       if (entry.ttl) {
-        if (isStale) {
+        if (isStale && entry?.result !== undefined ? isStale(entry.result) : false) {
           poll() // stale results should be refetched immediately
         } else if (entry.ttl && entry.ttl + keepUnusedDataFor > Date.now()) {
           timeout = setTimeout(poll, Math.max(0, entry.ttl - Date.now()))
@@ -68,7 +67,7 @@ export default function usePoll<T>(
       cache.set(key, { ttl, result })
       setData((data) => (data.key === key ? { key, result } : data))
     }
-  }, [cache, debounce, fetch, keepUnusedDataFor, key, pollingInterval, staleCallback])
+  }, [cache, debounce, fetch, isStale, keepUnusedDataFor, key, pollingInterval])
 
   useEffect(() => {
     // Cleanup stale entries when a new key is used.


### PR DESCRIPTION
Prevents a `useState` setter from being called after its component unmounts, which had resulted in the React warning

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```