### PR TITLE
fix: crash on HOP token search (#3904)

### DIFF
--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -120,11 +120,15 @@ export function useSearchInactiveTokenLists(search: string | undefined, minResul
       if (!list) continue
       for (const tokenInfo of list.tokens) {
         if (tokenInfo.chainId === chainId && tokenFilter(tokenInfo)) {
-          const wrapped: WrappedTokenInfo = new WrappedTokenInfo(tokenInfo, list)
-          if (!(wrapped.address in activeTokens) && !addressSet[wrapped.address]) {
-            addressSet[wrapped.address] = true
-            result.push(wrapped)
-            if (result.length >= minResults) return result
+          try {
+            const wrapped: WrappedTokenInfo = new WrappedTokenInfo(tokenInfo, list)
+            if (!(wrapped.address in activeTokens) && !addressSet[wrapped.address]) {
+              addressSet[wrapped.address] = true
+              result.push(wrapped)
+              if (result.length >= minResults) return result
+            }
+          } catch {
+            continue
           }
         }
       }

--- a/src/lib/hooks/useTokenList/utils.ts
+++ b/src/lib/hooks/useTokenList/utils.ts
@@ -16,16 +16,20 @@ export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainTok
 
   const [list, infos] = Array.isArray(tokens) ? [undefined, tokens] : [tokens, tokens.tokens]
   const map = infos.reduce<Mutable<ChainTokenMap>>((map, info) => {
-    const token = new WrappedTokenInfo(info, list)
-    if (map[token.chainId]?.[token.address] !== undefined) {
-      console.warn(`Duplicate token skipped: ${token.address}`)
+    try {
+      const token = new WrappedTokenInfo(info, list)
+      if (map[token.chainId]?.[token.address] !== undefined) {
+        console.warn(`Duplicate token skipped: ${token.address}`)
+        return map
+      }
+      if (!map[token.chainId]) {
+        map[token.chainId] = {}
+      }
+      map[token.chainId][token.address] = { token, list }
+      return map
+    } catch {
       return map
     }
-    if (!map[token.chainId]) {
-      map[token.chainId] = {}
-    }
-    map[token.chainId][token.address] = { token, list }
-    return map
   }, {}) as ChainTokenMap
   mapCache?.set(tokens, map)
   return map

--- a/src/state/lists/wrappedTokenInfo.ts
+++ b/src/state/lists/wrappedTokenInfo.ts
@@ -14,21 +14,22 @@ export class WrappedTokenInfo implements Token {
   public readonly isNative: false = false
   public readonly isToken: true = true
   public readonly list?: TokenList
-
   public readonly tokenInfo: TokenInfo
+
+  private _checksummedAddress: string
 
   constructor(tokenInfo: TokenInfo, list?: TokenList) {
     this.tokenInfo = tokenInfo
     this.list = list
+    const checksummedAddress = isAddress(this.tokenInfo.address)
+    if (!checksummedAddress) {
+      throw new Error(`Invalid token address: ${this.tokenInfo.address}`)
+    }
+    this._checksummedAddress = checksummedAddress
   }
 
-  private _checksummedAddress: string | null = null
-
   public get address(): string {
-    if (this._checksummedAddress) return this._checksummedAddress
-    const checksummedAddress = isAddress(this.tokenInfo.address)
-    if (!checksummedAddress) throw new Error(`Invalid token address: ${this.tokenInfo.address}`)
-    return (this._checksummedAddress = checksummedAddress)
+    return this._checksummedAddress
   }
 
   public get chainId(): number {


### PR DESCRIPTION
Fix: doesn't crash app when searching for a particular token (HOP) where a particular coin list (CMC) has wrong token address, such that the checksum fails.

Before:
<img width="300" alt="Screen Shot 2022-06-16 at 2 44 48 PM" src="https://user-images.githubusercontent.com/62825936/174143623-1f3a50a6-9a5a-4233-8171-15d70efb8058.png">

After:
<img width="300" alt="Screen Shot 2022-06-16 at 2 45 38 PM" src="https://user-images.githubusercontent.com/62825936/174143716-84397d27-1c74-4516-8415-345961947808.png">
<img width="300" alt="Screen Shot 2022-06-16 at 2 45 34 PM" src="https://user-images.githubusercontent.com/62825936/174143717-92307c84-b963-4a0d-8230-ba28ae21a30f.png">
gnosisSafe
