### PR TITLE
feat: token detail page metadata UI

### DIFF
--- a/src/components/Explore/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetail.tsx
@@ -2,10 +2,12 @@ import CurrencyLogo from 'components/CurrencyLogo'
 import { useCurrency, useToken } from 'hooks/Tokens'
 import { TimePeriod } from 'hooks/useTopTokens'
 import { atom, useAtom } from 'jotai'
+import { darken } from 'polished'
 import { useState } from 'react'
-import { ArrowDownRight, ArrowLeft, ArrowUpRight, Heart, Share } from 'react-feather'
+import { ArrowDownRight, ArrowLeft, ArrowUpRight, Copy, Heart, Share } from 'react-feather'
 import { Link } from 'react-router-dom'
 import styled, { useTheme } from 'styled-components/macro'
+import { ExternalLink } from 'theme'
 
 import { favoritesAtom } from './TokenTable'
 
@@ -18,6 +20,16 @@ const TIME_DISPLAYS: Record<TimePeriod, string> = {
 }
 const TIME_PERIODS = [TimePeriod.hour, TimePeriod.day, TimePeriod.week, TimePeriod.month, TimePeriod.year]
 
+const AboutSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 0px;
+`
+const AboutHeader = styled.span`
+  font-size: 28px;
+  line-height: 36px;
+`
 const ArrowCell = styled.div`
   padding-left: 2px;
   display: flex;
@@ -33,7 +45,7 @@ const BreadcrumbNavLink = styled(Link)`
   margin-bottom: 16px;
 
   &:hover {
-    text-decoration: underline;
+    color: ${({ theme }) => darken(0.1, theme.text2)};
   }
 `
 const ChartHeader = styled.div`
@@ -41,6 +53,31 @@ const ChartHeader = styled.div`
   display: flex;
   flex-direction: column;
   color: ${({ theme }) => theme.text1};
+  gap: 4px;
+  margin-bottom: 56px;
+`
+const ContractAddress = styled.button`
+  display: flex;
+  color: ${({ theme }) => theme.text1};
+  gap: 10px;
+  align-items: center;
+  background: transparent;
+  border: none;
+  padding: 0px;
+  cursor: pointer;
+
+  &:hover {
+    color: ${({ theme }) => theme.primary2};
+  }
+`
+const ContractAddressSection = styled.div`
+  padding: 24px 0px;
+`
+const ContractCell = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: ${({ theme }) => theme.text2};
+  font-size: 14px;
   gap: 4px;
 `
 const ChartContainer = styled.div`
@@ -51,7 +88,23 @@ const DeltaContainer = styled.div`
   display: flex;
   align-items: center;
 `
-
+const StatCell = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: ${({ theme }) => theme.text2};
+  font-size: 14px;
+  width: 168px;
+  gap: 4px;
+`
+const StatPrice = styled.span`
+  font-size: 28px;
+  color: ${({ theme }) => theme.text1};
+`
+const StatsSection = styled.div`
+  display: flex;
+  gap: 4px;
+  padding: 24px 0px;
+`
 const TimeButton = styled.button<{ active: boolean }>`
   background-color: ${({ theme, active }) => (active ? theme.primary1 : 'transparent')};
   font-size: 14px;
@@ -94,6 +147,24 @@ const TokenSymbol = styled.span`
 const TopArea = styled.div`
   width: 832px;
 `
+const ResourcesContainer = styled.div`
+  display: flex;
+  gap: 14px;
+`
+const ResourceLink = styled(ExternalLink)`
+  display: flex;
+  color: ${({ theme }) => theme.primary1};
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  gap: 4px;
+  text-decoration: none;
+
+  &:hover {
+    color: ${({ theme }) => darken(0.1, theme.primary1)};
+    text-decoration: none;
+  }
+`
 
 export default function TokenDetail({ address }: { address: string }) {
   const theme = useTheme()
@@ -116,7 +187,10 @@ export default function TokenDetail({ address }: { address: string }) {
   const tokenDelta = 1.22
   const isPositive = Math.sign(tokenDelta) > 0
   const deltaSign = isPositive ? '+' : '-'
-
+  const aboutToken =
+    'Ethereum is a decentralized computing platform that uses ETH (Ether) to pay transaction fees (gas). Developers can use Ethereum to run decentralized applications (dApps) and issue new crypto assets, known as Ethereum tokens.'
+  const tokenMarketCap = '23.02B'
+  const tokenVolume = '1.6B'
   return (
     <TopArea>
       <BreadcrumbNavLink to="/explore">
@@ -166,6 +240,36 @@ export default function TokenDetail({ address }: { address: string }) {
           })}
         </TimeOptionsContainer>
       </ChartHeader>
+      <AboutSection>
+        <AboutHeader>About</AboutHeader> {aboutToken}
+        <ResourcesContainer>
+          <ResourceLink href="https://etherscan.io/">
+            Etherscan
+            <sup>↗</sup>
+          </ResourceLink>
+          <ResourceLink href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
+            Protocol Info
+            <sup>↗</sup>
+          </ResourceLink>
+        </ResourcesContainer>
+      </AboutSection>
+      <StatsSection>
+        <StatCell>
+          Market Cap<StatPrice>${tokenMarketCap}</StatPrice>
+        </StatCell>
+        <StatCell>
+          {TIME_DISPLAYS[activeTimePeriod]} Volume
+          <StatPrice>${tokenVolume}</StatPrice>
+        </StatCell>
+      </StatsSection>
+      <ContractAddressSection>
+        <ContractCell>
+          Contract Address
+          <ContractAddress onClick={() => navigator.clipboard.writeText(address)}>
+            {address} <Copy size={13} color={theme.text2} />
+          </ContractAddress>
+        </ContractCell>
+      </ContractAddressSection>
     </TopArea>
   )
 }


### PR DESCRIPTION
token detail page with metadata skeleton with dummy data (but no chart). Currently working: Button links work (try pressing Explore, Etherscan, and protocol info), time button UI works, and copying the contract address to your clipboard.

<img width="781" alt="Screen Shot 2022-07-06 at 11 34 33 PM" src="https://user-images.githubusercontent.com/62825936/177685182-3f638f9f-2a5d-4798-988d-d859152c342c.png">
