### PR TITLE
chore(web3-react): fix connectEagerly for MetaMask mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@web3-react/eip1193": "^8.0.26-beta.0",
     "@web3-react/empty": "^8.0.20-beta.0",
     "@web3-react/gnosis-safe": "^8.0.6-beta.0",
-    "@web3-react/metamask": "^8.0.27-beta.0",
+    "@web3-react/metamask": "^8.0.28-beta.0",
     "@web3-react/network": "^8.0.27-beta.0",
     "@web3-react/types": "^8.0.20-beta.0",
     "@web3-react/url": "^8.0.25-beta.0",

--- a/src/hooks/useEagerlyConnect.ts
+++ b/src/hooks/useEagerlyConnect.ts
@@ -1,10 +1,9 @@
 import { Connector } from '@web3-react/types'
-import { gnosisSafeConnection, injectedConnection, networkConnection } from 'connection'
-import { getConnection, getIsMetaMask } from 'connection/utils'
+import { gnosisSafeConnection, networkConnection } from 'connection'
+import { getConnection } from 'connection/utils'
 import { useEffect } from 'react'
 import { BACKFILLABLE_WALLETS } from 'state/connection/constants'
 import { useAppSelector } from 'state/hooks'
-import { isMobile } from 'utils/userAgent'
 
 async function connect(connector: Connector) {
   try {
@@ -22,15 +21,11 @@ export default function useEagerlyConnect() {
   const selectedWalletBackfilled = useAppSelector((state) => state.user.selectedWalletBackfilled)
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
 
-  const isMetaMask = getIsMetaMask()
-
   useEffect(() => {
     connect(gnosisSafeConnection.connector)
     connect(networkConnection.connector)
 
-    if (isMobile && isMetaMask) {
-      injectedConnection.connector.activate()
-    } else if (selectedWallet) {
+    if (selectedWallet) {
       connect(getConnection(selectedWallet).connector)
     } else if (!selectedWalletBackfilled) {
       BACKFILLABLE_WALLETS.map(getConnection)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4789,10 +4789,10 @@
     "@gnosis.pm/safe-apps-sdk" "^7.5.0"
     "@web3-react/types" "^8.0.20-beta.0"
 
-"@web3-react/metamask@^8.0.27-beta.0":
-  version "8.0.27-beta.0"
-  resolved "https://registry.yarnpkg.com/@web3-react/metamask/-/metamask-8.0.27-beta.0.tgz#a2871a776365c8aac4798cc28d53a0e6173f6688"
-  integrity sha512-x97x3sy/kKoqoGRZ8+Dld1XEEQ9iv6/bY2gyjadJL99RXoEcvAPbZqCWSJGSySyzTFkq7M7rounkuGmaCMC8lg==
+"@web3-react/metamask@^8.0.28-beta.0":
+  version "8.0.28-beta.0"
+  resolved "https://registry.yarnpkg.com/@web3-react/metamask/-/metamask-8.0.28-beta.0.tgz#f7e9e0de446727a961745cbec75c8cbf6c961388"
+  integrity sha512-IXuVyj6vhRAhfGQ/sN4qgET8EEdqX844pB4kCDG9kjPD3LLm5kq47ykBosgTr9YCUtdHAXN0UaUimD0TbLMRFg==
   dependencies:
     "@metamask/detect-provider" "^1.2.0"
     "@web3-react/types" "^8.0.20-beta.0"
@@ -15096,7 +15096,7 @@ react-redux@^8.0.2:
     "@types/use-sync-external-store" "^0.0.3"
     hoist-non-react-statics "^3.3.2"
     react-is "^18.0.0"
-    use-sync-external-store "^1.1.0"
+    use-sync-external-store "^1.0.0"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -17786,6 +17786,11 @@ use-sync-external-store@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
   integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
+
+use-sync-external-store@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17782,15 +17782,10 @@ use-sidecar@^1.0.1:
     detect-node-es "^1.1.0"
     tslib "^1.9.3"
 
-use-sync-external-store@1.1.0:
+use-sync-external-store@1.1.0, use-sync-external-store@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
   integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
-
-use-sync-external-store@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This web3-react update fixes connectEagerly on MM Mobile browser, so we don't need to call activate manually.
