### PR TITLE
feat: add 1bp fee tier to polygon

### DIFF
--- a/src/components/FeeSelector/shared.tsx
+++ b/src/components/FeeSelector/shared.tsx
@@ -10,7 +10,7 @@ export const FEE_AMOUNT_DETAIL: Record<
   [FeeAmount.LOWEST]: {
     label: '0.01',
     description: <Trans>Best for very stable pairs.</Trans>,
-    supportedChains: [SupportedChainId.MAINNET],
+    supportedChains: [SupportedChainId.MAINNET, SupportedChainId.POLYGON, SupportedChainId.POLYGON_MUMBAI],
   },
   [FeeAmount.LOW]: {
     label: '0.05',


### PR DESCRIPTION
The fee tier is showing up on the UI and I was able to add liquidity for that fee tier. 

@justindomingue  helped me to test this by making sure a swap would go through the 1bp tier: 
<img width="520" alt="image (1)" src="https://user-images.githubusercontent.com/8795736/163399846-9ede502c-2d11-41b8-b6e6-cca75e9218a5.png">


The resulting transaction was https://mumbai.polygonscan.com/tx/0x744bb33f9f6086cc6b19c29ba604d3ad6bba6c3d9ab1d137bf27b19fc082b92c which we _think_ confirms that my swap went through that tier properly. 
