### PR TITLE
build: sleep for 10m after pinning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,8 @@ jobs:
         uses: uniswap/convert-cidv0-cidv1@v1.0.0
         with:
           cidv0: ${{ steps.upload.outputs.hash }}
+      
+      - run: sleep 600
 
       - name: Update DNS with new IPFS hash
         env:


### PR DESCRIPTION
Sleeps for 10m after pinning to IPFS to give cloudflare time to seed the assets

This will require manual intervention, and is done to facilitate deploying https://github.com/Uniswap/interface/pull/3990.
During the 10m interval, I will be pinging the cloudflare IPFS nodes to try to seed the assets.