### PR TITLE
feat: search responsiveness

### DIFF
--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -7,8 +7,6 @@ export const SMALL_MEDIA_BREAKPOINT = '580px'
 
 const StyledSearchBar = styled.div<{ focused: boolean }>`
   display: flex;
-  width: 100%;
-  justify-content: flex-start;
   align-items: center;
   gap: 8px;
   border-radius: 12px;

--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -7,6 +7,7 @@ export const SMALL_MEDIA_BREAKPOINT = '580px'
 
 const StyledSearchBar = styled.div<{ focused: boolean }>`
   display: flex;
+  flex: 1;
   align-items: center;
   gap: 8px;
   border-radius: 12px;

--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -3,21 +3,24 @@ import { useState } from 'react'
 import { Search } from 'react-feather'
 import styled from 'styled-components/macro'
 
+export const SMALL_MEDIA_BREAKPOINT = '580px'
+
 const StyledSearchBar = styled.div<{ focused: boolean }>`
   display: flex;
   width: 100%;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   gap: 8px;
   border-radius: 12px;
   background-color: ${({ theme, focused }) => (focused ? theme.bg2 : theme.bg0)};
   color: ${({ theme }) => theme.text1};
   font-size: 16px;
+  padding: 0px 12px;
 `
 const SearchInput = styled.input`
-  width: 90%;
   background-color: transparent;
   border: none;
+  width: 90%;
   font-size: 16px;
   color: ${({ theme }) => theme.text1};
 
@@ -33,6 +36,7 @@ const SearchInput = styled.input`
 export default function SearchBar() {
   const theme = useTheme()
   const [isFocused, setFocused] = useState(false)
+
   return (
     <StyledSearchBar focused={isFocused}>
       <Search size={20} color={theme.text3} />

--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -30,6 +30,9 @@ const SearchInput = styled.input`
   }
   ::placeholder {
     color: ${({ theme }) => theme.text3};
+    @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
+      color: transparent;
+    }
   }
 `
 

--- a/src/components/Explore/TokenRow.tsx
+++ b/src/components/Explore/TokenRow.tsx
@@ -14,6 +14,12 @@ import { formatAmount, formatDollarAmount } from 'utils/formatDollarAmt'
 import { TIME_DISPLAYS } from './TimeSelector'
 import { favoritesAtom } from './TokenTable'
 
+export const MAX_WIDTH_MEDIA_BREAKPOINT = '960px'
+export const LARGE_MEDIA_BREAKPOINT = '880px'
+export const MEDIUM_MEDIA_BREAKPOINT = '776px'
+export const SMALL_MEDIA_BREAKPOINT = '580px'
+export const MOBILE_MEDIA_BREAKPOINT = '410px'
+
 enum Category {
   percent_change = '% Change',
   market_cap = 'Market Cap',
@@ -25,11 +31,6 @@ enum SortDirection {
   Decreasing = 'Decreasing',
 }
 const SORT_CATEGORIES = Object.values(Category)
-const MAX_WIDTH_MEDIA_BREAKPOINT = '960px'
-const LARGE_MEDIA_BREAKPOINT = '880px'
-const MEDIUM_MEDIA_BREAKPOINT = '776px'
-const SMALL_MEDIA_BREAKPOINT = '640px'
-const MOBILE_MEDIA_BREAKPOINT = '410px'
 
 const ArrowCell = styled.div`
   padding-left: 2px;
@@ -44,7 +45,6 @@ const StyledTokenRow = styled.div`
   width: 100%;
   height: 60px;
   display: grid;
-  padding: 0px 12px;
   grid-template-columns: 1.2fr 1fr 7fr 4fr 4fr 4fr 4fr 5fr 2fr;
   font-size: 15px;
   line-height: 24px;
@@ -111,6 +111,7 @@ const StyledHeaderRow = styled(StyledTokenRow)`
   border-bottom: 1px solid;
   border-color: ${({ theme }) => theme.bg3};
   border-radius: 8px 8px 0px 0px;
+  padding: 0px 12px;
 
   @media only screen and (max-width: ${MOBILE_MEDIA_BREAKPOINT}) {
     display: none;

--- a/src/components/Explore/TokenRow.tsx
+++ b/src/components/Explore/TokenRow.tsx
@@ -11,14 +11,15 @@ import { ArrowDown, ArrowUp } from 'react-feather'
 import styled from 'styled-components/macro'
 import { formatAmount, formatDollarAmount } from 'utils/formatDollarAmt'
 
+import {
+  LARGE_MEDIA_BREAKPOINT,
+  MAX_WIDTH_MEDIA_BREAKPOINT,
+  MEDIUM_MEDIA_BREAKPOINT,
+  MOBILE_MEDIA_BREAKPOINT,
+  SMALL_MEDIA_BREAKPOINT,
+} from './constants'
 import { TIME_DISPLAYS } from './TimeSelector'
 import { favoritesAtom } from './TokenTable'
-
-export const MAX_WIDTH_MEDIA_BREAKPOINT = '960px'
-export const LARGE_MEDIA_BREAKPOINT = '880px'
-export const MEDIUM_MEDIA_BREAKPOINT = '776px'
-export const SMALL_MEDIA_BREAKPOINT = '580px'
-export const MOBILE_MEDIA_BREAKPOINT = '410px'
 
 enum Category {
   percent_change = '% Change',

--- a/src/components/Explore/TokenTable.tsx
+++ b/src/components/Explore/TokenTable.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import styled from 'styled-components/macro'
 
 import LoadedRow, { HeaderRow, LoadingRow } from './TokenRow'
+import { MOBILE_MEDIA_BREAKPOINT } from './TokenRow'
 
 const GridContainer = styled.div`
   display: flex;
@@ -20,9 +21,8 @@ const GridContainer = styled.div`
   border-radius: 8px;
   justify-content: center;
   align-items: center;
-  padding: 4px 0px 8px 0px;
 
-  @media only screen and (max-width: 410px) {
+  @media only screen and (max-width: ${MOBILE_MEDIA_BREAKPOINT}) {
     padding: 12px 16px;
   }
 `
@@ -30,10 +30,13 @@ const NoTokenDisplay = styled.div`
   display: flex;
   width: 100%;
   height: 60px;
-  color: ${({ theme }) => theme.text2};
+  color: ${({ theme }) => theme.text3};
   font-size: 16px;
   align-items: center;
   padding: 0px 28px;
+`
+const TokenRowsContainer = styled.div`
+  padding: 4px 12px;
 `
 const LOADING_ROWS = Array(10)
   .fill(0)
@@ -87,7 +90,7 @@ export default function TokenTable() {
   return (
     <GridContainer>
       <HeaderRow timeframe={timePeriod} />
-      {tokenRows}
+      <TokenRowsContainer>{tokenRows}</TokenRowsContainer>
     </GridContainer>
   )
 }

--- a/src/components/Explore/TokenTable.tsx
+++ b/src/components/Explore/TokenTable.tsx
@@ -6,8 +6,8 @@ import { showFavoritesAtom } from 'pages/Explore/index'
 import React from 'react'
 import styled from 'styled-components/macro'
 
+import { MOBILE_MEDIA_BREAKPOINT } from './constants'
 import LoadedRow, { HeaderRow, LoadingRow } from './TokenRow'
-import { MOBILE_MEDIA_BREAKPOINT } from './TokenRow'
 
 const GridContainer = styled.div`
   display: flex;

--- a/src/components/Explore/TokenTable.tsx
+++ b/src/components/Explore/TokenTable.tsx
@@ -58,7 +58,7 @@ export default function TokenTable() {
     return (
       <GridContainer>
         <HeaderRow timeframe={timePeriod} />
-        {LOADING_ROWS}
+        <TokenRowsContainer>{LOADING_ROWS}</TokenRowsContainer>
       </GridContainer>
     )
   } else if (error || data === null) {

--- a/src/components/Explore/constants.ts
+++ b/src/components/Explore/constants.ts
@@ -1,0 +1,5 @@
+export const MAX_WIDTH_MEDIA_BREAKPOINT = '960px'
+export const LARGE_MEDIA_BREAKPOINT = '880px'
+export const MEDIUM_MEDIA_BREAKPOINT = '776px'
+export const SMALL_MEDIA_BREAKPOINT = '580px'
+export const MOBILE_MEDIA_BREAKPOINT = '410px'

--- a/src/pages/Explore/index.tsx
+++ b/src/pages/Explore/index.tsx
@@ -5,29 +5,42 @@ import TokenTable from 'components/Explore/TokenTable'
 import { atomWithStorage } from 'jotai/utils'
 import styled from 'styled-components/macro'
 
-const GridContainer = styled.div`
-  padding: 12px;
+const MAX_WIDTH_MEDIA_BREAKPOINT = '960px'
+
+const ExploreContainer = styled.div`
+  width: 100%;
+  min-width: 390px;
+`
+const TokenTableContainer = styled.div`
+  padding: 16px 12px;
 `
 const FiltersContainer = styled.div`
-  display: flex;
+  display: grid;
   gap: 8px;
   height: 44px;
-  width: 960px;
+  max-width: 960px;
+  grid-template-columns: 9fr 1.5fr 1fr;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media only screen and (max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT}) {
+    padding: 0px 12px;
+  }
 `
 export const showFavoritesAtom = atomWithStorage<boolean>('showFavorites', false)
 const Explore = () => {
   return (
-    <>
+    <ExploreContainer>
       <FiltersContainer>
         <SearchBar />
         <FavoriteButton />
         <TimeSelector />
       </FiltersContainer>
 
-      <GridContainer>
+      <TokenTableContainer>
         <TokenTable />
-      </GridContainer>
-    </>
+      </TokenTableContainer>
+    </ExploreContainer>
   )
 }
 

--- a/src/pages/Explore/index.tsx
+++ b/src/pages/Explore/index.tsx
@@ -1,11 +1,10 @@
+import { MAX_WIDTH_MEDIA_BREAKPOINT } from 'components/Explore/constants'
 import FavoriteButton from 'components/Explore/FavoriteButton'
 import SearchBar from 'components/Explore/SearchBar'
 import TimeSelector from 'components/Explore/TimeSelector'
 import TokenTable from 'components/Explore/TokenTable'
 import { atomWithStorage } from 'jotai/utils'
 import styled from 'styled-components/macro'
-
-const MAX_WIDTH_MEDIA_BREAKPOINT = '960px'
 
 const ExploreContainer = styled.div`
   width: 100%;
@@ -15,7 +14,7 @@ const TokenTableContainer = styled.div`
   padding: 16px 12px;
 `
 const FiltersContainer = styled.div`
-  display: grid;
+  display: flex;
   gap: 8px;
   height: 44px;
   max-width: 960px;


### PR DESCRIPTION
fix search bar responsiveness in filtering bar above table and clean up some padding

<img width="719" alt="Screen Shot 2022-07-05 at 4 25 01 PM" src="https://user-images.githubusercontent.com/62825936/177410259-a968b121-7b17-4b8e-b8d6-6b2119660d24.png">
<img width="1024" alt="Screen Shot 2022-07-05 at 4 24 54 PM" src="https://user-images.githubusercontent.com/62825936/177410261-f92c12e5-a34b-47c2-a74c-17cbe587658d.png">

<img width="490" alt="Screen Shot 2022-07-05 at 5 22 16 PM" src="https://user-images.githubusercontent.com/62825936/177418814-334b6ebb-e802-4ea4-a248-9c577d338e3d.png">
<img width="486" alt="Screen Shot 2022-07-05 at 5 22 11 PM" src="https://user-images.githubusercontent.com/62825936/177418816-6ea8cdc8-729c-4208-9943-514c8689dbc3.png">

