### PR TITLE
fix: hide header when mobile

### DIFF
--- a/src/components/Explore/TokenRow.tsx
+++ b/src/components/Explore/TokenRow.tsx
@@ -85,6 +85,10 @@ const HeaderRowWrapper = styled(TokenRowWrapper)`
   border-bottom: 1px solid;
   border-color: ${({ theme }) => theme.bg3};
   border-radius: 8px 8px 0px 0px;
+
+  @media only screen and (max-width: 390px) {
+    display: none;
+  }
 `
 const ListNumberCell = styled(Cell)`
   color: ${({ theme }) => theme.text2};

--- a/src/components/Explore/TokenTable.tsx
+++ b/src/components/Explore/TokenTable.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components/macro'
 
 import TokenRow, { HeaderRow } from './TokenRow'
 
-//   min-width: 360px;
 const GridContainer = styled.div`
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Hide the token table header in mobile view

<img width="559" alt="Screen Shot 2022-06-28 at 5 35 57 PM" src="https://user-images.githubusercontent.com/62825936/176303140-91a13967-1f92-45c5-85e4-78d7e84bf11f.png">

