### PR TITLE
perf: remove Arbitrum polling override

### DIFF
--- a/src/utils/getLibrary.ts
+++ b/src/utils/getLibrary.ts
@@ -4,8 +4,6 @@ import ms from 'ms.macro'
 import { SupportedChainId } from '../constants/chains'
 
 const NETWORK_POLLING_INTERVALS: { [chainId: number]: number } = {
-  [SupportedChainId.ARBITRUM_ONE]: ms`1s`,
-  [SupportedChainId.ARBITRUM_RINKEBY]: ms`1s`,
   [SupportedChainId.OPTIMISM]: ms`1s`,
   [SupportedChainId.OPTIMISTIC_KOVAN]: ms`1s`,
 }


### PR DESCRIPTION
This PR remove the `NETWORK_POLLING_INTERVALS` override for **Arbitrum** networks to improve performance by reducing number of rpc requests.