### PR TITLE
fix: shows spot price on token select

### DIFF
--- a/src/components/CurrencyInputPanel/FiatValue.tsx
+++ b/src/components/CurrencyInputPanel/FiatValue.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
-import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent, Price, Token } from '@uniswap/sdk-core'
 import HoverInlineText from 'components/HoverInlineText'
 import { useMemo } from 'react'
 
@@ -13,9 +13,11 @@ import { MouseoverTooltip } from '../Tooltip'
 export function FiatValue({
   fiatValue,
   priceImpact,
+  spotValue,
 }: {
   fiatValue: CurrencyAmount<Currency> | null | undefined
   priceImpact?: Percent
+  spotValue?: Price<Currency, Token> | null | undefined
 }) {
   const theme = useTheme()
   const priceImpactColor = useMemo(() => {
@@ -38,6 +40,14 @@ export function FiatValue({
           <HoverInlineText
             text={fiatValue?.toFixed(visibleDecimalPlaces, { groupSeparator: ',' })}
             textColor={fiatValue ? theme.text3 : theme.text4}
+          />
+        </Trans>
+      ) : spotValue ? (
+        <Trans>
+          <span style={{ color: `${spotValue ? theme.text3 : theme.text4}` }}>~$</span>
+          <HoverInlineText
+            text={spotValue?.toSignificant(6, { groupSeparator: ',' })}
+            textColor={spotValue ? theme.text3 : theme.text4}
           />
         </Trans>
       ) : (

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -4,6 +4,7 @@ import { Pair } from '@uniswap/v2-sdk'
 import { AutoColumn } from 'components/Column'
 import { LoadingOpacityContainer, loadingOpacityMixin } from 'components/Loader/styled'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import useUSDCPrice from 'hooks/useUSDCPrice'
 import { darken } from 'polished'
 import { ReactNode, useCallback, useState } from 'react'
 import { Lock } from 'react-feather'
@@ -203,6 +204,7 @@ export default function CurrencyInputPanel({
   const [modalOpen, setModalOpen] = useState(false)
   const { account } = useActiveWeb3React()
   const selectedCurrencyBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
+  const spotValue = useUSDCPrice(currency ?? undefined)
   const theme = useTheme()
 
   const handleDismissSearch = useCallback(() => {
@@ -274,7 +276,7 @@ export default function CurrencyInputPanel({
           <FiatRow>
             <RowBetween>
               <LoadingOpacityContainer $loading={loading}>
-                <FiatValue fiatValue={fiatValue} priceImpact={priceImpact} />
+                <FiatValue fiatValue={fiatValue} priceImpact={priceImpact} spotValue={spotValue} />
               </LoadingOpacityContainer>
               {account ? (
                 <RowFixed style={{ height: '17px' }}>


### PR DESCRIPTION
https://github.com/Uniswap/interface/issues/1712

Adds spot price on token select when a user hasn't entered an amount yet. I wasn't sure how to display this, so I went with ~${spotPrice}. I can change this as needed as I expect some input on how we want to display this. 

Some examples: 
![image](https://user-images.githubusercontent.com/25194960/173445269-6bbdd6b6-fac4-4a0b-82d9-bbce3bb20c01.png)
![image](https://user-images.githubusercontent.com/25194960/173445284-85965e8d-6d93-46ff-a3ab-69229e44fc31.png)
![image](https://user-images.githubusercontent.com/25194960/173445312-4fa4a6cf-5c08-42e9-a58d-fe70c292814d.png)

