### PR TITLE
fix: catch vibrant failure

### DIFF
--- a/src/hooks/useColor.ts
+++ b/src/hooks/useColor.ts
@@ -46,7 +46,13 @@ async function getColorFromToken(token: Token): Promise<string | null> {
 async function getColorFromUriPath(uri: string): Promise<string | null> {
   const formattedPath = uriToHttp(uri)[0]
 
-  const palette = await Vibrant.from(formattedPath).getPalette()
+  let palette
+
+  try {
+    palette = await Vibrant.from(formattedPath).getPalette()
+  } catch (err) {
+    return null
+  }
   if (!palette?.Vibrant) {
     return null
   }


### PR DESCRIPTION
Just noticed the CI for my pull requests kept failing with an error like this:

<img width="1679" alt="CleanShot 2022-07-18 at 21 46 07@2x" src="https://user-images.githubusercontent.com/1091472/179525416-139905c2-3a9f-4a4d-bbee-5ac23e7f3c9b.png">

And I believe it's related to this bug in `node-vibrant` https://github.com/Vibrant-Colors/node-vibrant/issues/101 because it tries to load image from remote server to extract color.

And there's another issue reported here https://github.com/Uniswap/interface/issues/4011 which might be related to the same bug.

Hopefully the e2e tests for this pull request should succeed without error above.