### PR TITLE
fix: ignore dbg.json files during typechain

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "scripts": {
     "contracts:compile:abi": "typechain --target ethers-v5 --out-dir src/abis/types \"./src/abis/**/*.json\"",
-    "contracts:compile:v3": "typechain --target ethers-v5 --out-dir src/types/v3 \"./node_modules/@uniswap/**/artifacts/contracts/**/*.json\"",
+    "contracts:compile:v3": "typechain --target ethers-v5 --out-dir src/types/v3 \"./node_modules/@uniswap/**/artifacts/contracts/**/*[!dbg].json\"",
     "contracts:compile": "yarn contracts:compile:abi && yarn contracts:compile:v3",
     "graphql:generate": "graphql-codegen --config codegen.yml",
     "prei18n:extract": "touch src/locales/en-US.po",


### PR DESCRIPTION
If *.dbg.json files are present in the `/node_modules/@uniswap/**/artifacts/contracts/` directory, typechain will fail with

`$ typechain --target ethers-v5 --out-dir src/types/v3 "./node_modules/@uniswap/**/artifacts/contracts/**/*.json" --show-stack-traces
Error occured:  Not a valid ABI
Stack trace:  Error: Not a valid ABI`

This normally doesn't occur if `@uniswap` packages are installed via NPM as *.dbg.json files are excluded from the package, but when developing locally using either `file:...` syntax or `git+ssh:` these errors will occur.

This PR changes the `contracts:compile:v3` command to ignore `*.dbg.json` files.
