### PR TITLE
fix: Reload the app when there is a javascript error and a new version of the app

### DIFF
--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -51,7 +51,7 @@ const IS_UNISWAP = window.location.hostname === 'app.uniswap.org'
 
 async function updateServiceWorker(): Promise<ServiceWorkerRegistration> {
   const ready = await navigator.serviceWorker.ready
-  // the return type of update is incorrectly indicated as Promise<void>
+  // the return type of update is incorrectly typed as Promise<void>. See
   // https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/update
   return ready.update() as unknown as Promise<ServiceWorkerRegistration>
 }
@@ -65,13 +65,12 @@ export default class ErrorBoundary extends React.Component<unknown, ErrorBoundar
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     updateServiceWorker()
       .then(async (registration) => {
-        // We want to refresh only if we detect a new service worker is
-        // waiting to be activated.
-        // Details about it: https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle
+        // We want to refresh only if we detect a new service worker is waiting to be activated.
+        // See details about it: https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle
         if (registration?.waiting) {
           await registration.unregister()
 
-          // Makes Workbox call skipWaiting()
+          // Makes Workbox call skipWaiting(). For more info on skipWaiting see: https://developer.chrome.com/docs/workbox/handling-service-worker-updates/
           registration.waiting.postMessage({ type: 'SKIP_WAITING' })
 
           // Once the service worker is unregistered, we can reload the page to let

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -76,7 +76,6 @@ export default class ErrorBoundary extends React.Component<unknown, ErrorBoundar
 
           // Once the service worker is unregistered, we can reload the page to let
           // the browser download a fresh copy of our app (invalidating the cache)
-          console.log('reloading waiting', registration)
           window.location.reload()
         }
       })


### PR DESCRIPTION
The initial implementation by @moodysalem was done in: https://github.com/Uniswap/interface/pull/3435. The problem there was if there was no update from the app it would get stuck refreshing infinitely.

I copied that PR but added a check to ensure that there is actually a new version being returned from the update and only in that case will the app update. I also had to add a few more lines that appear to be required to make the refresh happen properly which I copied from: https://github.com/facebook/create-react-app/issues/5316#issuecomment-591075209