### PR TITLE
build: disable release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Release
 on:
-  schedule:
-    - cron:  '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
+  # disable deploys until this action is amended to include seeding cloudflare IPFS
+  # schedule:
+  #   - cron:  '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
 
   # manual trigger
   workflow_dispatch:


### PR DESCRIPTION
Disables release (for now) until it can be updated to include seeding IPFS nodes