### PR TITLE
Update graph link

### DIFF
--- a/src/state/data/slice.ts
+++ b/src/state/data/slice.ts
@@ -12,7 +12,7 @@ const CHAIN_SUBGRAPH_URL: Record<number, string> = {
 
   [SupportedChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-minimal',
 
-  [SupportedChainId.OPTIMISM]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-optimism-dev',
+  [SupportedChainId.OPTIMISM]: 'https://api.thegraph.com/subgraphs/name/ianlapham/optimism-post-regenesis',
 
   [SupportedChainId.POLYGON]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-polygon',
 }


### PR DESCRIPTION
Found this to be the proper Optimism graph link. info site uses this one, and I have tested in local environment, and it showed the graph while adding LQ
![image](https://user-images.githubusercontent.com/60412342/171335015-8b2757dd-9fdc-45df-a091-3e20879efb50.png)
