### PR TITLE
fix: revert "fix button jump on currency panel"

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -271,15 +271,14 @@ export default function CurrencyInputPanel({
             </Aligner>
           </CurrencySelect>
         </InputRow>
-
-        <FiatRow>
-          {!hideInput && !hideBalance && currency && (
+        {!hideInput && !hideBalance && currency && (
+          <FiatRow>
             <RowBetween>
               <LoadingOpacityContainer $loading={loading}>
                 <FiatValue fiatValue={fiatValue} priceImpact={priceImpact} />
               </LoadingOpacityContainer>
               {account ? (
-                <RowFixed>
+                <RowFixed style={{ height: '17px' }}>
                   <ThemedText.Body
                     onClick={onMax}
                     color={theme.text3}
@@ -305,8 +304,8 @@ export default function CurrencyInputPanel({
                 <span />
               )}
             </RowBetween>
-          )}
-        </FiatRow>
+          </FiatRow>
+        )}
       </Container>
       {onCurrencySelect && (
         <CurrencySearchModal


### PR DESCRIPTION
Revert button jump fix on currency panel because of padding issues (https://github.com/Uniswap/interface/pull/4017)

![image](https://user-images.githubusercontent.com/62825936/178514497-137ffb4c-d03f-4c64-920a-ef39808e7364.png)
