### PR TITLE
feat: show injected options in wallet browsers

### DIFF
--- a/src/components/SearchModal/CurrencyList/index.test.tsx
+++ b/src/components/SearchModal/CurrencyList/index.test.tsx
@@ -22,20 +22,21 @@ jest.mock(
       `CurrencyLogo currency=${currency.symbol}`
 )
 
-jest.mock('hooks/useActiveWeb3React', () => {
+jest.mock('@web3-react/core', () => {
+  const web3React = jest.requireActual('@web3-react/core')
   return {
-    __esModule: true,
-    default: () => ({
+    useWeb3React: () => ({
       account: '123',
-      active: true,
+      isActive: true,
     }),
+    ...web3React,
   }
 })
 
 jest.mock('../../../state/wallet/hooks', () => {
   return {
     useCurrencyBalance: (currency: Currency) => {
-      return mockCurrencyAmt[(currency as mockToken).address]
+      return mockCurrencyAmt[(currency as mockToken)?.address]
     },
   }
 })

--- a/src/components/SearchModal/CurrencyList/index.tsx
+++ b/src/components/SearchModal/CurrencyList/index.tsx
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { useWeb3React } from '@web3-react/core'
 import { LightGreyCard } from 'components/Card'
 import QuestionHelper from 'components/QuestionHelper'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useTheme from 'hooks/useTheme'
 import { CSSProperties, MutableRefObject, useCallback, useMemo } from 'react'
 import { FixedSizeList } from 'react-window'
@@ -114,7 +114,7 @@ function CurrencyRow({
   style: CSSProperties
   showCurrencyAmount?: boolean
 }) {
-  const { account } = useActiveWeb3React()
+  const { account } = useWeb3React()
   const key = currencyKey(currency)
   const selectedTokenList = useCombinedActiveList()
   const isOnSelectedList = isTokenOnList(selectedTokenList, currency.isToken ? currency : undefined)

--- a/src/components/WalletModal/Option.tsx
+++ b/src/components/WalletModal/Option.tsx
@@ -117,7 +117,7 @@ export default function Option({
       onClick={onClick}
       clickable={clickable && !active}
       active={active}
-      data-test="wallet-modal-option"
+      data-testid="wallet-modal-option"
     >
       <OptionCardLeft>
         <HeaderText color={color}>

--- a/src/components/WalletModal/Option.tsx
+++ b/src/components/WalletModal/Option.tsx
@@ -112,7 +112,13 @@ export default function Option({
   id: string
 }) {
   const content = (
-    <OptionCardClickable id={id} onClick={onClick} clickable={clickable && !active} active={active}>
+    <OptionCardClickable
+      id={id}
+      onClick={onClick}
+      clickable={clickable && !active}
+      active={active}
+      data-test="wallet-modal-option"
+    >
       <OptionCardLeft>
         <HeaderText color={color}>
           {active ? (

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -53,7 +53,7 @@ test('Loads Wallet Modal on mobile', async () => {
   global.window.web3 = undefined
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
-  // expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
+  expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
 })

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -35,6 +35,7 @@ test('Loads Wallet Modal on desktop', async () => {
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
+  expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(4)
 })
 
 test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
@@ -45,6 +46,7 @@ test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
+  expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(4)
 })
 
 test('Loads Wallet Modal on mobile', async () => {
@@ -56,6 +58,7 @@ test('Loads Wallet Modal on mobile', async () => {
   expect(screen.getByText('Open in Coinbase Wallet')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
+  expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(3)
 })
 
 test('Loads Wallet Modal on MetaMask browser', async () => {
@@ -64,6 +67,7 @@ test('Loads Wallet Modal on MetaMask browser', async () => {
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('MetaMask')).toBeInTheDocument()
+  expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(1)
 })
 
 test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
@@ -72,4 +76,5 @@ test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
+  expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(1)
 })

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -60,8 +60,6 @@ test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
 
 test('Loads Wallet Modal on mobile', async () => {
   UserAgentMock.isMobile = true
-  global.window.ethereum = undefined
-  global.window.web3 = undefined
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('Open in Coinbase Wallet')).toBeInTheDocument()

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -1,11 +1,19 @@
 import { render, screen } from '@testing-library/react'
+import { ReactChildren } from 'react'
 import { ApplicationModal } from 'state/application/reducer'
+import { ThemeProvider } from 'styled-components/macro'
+import { getTheme } from 'theme'
 
 import WalletModal from './index'
+
+jest.mock('@lingui/macro', () => ({ Trans: ({ children }: { children: ReactChildren }) => children }))
 
 jest.mock('.../../state/application/hooks', () => {
   return {
     useModalOpen: (_modal: ApplicationModal) => true,
+    useWalletModalToggle: () => {
+      return
+    },
   }
 })
 
@@ -15,8 +23,24 @@ jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
 }))
 
+jest.mock('hooks/useActiveWeb3React', () => {
+  return {
+    __esModule: true,
+    default: () => ({
+      account: undefined,
+      isActive: false,
+      isActivating: false,
+      connector: undefined,
+    }),
+  }
+})
+
 test('Loads Wallet Modal on desktop', async () => {
-  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  render(
+    <ThemeProvider theme={getTheme(false)}>
+      <WalletModal pendingTransactions={[]} confirmedTransactions={[]} />
+    </ThemeProvider>
+  )
   // expect(screen.getByText('Install MetaMask')).toBeInTheDocument()
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -38,7 +38,7 @@ jest.mock('@web3-react/core', () => {
   }
 })
 
-test('Loads Wallet Modal on desktop', async () => {
+it('loads Wallet Modal on desktop', async () => {
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('Install MetaMask')).toBeInTheDocument()
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
@@ -47,7 +47,7 @@ test('Loads Wallet Modal on desktop', async () => {
   expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(4)
 })
 
-test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
+it('loads Wallet Modal on desktop with MetaMask installed', async () => {
   global.window.ethereum = { isMetaMask: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
@@ -58,7 +58,7 @@ test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
   expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(4)
 })
 
-test('Loads Wallet Modal on mobile', async () => {
+it('loads Wallet Modal on mobile', async () => {
   UserAgentMock.isMobile = true
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
@@ -68,7 +68,7 @@ test('Loads Wallet Modal on mobile', async () => {
   expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(3)
 })
 
-test('Loads Wallet Modal on MetaMask browser', async () => {
+it('loads Wallet Modal on MetaMask browser', async () => {
   UserAgentMock.isMobile = true
   global.window.ethereum = { isMetaMask: true }
 
@@ -77,7 +77,7 @@ test('Loads Wallet Modal on MetaMask browser', async () => {
   expect(screen.getAllByTestId('wallet-modal-option')).toHaveLength(1)
 })
 
-test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
+it('loads Wallet Modal on Coinbase Wallet browser', async () => {
   UserAgentMock.isMobile = true
   global.window.ethereum = { isCoinbaseWallet: true }
 

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -1,10 +1,7 @@
-import { ReactChildren } from 'react'
 import { ApplicationModal } from 'state/application/reducer'
 
 import { render, screen } from '../../test-utils'
 import WalletModal from './index'
-
-jest.mock('@lingui/macro', () => ({ Trans: ({ children }: { children: ReactChildren }) => children }))
 
 jest.mock('.../../state/application/hooks', () => {
   return {
@@ -35,14 +32,40 @@ test('Loads Wallet Modal on desktop', async () => {
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
 })
 
-// test('Loads Wallet Modal on mobile', async () => {
-//   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
-// })
+test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
+  window.ethereum = { isMetaMask: true }
 
-// test('Loads Wallet Modal on MetaMask browser', async () => {
-//   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
-// })
+  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  expect(screen.getByText('MetaMask')).toBeInTheDocument()
+  expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
+  expect(screen.getByText('WalletConnect')).toBeInTheDocument()
+  expect(screen.getByText('Fortmatic')).toBeInTheDocument()
+})
 
-// test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
-//   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
-// })
+test('Loads Wallet Modal on MetaMask browser', async () => {
+  jest.doMock('../../utils/userAgent', () => {
+    return {
+      isMobile() {
+        return true
+      },
+    }
+  })
+  window.ethereum = { isMetaMask: true }
+
+  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  expect(screen.getByText('MetaMask')).toBeInTheDocument()
+})
+
+test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
+  jest.doMock('../../utils/userAgent', () => {
+    return {
+      isMobile() {
+        return true
+      },
+    }
+  })
+  window.ethereum = { isCoinbaseWallet: true }
+
+  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
+})

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -3,12 +3,6 @@ import { ApplicationModal } from 'state/application/reducer'
 import { render, screen } from '../../test-utils'
 import WalletModal from './index'
 
-const { location } = window
-
-afterEach(() => {
-  window.location = location
-})
-
 const UserAgentMock = jest.requireMock('utils/userAgent')
 jest.mock('utils/userAgent', () => ({
   isMobile: false,
@@ -44,7 +38,7 @@ test('Loads Wallet Modal on desktop', async () => {
 })
 
 test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
-  window.ethereum = { isMetaMask: true }
+  global.window.ethereum = { isMetaMask: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('MetaMask')).toBeInTheDocument()
@@ -54,8 +48,9 @@ test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
 })
 
 test('Loads Wallet Modal on mobile', async () => {
-  console.log(window.ethereum)
   UserAgentMock.isMobile = true
+  global.window.ethereum = undefined
+  global.window.web3 = undefined
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   // expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
@@ -65,7 +60,7 @@ test('Loads Wallet Modal on mobile', async () => {
 
 test('Loads Wallet Modal on MetaMask browser', async () => {
   UserAgentMock.isMobile = true
-  window.ethereum = { isMetaMask: true }
+  global.window.ethereum = { isMetaMask: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('MetaMask')).toBeInTheDocument()
@@ -73,7 +68,7 @@ test('Loads Wallet Modal on MetaMask browser', async () => {
 
 test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
   UserAgentMock.isMobile = true
-  window.ethereum = { isCoinbaseWallet: true }
+  global.window.ethereum = { isCoinbaseWallet: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -5,19 +5,14 @@ import WalletModal from './index'
 
 const { location } = window
 
-beforeEach(() => {
-  jest.resetModules()
-})
-
-afterAll(() => {
+afterEach(() => {
   window.location = location
 })
 
-jest.doMock('../../utils/userAgent', () => {
-  return {
-    isMobile: true,
-  }
-})
+const UserAgentMock = jest.requireMock('utils/userAgent')
+jest.mock('utils/userAgent', () => ({
+  isMobile: false,
+}))
 
 jest.mock('.../../state/application/hooks', () => {
   return {
@@ -59,16 +54,17 @@ test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
 })
 
 test('Loads Wallet Modal on mobile', async () => {
-  jest.doMock('../../utils/userAgent', () => ({ isMobile: true }))
+  console.log(window.ethereum)
+  UserAgentMock.isMobile = true
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
-  expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
+  // expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
 })
 
 test('Loads Wallet Modal on MetaMask browser', async () => {
-  jest.doMock('../../utils/userAgent', () => ({ isMobile: true }))
+  UserAgentMock.isMobile = true
   window.ethereum = { isMetaMask: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
@@ -76,7 +72,7 @@ test('Loads Wallet Modal on MetaMask browser', async () => {
 })
 
 test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
-  jest.doMock('../../utils/userAgent', () => ({ isMobile: true }))
+  UserAgentMock.isMobile = true
   window.ethereum = { isCoinbaseWallet: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -3,6 +3,22 @@ import { ApplicationModal } from 'state/application/reducer'
 import { render, screen } from '../../test-utils'
 import WalletModal from './index'
 
+const { location } = window
+
+beforeEach(() => {
+  jest.resetModules()
+})
+
+afterAll(() => {
+  window.location = location
+})
+
+jest.doMock('../../utils/userAgent', () => {
+  return {
+    isMobile: true,
+  }
+})
+
 jest.mock('.../../state/application/hooks', () => {
   return {
     useModalOpen: (_modal: ApplicationModal) => true,
@@ -42,14 +58,17 @@ test('Loads Wallet Modal on desktop with MetaMask installed', async () => {
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
 })
 
+test('Loads Wallet Modal on mobile', async () => {
+  jest.doMock('../../utils/userAgent', () => ({ isMobile: true }))
+
+  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
+  expect(screen.getByText('WalletConnect')).toBeInTheDocument()
+  expect(screen.getByText('Fortmatic')).toBeInTheDocument()
+})
+
 test('Loads Wallet Modal on MetaMask browser', async () => {
-  jest.doMock('../../utils/userAgent', () => {
-    return {
-      isMobile() {
-        return true
-      },
-    }
-  })
+  jest.doMock('../../utils/userAgent', () => ({ isMobile: true }))
   window.ethereum = { isMetaMask: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
@@ -57,13 +76,7 @@ test('Loads Wallet Modal on MetaMask browser', async () => {
 })
 
 test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
-  jest.doMock('../../utils/userAgent', () => {
-    return {
-      isMobile() {
-        return true
-      },
-    }
-  })
+  jest.doMock('../../utils/userAgent', () => ({ isMobile: true }))
   window.ethereum = { isCoinbaseWallet: true }
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -53,7 +53,7 @@ test('Loads Wallet Modal on mobile', async () => {
   global.window.web3 = undefined
 
   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
-  expect(screen.getByText('Open in Coinbase Wallet app.')).toBeInTheDocument()
+  expect(screen.getByText('Open in Coinbase Wallet')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()
 })

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -3,6 +3,14 @@ import { ApplicationModal } from 'state/application/reducer'
 import { render, screen } from '../../test-utils'
 import WalletModal from './index'
 
+beforeEach(() => {
+  delete global.window.ethereum
+})
+
+afterAll(() => {
+  delete global.window.ethereum
+})
+
 const UserAgentMock = jest.requireMock('utils/userAgent')
 jest.mock('utils/userAgent', () => ({
   isMobile: false,
@@ -17,15 +25,16 @@ jest.mock('.../../state/application/hooks', () => {
   }
 })
 
-jest.mock('hooks/useActiveWeb3React', () => {
+jest.mock('@web3-react/core', () => {
+  const web3React = jest.requireActual('@web3-react/core')
   return {
-    __esModule: true,
-    default: () => ({
+    useWeb3React: () => ({
       account: undefined,
       isActive: false,
       isActivating: false,
       connector: undefined,
     }),
+    ...web3React,
   }
 })
 

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { ApplicationModal } from 'state/application/reducer'
+
+import WalletModal from './index'
+
+jest.mock('.../../state/application/hooks', () => {
+  return {
+    useModalOpen: (_modal: ApplicationModal) => true,
+  }
+})
+
+const mockDispatch = jest.fn()
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: () => mockDispatch,
+}))
+
+test('Loads Wallet Modal on desktop', async () => {
+  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  // expect(screen.getByText('Install MetaMask')).toBeInTheDocument()
+  expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
+  expect(screen.getByText('WalletConnect')).toBeInTheDocument()
+  expect(screen.getByText('Fortmatic')).toBeInTheDocument()
+})
+
+// test('Loads Wallet Modal on mobile', async () => {
+//   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+// })
+
+// test('Loads Wallet Modal on MetaMask browser', async () => {
+//   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+// })
+
+// test('Loads Wallet Modal on Coinbase Wallet browser', async () => {
+//   render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+// })

--- a/src/components/WalletModal/index.test.tsx
+++ b/src/components/WalletModal/index.test.tsx
@@ -1,9 +1,7 @@
-import { render, screen } from '@testing-library/react'
 import { ReactChildren } from 'react'
 import { ApplicationModal } from 'state/application/reducer'
-import { ThemeProvider } from 'styled-components/macro'
-import { getTheme } from 'theme'
 
+import { render, screen } from '../../test-utils'
 import WalletModal from './index'
 
 jest.mock('@lingui/macro', () => ({ Trans: ({ children }: { children: ReactChildren }) => children }))
@@ -16,12 +14,6 @@ jest.mock('.../../state/application/hooks', () => {
     },
   }
 })
-
-const mockDispatch = jest.fn()
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-  useDispatch: () => mockDispatch,
-}))
 
 jest.mock('hooks/useActiveWeb3React', () => {
   return {
@@ -36,12 +28,8 @@ jest.mock('hooks/useActiveWeb3React', () => {
 })
 
 test('Loads Wallet Modal on desktop', async () => {
-  render(
-    <ThemeProvider theme={getTheme(false)}>
-      <WalletModal pendingTransactions={[]} confirmedTransactions={[]} />
-    </ThemeProvider>
-  )
-  // expect(screen.getByText('Install MetaMask')).toBeInTheDocument()
+  render(<WalletModal pendingTransactions={[]} confirmedTransactions={[]} />)
+  expect(screen.getByText('Install MetaMask')).toBeInTheDocument()
   expect(screen.getByText('Coinbase Wallet')).toBeInTheDocument()
   expect(screen.getByText('WalletConnect')).toBeInTheDocument()
   expect(screen.getByText('Fortmatic')).toBeInTheDocument()

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -184,8 +184,9 @@ export default function WalletModal({
 
   // get wallets user can switch too, depending on device/browser
   function getOptions() {
-    const isMetamask = !!window.ethereum?.isMetaMask
+    const isMetaMask = !!window.ethereum?.isMetaMask
     const isTally = !!window.ethereum?.isTally
+    const isCoinbaseWallet = !!window.ethereum?.isCoinbaseWallet
     return Object.keys(SUPPORTED_WALLETS).map((key) => {
       const option = SUPPORTED_WALLETS[key]
       const isActive = option.connector === connector
@@ -202,7 +203,11 @@ export default function WalletModal({
 
       // check for mobile options
       if (isMobile) {
-        if (!window.web3 && !window.ethereum && option.mobile) {
+        if (
+          (!window.web3 && !window.ethereum && option.mobile) ||
+          (isMetaMask && option.name === 'MetaMask') ||
+          (isCoinbaseWallet && option.name === 'Coinbase Wallet')
+        ) {
           return (
             <Option
               {...optionProps}
@@ -239,11 +244,11 @@ export default function WalletModal({
           }
         }
         // don't return metamask if injected provider isn't metamask
-        else if (option.name === 'MetaMask' && !isMetamask) {
+        else if (option.name === 'MetaMask' && !isMetaMask) {
           return null
         }
         // likewise for generic
-        else if (option.name === 'Injected' && isMetamask) {
+        else if (option.name === 'Injected' && isMetaMask) {
           return null
         } else if (option.name === 'Injected' && isTally) {
           return (

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -202,6 +202,7 @@ export default function WalletModal({
       }
 
       // check for mobile options
+      console.log(isMobile)
       if (isMobile) {
         if (
           (!window.web3 && !window.ethereum && option.mobile) ||

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -202,7 +202,6 @@ export default function WalletModal({
       }
 
       // check for mobile options
-      console.log(isMetaMask, isCoinbaseWallet)
       if (isMobile) {
         if (
           (!window.web3 && !window.ethereum && option.mobile) ||

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -202,7 +202,7 @@ export default function WalletModal({
       }
 
       // check for mobile options
-      console.log(isMobile)
+      console.log(isMetaMask, isCoinbaseWallet)
       if (isMobile) {
         if (
           (!window.web3 && !window.ethereum && option.mobile) ||

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -1,9 +1,9 @@
 import { Trans } from '@lingui/macro'
-import { useWeb3React } from '@web3-react/core'
 import { Connector } from '@web3-react/types'
 import { sendEvent } from 'components/analytics'
 import { AutoColumn } from 'components/Column'
 import { AutoRow } from 'components/Row'
+import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useCallback, useEffect, useState } from 'react'
 import { ArrowLeft } from 'react-feather'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
@@ -120,7 +120,7 @@ export default function WalletModal({
   ENSName?: string
 }) {
   const dispatch = useAppDispatch()
-  const { connector, account } = useWeb3React()
+  const { connector, account } = useActiveWeb3React()
 
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
 

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -233,7 +233,7 @@ export default function WalletModal({
                 id={`connect-${key}`}
                 key={key}
                 color={'#E8831D'}
-                header={<Trans>Install Metamask</Trans>}
+                header={<Trans>Install MetaMask</Trans>}
                 subheader={null}
                 link={'https://metamask.io/'}
                 icon={MetamaskIcon}

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -1,9 +1,9 @@
 import { Trans } from '@lingui/macro'
+import { useWeb3React } from '@web3-react/core'
 import { Connector } from '@web3-react/types'
 import { sendEvent } from 'components/analytics'
 import { AutoColumn } from 'components/Column'
 import { AutoRow } from 'components/Row'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useCallback, useEffect, useState } from 'react'
 import { ArrowLeft } from 'react-feather'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
@@ -120,7 +120,7 @@ export default function WalletModal({
   ENSName?: string
 }) {
   const dispatch = useAppDispatch()
-  const { connector, account } = useActiveWeb3React()
+  const { connector, account } = useWeb3React()
 
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
 

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,6 +1,8 @@
 import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
 import { render } from '@testing-library/react'
+import { Web3ReactProvider } from '@web3-react/core'
+import { injected, injectedHooks } from 'connectors'
 import { DEFAULT_LOCALE } from 'constants/locales'
 import { en } from 'make-plural/plurals'
 import { ReactElement, ReactNode } from 'react'
@@ -24,7 +26,9 @@ const WithProviders = ({ children }: { children?: ReactNode }) => {
   return (
     <MockedI18nProvider>
       <Provider store={store}>
-        <ThemeProvider>{children}</ThemeProvider>
+        <Web3ReactProvider connectors={[[injected, injectedHooks]]}>
+          <ThemeProvider>{children}</ThemeProvider>
+        </Web3ReactProvider>
       </Provider>
     </MockedI18nProvider>
   )

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,19 +1,36 @@
-import { render, RenderOptions } from '@testing-library/react'
-import React, { FC, ReactElement, ReactNode } from 'react'
+import { i18n } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { render } from '@testing-library/react'
+import { DEFAULT_LOCALE } from 'constants/locales'
+import { en } from 'make-plural/plurals'
+import { ReactElement, ReactNode } from 'react'
 import { Provider } from 'react-redux'
 import store from 'state'
 import ThemeProvider from 'theme'
 
-const WithProviders: FC = ({ children }: { children?: ReactNode }) => {
+import catalog from './locales/en-US'
+
+i18n.load({
+  [DEFAULT_LOCALE]: catalog.messages,
+})
+i18n.loadLocaleData({
+  [DEFAULT_LOCALE]: { plurals: en },
+})
+i18n.activate(DEFAULT_LOCALE)
+
+const MockedI18nProvider = ({ children }: any) => <I18nProvider i18n={i18n}>{children}</I18nProvider>
+
+const WithProviders = ({ children }: { children?: ReactNode }) => {
   return (
-    <Provider store={store}>
-      <ThemeProvider>{children}</ThemeProvider>
-    </Provider>
+    <MockedI18nProvider>
+      <Provider store={store}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </Provider>
+    </MockedI18nProvider>
   )
 }
 
-const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
-  render(ui, { wrapper: WithProviders, ...options })
+const customRender = (ui: ReactElement) => render(ui, { wrapper: WithProviders })
 
 export * from '@testing-library/react'
 export { customRender as render }

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -113,7 +113,7 @@ function colors(darkMode: boolean): Colors {
   }
 }
 
-function theme(darkMode: boolean): DefaultTheme {
+export function getTheme(darkMode: boolean): DefaultTheme {
   return {
     ...colors(darkMode),
 
@@ -144,7 +144,7 @@ function theme(darkMode: boolean): DefaultTheme {
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
   const darkMode = useIsDarkMode()
 
-  const themeObject = useMemo(() => theme(darkMode), [darkMode])
+  const themeObject = useMemo(() => getTheme(darkMode), [darkMode])
 
   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 }

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -113,7 +113,7 @@ function colors(darkMode: boolean): Colors {
   }
 }
 
-export function getTheme(darkMode: boolean): DefaultTheme {
+function getTheme(darkMode: boolean): DefaultTheme {
   return {
     ...colors(darkMode),
 


### PR DESCRIPTION
If we are in Coinbase Wallet browser then we need to show the Coinbase Wallet option in the WalletModal. Similar logic for MetaMask.

In the future, it would be good to figure out how to avoid special-casing this type of logic.

To reproduce the current issue:
- Open Metamask Mobile browser
- Navigate to app.uniswap.org
- Decline the signature request
- Click the connect button

You'll see a modal with no options like this:
![IMG_0593](https://user-images.githubusercontent.com/4899429/176722435-a7304869-e63a-4c1b-a668-d87ad9c57933.PNG)

After:
![IMG_0594](https://user-images.githubusercontent.com/4899429/176724255-0d09d23b-d43c-430b-9265-9e418747926b.PNG)
