### PR TITLE
fix: add celo gas override

### DIFF
--- a/src/hooks/useClientSideV3Trade.ts
+++ b/src/hooks/useClientSideV3Trade.ts
@@ -14,6 +14,8 @@ import { useQuoter } from './useContract'
 const QUOTE_GAS_OVERRIDES: { [chainId: number]: number } = {
   [SupportedChainId.ARBITRUM_ONE]: 25_000_000,
   [SupportedChainId.ARBITRUM_RINKEBY]: 25_000_000,
+  [SupportedChainId.CELO]: 50_000_000,
+  [SupportedChainId.CELO_ALFAJORES]: 50_000_000,
 }
 
 const DEFAULT_GAS_QUOTE = 2_000_000


### PR DESCRIPTION
This circumvents the 'out of gas' error thrown by the multicall