### PR TITLE
build: wait on passing cypress

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,8 +71,19 @@ jobs:
         with:
           cidv0: ${{ steps.pinata.outputs.hash }}
       
-      # Delay updating DNS to give IPFS a chance to propagate.
-      - run: sleep 600
+      - uses: actions/cache@v3
+        id: cypress-cache
+        with:
+          path: /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('node_modules/cypress') }}
+      - if: steps.cypress-cache.outputs.cache-hit != 'true'
+        run: yarn cypress install
+      - uses: cypress-io/github-action@v4
+        with:
+          install: false
+          browser: chrome
+          config-file: cypress.release.config.ts
+          config: baseUrl=https://cloudflare-ipfs.com/ipfs/${{ steps.pinata.outputs.hash }}
 
       - name: Update DNS with new IPFS hash
         env:

--- a/cypress.release.config.ts
+++ b/cypress.release.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   projectId: 'yp82ef',
-  videoUploadOnPasses: false,
   pageLoadTimeout: 60000,
   retries: 30,
   e2e: {

--- a/cypress.release.config.ts
+++ b/cypress.release.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  projectId: 'yp82ef',
+  videoUploadOnPasses: false,
+  pageLoadTimeout: 60000,
+  retries: 30,
+  e2e: {
+    specPattern: 'cypress/release.ts',
+  },
+})

--- a/cypress/release.ts
+++ b/cypress/release.ts
@@ -1,0 +1,8 @@
+describe('Release', () => {
+  it('loads swap page', () => {
+    cy.visit('/', {
+      retryOnStatusCodeFailure: true,
+      retryOnNetworkFailure: true,
+    }).get('#swap-page')
+  })
+})


### PR DESCRIPTION
Instead of waiting 10m for IPFS to propagate, test every minute for 30m for a pageload using cypress.