### PR TITLE
build: wait on tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,17 +6,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  wait-on-test:
+  wait-on-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: jitterbit/await-check-suites@v1
+      - id: unit-tests
+        uses: fountainhead/action-wait-for-check@v1.0.0
         with:
-          timeoutSeconds: 600
-          # Only wait for the first check suite, so that only tests are awaited, and not eg crowdin.
-          onlyFirstCheckSuite: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: unit-tests
+      - id: cypress-tests
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: cypress-tests
+      - if: steps.unit-tests.outputs.conclusion != 'success' || steps.cypress-tests.outputs.conclusion != 'success'
+        run: exit 1
 
   tag:
-    needs: wait-on-test
+    needs: wait-on-tests
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.github-tag-action.outputs.new_tag }}


### PR DESCRIPTION
Use a different action to wait on tests, as the old action could not disambiguate check suites.