### PR TITLE
feat: add `Queue` and `Execute` buttons

### DIFF
--- a/src/components/AccountDetails/TransactionSummary.tsx
+++ b/src/components/AccountDetails/TransactionSummary.tsx
@@ -17,7 +17,9 @@ import {
   DepositLiquidityStakingTransactionInfo,
   ExactInputSwapTransactionInfo,
   ExactOutputSwapTransactionInfo,
+  ExecuteTransactionInfo,
   MigrateV2LiquidityToV3TransactionInfo,
+  QueueTransactionInfo,
   RemoveLiquidityV3TransactionInfo,
   SubmitProposalTransactionInfo,
   TransactionInfo,
@@ -124,6 +126,16 @@ function VoteSummary({ info }: { info: VoteTransactionInfo }) {
         )
     }
   }
+}
+
+function QueueSummary({ info }: { info: QueueTransactionInfo }) {
+  const proposalKey = `${info.governorAddress}/${info.proposalId}`
+  return <Trans>Queue proposal {proposalKey}.</Trans>
+}
+
+function ExecuteSummary({ info }: { info: ExecuteTransactionInfo }) {
+  const proposalKey = `${info.governorAddress}/${info.proposalId}`
+  return <Trans>Execute proposal {proposalKey}.</Trans>
 }
 
 function DelegateSummary({ info: { delegatee } }: { info: DelegateTransactionInfo }) {
@@ -338,6 +350,12 @@ export function TransactionSummary({ info }: { info: TransactionInfo }) {
 
     case TransactionType.REMOVE_LIQUIDITY_V3:
       return <RemoveLiquidityV3Summary info={info} />
+
+    case TransactionType.QUEUE:
+      return <QueueSummary info={info} />
+
+    case TransactionType.EXECUTE:
+      return <ExecuteSummary info={info} />
 
     case TransactionType.SUBMIT_PROPOSAL:
       return <SubmitProposalTransactionSummary info={info} />

--- a/src/components/earn/UnstakingModal.tsx
+++ b/src/components/earn/UnstakingModal.tsx
@@ -42,7 +42,7 @@ export default function UnstakingModal({ isOpen, onDismiss, stakingInfo }: Staki
   const [hash, setHash] = useState<string | undefined>()
   const [attempting, setAttempting] = useState(false)
 
-  function wrappedOndismiss() {
+  function wrappedOnDismiss() {
     setHash(undefined)
     setAttempting(false)
     onDismiss()
@@ -79,14 +79,14 @@ export default function UnstakingModal({ isOpen, onDismiss, stakingInfo }: Staki
   }
 
   return (
-    <Modal isOpen={isOpen} onDismiss={wrappedOndismiss} maxHeight={90}>
+    <Modal isOpen={isOpen} onDismiss={wrappedOnDismiss} maxHeight={90}>
       {!attempting && !hash && (
         <ContentWrapper gap="lg">
           <RowBetween>
             <ThemedText.MediumHeader>
               <Trans>Withdraw</Trans>
             </ThemedText.MediumHeader>
-            <CloseIcon onClick={wrappedOndismiss} />
+            <CloseIcon onClick={wrappedOnDismiss} />
           </RowBetween>
           {stakingInfo?.stakedAmount && (
             <AutoColumn justify="center" gap="md">
@@ -117,7 +117,7 @@ export default function UnstakingModal({ isOpen, onDismiss, stakingInfo }: Staki
         </ContentWrapper>
       )}
       {attempting && !hash && (
-        <LoadingView onDismiss={wrappedOndismiss}>
+        <LoadingView onDismiss={wrappedOnDismiss}>
           <AutoColumn gap="12px" justify={'center'}>
             <ThemedText.Body fontSize={20}>
               <Trans>Withdrawing {stakingInfo?.stakedAmount?.toSignificant(4)} UNI-V2</Trans>
@@ -129,7 +129,7 @@ export default function UnstakingModal({ isOpen, onDismiss, stakingInfo }: Staki
         </LoadingView>
       )}
       {hash && (
-        <SubmittedView onDismiss={wrappedOndismiss} hash={hash}>
+        <SubmittedView onDismiss={wrappedOnDismiss} hash={hash}>
           <AutoColumn gap="12px" justify={'center'}>
             <ThemedText.LargeHeader>
               <Trans>Transaction Submitted</Trans>

--- a/src/components/vote/DelegateModal.tsx
+++ b/src/components/vote/DelegateModal.tsx
@@ -66,7 +66,7 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
   const [attempting, setAttempting] = useState(false)
 
   // wrapper to reset state on modal close
-  function wrappedOndismiss() {
+  function wrappedOnDismiss() {
     setHash(undefined)
     setAttempting(false)
     onDismiss()
@@ -90,13 +90,13 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
   }
 
   return (
-    <Modal isOpen={isOpen} onDismiss={wrappedOndismiss} maxHeight={90}>
+    <Modal isOpen={isOpen} onDismiss={wrappedOnDismiss} maxHeight={90}>
       {!attempting && !hash && (
         <ContentWrapper gap="lg">
           <AutoColumn gap="lg" justify="center">
             <RowBetween>
               <ThemedText.MediumHeader fontWeight={500}>{title}</ThemedText.MediumHeader>
-              <StyledClosed stroke="black" onClick={wrappedOndismiss} />
+              <StyledClosed stroke="black" onClick={wrappedOnDismiss} />
             </RowBetween>
             <ThemedText.Body>
               <Trans>Earned UNI tokens represent voting shares in Uniswap governance.</Trans>
@@ -119,7 +119,7 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
         </ContentWrapper>
       )}
       {attempting && !hash && (
-        <LoadingView onDismiss={wrappedOndismiss}>
+        <LoadingView onDismiss={wrappedOnDismiss}>
           <AutoColumn gap="12px" justify={'center'}>
             <ThemedText.LargeHeader>
               {usingDelegate ? <Trans>Delegating votes</Trans> : <Trans>Unlocking Votes</Trans>}
@@ -129,7 +129,7 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
         </LoadingView>
       )}
       {hash && (
-        <SubmittedView onDismiss={wrappedOndismiss} hash={hash}>
+        <SubmittedView onDismiss={wrappedOnDismiss} hash={hash}>
           <AutoColumn gap="12px" justify={'center'}>
             <ThemedText.LargeHeader>
               <Trans>Transaction Submitted</Trans>

--- a/src/components/vote/ExecuteModal.tsx
+++ b/src/components/vote/ExecuteModal.tsx
@@ -42,7 +42,7 @@ interface ExecuteModalProps {
 
 export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteModalProps) {
   const { chainId } = useActiveWeb3React()
-  const { executeCallback } = useExecuteCallback()
+  const executeCallback = useExecuteCallback()
 
   // monitor call to help UI loading state
   const [hash, setHash] = useState<string | undefined>()

--- a/src/components/vote/ExecuteModal.tsx
+++ b/src/components/vote/ExecuteModal.tsx
@@ -3,11 +3,9 @@ import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useContext, useState } from 'react'
 import { ArrowUpCircle, X } from 'react-feather'
 import styled, { ThemeContext } from 'styled-components/macro'
-import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import Circle from '../../assets/images/blue-loader.svg'
-import { useUserVotes, useVoteCallback } from '../../state/governance/hooks'
-import { VoteOption } from '../../state/governance/types'
+import { useExecuteCallback } from '../../state/governance/hooks'
 import { CustomLightSpinner, ThemedText } from '../../theme'
 import { ExternalLink } from '../../theme'
 import { ExplorerDataType, getExplorerLink } from '../../utils/getExplorerLink'
@@ -36,17 +34,15 @@ const ConfirmedIcon = styled(ColumnCenter)`
   padding: 60px 0;
 `
 
-interface VoteModalProps {
+interface ExecuteModalProps {
   isOpen: boolean
   onDismiss: () => void
-  voteOption: VoteOption | undefined
-  proposalId: string | undefined // id for the proposal to vote on
+  proposalId: string | undefined // id for the proposal to execute
 }
 
-export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }: VoteModalProps) {
+export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteModalProps) {
   const { chainId } = useActiveWeb3React()
-  const { voteCallback } = useVoteCallback()
-  const { votes: availableVotes } = useUserVotes()
+  const { executeCallback } = useExecuteCallback()
 
   // monitor call to help UI loading state
   const [hash, setHash] = useState<string | undefined>()
@@ -62,14 +58,14 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
     onDismiss()
   }
 
-  async function onVote() {
+  async function onExecute() {
     setAttempting(true)
 
     // if callback not returned properly ignore
-    if (!voteCallback || voteOption === undefined) return
+    if (!executeCallback) return
 
     // try delegation and store hash
-    const hash = await voteCallback(proposalId, voteOption)?.catch((error) => {
+    const hash = await executeCallback(proposalId)?.catch((error) => {
       setAttempting(false)
       console.log(error)
     })
@@ -86,28 +82,13 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
           <AutoColumn gap="lg" justify="center">
             <RowBetween>
               <ThemedText.MediumHeader fontWeight={500}>
-                {voteOption === VoteOption.Against ? (
-                  <Trans>Vote against proposal {proposalId}</Trans>
-                ) : voteOption === VoteOption.For ? (
-                  <Trans>Vote for proposal {proposalId}</Trans>
-                ) : (
-                  <Trans>Vote to abstain on proposal {proposalId}</Trans>
-                )}
+                <Trans>Execute Proposal {proposalId}</Trans>
               </ThemedText.MediumHeader>
               <StyledClosed onClick={wrappedOndismiss} />
             </RowBetween>
-            <ThemedText.LargeHeader>
-              <Trans>{formatCurrencyAmount(availableVotes, 4)} Votes</Trans>
-            </ThemedText.LargeHeader>
-            <ButtonPrimary onClick={onVote}>
+            <ButtonPrimary onClick={onExecute}>
               <ThemedText.MediumHeader color="white">
-                {voteOption === VoteOption.Against ? (
-                  <Trans>Vote against proposal {proposalId}</Trans>
-                ) : voteOption === VoteOption.For ? (
-                  <Trans>Vote for proposal {proposalId}</Trans>
-                ) : (
-                  <Trans>Vote to abstain on proposal {proposalId}</Trans>
-                )}
+                <Trans>Execute</Trans>
               </ThemedText.MediumHeader>
             </ButtonPrimary>
           </AutoColumn>
@@ -125,7 +106,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
           <AutoColumn gap="100px" justify={'center'}>
             <AutoColumn gap="12px" justify={'center'}>
               <ThemedText.LargeHeader>
-                <Trans>Submitting Vote</Trans>
+                <Trans>Executing</Trans>
               </ThemedText.LargeHeader>
             </AutoColumn>
             <ThemedText.SubHeader>

--- a/src/components/vote/ExecuteModal.tsx
+++ b/src/components/vote/ExecuteModal.tsx
@@ -52,7 +52,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
   const theme = useContext(ThemeContext)
 
   // wrapper to reset state on modal close
-  function wrappedOndismiss() {
+  function wrappedOnDismiss() {
     setHash(undefined)
     setAttempting(false)
     onDismiss()
@@ -76,7 +76,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
   }
 
   return (
-    <Modal isOpen={isOpen} onDismiss={wrappedOndismiss} maxHeight={90}>
+    <Modal isOpen={isOpen} onDismiss={wrappedOnDismiss} maxHeight={90}>
       {!attempting && !hash && (
         <ContentWrapper gap="lg">
           <AutoColumn gap="lg" justify="center">
@@ -84,7 +84,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
               <ThemedText.MediumHeader fontWeight={500}>
                 <Trans>Execute Proposal {proposalId}</Trans>
               </ThemedText.MediumHeader>
-              <StyledClosed onClick={wrappedOndismiss} />
+              <StyledClosed onClick={wrappedOnDismiss} />
             </RowBetween>
             <RowBetween>
               <ThemedText.Body>
@@ -103,7 +103,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
         <ConfirmOrLoadingWrapper>
           <RowBetween>
             <div />
-            <StyledClosed onClick={wrappedOndismiss} />
+            <StyledClosed onClick={wrappedOnDismiss} />
           </RowBetween>
           <ConfirmedIcon>
             <CustomLightSpinner src={Circle} alt="loader" size={'90px'} />
@@ -124,7 +124,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
         <ConfirmOrLoadingWrapper>
           <RowBetween>
             <div />
-            <StyledClosed onClick={wrappedOndismiss} />
+            <StyledClosed onClick={wrappedOnDismiss} />
           </RowBetween>
           <ConfirmedIcon>
             <ArrowUpCircle strokeWidth={0.5} size={90} color={theme.primary1} />
@@ -132,7 +132,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
           <AutoColumn gap="100px" justify={'center'}>
             <AutoColumn gap="12px" justify={'center'}>
               <ThemedText.LargeHeader>
-                <Trans>Transaction Submitted</Trans>
+                <Trans>Execution Submitted</Trans>
               </ThemedText.LargeHeader>
             </AutoColumn>
             {chainId && (

--- a/src/components/vote/ExecuteModal.tsx
+++ b/src/components/vote/ExecuteModal.tsx
@@ -86,6 +86,11 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
               </ThemedText.MediumHeader>
               <StyledClosed onClick={wrappedOndismiss} />
             </RowBetween>
+            <RowBetween>
+              <ThemedText.Body>
+                <Trans>Executing this proposal will enact the calldata on-chain.</Trans>
+              </ThemedText.Body>
+            </RowBetween>
             <ButtonPrimary onClick={onExecute}>
               <ThemedText.MediumHeader color="white">
                 <Trans>Execute</Trans>

--- a/src/components/vote/QueueModal.tsx
+++ b/src/components/vote/QueueModal.tsx
@@ -42,7 +42,7 @@ interface QueueModalProps {
 
 export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModalProps) {
   const { chainId } = useActiveWeb3React()
-  const { queueCallback } = useQueueCallback()
+  const queueCallback = useQueueCallback()
 
   // monitor call to help UI loading state
   const [hash, setHash] = useState<string | undefined>()

--- a/src/components/vote/QueueModal.tsx
+++ b/src/components/vote/QueueModal.tsx
@@ -3,11 +3,9 @@ import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useContext, useState } from 'react'
 import { ArrowUpCircle, X } from 'react-feather'
 import styled, { ThemeContext } from 'styled-components/macro'
-import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import Circle from '../../assets/images/blue-loader.svg'
-import { useUserVotes, useVoteCallback } from '../../state/governance/hooks'
-import { VoteOption } from '../../state/governance/types'
+import { useQueueCallback } from '../../state/governance/hooks'
 import { CustomLightSpinner, ThemedText } from '../../theme'
 import { ExternalLink } from '../../theme'
 import { ExplorerDataType, getExplorerLink } from '../../utils/getExplorerLink'
@@ -36,17 +34,15 @@ const ConfirmedIcon = styled(ColumnCenter)`
   padding: 60px 0;
 `
 
-interface VoteModalProps {
+interface QueueModalProps {
   isOpen: boolean
   onDismiss: () => void
-  voteOption: VoteOption | undefined
-  proposalId: string | undefined // id for the proposal to vote on
+  proposalId: string | undefined // id for the proposal to queue
 }
 
-export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }: VoteModalProps) {
+export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModalProps) {
   const { chainId } = useActiveWeb3React()
-  const { voteCallback } = useVoteCallback()
-  const { votes: availableVotes } = useUserVotes()
+  const { queueCallback } = useQueueCallback()
 
   // monitor call to help UI loading state
   const [hash, setHash] = useState<string | undefined>()
@@ -62,14 +58,14 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
     onDismiss()
   }
 
-  async function onVote() {
+  async function onQueue() {
     setAttempting(true)
 
     // if callback not returned properly ignore
-    if (!voteCallback || voteOption === undefined) return
+    if (!queueCallback) return
 
     // try delegation and store hash
-    const hash = await voteCallback(proposalId, voteOption)?.catch((error) => {
+    const hash = await queueCallback(proposalId)?.catch((error) => {
       setAttempting(false)
       console.log(error)
     })
@@ -86,28 +82,18 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
           <AutoColumn gap="lg" justify="center">
             <RowBetween>
               <ThemedText.MediumHeader fontWeight={500}>
-                {voteOption === VoteOption.Against ? (
-                  <Trans>Vote against proposal {proposalId}</Trans>
-                ) : voteOption === VoteOption.For ? (
-                  <Trans>Vote for proposal {proposalId}</Trans>
-                ) : (
-                  <Trans>Vote to abstain on proposal {proposalId}</Trans>
-                )}
+                <Trans>Queue Proposal {proposalId}</Trans>
               </ThemedText.MediumHeader>
               <StyledClosed onClick={wrappedOndismiss} />
             </RowBetween>
-            <ThemedText.LargeHeader>
-              <Trans>{formatCurrencyAmount(availableVotes, 4)} Votes</Trans>
-            </ThemedText.LargeHeader>
-            <ButtonPrimary onClick={onVote}>
+            <RowBetween>
+              <ThemedText.Body>
+                <Trans>Adding this proposal to the queue will allow it to be executed, after a delay.</Trans>
+              </ThemedText.Body>
+            </RowBetween>
+            <ButtonPrimary onClick={onQueue}>
               <ThemedText.MediumHeader color="white">
-                {voteOption === VoteOption.Against ? (
-                  <Trans>Vote against proposal {proposalId}</Trans>
-                ) : voteOption === VoteOption.For ? (
-                  <Trans>Vote for proposal {proposalId}</Trans>
-                ) : (
-                  <Trans>Vote to abstain on proposal {proposalId}</Trans>
-                )}
+                <Trans>Queue</Trans>
               </ThemedText.MediumHeader>
             </ButtonPrimary>
           </AutoColumn>
@@ -125,7 +111,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
           <AutoColumn gap="100px" justify={'center'}>
             <AutoColumn gap="12px" justify={'center'}>
               <ThemedText.LargeHeader>
-                <Trans>Submitting Vote</Trans>
+                <Trans>Queueing</Trans>
               </ThemedText.LargeHeader>
             </AutoColumn>
             <ThemedText.SubHeader>

--- a/src/components/vote/QueueModal.tsx
+++ b/src/components/vote/QueueModal.tsx
@@ -52,7 +52,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
   const theme = useContext(ThemeContext)
 
   // wrapper to reset state on modal close
-  function wrappedOndismiss() {
+  function wrappedOnDismiss() {
     setHash(undefined)
     setAttempting(false)
     onDismiss()
@@ -76,7 +76,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
   }
 
   return (
-    <Modal isOpen={isOpen} onDismiss={wrappedOndismiss} maxHeight={90}>
+    <Modal isOpen={isOpen} onDismiss={wrappedOnDismiss} maxHeight={90}>
       {!attempting && !hash && (
         <ContentWrapper gap="lg">
           <AutoColumn gap="lg" justify="center">
@@ -84,7 +84,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
               <ThemedText.MediumHeader fontWeight={500}>
                 <Trans>Queue Proposal {proposalId}</Trans>
               </ThemedText.MediumHeader>
-              <StyledClosed onClick={wrappedOndismiss} />
+              <StyledClosed onClick={wrappedOnDismiss} />
             </RowBetween>
             <RowBetween>
               <ThemedText.Body>
@@ -103,7 +103,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
         <ConfirmOrLoadingWrapper>
           <RowBetween>
             <div />
-            <StyledClosed onClick={wrappedOndismiss} />
+            <StyledClosed onClick={wrappedOnDismiss} />
           </RowBetween>
           <ConfirmedIcon>
             <CustomLightSpinner src={Circle} alt="loader" size={'90px'} />
@@ -124,7 +124,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
         <ConfirmOrLoadingWrapper>
           <RowBetween>
             <div />
-            <StyledClosed onClick={wrappedOndismiss} />
+            <StyledClosed onClick={wrappedOnDismiss} />
           </RowBetween>
           <ConfirmedIcon>
             <ArrowUpCircle strokeWidth={0.5} size={90} color={theme.primary1} />

--- a/src/components/vote/VoteModal.tsx
+++ b/src/components/vote/VoteModal.tsx
@@ -56,7 +56,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
   const theme = useContext(ThemeContext)
 
   // wrapper to reset state on modal close
-  function wrappedOndismiss() {
+  function wrappedOnDismiss() {
     setHash(undefined)
     setAttempting(false)
     onDismiss()
@@ -80,7 +80,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
   }
 
   return (
-    <Modal isOpen={isOpen} onDismiss={wrappedOndismiss} maxHeight={90}>
+    <Modal isOpen={isOpen} onDismiss={wrappedOnDismiss} maxHeight={90}>
       {!attempting && !hash && (
         <ContentWrapper gap="lg">
           <AutoColumn gap="lg" justify="center">
@@ -94,7 +94,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
                   <Trans>Vote to abstain on proposal {proposalId}</Trans>
                 )}
               </ThemedText.MediumHeader>
-              <StyledClosed onClick={wrappedOndismiss} />
+              <StyledClosed onClick={wrappedOnDismiss} />
             </RowBetween>
             <ThemedText.LargeHeader>
               <Trans>{formatCurrencyAmount(availableVotes, 4)} Votes</Trans>
@@ -117,7 +117,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
         <ConfirmOrLoadingWrapper>
           <RowBetween>
             <div />
-            <StyledClosed onClick={wrappedOndismiss} />
+            <StyledClosed onClick={wrappedOnDismiss} />
           </RowBetween>
           <ConfirmedIcon>
             <CustomLightSpinner src={Circle} alt="loader" size={'90px'} />
@@ -138,7 +138,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
         <ConfirmOrLoadingWrapper>
           <RowBetween>
             <div />
-            <StyledClosed onClick={wrappedOndismiss} />
+            <StyledClosed onClick={wrappedOnDismiss} />
           </RowBetween>
           <ConfirmedIcon>
             <ArrowUpCircle strokeWidth={0.5} size={90} color={theme.primary1} />

--- a/src/components/vote/VoteModal.tsx
+++ b/src/components/vote/VoteModal.tsx
@@ -45,7 +45,7 @@ interface VoteModalProps {
 
 export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }: VoteModalProps) {
   const { chainId } = useActiveWeb3React()
-  const { voteCallback } = useVoteCallback()
+  const voteCallback = useVoteCallback()
   const { votes: availableVotes } = useUserVotes()
 
   // monitor call to help UI loading state

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -228,7 +228,7 @@ export default function VotePage({
   // we only show the button if there's an account connected and the proposal state is correct
   const showQueueButton = account && proposalData?.status === ProposalState.SUCCEEDED
 
-  // we only show the button if there's an account connected and the proposal state is correct
+  // we only show the button if there's an account connected, the proposal state is correct, and the eta has passed
   const showExecuteButton =
     account &&
     proposalData?.status === ProposalState.QUEUED &&

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -232,9 +232,9 @@ export default function VotePage({
   const showExecuteButton =
     account &&
     proposalData?.status === ProposalState.QUEUED &&
-    currentBlock &&
+    currentTimestamp &&
     proposalData?.eta &&
-    proposalData.eta <= currentBlock
+    currentTimestamp.gte(proposalData.eta)
 
   const uniBalance: CurrencyAmount<Token> | undefined = useTokenBalance(
     account ?? undefined,

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -44,6 +44,14 @@ export function useToggleVoteModal(): () => void {
   return useToggleModal(ApplicationModal.VOTE)
 }
 
+export function useToggleQueueModal(): () => void {
+  return useToggleModal(ApplicationModal.QUEUE)
+}
+
+export function useToggleExecuteModal(): () => void {
+  return useToggleModal(ApplicationModal.EXECUTE)
+}
+
 export function useTogglePrivacyPolicy(): () => void {
   return useToggleModal(ApplicationModal.PRIVACY_POLICY)
 }

--- a/src/state/application/reducer.ts
+++ b/src/state/application/reducer.ts
@@ -26,6 +26,8 @@ export enum ApplicationModal {
   SETTINGS,
   VOTE,
   WALLET,
+  QUEUE,
+  EXECUTE,
 }
 
 type PopupList = Array<{ key: string; show: boolean; content: PopupContent; removeAfterMs: number | null }>

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -1,5 +1,6 @@
 import { defaultAbiCoder, Interface } from '@ethersproject/abi'
 import { isAddress } from '@ethersproject/address'
+import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
 import { TransactionResponse } from '@ethersproject/providers'
 import { toUtf8String, Utf8ErrorFuncs, Utf8ErrorReason } from '@ethersproject/strings'
@@ -73,7 +74,7 @@ export interface ProposalData {
   againstCount: CurrencyAmount<Token>
   startBlock: number
   endBlock: number
-  eta: number
+  eta: BigNumber
   details: ProposalDetail[]
   governorIndex: number // index in the governance address array for which this proposal pertains
 }
@@ -302,7 +303,7 @@ export function useAllProposalData(): { data: ProposalData[]; loading: boolean }
           againstCount: CurrencyAmount.fromRawAmount(uni, proposal?.result?.againstVotes),
           startBlock,
           endBlock: parseInt(proposal?.result?.endBlock?.toString()),
-          eta: parseInt(proposal?.result?.eta?.toString()),
+          eta: proposal?.result?.eta,
           details: formattedLogs[i]?.details,
           governorIndex: i >= proposalsV0.length + proposalsV1.length ? 2 : i >= proposalsV0.length ? 1 : 0,
         }

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -410,16 +410,15 @@ export function useDelegateCallback(): (delegatee: string | undefined) => undefi
   )
 }
 
-export function useVoteCallback(): {
-  voteCallback: (proposalId: string | undefined, voteOption: VoteOption) => undefined | Promise<string>
-} {
+export function useVoteCallback(): (
+  proposalId: string | undefined,
+  voteOption: VoteOption
+) => undefined | Promise<string> {
   const { account, chainId } = useActiveWeb3React()
-
   const latestGovernanceContract = useLatestGovernanceContract()
-
   const addTransaction = useTransactionAdder()
 
-  const voteCallback = useCallback(
+  return useCallback(
     (proposalId: string | undefined, voteOption: VoteOption) => {
       if (!account || !latestGovernanceContract || !proposalId || !chainId) return
       const args = [proposalId, voteOption === VoteOption.Against ? 0 : voteOption === VoteOption.For ? 1 : 2]
@@ -440,19 +439,14 @@ export function useVoteCallback(): {
     },
     [account, addTransaction, latestGovernanceContract, chainId]
   )
-  return { voteCallback }
 }
 
-export function useQueueCallback(): {
-  queueCallback: (proposalId: string | undefined) => undefined | Promise<string>
-} {
+export function useQueueCallback(): (proposalId: string | undefined) => undefined | Promise<string> {
   const { account, chainId } = useActiveWeb3React()
-
   const latestGovernanceContract = useLatestGovernanceContract()
-
   const addTransaction = useTransactionAdder()
 
-  const queueCallback = useCallback(
+  return useCallback(
     (proposalId: string | undefined) => {
       if (!account || !latestGovernanceContract || !proposalId || !chainId) return
       const args = [proposalId]
@@ -471,19 +465,14 @@ export function useQueueCallback(): {
     },
     [account, addTransaction, latestGovernanceContract, chainId]
   )
-  return { queueCallback }
 }
 
-export function useExecuteCallback(): {
-  executeCallback: (proposalId: string | undefined) => undefined | Promise<string>
-} {
+export function useExecuteCallback(): (proposalId: string | undefined) => undefined | Promise<string> {
   const { account, chainId } = useActiveWeb3React()
-
   const latestGovernanceContract = useLatestGovernanceContract()
-
   const addTransaction = useTransactionAdder()
 
-  const executeCallback = useCallback(
+  return useCallback(
     (proposalId: string | undefined) => {
       if (!account || !latestGovernanceContract || !proposalId || !chainId) return
       const args = [proposalId]
@@ -502,14 +491,12 @@ export function useExecuteCallback(): {
     },
     [account, addTransaction, latestGovernanceContract, chainId]
   )
-  return { executeCallback }
 }
 
 export function useCreateProposalCallback(): (
   createProposalData: CreateProposalData | undefined
 ) => undefined | Promise<string> {
   const { account, chainId } = useActiveWeb3React()
-
   const latestGovernanceContract = useLatestGovernanceContract()
   const addTransaction = useTransactionAdder()
 

--- a/src/state/transactions/types.ts
+++ b/src/state/transactions/types.ts
@@ -18,7 +18,7 @@ interface SerializableTransactionReceipt {
  * These values is persisted in state and if you change the value it will cause errors
  */
 export enum TransactionType {
-  APPROVAL,
+  APPROVAL = 0,
   SWAP,
   DEPOSIT_LIQUIDITY_STAKING,
   WITHDRAW_LIQUIDITY_STAKING,

--- a/src/state/transactions/types.ts
+++ b/src/state/transactions/types.ts
@@ -18,21 +18,23 @@ interface SerializableTransactionReceipt {
  * These values is persisted in state and if you change the value it will cause errors
  */
 export enum TransactionType {
-  APPROVAL = 0,
-  SWAP = 1,
-  DEPOSIT_LIQUIDITY_STAKING = 2,
-  WITHDRAW_LIQUIDITY_STAKING = 3,
-  CLAIM = 4,
-  VOTE = 5,
-  DELEGATE = 6,
-  WRAP = 7,
-  CREATE_V3_POOL = 8,
-  ADD_LIQUIDITY_V3_POOL = 9,
-  ADD_LIQUIDITY_V2_POOL = 10,
-  MIGRATE_LIQUIDITY_V3 = 11,
-  COLLECT_FEES = 12,
-  REMOVE_LIQUIDITY_V3 = 13,
-  SUBMIT_PROPOSAL = 14,
+  APPROVAL,
+  SWAP,
+  DEPOSIT_LIQUIDITY_STAKING,
+  WITHDRAW_LIQUIDITY_STAKING,
+  CLAIM,
+  VOTE,
+  DELEGATE,
+  WRAP,
+  CREATE_V3_POOL,
+  ADD_LIQUIDITY_V3_POOL,
+  ADD_LIQUIDITY_V2_POOL,
+  MIGRATE_LIQUIDITY_V3,
+  COLLECT_FEES,
+  REMOVE_LIQUIDITY_V3,
+  SUBMIT_PROPOSAL,
+  QUEUE,
+  EXECUTE,
 }
 
 export interface BaseTransactionInfo {
@@ -45,6 +47,18 @@ export interface VoteTransactionInfo extends BaseTransactionInfo {
   proposalId: number
   decision: VoteOption
   reason: string
+}
+
+export interface QueueTransactionInfo extends BaseTransactionInfo {
+  type: TransactionType.QUEUE
+  governorAddress: string
+  proposalId: number
+}
+
+export interface ExecuteTransactionInfo extends BaseTransactionInfo {
+  type: TransactionType.EXECUTE
+  governorAddress: string
+  proposalId: number
 }
 
 export interface DelegateTransactionInfo extends BaseTransactionInfo {
@@ -158,6 +172,8 @@ export type TransactionInfo =
   | ExactInputSwapTransactionInfo
   | ClaimTransactionInfo
   | VoteTransactionInfo
+  | QueueTransactionInfo
+  | ExecuteTransactionInfo
   | DelegateTransactionInfo
   | DepositLiquidityStakingTransactionInfo
   | WithdrawLiquidityStakingTransactionInfo


### PR DESCRIPTION
this PR introduces 2 new flows to queue successful proposals and execute queued proposals, when necessary