### PR TITLE
build: pause deploy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Release
 on:
-  schedule:
-    - cron:  '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
+  # Auto-deploy is disabled while react 18 upgrade is tested further.
+  # schedule:
+  #   - cron:  '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
   # manual trigger
   workflow_dispatch:
 
@@ -70,7 +71,7 @@ jobs:
         uses: uniswap/convert-cidv0-cidv1@v1.0.0
         with:
           cidv0: ${{ steps.pinata.outputs.hash }}
-      
+
       - uses: actions/cache@v3
         id: cypress-cache
         with:


### PR DESCRIPTION
There are some new errors on the Swap page shown below.

When I reset local to before the react 18 PR merge the issues went away, so it's possible it's related to the upgrade. For now, we can just block deploys and resolve the issue.
