### PR TITLE
feat: logScale price axis in LiquidityChart

### DIFF
--- a/src/components/LiquidityChartRangeInput/AxisBottom.tsx
+++ b/src/components/LiquidityChartRangeInput/AxisBottom.tsx
@@ -36,7 +36,7 @@ export const AxisBottom = ({
   useMemo(
     () => (
       <StyledGroup transform={`translate(0, ${innerHeight + offset})`}>
-        <Axis axisGenerator={axisBottom(xScale).ticks(6)} />
+        <Axis axisGenerator={axisBottom(xScale).ticks(8)} />
       </StyledGroup>
     ),
     [innerHeight, offset, xScale]

--- a/src/components/LiquidityChartRangeInput/Chart.tsx
+++ b/src/components/LiquidityChartRangeInput/Chart.tsx
@@ -1,4 +1,4 @@
-import { max, scaleLinear, ZoomTransform } from 'd3'
+import { max, scaleLinear, scaleLog, ZoomTransform } from 'd3'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Bound } from 'state/mint/v3/actions'
 
@@ -36,9 +36,9 @@ export function Chart({
 
   const { xScale, yScale } = useMemo(() => {
     const scales = {
-      xScale: scaleLinear()
+      xScale: scaleLog()
         .domain([current * zoomLevels.initialMin, current * zoomLevels.initialMax] as number[])
-        .range([0, innerWidth]),
+        .range([1, innerWidth]),
       yScale: scaleLinear()
         .domain([0, max(series, yAccessor)] as number[])
         .range([innerHeight, 0]),


### PR DESCRIPTION
- feat: use a log scale for the price axis in the LiquidityChart

Notes:

- Using a linear price axis can lead users to scroll to negative prices
- Log axis is a more accurate representation of liquidity due to the tick-based nature of pricing in Uni v3
- Linear price axes are a crime against humanity overall, best to avoid it altogether. 

