### PR TITLE
build: wait an hour for IPFS release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,9 @@ jobs:
       - run: yarn prepare
       - run: yarn build
 
-      - name: Pin to IPFS
+      # Cloudflare IPFS nodes peer with Pinata nodes
+      # https://blog.cloudflare.com/continuing-to-improve-our-ipfs-gateway/#connecting-with-pinata
+      - name: Pin to IPFS (Pinata)
         id: pinata
         uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
         with:
@@ -57,7 +59,7 @@ jobs:
           pinata-api-key: ${{ secrets.PINATA_API_KEY }}
           pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
 
-      - name: Pin to Crust
+      - name: Pin to IPFS (Crust)
         uses: crustio/ipfs-crust-action@v2.0.3
         continue-on-error: true
         timeout-minutes: 2
@@ -84,7 +86,18 @@ jobs:
           browser: chrome
           record: false
           config-file: cypress.release.config.ts
-          config: baseUrl=https://cloudflare-ipfs.com/ipfs/${{ steps.pinata.outputs.hash }}
+          config: baseUrl=https://${{ steps.convert-cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/
+      # This only guarantees that pinata has pinned the file such that it is available to
+      # cloudflare's gateway *in this locality*. We have no guarantee that cloudflare's gateway
+      # retains served files [1].
+      #
+      # When it is requested through our dedicated gateway *in a new locality*, it should be
+      # available within a few minutes [2]. uniswap.org explicitly sets the proxy read timeout [3]
+      # to 480 (8m) to facilitate initial IPFS requests.
+      #
+      # [1]: https://github.com/aragon/aragon-cli/issues/1114#issuecomment-579250246
+      # [2]: https://spectrum.chat/aragon/app-development/how-to-use-pinata-for-propagation~33e4c1d0-3c86-4cc9-b7e7-e5e392acf902
+      # [3]: https://api.cloudflare.com/#zone-settings-change-proxy-read-timeout-setting
 
       - name: Update DNS with new IPFS hash
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,7 @@ jobs:
         with:
           install: false
           browser: chrome
+          record: false
           config-file: cypress.release.config.ts
           config: baseUrl=https://cloudflare-ipfs.com/ipfs/${{ steps.pinata.outputs.hash }}
 

--- a/cypress.release.config.ts
+++ b/cypress.release.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   projectId: 'yp82ef',
-  video: false,
   e2e: {
     specPattern: 'cypress/release.ts',
   },

--- a/cypress.release.config.ts
+++ b/cypress.release.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   projectId: 'yp82ef',
+  video: false,
   e2e: {
     specPattern: 'cypress/release.ts',
   },

--- a/cypress/release.ts
+++ b/cypress/release.ts
@@ -4,17 +4,12 @@ describe(
   'Release',
   {
     pageLoadTimeout: ONE_MINUTE,
-    retries: 30,
+    retries: 60,
   },
   () => {
     it('loads swap page', () => {
       // We *must* wait in order to space out the retry attempts.
-      cy.wait(ONE_MINUTE)
-        .visit('/', {
-          retryOnStatusCodeFailure: true,
-          retryOnNetworkFailure: true,
-        })
-        .get('#swap-page')
+      cy.wait(ONE_MINUTE).visit('/').get('#swap-page')
     })
   }
 )


### PR DESCRIPTION
- Increases the wait time for IPFS to be available during release to an hour.
  The current setup is functional, but eg https://github.com/Uniswap/interface/runs/7298181685?check_suite_focus=true#step:12:69 took 27 (of 31) tries, so the number of retries needs to be increased.
- Documents IPFS initial request delays.
  As part of this PR, the proxy read timeout should be extended to 8m on cloudflare.

Essentially, IPFS content only propagates to a new node when it is requested by a client, so a cloudflare data center's first load will always have some delay. Anecdotally, that delay is about 5 minutes.

We seem to be able to mitigate that delay for US nodes by pre-requesting the asset through cloudflare's public gateway (although we have no guarantees about this). However, this does not mitigate the delay for international nodes.

I think this leaves us with 3 choices:
1. Increase the proxy read timeout so that initial requests to IPFS do not time out.
2. Maintain our own internationally placed IPFS cluster to intentionally propagate and make the content more available.
3. Abandon IPFS as our primary hosting service.

This PR documents (1) an increased proxy read timeout to 8 minutes, which will need to be made separately using cloudflare's API.