### PR TITLE
build: change project name to @uniswap/interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uniswap/widgets",
+  "name": "@uniswap/interface",
   "version": "1.0.7",
   "description": "Uniswap Interface",
   "homepage": ".",


### PR DESCRIPTION
I always found this confusing, but I think it was because Widgets used to be in this repo.
