### PR TITLE
fix: block number stability

### DIFF
--- a/src/lib/hooks/useBlockNumber.ts
+++ b/src/lib/hooks/useBlockNumber.ts
@@ -18,10 +18,8 @@ function useUpdateChainBlock() {
   const onBlock = useCallback(
     (block: number) => {
       setChainBlock((chainBlock) => {
-        if (chainBlock.chainId === chainId) {
-          if (chainBlock.block === block) return chainBlock
-          if (typeof chainBlock.block !== 'number') return { chainId, block }
-          return { chainId, block: Math.max(block, chainBlock.block) }
+        if (chainBlock.chainId === chainId && chainBlock.block && chainBlock.block < block) {
+          return { chainId, block }
         }
         return chainBlock
       })

--- a/src/lib/hooks/useBlockNumber.ts
+++ b/src/lib/hooks/useBlockNumber.ts
@@ -18,8 +18,10 @@ function useUpdateChainBlock() {
   const onBlock = useCallback(
     (block: number) => {
       setChainBlock((chainBlock) => {
-        if (chainBlock.chainId === chainId && chainBlock.block && chainBlock.block < block) {
-          return { chainId, block }
+        if (chainBlock.chainId === chainId) {
+          if (!chainBlock.block || chainBlock.block < block) {
+            return { chainId, block }
+          }
         }
         return chainBlock
       })


### PR DESCRIPTION
Fixes block number stability, where it had been causing re-renders despite having the same value, because the chainBlock object (`{ chainId, block }`) was being re-instantiated with the same values.