### PR TITLE
fix: fixes Popover arrow positioning

### DIFF
--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -26,6 +26,7 @@ const Arrow = styled.div`
     position: absolute;
     width: 8px;
     height: 8px;
+    box-sizing: border-box;
     z-index: 9998;
 
     content: '';
@@ -35,7 +36,7 @@ const Arrow = styled.div`
   }
 
   &.arrow-top {
-    bottom: -5px;
+    bottom: -4px;
     ::before {
       border-top: none;
       border-left: none;
@@ -43,7 +44,7 @@ const Arrow = styled.div`
   }
 
   &.arrow-bottom {
-    top: -5px;
+    top: -4px;
     ::before {
       border-bottom: none;
       border-right: none;
@@ -51,7 +52,7 @@ const Arrow = styled.div`
   }
 
   &.arrow-left {
-    right: -5px;
+    right: -4px;
 
     ::before {
       border-bottom: none;
@@ -60,7 +61,7 @@ const Arrow = styled.div`
   }
 
   &.arrow-right {
-    left: -5px;
+    left: -4px;
     ::before {
       border-right: none;
       border-top: none;


### PR DESCRIPTION
If we zoom in, we can find the arrow not really an arrow:

![CleanShot 2022-07-17 at 15 26 55@2x](https://user-images.githubusercontent.com/1091472/179388442-c6b1f090-de31-41f4-8b65-12c4d57395fb.png)

![CleanShot 2022-07-17 at 15 29 50@2x](https://user-images.githubusercontent.com/1091472/179388526-fdab7ae7-ea0d-46fd-b6cc-744254e4463f.png)
