### PR TITLE
fix: handle non existing inputCurrency from url #3056

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -426,7 +426,7 @@ export default function Swap({ history }: RouteComponentProps) {
                 }
                 value={formattedAmounts[Field.INPUT]}
                 showMaxButton={showMaxButton}
-                currency={currencies[Field.INPUT]}
+                currency={currencies[Field.INPUT] ?? null}
                 onUserInput={handleTypeInput}
                 onMax={handleMaxInput}
                 fiatValue={fiatValueInput ?? undefined}
@@ -454,7 +454,7 @@ export default function Swap({ history }: RouteComponentProps) {
                 hideBalance={false}
                 fiatValue={fiatValueOutput ?? undefined}
                 priceImpact={priceImpact}
-                currency={currencies[Field.OUTPUT]}
+                currency={currencies[Field.OUTPUT] ?? null}
                 onCurrencySelect={handleOutputSelect}
                 otherCurrency={currencies[Field.INPUT]}
                 showCommonBases={true}


### PR DESCRIPTION
closes #3056
opening an url swap?inputCurrency=not_existing_address
cause a state where you are not able to change input currency

same technique used here https://github.com/Uniswap/interface/blob/main/src/pages/AddLiquidity/index.tsx#L586

how it looks now:
<img width="300" alt="Screenshot 2022-05-20 at 22 14 45" src="https://user-images.githubusercontent.com/1488195/169589413-f38d1e3e-a0f6-4444-a060-1c60d0168e83.png">

