### PR TITLE
chore(deps): bump token-lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@uniswap/router-sdk": "^1.0.3",
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/smart-order-router": "^2.5.26",
-    "@uniswap/token-lists": "^1.0.0-beta.27",
+    "@uniswap/token-lists": "^1.0.0-beta.30",
     "@uniswap/v2-core": "1.0.0",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v2-sdk": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4967,10 +4967,15 @@
     dotenv "^14.2.0"
     hardhat-watcher "^2.1.1"
 
-"@uniswap/token-lists@^1.0.0-beta.25", "@uniswap/token-lists@^1.0.0-beta.27":
+"@uniswap/token-lists@^1.0.0-beta.25":
   version "1.0.0-beta.28"
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.28.tgz#76bb6ec25e76ae6bece9efc11b9b68079b2b9402"
   integrity sha512-MmVeoOd/HlZYOn5NT2mlDoOUYjnZb+3V7aCD5/YwSgsqeDRXZmKfKHafEEhiZoMvXuZdqSBg4L/ythvzAf9cwA==
+
+"@uniswap/token-lists@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.30.tgz#2103ca23b8007c59ec71718d34cdc97861c409e5"
+  integrity sha512-HwY2VvkQ8lNR6ks5NqQfAtg+4IZqz3KV1T8d2DlI8emIn9uMmaoFbIOg0nzjqAVKKnZSbMTRRtUoAh6mmjRvog==
 
 "@uniswap/v2-core@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Bumps version of @uniswap/token-lists package to latest version (1.0.0-beta.30). This is to bring in the changes that:
- fix an inconsistency with the tokenList type ([PR](https://github.com/Uniswap/token-lists/pull/140))
- increase the max length of token list names to 30 characters ([PR](https://github.com/Uniswap/token-lists/pull/136#pullrequestreview-998312835))

This will prevent issues when default tokenList is updated with cross-chain mappings and name is updated to "Uniswap Labs Default List" ([PR1](https://github.com/Uniswap/default-token-list/pull/1130) [PR2](https://github.com/Uniswap/default-token-list/pull/1129)).