### PR TITLE
build: lock jest-styled-components@7.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-react-hooks": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "jest-styled-components": "^7.0.5",
+    "jest-styled-components": "7.0.7",
     "ms.macro": "^2.0.0",
     "prettier": "^2.7.1",
     "react-scripts": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,6 +3897,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/prettier@^2.0.0", "@types/prettier@^2.1.1":
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
+  integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
+
 "@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
@@ -11627,10 +11632,10 @@ jest-snapshot@^26.6.0, jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
-jest-styled-components@^7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.5.tgz#6da3f1a1c8bd98bccc6bcf9aabfdefdcd88fd92c"
-  integrity sha512-ZR/r3IKNkgaaVIOThn0Qis4sNQtA352qHjhbxSHeLS3FDIvHSUSJoI2b3kzk+bHHQ1VOeV630usERtnyhyZh4A==
+jest-styled-components@7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.7.tgz#8eb1c0a64278b06222df0e749e561dba4e771057"
+  integrity sha512-iisbHp0X5n61gSjHuzBdqeMtQpg31Lmq+J06LjWfYPYIo3AC1h2oGdF5A7Os2F8TpRaS/RtdimpZ8OwxkEiKJg==
   dependencies:
     css "^3.0.0"
 
@@ -14619,7 +14624,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.7.1:
+prettier@^2.1.2, prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==


### PR DESCRIPTION
Seems like this PR made some changes in the lock file: https://github.com/Uniswap/interface/pull/4128

Then this PR failed the unit-tests based on snapshots: https://github.com/Uniswap/interface/pull/4125

Then this PR updated the snapshots as an unrelated issue: https://github.com/Uniswap/interface/pull/4130

This issue states that 7.0.8 (latest version) has a bug where the sc-* classNames from styled-components are regenerated randomly, leading the snapshot flakes: https://github.com/styled-components/jest-styled-components/issues/405, https://github.com/styled-components/jest-styled-components/issues/276#issuecomment-1149749113

So this re-adds some potentially necessary pieces of the yarn.lock, and also fixes the jest-styled-components version for now.