### PR TITLE
style: `endOfLine` error on Windows 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,12 @@
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "prettier/prettier": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/ban-ts-ignore": "off",


### PR DESCRIPTION
By default, on Windows, line-endings are terminated with a combination of a carriage return (ASCII 0x0d or \r) and a newline(\n), also referred to as CR/LF.

Without making this change to the `.eslintrc.json` file

```json
"prettier/prettier": [
      "error",
      {
        "endOfLine": "auto"
      }
    ],
```

the default Windows development experience would be to see these errors:

![image](https://user-images.githubusercontent.com/18399089/163274396-357a66da-1d74-4343-ac52-d7c585cc4f9d.png)

Although it is possible to work around this in VS Code by editing the `Change end of Line Sequence`  setting, I think it would be best if it worked "out of the box" for all prospective developers

![image](https://user-images.githubusercontent.com/18399089/163274597-aa619921-3b71-48ab-b1ad-8379828caf0b.png)



