### PR TITLE
fix: resolves network switch race condition

### DIFF
--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -292,27 +292,14 @@ export default function NetworkSelector() {
         if (!skipToggle) {
           toggle()
         }
-        history.replace({
-          search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(targetChain)),
-        })
       } catch (error) {
         console.error('Failed to switch networks', error)
-
-        // we want app network <-> chainId param to be in sync, so if user changes the network by changing the URL
-        // but the request fails, revert the URL back to current chainId
-        if (chainId) {
-          history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
-        }
-
-        if (!skipToggle) {
-          toggle()
-        }
 
         dispatch(updateWalletError({ wallet, error: error.message }))
         dispatch(addPopup({ content: { failedSwitchNetwork: targetChain }, key: `failed-network-switch` }))
       }
     },
-    [connector, toggle, dispatch, history, chainId]
+    [connector, toggle, dispatch]
   )
 
   useEffect(() => {

--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -296,11 +296,21 @@ export default function NetworkSelector() {
       } catch (error) {
         console.error('Failed to switch networks', error)
 
+        // we want app network <-> chainId param to be in sync, so if user changes the network by changing the URL
+        // but the request fails, revert the URL back to current chainId
+        if (chainId) {
+          history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
+        }
+
+        if (!skipToggle) {
+          toggle()
+        }
+
         dispatch(updateWalletError({ wallet, error: error.message }))
         dispatch(addPopup({ content: { failedSwitchNetwork: targetChain }, key: `failed-network-switch` }))
       }
     },
-    [connector, toggle, dispatch]
+    [connector, toggle, dispatch, chainId, history]
   )
 
   useEffect(() => {

--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -268,9 +268,10 @@ const NETWORK_SELECTOR_CHAINS = [
 export default function NetworkSelector() {
   const dispatch = useAppDispatch()
   const { chainId, provider, connector } = useActiveWeb3React()
+  const previousChainId = usePrevious(chainId)
   const parsedQs = useParsedQueryString()
   const { urlChain, urlChainId } = getParsedChainId(parsedQs)
-  const prevChainId = usePrevious(chainId)
+  const previousUrlChainId = usePrevious(urlChainId)
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.NETWORK_SELECTOR)
   const toggle = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
@@ -303,17 +304,16 @@ export default function NetworkSelector() {
   )
 
   useEffect(() => {
-    if (!chainId || !prevChainId) return
+    if (!chainId || !previousChainId) return
 
     // when network change originates from wallet or dropdown selector, just update URL
-    if (chainId !== prevChainId && chainId !== urlChainId) {
-      console.log(chainId, prevChainId, urlChainId)
+    if (chainId !== previousChainId && chainId !== urlChainId) {
       history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
       // otherwise assume network change originates from URL
-    } else if (urlChainId && urlChainId !== chainId) {
+    } else if (urlChainId && urlChainId !== previousUrlChainId && urlChainId !== chainId) {
       onSelectChain(urlChainId, true)
     }
-  }, [chainId, urlChainId, prevChainId, onSelectChain, history])
+  }, [chainId, urlChainId, previousChainId, previousUrlChainId, onSelectChain, history])
 
   // set chain parameter on initial load if not there
   useEffect(() => {

--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -306,7 +306,8 @@ export default function NetworkSelector() {
     if (!chainId || !prevChainId) return
 
     // when network change originates from wallet or dropdown selector, just update URL
-    if (chainId !== prevChainId) {
+    if (chainId !== prevChainId && chainId !== urlChainId) {
+      console.log(chainId, prevChainId, urlChainId)
       history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
       // otherwise assume network change originates from URL
     } else if (urlChainId && urlChainId !== chainId) {

--- a/src/utils/switchChain.ts
+++ b/src/utils/switchChain.ts
@@ -45,11 +45,11 @@ export function isChainAllowed(connector: Connector, chainId: number) {
   }
 }
 
-export const switchChain = async (connector: Connector, chainId: number) => {
+export const switchChain = (connector: Connector, chainId: number) => {
   if (!isChainAllowed(connector, chainId)) {
     throw new Error(`Chain ${chainId} not supported for connector (${typeof connector})`)
   } else if (connector === walletConnect || connector === network) {
-    await connector.activate(chainId)
+    return connector.activate(chainId)
   } else {
     const info = CHAIN_INFO[chainId]
     const addChainParameter = {
@@ -59,6 +59,6 @@ export const switchChain = async (connector: Connector, chainId: number) => {
       nativeCurrency: info.nativeCurrency,
       blockExplorerUrls: [info.explorer],
     }
-    await connector.activate(addChainParameter)
+    return connector.activate(addChainParameter)
   }
 }

--- a/src/utils/switchChain.ts
+++ b/src/utils/switchChain.ts
@@ -45,11 +45,11 @@ export function isChainAllowed(connector: Connector, chainId: number) {
   }
 }
 
-export const switchChain = (connector: Connector, chainId: number) => {
+export const switchChain = async (connector: Connector, chainId: number) => {
   if (!isChainAllowed(connector, chainId)) {
     throw new Error(`Chain ${chainId} not supported for connector (${typeof connector})`)
   } else if (connector === walletConnect || connector === network) {
-    return connector.activate(chainId)
+    await connector.activate(chainId)
   } else {
     const info = CHAIN_INFO[chainId]
     const addChainParameter = {
@@ -59,6 +59,6 @@ export const switchChain = (connector: Connector, chainId: number) => {
       nativeCurrency: info.nativeCurrency,
       blockExplorerUrls: [info.explorer],
     }
-    return connector.activate(addChainParameter)
+    await connector.activate(addChainParameter)
   }
 }


### PR DESCRIPTION
We have a hook that currently handles two cases:
- If the network is switched outside of the app, make sure we change the URL accordingly
- If the a chain is added as a param in the URL, change the network in the app

There are two bugs:
- If the chainId has changed, confirm that the urlChainId is stale before switching the history
- If There is a urlChainId, make sure that it's actually changed before automatically selecting it in the app

On prod reproduce the bug by having no wallet selected, then switching from ETH to Polygon. It will switch back to ETH.