### PR TITLE
fix: Mobile layout: hide closed positions disappears #3344

### DIFF
--- a/src/components/PositionList/index.tsx
+++ b/src/components/PositionList/index.tsx
@@ -28,6 +28,8 @@ const MobileHeader = styled.div`
   font-size: 16px;
   font-weight: 500;
   padding: 8px;
+  display: flex;
+  justify-content: space-between;
   @media screen and (min-width: ${MEDIA_WIDTHS.upToSmall}px) {
     display: none;
   }
@@ -57,6 +59,9 @@ export default function PositionList({
       </DesktopHeader>
       <MobileHeader>
         <Trans>Your positions</Trans>
+        <ButtonText style={{ opacity: 0.6 }} onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}>
+          <Trans>Hide closed positions</Trans>
+        </ButtonText>
       </MobileHeader>
       {positions.map((p) => {
         return <PositionListItem key={p.tokenId.toString()} positionDetails={p} />

--- a/src/components/PositionList/index.tsx
+++ b/src/components/PositionList/index.tsx
@@ -49,9 +49,16 @@ const ToggleWrap = styled.div`
   align-items: center;
 `
 
-const ToggleLabelWrap = styled.div`
+const ToggleLabel = styled.div`
   opacity: 0.6;
   margin-right: 10px;
+`
+
+const MobileTogglePosition = styled.div`
+  @media screen and (max-width: ${MEDIA_WIDTHS.upToExtraSmall}px) {
+    position: absolute;
+    right: 20px;
+  }
 `
 
 type PositionListProps = React.PropsWithChildren<{
@@ -73,9 +80,9 @@ export default function PositionList({
           {positions && ' (' + positions.length + ')'}
         </div>
         <ToggleWrap>
-          <ToggleLabelWrap>
+          <ToggleLabel>
             <Trans>Show closed positions</Trans>
-          </ToggleLabelWrap>
+          </ToggleLabel>
           <SimpleToggle
             id="desktop-hide-closed-positions"
             isActive={!userHideClosedPositions}
@@ -88,16 +95,18 @@ export default function PositionList({
       <MobileHeader>
         <Trans>Your positions</Trans>
         <ToggleWrap>
-          <ToggleLabelWrap>
+          <ToggleLabel>
             <Trans>Show closed positions</Trans>
-          </ToggleLabelWrap>
-          <SimpleToggle
-            id="mobile-hide-closed-positions"
-            isActive={!userHideClosedPositions}
-            toggle={() => {
-              setUserHideClosedPositions(!userHideClosedPositions)
-            }}
-          />
+          </ToggleLabel>
+          <MobileTogglePosition>
+            <SimpleToggle
+              id="mobile-hide-closed-positions"
+              isActive={!userHideClosedPositions}
+              toggle={() => {
+                setUserHideClosedPositions(!userHideClosedPositions)
+              }}
+            />
+          </MobileTogglePosition>
         </ToggleWrap>
       </MobileHeader>
       {positions.map((p) => {

--- a/src/components/PositionList/index.tsx
+++ b/src/components/PositionList/index.tsx
@@ -59,7 +59,10 @@ export default function PositionList({
       </DesktopHeader>
       <MobileHeader>
         <Trans>Your positions</Trans>
-        <ButtonText style={{ opacity: 0.6 }} onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}>
+        <ButtonText
+          style={{ opacity: 0.6, fontSize: '14px' }}
+          onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}
+        >
           <Trans>Hide closed positions</Trans>
         </ButtonText>
       </MobileHeader>

--- a/src/components/PositionList/index.tsx
+++ b/src/components/PositionList/index.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
-import { ButtonText } from 'components/Button'
 import PositionListItem from 'components/PositionListItem'
+import SimpleToggle from 'components/Toggle/SimpleToggle'
 import React from 'react'
 import styled from 'styled-components/macro'
 import { MEDIA_WIDTHS } from 'theme'
@@ -30,9 +30,28 @@ const MobileHeader = styled.div`
   padding: 8px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+
   @media screen and (min-width: ${MEDIA_WIDTHS.upToSmall}px) {
     display: none;
   }
+
+  @media screen and (max-width: ${MEDIA_WIDTHS.upToExtraSmall}px) {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+  }
+`
+
+const ToggleWrap = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
+const ToggleLabelWrap = styled.div`
+  opacity: 0.6;
+  margin-right: 10px;
 `
 
 type PositionListProps = React.PropsWithChildren<{
@@ -53,18 +72,33 @@ export default function PositionList({
           <Trans>Your positions</Trans>
           {positions && ' (' + positions.length + ')'}
         </div>
-        <ButtonText style={{ opacity: 0.6 }} onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}>
-          <Trans>Hide closed positions</Trans>
-        </ButtonText>
+        <ToggleWrap>
+          <ToggleLabelWrap>
+            <Trans>Show closed positions</Trans>
+          </ToggleLabelWrap>
+          <SimpleToggle
+            id="desktop-hide-closed-positions"
+            isActive={!userHideClosedPositions}
+            toggle={() => {
+              setUserHideClosedPositions(!userHideClosedPositions)
+            }}
+          />
+        </ToggleWrap>
       </DesktopHeader>
       <MobileHeader>
         <Trans>Your positions</Trans>
-        <ButtonText
-          style={{ opacity: 0.6, fontSize: '14px' }}
-          onClick={() => setUserHideClosedPositions(!userHideClosedPositions)}
-        >
-          <Trans>Hide closed positions</Trans>
-        </ButtonText>
+        <ToggleWrap>
+          <ToggleLabelWrap>
+            <Trans>Show closed positions</Trans>
+          </ToggleLabelWrap>
+          <SimpleToggle
+            id="mobile-hide-closed-positions"
+            isActive={!userHideClosedPositions}
+            toggle={() => {
+              setUserHideClosedPositions(!userHideClosedPositions)
+            }}
+          />
+        </ToggleWrap>
       </MobileHeader>
       {positions.map((p) => {
         return <PositionListItem key={p.tokenId.toString()} positionDetails={p} />

--- a/src/components/Toggle/SimpleToggle.tsx
+++ b/src/components/Toggle/SimpleToggle.tsx
@@ -20,7 +20,7 @@ const ToggleElement = styled.span<{ isActive?: boolean; isOnSwitch?: boolean }>`
   height: 24px;
   width: 24px;
   position: absolute;
-  background: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.primary1 : theme.bg4) : 'none')};
+  background: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.primary1 : theme.text3) : 'none')};
   :hover {
     user-select: ${({ isOnSwitch }) => (isOnSwitch ? 'none' : 'initial')};
     background: ${({ theme, isActive, isOnSwitch }) =>

--- a/src/components/Toggle/SimpleToggle.tsx
+++ b/src/components/Toggle/SimpleToggle.tsx
@@ -1,0 +1,45 @@
+import { darken } from 'polished'
+import styled from 'styled-components/macro'
+
+const Wrapper = styled.button<{ isActive?: boolean; activeElement?: boolean }>`
+  border-radius: 20px;
+  border: none;
+  background: ${({ theme }) => theme.bg1};
+  display: flex;
+  cursor: pointer;
+  outline: none;
+  padding: 0.4rem 0.4rem;
+  align-items: center;
+  height: 32px;
+  width: 56px;
+  position: relative;
+`
+
+const ToggleElement = styled.span<{ isActive?: boolean; isOnSwitch?: boolean }>`
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  background: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.primary1 : theme.bg4) : 'none')};
+  :hover {
+    user-select: ${({ isOnSwitch }) => (isOnSwitch ? 'none' : 'initial')};
+    background: ${({ theme, isActive, isOnSwitch }) =>
+      isActive ? (isOnSwitch ? darken(0.05, theme.primary1) : darken(0.05, theme.bg4)) : 'none'};
+    color: ${({ theme, isActive, isOnSwitch }) => (isActive ? (isOnSwitch ? theme.white : theme.white) : theme.text3)};
+  }
+`
+
+interface ToggleProps {
+  id?: string
+  isActive: boolean
+  toggle: () => void
+}
+
+export default function SimpleToggle({ id, isActive, toggle }: ToggleProps) {
+  return (
+    <Wrapper id={id} isActive={isActive} onClick={toggle}>
+      <ToggleElement isActive={isActive} isOnSwitch={false} style={{ left: '4px' }} />
+      <ToggleElement isActive={!isActive} isOnSwitch={true} style={{ right: '4px' }} />
+    </Wrapper>
+  )
+}

--- a/src/components/Toggle/SimpleToggle.tsx
+++ b/src/components/Toggle/SimpleToggle.tsx
@@ -38,8 +38,8 @@ interface ToggleProps {
 export default function SimpleToggle({ id, isActive, toggle }: ToggleProps) {
   return (
     <Wrapper id={id} isActive={isActive} onClick={toggle}>
-      <ToggleElement isActive={isActive} isOnSwitch={false} style={{ left: '4px' }} />
-      <ToggleElement isActive={!isActive} isOnSwitch={true} style={{ right: '4px' }} />
+      <ToggleElement isActive={!isActive} isOnSwitch={false} style={{ left: '4px' }} />
+      <ToggleElement isActive={isActive} isOnSwitch={true} style={{ right: '4px' }} />
     </Wrapper>
   )
 }


### PR DESCRIPTION
This change adds the 'Hide closed positions' button to the mobile Pool page view. As referenced in #3344 , without this, the pool page can accumulate closed positions and the request can even time out with a large number of positions. We shouldn't limit user functionality due to mobile view whenever possible.

By default, the button is identical to the font size of the 'Your positions'. This supports widths up to 340px.
![image](https://user-images.githubusercontent.com/25194960/169706549-f96fccbc-32d0-4572-b8cb-2af29d6d3c96.png)

The smallest mobile view that I typically support is 320px (iPhone 5). With this, the bar overflows and doesn't look great.
![image](https://user-images.githubusercontent.com/25194960/169706625-9dae4330-63c0-4653-9817-53cfb39f0d4e.png)

With a font size of 14px on 'Hide closed positions', we are able to fit the 'Your positions' + 'Hide closed positions' in one line on screen widths as small as 320px.
![image](https://user-images.githubusercontent.com/25194960/169706707-72f744bb-d2d5-451d-8633-06a1efd5f849.png)




