### PR TITLE
style: rename library to provider

### DIFF
--- a/src/lib/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/lib/hooks/swap/useSendSwapTransaction.tsx
@@ -40,12 +40,12 @@ interface FailedCall extends SwapCallEstimate {
 export default function useSendSwapTransaction(
   account: string | null | undefined,
   chainId: number | undefined,
-  library: JsonRpcProvider | undefined,
+  provider: JsonRpcProvider | undefined,
   trade: AnyTrade | undefined, // trade to execute, required
   swapCalls: SwapCall[]
 ): { callback: null | (() => Promise<TransactionResponse>) } {
   return useMemo(() => {
-    if (!trade || !library || !account || !chainId) {
+    if (!trade || !provider || !account || !chainId) {
       return { callback: null }
     }
     return {
@@ -64,7 +64,7 @@ export default function useSendSwapTransaction(
                     value,
                   }
 
-            return library
+            return provider
               .estimateGas(tx)
               .then((gasEstimate) => {
                 return {
@@ -75,7 +75,7 @@ export default function useSendSwapTransaction(
               .catch((gasError) => {
                 console.debug('Gas estimate failed, trying eth_call to extract error', call)
 
-                return library
+                return provider
                   .call(tx)
                   .then((result) => {
                     console.debug('Unexpected successful call after failed estimate gas', call, gasError, result)
@@ -110,7 +110,7 @@ export default function useSendSwapTransaction(
           call: { address, calldata, value },
         } = bestCallOption
 
-        return library
+        return provider
           .getSigner()
           .sendTransaction({
             from: account,
@@ -136,5 +136,5 @@ export default function useSendSwapTransaction(
           })
       },
     }
-  }, [account, chainId, library, swapCalls, trade])
+  }, [account, chainId, provider, swapCalls, trade])
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,22 +25,22 @@ export function shortenAddress(address: string, chars = 4): string {
 }
 
 // account is not optional
-function getSigner(library: JsonRpcProvider, account: string): JsonRpcSigner {
-  return library.getSigner(account).connectUnchecked()
+function getSigner(provider: JsonRpcProvider, account: string): JsonRpcSigner {
+  return provider.getSigner(account).connectUnchecked()
 }
 
 // account is optional
-function getProviderOrSigner(library: JsonRpcProvider, account?: string): JsonRpcProvider | JsonRpcSigner {
-  return account ? getSigner(library, account) : library
+function getProviderOrSigner(provider: JsonRpcProvider, account?: string): JsonRpcProvider | JsonRpcSigner {
+  return account ? getSigner(provider, account) : provider
 }
 
 // account is optional
-export function getContract(address: string, ABI: any, library: JsonRpcProvider, account?: string): Contract {
+export function getContract(address: string, ABI: any, provider: JsonRpcProvider, account?: string): Contract {
   if (!isAddress(address) || address === AddressZero) {
     throw Error(`Invalid 'address' parameter '${address}'.`)
   }
 
-  return new Contract(address, ABI, getProviderOrSigner(library, account) as any)
+  return new Contract(address, ABI, getProviderOrSigner(provider, account) as any)
 }
 
 export function escapeRegExp(string: string): string {


### PR DESCRIPTION
A styling change as `web3-react` renamed `library` to `provider` in v8
