### PR TITLE
fix: expand state

### DIFF
--- a/src/components/Explore/SearchBar.tsx
+++ b/src/components/Explore/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useAtom } from 'jotai'
+import { useState } from 'react'
 import styled from 'styled-components/macro'
 
 import searchIcon from './search.svg'
@@ -13,7 +14,7 @@ const SearchBarContainer = styled.div`
   flex: 1;
 `
 
-const SearchInput = styled.input`
+const SearchInput = styled.input<{ expanded: boolean }>`
   background: no-repeat scroll 7px 7px;
   background-image: url(${searchIcon});
   background-size: 20px 20px;
@@ -23,7 +24,7 @@ const SearchInput = styled.input`
   border-radius: 12px;
   border: none;
   height: 100%;
-  width: 44px;
+  width: ${({ expanded }) => (expanded ? '100%' : '44px')};
   font-size: 16px;
   padding-left: 40px;
   color: ${({ theme }) => theme.text2};
@@ -32,15 +33,11 @@ const SearchInput = styled.input`
   :focus {
     outline: none;
     background-color: ${({ theme }) => theme.bg2};
-    width: 100%;
   }
   ::placeholder {
-    color: none;
+    color: ${({ expanded, theme }) => expanded && theme.text3};
     @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
       color: transparent;
-    }
-    :focus {
-      color: ${({ theme }) => theme.text3};
     }
   }
   ::-webkit-search-cancel-button {
@@ -57,14 +54,17 @@ const SearchInput = styled.input`
 
 export default function SearchBar() {
   const [filterString, setFilterString] = useAtom(filterStringAtom)
+  const [isExpanded, setExpanded] = useState(false)
 
   return (
     <SearchBarContainer>
       <SearchInput
+        expanded={isExpanded}
         type="search"
         placeholder="Search token or paste address"
         id="searchBar"
-        onBlur={() => filterString.length === 0}
+        onBlur={() => isExpanded && filterString.length === 0 && setExpanded(false)}
+        onFocus={() => setExpanded(true)}
         autoComplete="off"
         value={filterString}
         onChange={({ target: { value } }) => setFilterString(value)}


### PR DESCRIPTION
search bar shouldn't collapse when there is a string in it

<img width="758" alt="Screen Shot 2022-07-18 at 11 27 20 AM" src="https://user-images.githubusercontent.com/62825936/179546534-76e92ebd-d70d-4b7f-afa0-c16659710100.png">
 