### PR TITLE
fix: unused onClickOutside reference

### DIFF
--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -295,8 +295,6 @@ export default function NetworkSelector() {
   const closeModal = useCloseModal(ApplicationModal.NETWORK_SELECTOR)
   const toggleModal = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
 
-  useOnClickOutside(node, isOpen ? toggle : undefined)
-
   const info = getChainInfo(chainId)
 
   const replaceURLChainParam = useCallback(() => {


### PR DESCRIPTION
I accidentally merged https://github.com/Uniswap/interface/pull/4019 because it was on auto-merge, even though stuff failed. This removes an unused line.
