### PR TITLE
fix: Crowdin translations download

### DIFF
--- a/.github/workflows/crowdin-sync.yaml
+++ b/.github/workflows/crowdin-sync.yaml
@@ -38,8 +38,9 @@ jobs:
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN_SECRET }}
           source: 'src/locales/en-US.po'
           translation: 'src/locales/%locale%.po'
-          create_pull_request: false
-          localization_branch_name: main
+          create_pull_request: true
+          pull_request_title: 'chore(i18n): new Crowdin translations'
+          localization_branch_name: l10n_crowdin
           commit_message: "chore(i18n): synchronize translations from crowdin [skip ci]"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey everyone,

Since the `main` branch is protected, the download translations workflow is failing. Just updated the workflow to push translations into the separate branch and create a PR with the translations instead of direct pushing them into the `main`.

#3747