### PR TITLE
fix: show no price impact eth to weth

### DIFF
--- a/cypress/e2e/swap.test.ts
+++ b/cypress/e2e/swap.test.ts
@@ -48,6 +48,17 @@ describe('Swap', () => {
     cy.get('#add-recipient-button').should('not.exist')
   })
 
+  it('ETH to wETH is same value (wrapped swaps have no price impact)', () => {
+    cy.get('#swap-currency-output .open-currency-select-button').click()
+    cy.get('.token-item-0xc778417E063141139Fce010982780140Aa0cD5Ab').should('be.visible')
+    cy.get('.token-item-0xc778417E063141139Fce010982780140Aa0cD5Ab').click({ force: true })
+    cy.get('#swap-currency-input .token-amount-input').should('be.visible')
+    cy.get('#swap-currency-input .token-amount-input').type('0.01', { force: true, delay: 100 })
+    console.log(cy.get('#swap-currency-input .token-amount-input'))
+    console.log(cy.get('#swap-currency-output .token-amount-input'))
+    cy.get('#swap-currency-output .token-amount-input').should('have.value', '0.01')
+  })
+
   describe('expert mode', () => {
     beforeEach(() => {
       cy.window().then((win) => {

--- a/cypress/e2e/swap.test.ts
+++ b/cypress/e2e/swap.test.ts
@@ -54,8 +54,6 @@ describe('Swap', () => {
     cy.get('.token-item-0xc778417E063141139Fce010982780140Aa0cD5Ab').click({ force: true })
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
     cy.get('#swap-currency-input .token-amount-input').type('0.01', { force: true, delay: 100 })
-    console.log(cy.get('#swap-currency-input .token-amount-input'))
-    console.log(cy.get('#swap-currency-output .token-amount-input'))
     cy.get('#swap-currency-output .token-amount-input').should('have.value', '0.01')
   })
 

--- a/cypress/e2e/swap.test.ts
+++ b/cypress/e2e/swap.test.ts
@@ -50,9 +50,7 @@ describe('Swap', () => {
 
   it('ETH to wETH is same value (wrapped swaps have no price impact)', () => {
     cy.get('#swap-currency-output .open-currency-select-button').click()
-    cy.get('.token-item-0xc778417E063141139Fce010982780140Aa0cD5Ab').should('be.visible')
     cy.get('.token-item-0xc778417E063141139Fce010982780140Aa0cD5Ab').click({ force: true })
-    cy.get('#swap-currency-input .token-amount-input').should('be.visible')
     cy.get('#swap-currency-input .token-amount-input').type('0.01', { force: true, delay: 100 })
     cy.get('#swap-currency-output .token-amount-input').should('have.value', '0.01')
   })

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -148,11 +148,8 @@ export default function Swap({ history }: RouteComponentProps) {
     [trade, tradeState]
   )
   // show price estimates based on wrap trade
-  let inputValue = trade?.inputAmount
-  let outputValue = trade?.outputAmount
-  if (showWrap) {
-    inputValue = outputValue = parsedAmount
-  }
+  const inputValue = showWrap ? parsedAmount : trade?.inputAmount
+  const outputValue = showWrap ? parsedAmount : trade?.outputAmount
   const fiatValueInput = useUSDCValue(inputValue)
   const fiatValueOutput = useUSDCValue(outputValue)
   const priceImpact = useMemo(

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -147,9 +147,14 @@ export default function Swap({ history }: RouteComponentProps) {
     () => [!trade?.swaps, TradeState.LOADING === tradeState, TradeState.SYNCING === tradeState],
     [trade, tradeState]
   )
-
-  const fiatValueInput = useUSDCValue(trade?.inputAmount)
-  const fiatValueOutput = useUSDCValue(trade?.outputAmount)
+  // show price estimates based on wrap trade
+  let inputValue = trade?.inputAmount
+  let outputValue = trade?.outputAmount
+  if (showWrap) {
+    inputValue = outputValue = parsedAmount
+  }
+  const fiatValueInput = useUSDCValue(inputValue)
+  const fiatValueOutput = useUSDCValue(outputValue)
   const priceImpact = useMemo(
     () => (routeIsSyncing ? undefined : computeFiatValuePriceImpact(fiatValueInput, fiatValueOutput)),
     [fiatValueInput, fiatValueOutput, routeIsSyncing]


### PR DESCRIPTION
Fix: https://github.com/Uniswap/interface/issues/3906. Fixed to display the correct price estimates depending on whether it is a wrapped trade (eth -> weth should show no price impact).

Before:
<img width="300" alt="Screen Shot 2022-06-16 at 11 56 22 AM" src="https://user-images.githubusercontent.com/62825936/174114427-faf1cc3b-aa37-46db-b8ea-e991431a979b.png">

After:
<img width="300" alt="Screen Shot 2022-06-16 at 11 58 42 AM" src="https://user-images.githubusercontent.com/62825936/174114528-9e35fa3f-6099-4a58-9786-c142bbe0268a.png">
