### PR TITLE
feat: update privacy policy to include amplitude

### DIFF
--- a/src/components/PrivacyPolicy/index.tsx
+++ b/src/components/PrivacyPolicy/index.tsx
@@ -70,7 +70,7 @@ const EXTERNAL_APIS = [
     ),
   },
   {
-    name: 'Google Analytics',
+    name: 'Google Analytics & Amplitude',
     description: <Trans>The app logs anonymized usage statistics in order to improve over time.</Trans>,
   },
   {


### PR DESCRIPTION
Update privacy policy here to show Google Analytics & Amplitude, to prepare for integrating amplitude analytics into interface codebase: 
<img width="454" alt="Screen Shot 2022-07-04 at 3 40 10 PM" src="https://user-images.githubusercontent.com/41491154/177649027-6ff56415-520f-48a7-8fa9-20dfb650ddfc.png">