### PR TITLE
feat: locally store fiatValueOfFees

### DIFF
--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -418,9 +418,9 @@ export function PositionPage({
 
   if (fiatValueOfFees?.greaterThan(new Fraction(1, 100))) {
     localStorage.setItem(tokenId ? tokenId.toString() : '', fiatValueOfFees.toFixed(2))
-  } else {
-    const fiatValueOfFeesCached = localStorage.getItem(tokenId ? tokenId.toString() : '')
   }
+  const feesCached = localStorage.getItem(tokenId ? tokenId.toString() : '')
+  const fiatValueOfFeesCached = feesCached ? feesCached : '-'
   const fiatValueOfLiquidity: CurrencyAmount<Token> | null = useMemo(() => {
     if (!price0 || !price1 || !position) return null
     const amount0 = price0.quote(position.amount0)
@@ -739,7 +739,7 @@ export function PositionPage({
                           </ThemedText.LargeHeader>
                         ) : (
                           <ThemedText.LargeHeader color={theme.text1} fontSize="36px" fontWeight={500}>
-                            <Trans>${fiatValueOfFeesCached ? fiatValueOfFeesCached : '-'}</Trans>
+                            <Trans>${fiatValueOfFeesCached}</Trans>
                           </ThemedText.LargeHeader>
                         )}
                       </AutoColumn>

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -416,6 +416,11 @@ export function PositionPage({
     return amount0.add(amount1)
   }, [price0, price1, feeValue0, feeValue1])
 
+  if (fiatValueOfFees?.greaterThan(new Fraction(1, 100))) {
+    localStorage.setItem(tokenId ? tokenId.toString() : '', fiatValueOfFees.toFixed(2))
+  } else {
+    const fiatValueOfFeesCached = localStorage.getItem(tokenId ? tokenId.toString() : '')
+  }
   const fiatValueOfLiquidity: CurrencyAmount<Token> | null = useMemo(() => {
     if (!price0 || !price1 || !position) return null
     const amount0 = price0.quote(position.amount0)
@@ -734,7 +739,7 @@ export function PositionPage({
                           </ThemedText.LargeHeader>
                         ) : (
                           <ThemedText.LargeHeader color={theme.text1} fontSize="36px" fontWeight={500}>
-                            <Trans>$-</Trans>
+                            <Trans>${fiatValueOfFeesCached ? fiatValueOfFeesCached : '-'}</Trans>
                           </ThemedText.LargeHeader>
                         )}
                       </AutoColumn>


### PR DESCRIPTION
- feat: store the computed fiatValueOfFees using localStorage

Notes:

- Sometimes the static calls fail when fetching the uncollected fees for a position. 
- When it fails, the "Unclaimed fees" value on PositionPage shows `-`, which is annoying
- This feature stores the `fiatValueOfFees` locally using `localStorage` every time `fiatValueOfFees` is successfully computed
- This is better for LPs: rather than seeing `-` and having to reload the page until an actual value shows up, unclaimed fees now shows the latest value that was computed..