### PR TITLE
fix: fix slow favoriting bug

### DIFF
--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -11,7 +11,7 @@ const StyledSearchBar = styled.div<{ focused: boolean }>`
   gap: 8px;
   border-radius: 12px;
   background-color: ${({ theme, focused }) => (focused ? theme.bg2 : theme.bg0)};
-  color: ${({ theme }) => theme.text1};
+  color: ${({ theme }) => theme.text2};
   font-size: 16px;
 `
 const SearchInput = styled.input`
@@ -19,7 +19,7 @@ const SearchInput = styled.input`
   background-color: transparent;
   border: none;
   font-size: 16px;
-  color: ${({ theme }) => theme.text1};
+  color: ${({ theme }) => theme.text2};
 
   :focus {
     outline: none;

--- a/src/components/Explore/TokenRow.tsx
+++ b/src/components/Explore/TokenRow.tsx
@@ -463,6 +463,7 @@ export default function LoadedRow({
   const tokenData = data[tokenAddress]
   const [favoriteTokens, updateFavoriteTokens] = useAtom(favoritesAtom)
   const theme = useTheme()
+  const isFavorited = favoriteTokens.includes(tokenAddress)
   // TODO: remove magic number colors
   const tokenPercentChangeInfo = (
     <>
@@ -479,13 +480,13 @@ export default function LoadedRow({
 
   /* handle favorite token logic */
   const toggleFavoriteToken = () => {
-    let updatedFavoriteTokens = favoriteTokens.slice()
+    let updatedFavoriteTokens
     if (favoriteTokens.includes(tokenAddress)) {
       updatedFavoriteTokens = favoriteTokens.filter((address: string) => {
         return address !== tokenAddress
       })
     } else {
-      updatedFavoriteTokens.push(tokenAddress)
+      updatedFavoriteTokens = [...favoriteTokens, tokenAddress]
     }
     updateFavoriteTokens(updatedFavoriteTokens)
   }
@@ -499,8 +500,8 @@ export default function LoadedRow({
         <ClickFavorited onClick={() => toggleFavoriteToken()}>
           <Heart
             size={15}
-            color={favoriteTokens.includes(tokenAddress) ? theme.primary1 : undefined}
-            fill={favoriteTokens.includes(tokenAddress) ? theme.primary1 : undefined}
+            color={isFavorited ? theme.primary1 : undefined}
+            fill={isFavorited ? theme.primary1 : undefined}
           />
         </ClickFavorited>
       }

--- a/src/components/Explore/TokenRow.tsx
+++ b/src/components/Explore/TokenRow.tsx
@@ -481,7 +481,7 @@ export default function LoadedRow({
   /* handle favorite token logic */
   const toggleFavoriteToken = () => {
     let updatedFavoriteTokens
-    if (favoriteTokens.includes(tokenAddress)) {
+    if (isFavorited) {
       updatedFavoriteTokens = favoriteTokens.filter((address: string) => {
         return address !== tokenAddress
       })

--- a/src/components/Explore/TokenRow.tsx
+++ b/src/components/Explore/TokenRow.tsx
@@ -3,7 +3,7 @@ import CurrencyLogo from 'components/CurrencyLogo'
 import { useCurrency, useToken } from 'hooks/Tokens'
 import useTheme from 'hooks/useTheme'
 import { TimePeriod, TokenData } from 'hooks/useTopTokens'
-import { atom, useAtom } from 'jotai'
+import { useAtom } from 'jotai'
 import { darken } from 'polished'
 import React, { ReactNode } from 'react'
 import { ArrowDownRight, ArrowUpRight, Heart } from 'react-feather'
@@ -462,27 +462,25 @@ export default function LoadedRow({
   const tokenSymbol = token?.symbol
   const tokenData = data[tokenAddress]
   const [favoriteTokens, updateFavoriteTokens] = useAtom(favoritesAtom)
+  const theme = useTheme()
   // TODO: remove magic number colors
   const tokenPercentChangeInfo = (
     <>
       {tokenData.delta}%
       <ArrowCell>
         {Math.sign(tokenData.delta) > 0 ? (
-          <ArrowUpRight size={16} color={'#57bd0f'} />
+          <ArrowUpRight size={16} color={theme.green1} />
         ) : (
-          <ArrowDownRight size={16} color={'red'} />
+          <ArrowDownRight size={16} color={theme.red1} />
         )}
       </ArrowCell>
     </>
   )
-  const theme = useTheme()
 
   /* handle favorite token logic */
-  const isTokenFavorited = atom<boolean>(favoriteTokens.includes(tokenAddress))
-  const [tokenFavorited, setTokenFavorite] = useAtom(isTokenFavorited)
   const toggleFavoriteToken = () => {
-    let updatedFavoriteTokens = favoriteTokens
-    if (tokenFavorited) {
+    let updatedFavoriteTokens = favoriteTokens.slice()
+    if (favoriteTokens.includes(tokenAddress)) {
       updatedFavoriteTokens = favoriteTokens.filter((address: string) => {
         return address !== tokenAddress
       })
@@ -490,7 +488,6 @@ export default function LoadedRow({
       updatedFavoriteTokens.push(tokenAddress)
     }
     updateFavoriteTokens(updatedFavoriteTokens)
-    setTokenFavorite(!tokenFavorited)
   }
 
   // TODO: currency logo sizing mobile (32px) vs. desktop (24px)
@@ -502,8 +499,8 @@ export default function LoadedRow({
         <ClickFavorited onClick={() => toggleFavoriteToken()}>
           <Heart
             size={15}
-            color={tokenFavorited ? theme.primary1 : undefined}
-            fill={tokenFavorited ? theme.primary1 : undefined}
+            color={favoriteTokens.includes(tokenAddress) ? theme.primary1 : undefined}
+            fill={favoriteTokens.includes(tokenAddress) ? theme.primary1 : undefined}
           />
         </ClickFavorited>
       }


### PR DESCRIPTION
fix favoriting bug by copying the array by value (not by address). Favorite and unfavorite a token should be ~speedy ~ (and update some color scheme stuff)

<img width="986" alt="Screen Shot 2022-07-05 at 1 20 16 PM" src="https://user-images.githubusercontent.com/62825936/177382160-45913af0-830d-4e80-bd8e-dd68fd116f6d.png">

