### PR TITLE
feat: explore search bar UI

### DIFF
--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -20,6 +20,7 @@ const SearchInput = styled.input`
   border: none;
   font-size: 16px;
   color: ${({ theme }) => theme.text1};
+
   :focus {
     outline: none;
     background-color: ${({ theme }) => theme.bg2};

--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -1,5 +1,5 @@
 import useTheme from 'hooks/useTheme'
-import { atom, useAtom } from 'jotai'
+import { useState } from 'react'
 import { Search } from 'react-feather'
 import styled from 'styled-components/macro'
 
@@ -29,10 +29,10 @@ const SearchInput = styled.input`
     color: ${({ theme }) => theme.text3};
   }
 `
-const focused = atom<boolean>(false)
+
 export default function SearchBar() {
   const theme = useTheme()
-  const [isFocused, setFocused] = useAtom(focused)
+  const [isFocused, setFocused] = useState(false)
   return (
     <StyledSearchBar focused={isFocused}>
       <Search size={20} color={theme.text3} />

--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -1,0 +1,47 @@
+import useTheme from 'hooks/useTheme'
+import { atom, useAtom } from 'jotai'
+import { Search } from 'react-feather'
+import styled from 'styled-components/macro'
+
+const StyledSearchBar = styled.div<{ focused: boolean }>`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  border-radius: 12px;
+  background-color: ${({ theme, focused }) => (focused ? theme.bg2 : theme.bg0)};
+  color: ${({ theme }) => theme.text1};
+  font-size: 16px;
+`
+const SearchInput = styled.input`
+  width: 90%;
+  background-color: transparent;
+  border: none;
+  font-size: 16px;
+  color: ${({ theme }) => theme.text1};
+  :focus {
+    outline: none;
+    background-color: ${({ theme }) => theme.bg2};
+  }
+  ::placeholder {
+    color: ${({ theme }) => theme.text3};
+  }
+`
+const focused = atom<boolean>(false)
+export default function SearchBar() {
+  const theme = useTheme()
+  const [isFocused, setFocused] = useAtom(focused)
+  return (
+    <StyledSearchBar focused={isFocused}>
+      <Search size={20} color={theme.text3} />
+      <SearchInput
+        type="text"
+        placeholder="Search token or paste address"
+        id="searchBar"
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+      />
+    </StyledSearchBar>
+  )
+}

--- a/src/pages/Explore/index.tsx
+++ b/src/pages/Explore/index.tsx
@@ -1,4 +1,5 @@
 import FavoriteButton from 'components/Explore/FavoriteButton'
+import SearchBar from 'components/Explore/SearchBar'
 import TimeSelector from 'components/Explore/TimeSelector'
 import TokenTable from 'components/Explore/TokenTable'
 import { atomWithStorage } from 'jotai/utils'
@@ -11,12 +12,14 @@ const FiltersContainer = styled.div`
   display: flex;
   gap: 8px;
   height: 44px;
+  width: 960px;
 `
 export const showFavoritesAtom = atomWithStorage<boolean>('showFavorites', false)
 const Explore = () => {
   return (
     <>
       <FiltersContainer>
+        <SearchBar />
         <FavoriteButton />
         <TimeSelector />
       </FiltersContainer>


### PR DESCRIPTION
add explore search bar UI (non-functional filtering hehe)

<img width="1054" alt="Screen Shot 2022-07-01 at 5 49 04 PM" src="https://user-images.githubusercontent.com/62825936/176971605-3e5623b7-9f29-445b-b8ab-6db844dcc500.png">

<img width="1023" alt="Screen Shot 2022-07-01 at 5 49 18 PM" src="https://user-images.githubusercontent.com/62825936/176971603-a5b653cb-26d4-4c8b-a71c-6e1d5faad11c.png">


