### PR TITLE
fix: Mobile layout: hide closed positions disappears #3344

### DIFF
--- a/src/components/PositionList/index.tsx
+++ b/src/components/PositionList/index.tsx
@@ -57,6 +57,9 @@ export default function PositionList({
       </DesktopHeader>
       <MobileHeader>
         <Trans>Your positions</Trans>
+        <ButtonText style={{ opacity: 0.6 }} onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}>
+          <Trans>Hide closed positions</Trans>
+        </ButtonText>
       </MobileHeader>
       {positions.map((p) => {
         return <PositionListItem key={p.tokenId.toString()} positionDetails={p} />


### PR DESCRIPTION
It's the below of the "Your Positions".
