### PR TITLE
fix: initial transitions

### DIFF
--- a/src/lib/components/ActionButton.tsx
+++ b/src/lib/components/ActionButton.tsx
@@ -5,17 +5,7 @@ import { ReactNode, useMemo } from 'react'
 import Button from './Button'
 import Row from './Row'
 
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-`
-
 const StyledButton = styled(Button)`
-  animation: ${fadeIn} 0.25s ease-in;
   border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   flex-grow: 1;
   transition: background-color 0.25s ease-out, border-radius 0.25s ease-out, flex-grow 0.25s ease-out;

--- a/src/lib/components/Button.tsx
+++ b/src/lib/components/Button.tsx
@@ -1,5 +1,5 @@
 import { Icon } from 'lib/icons'
-import styled, { Color, css, keyframes } from 'lib/theme'
+import styled, { Color, css } from 'lib/theme'
 import { ComponentProps, forwardRef } from 'react'
 
 export const BaseButton = styled.button`
@@ -14,37 +14,27 @@ export const BaseButton = styled.button`
   line-height: inherit;
   margin: 0;
   padding: 0;
-  transition: filter 0.125s linear;
+
+  :enabled {
+    transition: filter 0.125s linear;
+  }
 
   :disabled {
     cursor: initial;
     filter: saturate(0) opacity(0.4);
-    transition: none;
   }
 `
-
-const bleedIn = (outline: string, color: string) => keyframes`
-  from {
-    border-color: ${color};
-    background-color: transparent;
-    filter: saturate(0) opacity(0.4);
-  }
+const transitionCss = css`
+  transition: background-color 0.125s linear, border-color 0.125s linear, filter 0.125s linear;
 `
 
-const bleedInCss = css<{ color?: Color }>`
-  :enabled {
-    animation: ${({ color = 'interactive', theme }) => bleedIn(theme.outline, theme[color])} 0.125s linear;
-    will-change: border-color, background-color;
-  }
-`
-
-export default styled(BaseButton)<{ color?: Color; animate?: boolean }>`
+export default styled(BaseButton)<{ color?: Color; transition?: boolean }>`
   border: 1px solid transparent;
   color: ${({ color = 'interactive', theme }) => color === 'interactive' && theme.onInteractive};
 
   :enabled {
     background-color: ${({ color = 'interactive', theme }) => theme[color]};
-    ${({ animate }) => animate && bleedInCss}
+    ${({ transition = true }) => transition && transitionCss};
   }
 
   :enabled:hover {

--- a/src/lib/components/Button.tsx
+++ b/src/lib/components/Button.tsx
@@ -14,10 +14,12 @@ export const BaseButton = styled.button`
   line-height: inherit;
   margin: 0;
   padding: 0;
+  transition: filter 0.125s linear;
 
   :disabled {
     cursor: initial;
     filter: saturate(0) opacity(0.4);
+    transition: none;
   }
 `
 
@@ -25,10 +27,7 @@ const bleedIn = (outline: string, color: string) => keyframes`
   from {
     border-color: ${color};
     background-color: transparent;
-  }
-  to {
-    border-color: transparent
-    background-color: ${color};
+    filter: saturate(0) opacity(0.4);
   }
 `
 
@@ -39,13 +38,13 @@ const bleedInCss = css<{ color?: Color }>`
   }
 `
 
-export default styled(BaseButton)<{ color?: Color; bleedIn?: boolean }>`
+export default styled(BaseButton)<{ color?: Color; animate?: boolean }>`
   border: 1px solid transparent;
   color: ${({ color = 'interactive', theme }) => color === 'interactive' && theme.onInteractive};
 
   :enabled {
     background-color: ${({ color = 'interactive', theme }) => theme[color]};
-    ${({ bleedIn }) => bleedIn && bleedInCss}
+    ${({ animate }) => animate && bleedInCss}
   }
 
   :enabled:hover {

--- a/src/lib/components/Button.tsx
+++ b/src/lib/components/Button.tsx
@@ -1,5 +1,5 @@
 import { Icon } from 'lib/icons'
-import styled, { Color } from 'lib/theme'
+import styled, { Color, css, keyframes } from 'lib/theme'
 import { ComponentProps, forwardRef } from 'react'
 
 export const BaseButton = styled.button`
@@ -21,11 +21,31 @@ export const BaseButton = styled.button`
   }
 `
 
-export default styled(BaseButton)<{ color?: Color }>`
+const bleedIn = (outline: string, color: string) => keyframes`
+  from {
+    border-color: ${color};
+    background-color: transparent;
+  }
+  to {
+    border-color: transparent
+    background-color: ${color};
+  }
+`
+
+const bleedInCss = css<{ color?: Color }>`
+  :enabled {
+    animation: ${({ color = 'interactive', theme }) => bleedIn(theme.outline, theme[color])} 0.125s linear;
+    will-change: border-color, background-color;
+  }
+`
+
+export default styled(BaseButton)<{ color?: Color; bleedIn?: boolean }>`
+  border: 1px solid transparent;
   color: ${({ color = 'interactive', theme }) => color === 'interactive' && theme.onInteractive};
 
   :enabled {
     background-color: ${({ color = 'interactive', theme }) => theme[color]};
+    ${({ bleedIn }) => bleedIn && bleedInCss}
   }
 
   :enabled:hover {
@@ -33,9 +53,8 @@ export default styled(BaseButton)<{ color?: Color }>`
   }
 
   :disabled {
-    border: 1px solid ${({ theme }) => theme.outline};
+    border-color: ${({ theme }) => theme.outline};
     color: ${({ theme }) => theme.secondary};
-    cursor: initial;
   }
 `
 

--- a/src/lib/components/Input.tsx
+++ b/src/lib/components/Input.tsx
@@ -1,4 +1,6 @@
+import { loadingOpacity } from 'lib/css/loading'
 import styled, { css } from 'lib/theme'
+import { transparentize } from 'polished'
 import { ChangeEvent, forwardRef, HTMLProps, useCallback } from 'react'
 
 const Input = styled.input`
@@ -33,6 +35,16 @@ const Input = styled.input`
 
   ::placeholder {
     color: ${({ theme }) => theme.secondary};
+  }
+
+  :enabled {
+    transition: color 0.125s linear;
+  }
+
+  :disabled {
+    // Overrides WebKit's override of input:disabled color.
+    -webkit-text-fill-color: ${({ theme }) => transparentize(1 - loadingOpacity, theme.primary)};
+    color: ${({ theme }) => transparentize(1 - loadingOpacity, theme.primary)};
   }
 `
 

--- a/src/lib/components/Swap/Input.tsx
+++ b/src/lib/components/Swap/Input.tsx
@@ -80,7 +80,7 @@ export default function Input({ disabled, focused }: InputProps) {
   // extract eagerly in case of reversal
   usePrefetchCurrencyColor(inputCurrency)
 
-  const isRouteLoading = tradeState === TradeState.SYNCING || tradeState === TradeState.LOADING
+  const isRouteLoading = disabled || tradeState === TradeState.SYNCING || tradeState === TradeState.LOADING
   const isDependentField = !useIsSwapFieldIndependent(Field.INPUT)
   const isLoading = isRouteLoading && isDependentField
 

--- a/src/lib/components/Swap/Output.tsx
+++ b/src/lib/components/Swap/Output.tsx
@@ -46,7 +46,7 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
   const [swapOutputAmount, updateSwapOutputAmount] = useSwapAmount(Field.OUTPUT)
   const [swapOutputCurrency, updateSwapOutputCurrency] = useSwapCurrency(Field.OUTPUT)
 
-  const isRouteLoading = tradeState === TradeState.SYNCING || tradeState === TradeState.LOADING
+  const isRouteLoading = disabled || tradeState === TradeState.SYNCING || tradeState === TradeState.LOADING
   const isDependentField = !useIsSwapFieldIndependent(Field.OUTPUT)
   const isLoading = isRouteLoading && isDependentField
 

--- a/src/lib/components/Swap/ReverseButton.tsx
+++ b/src/lib/components/Swap/ReverseButton.tsx
@@ -33,6 +33,7 @@ const Overlay = styled.div`
 
 const StyledReverseButton = styled(Button)<{ turns: number }>`
   border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
+  color: ${({ theme }) => theme.primary};
   height: 2.5em;
   position: relative;
   width: 2.5em;
@@ -55,7 +56,7 @@ export default function ReverseButton({ disabled }: { disabled?: boolean }) {
   return (
     <ReverseRow justify="center">
       <Overlay>
-        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns} bleedIn>
+        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns} animate>
           <div>
             <ArrowUp strokeWidth={3} />
             <ArrowDown strokeWidth={3} />

--- a/src/lib/components/Swap/ReverseButton.tsx
+++ b/src/lib/components/Swap/ReverseButton.tsx
@@ -55,7 +55,7 @@ export default function ReverseButton({ disabled }: { disabled?: boolean }) {
   return (
     <ReverseRow justify="center">
       <Overlay>
-        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns}>
+        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns} bleedIn>
           <div>
             <ArrowUp strokeWidth={3} />
             <ArrowDown strokeWidth={3} />

--- a/src/lib/components/Swap/ReverseButton.tsx
+++ b/src/lib/components/Swap/ReverseButton.tsx
@@ -56,7 +56,7 @@ export default function ReverseButton({ disabled }: { disabled?: boolean }) {
   return (
     <ReverseRow justify="center">
       <Overlay>
-        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns} animate>
+        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns}>
           <div>
             <ArrowUp strokeWidth={3} />
             <ArrowDown strokeWidth={3} />

--- a/src/lib/components/Swap/SwapButton/index.tsx
+++ b/src/lib/components/Swap/SwapButton/index.tsx
@@ -14,6 +14,7 @@ import { TransactionType } from 'lib/state/transactions'
 import { useTheme } from 'lib/theme'
 import { isAnimating } from 'lib/utils/animations'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { TradeState } from 'state/routing/types'
 import invariant from 'tiny-invariant'
 
 import ActionButton, { ActionButtonProps } from '../../ActionButton'
@@ -152,13 +153,17 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
     if (disableSwap) {
       return { disabled: true }
     } else if (wrapType === WrapType.NONE) {
-      return approvalAction ? { action: approvalAction } : { onClick: () => setOpen(true) }
+      return approvalAction
+        ? { action: approvalAction }
+        : trade.state === TradeState.VALID
+        ? { onClick: () => setOpen(true) }
+        : { disabled: true }
     } else {
       return isPending
         ? { action: { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner } }
         : { onClick: onWrap }
     }
-  }, [approvalAction, disableSwap, isPending, onWrap, wrapType])
+  }, [approvalAction, disableSwap, isPending, onWrap, trade.state, wrapType])
   const Label = useCallback(() => {
     switch (wrapType) {
       case WrapType.UNWRAP:

--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -10,8 +10,8 @@ import TokenImg from '../TokenImg'
 
 const StyledTokenButton = styled(Button)<{ empty?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius}em;
-  padding: calc(0.25em - 1px); // 1px accounts for the border
-  padding-left: calc(${({ empty }) => (empty ? 0.75 : 0.25)}em - 1px);
+  padding: 0.25em;
+  padding-left: ${({ empty }) => (empty ? 0.75 : 0.25)}em;
 `
 
 const TokenButtonRow = styled(Row)<{ collapsed: boolean }>`

--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -63,7 +63,7 @@ export default function TokenButton({ value, collapsed, disabled, onClick }: Tok
       onClick={onClick}
       color={buttonBackgroundColor}
       disabled={disabled}
-      bleedIn={shouldTransition}
+      animate={shouldTransition}
       onAnimationEnd={() => setShouldTransition(false)}
       ref={button}
       style={style}

--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -46,24 +46,21 @@ interface TokenButtonProps {
 export default function TokenButton({ value, collapsed, disabled, onClick }: TokenButtonProps) {
   const buttonBackgroundColor = useMemo(() => (value ? 'interactive' : 'accent'), [value])
   const contentColor = useMemo(() => (value || disabled ? 'onInteractive' : 'onAccent'), [value, disabled])
-  const isEmpty = !value
 
   // Transition the button only if transitioning from a disabled state.
   // This makes initialization cleaner without adding distracting UX to normal swap flows.
-  const [shouldTransition, setShouldTransition] = useState(true)
+  const [shouldTransition, setShouldTransition] = useState(disabled)
   useEffect(() => {
     if (disabled) {
       setShouldTransition(true)
-    } else if (isEmpty) {
-      setShouldTransition(false)
     }
-  }, [disabled, isEmpty])
+  }, [disabled])
 
   // width must have an absolute value in order to transition, so it is taken from the row ref.
   const [row, setRow] = useState<HTMLDivElement | null>(null)
   const style = useMemo(() => {
-    const width = row?.clientWidth
-    return { width: shouldTransition && width ? width + 10 : undefined }
+    if (!shouldTransition) return
+    return { width: row ? row.clientWidth + /* padding= */ 8 + /* border= */ 2 : undefined }
   }, [row, shouldTransition])
 
   return (
@@ -78,7 +75,7 @@ export default function TokenButton({ value, collapsed, disabled, onClick }: Tok
       <ThemedText.ButtonLarge color={contentColor}>
         <TokenButtonRow
           gap={0.4}
-          empty={isEmpty}
+          empty={!value}
           collapsed={collapsed}
           // ref is used to set an absolute width, so it must be reset for each value passed.
           // To force this, value?.symbol is passed as a key.

--- a/src/lib/components/TokenSelect/TokenButton.tsx
+++ b/src/lib/components/TokenSelect/TokenButton.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Currency } from '@uniswap/sdk-core'
 import { ChevronDown } from 'lib/icons'
 import styled, { ThemedText } from 'lib/theme'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import Button from '../Button'
 import Row from '../Row'
@@ -10,14 +10,8 @@ import TokenImg from '../TokenImg'
 
 const StyledTokenButton = styled(Button)<{ empty?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius}em;
-  padding: 0.25em;
-  padding-left: ${({ empty }) => (empty ? 0.75 : 0.25)}em;
-
-  :disabled {
-    // prevents border from expanding the button's box size
-    padding: calc(0.25em - 1px);
-    padding-left: calc(${({ empty }) => (empty ? 0.75 : 0.25)}em - 1px);
-  }
+  padding: calc(0.25em - 1px); // 1px accounts for the border
+  padding-left: calc(${({ empty }) => (empty ? 0.75 : 0.25)}em - 1px);
 `
 
 const TokenButtonRow = styled(Row)<{ collapsed: boolean }>`
@@ -42,10 +36,30 @@ interface TokenButtonProps {
 export default function TokenButton({ value, collapsed, disabled, onClick }: TokenButtonProps) {
   const buttonBackgroundColor = useMemo(() => (value ? 'interactive' : 'accent'), [value])
   const contentColor = useMemo(() => (value || disabled ? 'onInteractive' : 'onAccent'), [value, disabled])
+
+  const button = useRef<HTMLButtonElement>(null)
+  const empty = !value
+  const [bleedIn, setBleedIn] = useState(true)
+  useEffect(() => {
+    if (disabled) {
+      setBleedIn(true)
+    } else if (empty) {
+      setBleedIn(false)
+    }
+  }, [disabled, empty])
+
   return (
-    <StyledTokenButton onClick={onClick} empty={!value} color={buttonBackgroundColor} disabled={disabled}>
+    <StyledTokenButton
+      onClick={onClick}
+      empty={empty}
+      color={buttonBackgroundColor}
+      disabled={disabled}
+      bleedIn={bleedIn}
+      onAnimationEnd={() => setBleedIn(false)}
+      ref={button}
+    >
       <ThemedText.ButtonLarge color={contentColor}>
-        <TokenButtonRow gap={0.4} collapsed={Boolean(value) && collapsed}>
+        <TokenButtonRow gap={0.4} collapsed={!empty && collapsed}>
           {value ? (
             <>
               <TokenImg token={value} size={1.2} />

--- a/src/lib/components/Widget.tsx
+++ b/src/lib/components/Widget.tsx
@@ -31,7 +31,7 @@ const WidgetWrapper = styled.div<{ width?: number | string }>`
   font-size: 16px;
   font-smooth: always;
   font-variant: none;
-  height: 356px;
+  height: 360px;
   min-width: 300px;
   padding: 0.25em;
   position: relative;

--- a/src/lib/css/loading.ts
+++ b/src/lib/css/loading.ts
@@ -9,6 +9,6 @@ export const loadingCss = css`
 
 // need to use isLoading as `loading` is a reserved prop
 export const loadingTransitionCss = css<{ isLoading: boolean }>`
-  ${({ isLoading }) => isLoading && loadingCss};
-  transition: opacity ${({ isLoading }) => (isLoading ? 0 : 0.2)}s ease-in-out;
+  opacity: ${({ isLoading }) => isLoading && loadingOpacity};
+  transition: color 0.125s linear, opacity ${({ isLoading }) => (isLoading ? 0 : 0.25)}s ease-in-out;
 `


### PR DESCRIPTION
These changes remove any jarring UX on initial provider connection. It adds a transition to any element that is already rendered initially (eg input and token buttons). It intentionally does _not_ add transitions to those elements which were not already rendered (eg "Connect your wallet").

- Cleans up the action button (including fixing a bug that allowed stale swaps)
- Adds fade in to reverse and token select buttons when transitioning from disabled state
- Adds fade in to input text

https://user-images.githubusercontent.com/5403956/163095872-b30cbf7e-41de-4614-8ac8-8eef1e4709b5.mov


