### PR TITLE
feat: Ambire Wallet batch transaction skipping gas estimation

### DIFF
--- a/src/hooks/useIsAmbireWC.ts
+++ b/src/hooks/useIsAmbireWC.ts
@@ -1,0 +1,8 @@
+import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import { WalletConnectConnector } from 'web3-react-walletconnect-connector'
+
+export default function useIsAmbireWC(): boolean {
+  const res = useActiveWeb3React()
+  const wcConnector = res?.connector as WalletConnectConnector
+  return wcConnector?.walletConnectProvider?.signer?.connection?.wc?._peerMeta?.name === 'Ambire Wallet'
+}

--- a/src/lib/hooks/swap/useSwapCallback.tsx
+++ b/src/lib/hooks/swap/useSwapCallback.tsx
@@ -2,7 +2,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
-import { Percent } from '@uniswap/sdk-core'
+import { Trade } from '@uniswap/router-sdk'
+import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { FeeOptions } from '@uniswap/v3-sdk'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useENS from 'hooks/useENS'
@@ -10,6 +11,7 @@ import { SignatureData } from 'hooks/useERC20Permit'
 import { AnyTrade, useSwapCallArguments } from 'hooks/useSwapCallArguments'
 import { ReactNode, useMemo } from 'react'
 
+import { useApprovalOptimizedTrade, useApproveCallbackFromTrade } from '../../../hooks/useApproveCallback'
 import useSendSwapTransaction from './useSendSwapTransaction'
 
 export enum SwapCallbackState {
@@ -52,7 +54,14 @@ export function useSwapCallback({
     deadline,
     feeOptions
   )
-  const { callback } = useSendSwapTransaction(account, chainId, library, trade, swapCalls)
+
+  const approvalOptimizedTrade = useApprovalOptimizedTrade(
+    trade as Trade<Currency, Currency, TradeType>,
+    allowedSlippage
+  )
+  const [approvalState] = useApproveCallbackFromTrade(approvalOptimizedTrade, allowedSlippage)
+
+  const { callback } = useSendSwapTransaction(account, chainId, library, trade, approvalState, swapCalls)
 
   const { address: recipientAddress } = useENS(recipientAddressOrName)
   const recipient = recipientAddressOrName === null ? account : recipientAddress

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -38,6 +38,7 @@ import { useAllTokens, useCurrency } from '../../hooks/Tokens'
 import { ApprovalState, useApprovalOptimizedTrade, useApproveCallbackFromTrade } from '../../hooks/useApproveCallback'
 import useENSAddress from '../../hooks/useENSAddress'
 import { useERC20PermitFromTrade, UseERC20PermitState } from '../../hooks/useERC20Permit'
+import useIsAmbireWC from '../../hooks/useIsAmbireWC'
 import useIsArgentWallet from '../../hooks/useIsArgentWallet'
 import { useIsSwapUnsupported } from '../../hooks/useIsSwapUnsupported'
 import { useUSDCValue } from '../../hooks/useUSDCPrice'
@@ -339,11 +340,13 @@ export default function Swap({ history }: RouteComponentProps) {
     )
   }, [priceImpact, trade])
 
+  const isAmbireWC = useIsAmbireWC()
   const isArgentWallet = useIsArgentWallet()
 
   // show approve flow when: no error on inputs, not approved or pending, or approved in current session
   // never show if price impact is above threshold in non expert mode
   const showApproveFlow =
+    !isAmbireWC &&
     !isArgentWallet &&
     !swapInputError &&
     (approvalState === ApprovalState.NOT_APPROVED ||


### PR DESCRIPTION
This PR implements batching for ERC20 approvals with Ambire, which is a smart wallet that allows for transaction batching, smart recovery, gas abstractions and others. Rather than having to sign & send the ERC20 approval transaction separately, with this PR, it will be batched together with the specific action when the wallet used is Ambire.

The UX impact is immense, as the approval step is essentially permanently eliminated, without compromising security (the same calls are being done, just in one tx).

While this PR implements some logic custom to Ambire, this logic can be easily modified into an implementation of the batching EIP that’s currently being worked on by Gnosis Safe and Ambire, turning the code into a general implementation of txn batching.

This implementation uses altered SwapCall structure to skip the swap gas estimation, therefore no error is thrown. It can also be future proof, for smart wallets that calculate the gas independently from the dapp.

This PR is similar to the custom logic for Argent with wc_multiCall