### PR TITLE
feat: token link page with token address URL param

### DIFF
--- a/src/components/Explore/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetail.tsx
@@ -1,37 +1,67 @@
 import CurrencyLogo from 'components/CurrencyLogo'
 import { useCurrency, useToken } from 'hooks/Tokens'
+import useTokenPrice from 'hooks/useTokenPrice'
+import { TimePeriod } from 'hooks/useTopTokens'
 import { atom, useAtom } from 'jotai'
-import { ArrowLeft, Heart, Share } from 'react-feather'
+import { ArrowDownRight, ArrowLeft, ArrowUpRight, Heart, Share } from 'react-feather'
 import styled, { useTheme } from 'styled-components/macro'
 
 import { favoritesAtom } from './TokenTable'
 
+const ArrowCell = styled.div`
+  padding-left: 2px;
+  display: flex;
+`
+
+const BreadcrumbContainer = styled.div`
+  display: flex;
+  color: ${({ theme }) => theme.text2};
+  font-size: 14px;
+  line-height: 20px;
+  align-items: center;
+  gap: 8px;
+`
+
 const ChartAreaContainer = styled.div`
   display: flex;
   flex-direction: column;
-`
-const MetaDataContainer = styled.div`
-  display: flex;
+  width: 832px;
+  gap: 20px;
 `
 const ChartHeader = styled.div`
+  width: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: flex-start;
+  color: ${({ theme }) => theme.text1};
+  gap: 8px;
+`
+const DeltaContainer = styled.div`
+  display: flex;
+  font-size: 16px;
 `
 const TokenInfoHeaderCell = styled.div`
+  width: 100%;
   display: flex;
   justify-content: flex-start;
   gap: 8px;
 `
 const TokenActions = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: right;
   gap: 24px;
+  color: ${({ theme }) => theme.text2};
 `
 const TokenInfoContainer = styled.div`
+  width: 100%;
   display: flex;
 `
+const TokenPrice = styled.span`
+  font-size: 36px;
+  line-height: 44px;
+`
 const TokenSymbol = styled.span`
-  color: ${({ theme }) => theme.text3};
+  color: ${({ theme }) => theme.text2};
 `
 
 export default function TokenDetail({ tokenAddress }: { tokenAddress: string }) {
@@ -42,14 +72,27 @@ export default function TokenDetail({ tokenAddress }: { tokenAddress: string }) 
   const [favoriteTokens, updateFavoriteTokens] = useAtom(favoritesAtom)
   const isTokenFavorited = atom<boolean>(favoriteTokens.includes(tokenAddress))
   const theme = useTheme()
+  const set = new Set<string>()
+  const currencyLogo = useCurrency(tokenAddress)
+  set.add(tokenAddress)
+  const { data, loading, error } = useTokenPrice(set)
+  if (error || data === null) return <div></div>
+  const tokenDetails = data[tokenAddress]
+  const tokenPrice = tokenDetails.price
+  const timePeriod = TimePeriod.hour
+  const tokenDelta = tokenDetails.delta[timePeriod]
+  if (tokenDelta === undefined) return <div></div>
+  const deltaSign = Math.sign(tokenDelta) > 0 ? '+' : '-'
 
   return (
     <ChartAreaContainer>
-      <ArrowLeft size={10} /> Explore
+      <BreadcrumbContainer>
+        <ArrowLeft size={10} /> Explore
+      </BreadcrumbContainer>
       <ChartHeader>
         <TokenInfoContainer>
           <TokenInfoHeaderCell>
-            <CurrencyLogo currency={useCurrency(tokenAddress)} />
+            <CurrencyLogo currency={currencyLogo} />
             {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
           </TokenInfoHeaderCell>
           <TokenActions>
@@ -61,6 +104,18 @@ export default function TokenDetail({ tokenAddress }: { tokenAddress: string }) 
             />
           </TokenActions>
         </TokenInfoContainer>
+        <TokenPrice>${tokenPrice}</TokenPrice>
+        <DeltaContainer>
+          {deltaSign}
+          {tokenDelta}%
+          <ArrowCell>
+            {deltaSign === '+' ? (
+              <ArrowUpRight size={16} color={theme.green1} />
+            ) : (
+              <ArrowDownRight size={16} color={theme.red1} />
+            )}
+          </ArrowCell>
+        </DeltaContainer>
       </ChartHeader>
     </ChartAreaContainer>
   )

--- a/src/components/Explore/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetail.tsx
@@ -1,0 +1,67 @@
+import CurrencyLogo from 'components/CurrencyLogo'
+import { useCurrency, useToken } from 'hooks/Tokens'
+import { atom, useAtom } from 'jotai'
+import { ArrowLeft, Heart, Share } from 'react-feather'
+import styled, { useTheme } from 'styled-components/macro'
+
+import { favoritesAtom } from './TokenTable'
+
+const ChartAreaContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+const MetaDataContainer = styled.div`
+  display: flex;
+`
+const ChartHeader = styled.div`
+  display: flex;
+  justify-content: flex-start;
+`
+const TokenInfoHeaderCell = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  gap: 8px;
+`
+const TokenActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 24px;
+`
+const TokenInfoContainer = styled.div`
+  display: flex;
+`
+const TokenSymbol = styled.span`
+  color: ${({ theme }) => theme.text3};
+`
+
+export default function TokenDetail({ tokenAddress }: { tokenAddress: string }) {
+  const token = useToken(tokenAddress)
+  const tokenName = token?.name
+  const tokenSymbol = token?.symbol
+
+  const [favoriteTokens, updateFavoriteTokens] = useAtom(favoritesAtom)
+  const isTokenFavorited = atom<boolean>(favoriteTokens.includes(tokenAddress))
+  const theme = useTheme()
+
+  return (
+    <ChartAreaContainer>
+      <ArrowLeft size={10} /> Explore
+      <ChartHeader>
+        <TokenInfoContainer>
+          <TokenInfoHeaderCell>
+            <CurrencyLogo currency={useCurrency(tokenAddress)} />
+            {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
+          </TokenInfoHeaderCell>
+          <TokenActions>
+            <Share size={18} />
+            <Heart
+              size={15}
+              color={isTokenFavorited ? theme.primary1 : undefined}
+              fill={isTokenFavorited ? theme.primary1 : undefined}
+            />
+          </TokenActions>
+        </TokenInfoContainer>
+      </ChartHeader>
+    </ChartAreaContainer>
+  )
+}

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -18,6 +18,7 @@ import { RedirectDuplicateTokenIdsV2 } from './AddLiquidityV2/redirects'
 import Earn from './Earn'
 import Manage from './Earn/Manage'
 import Explore from './Explore'
+import { TokenDetails } from './Explore/TokenDetails'
 import MigrateV2 from './MigrateV2'
 import MigrateV2Pair from './MigrateV2/MigrateV2Pair'
 import Pool from './Pool'
@@ -92,6 +93,7 @@ export default function App() {
           <Suspense fallback={<Loader />}>
             <Switch>
               <Route exact strict path="/explore" component={Explore} />
+              <Route exact strict path="/tokens/:tokenAddress" component={TokenDetails} />
 
               <Route strict path="/vote" component={Vote} />
               <Route exact strict path="/create-proposal">

--- a/src/pages/Explore/TokenDetails.tsx
+++ b/src/pages/Explore/TokenDetails.tsx
@@ -1,0 +1,9 @@
+import TokenDetail from 'components/Explore/TokenDetail'
+import { RouteComponentProps } from 'react-router-dom'
+export function TokenDetails({
+  match: {
+    params: { tokenAddress },
+  },
+}: RouteComponentProps<{ tokenAddress: string }>) {
+  return <TokenDetail tokenAddress={tokenAddress} />
+}


### PR DESCRIPTION
Add route for token details page with path: '/tokens/<address>?network=mainnet' and some basic information on the page 

test with for example: http://localhost:3000/#/tokens/0x03ab458634910aad20ef5f1c8ee96f1d6ac54919?chain=mainnet

<img width="1208" alt="Screen Shot 2022-07-06 at 12 30 09 PM" src="https://user-images.githubusercontent.com/62825936/177599202-0856c4da-2a9f-4c7b-ba0f-e895d963e74f.png">

