### PR TITLE
feat: implement other swap events part 1

### DIFF
--- a/src/components/AmplitudeAnalytics/constants.ts
+++ b/src/components/AmplitudeAnalytics/constants.ts
@@ -7,6 +7,7 @@
 export enum EventName {
   CONNECT_WALLET_BUTTON_CLICKED = 'Connect Wallet Button Clicked',
   PAGE_VIEWED = 'Page Viewed',
+  SWAP_AUTOROUTER_VISUALIZATION_EXPANDED = 'Swap Autorouter Visualization Expanded',
   SWAP_DETAILS_EXPANDED = 'Swap Details Expanded',
   SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
   SWAP_SUBMITTED = 'Swap Submitted',
@@ -58,6 +59,7 @@ export const enum ModalName {
  * Use to identify low-level components given a TraceContext
  */
 export const enum ElementName {
+  AUTOROUTER_VISUALIZATION_ROW = 'expandable-autorouter-visualization-row',
   COMMON_BASES_CURRENCY_BUTTON = 'common-bases-currency-button',
   CONFIRM_SWAP_BUTTON = 'confirm-swap-or-send',
   CONNECT_WALLET_BUTTON = 'connect-wallet-button',

--- a/src/components/AmplitudeAnalytics/constants.ts
+++ b/src/components/AmplitudeAnalytics/constants.ts
@@ -7,7 +7,10 @@
 export enum EventName {
   CONNECT_WALLET_BUTTON_CLICKED = 'Connect Wallet Button Clicked',
   PAGE_VIEWED = 'Page Viewed',
+  SWAP_DETAILS_EXPANDED = 'Swap Details Expanded',
+  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
   SWAP_SUBMITTED = 'Swap Submitted',
+  SWAP_TOKENS_REVERSED = 'Swap Tokens Reversed',
   TOKEN_IMPORTED = 'Token Imported',
   TOKEN_SELECTED = 'Token Selected',
   TOKEN_SELECTOR_OPENED = 'Token Selector Opened',
@@ -45,7 +48,7 @@ export const enum SectionName {
 
 /** Known modals for analytics purposes. */
 export const enum ModalName {
-  SWAP = 'swap-modal',
+  CONFIRM_SWAP = 'confirm-swap-modal',
   TOKEN_SELECTOR = 'token-selector-modal',
   // alphabetize additional modal names.
 }
@@ -59,7 +62,10 @@ export const enum ElementName {
   CONFIRM_SWAP_BUTTON = 'confirm-swap-or-send',
   CONNECT_WALLET_BUTTON = 'connect-wallet-button',
   IMPORT_TOKEN_BUTTON = 'import-token-button',
+  MAX_TOKEN_AMOUNT_BUTTON = 'max-token-amount-button',
   SWAP_BUTTON = 'swap-button',
+  SWAP_DETAILS_DROPDOWN = 'swap-details-dropdown',
+  SWAP_TOKENS_REVERSE_ARROW_BUTTON = 'swap-tokens-reverse-arrow-button',
   TOKEN_SELECTOR_ROW = 'token-selector-row',
   WALLET_TYPE_OPTION = 'wallet-type-option',
   // alphabetize additional element names.

--- a/src/components/AmplitudeAnalytics/index.ts
+++ b/src/components/AmplitudeAnalytics/index.ts
@@ -7,7 +7,6 @@ import { Identify, identify, init, track } from '@amplitude/analytics-browser'
  * member of the organization on Amplitude to view details.
  */
 export function initializeAnalytics(isDevEnvironment = process.env.NODE_ENV === 'development') {
-  console.log(process.env.NODE_ENV)
   if (isDevEnvironment) return
 
   const API_KEY = process.env.REACT_APP_AMPLITUDE_KEY

--- a/src/components/AmplitudeAnalytics/index.ts
+++ b/src/components/AmplitudeAnalytics/index.ts
@@ -7,6 +7,7 @@ import { Identify, identify, init, track } from '@amplitude/analytics-browser'
  * member of the organization on Amplitude to view details.
  */
 export function initializeAnalytics(isDevEnvironment = process.env.NODE_ENV === 'development') {
+  console.log(process.env.NODE_ENV)
   if (isDevEnvironment) return
 
   const API_KEY = process.env.REACT_APP_AMPLITUDE_KEY

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -2,6 +2,8 @@ import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { useWeb3React } from '@web3-react/core'
+import { ElementName, Event, EventName } from 'components/AmplitudeAnalytics/constants'
+import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import { AutoColumn } from 'components/Column'
 import { LoadingOpacityContainer, loadingOpacityMixin } from 'components/Loader/styled'
 import { darken } from 'polished'
@@ -295,9 +297,15 @@ export default function CurrencyInputPanel({
                     ) : null}
                   </ThemedText.Body>
                   {showMaxButton && selectedCurrencyBalance ? (
-                    <StyledBalanceMax onClick={onMax}>
-                      <Trans>MAX</Trans>
-                    </StyledBalanceMax>
+                    <TraceEvent
+                      events={[Event.onClick]}
+                      name={EventName.SWAP_MAX_TOKEN_AMOUNT_SELECTED}
+                      element={ElementName.MAX_TOKEN_AMOUNT_BUTTON}
+                    >
+                      <StyledBalanceMax onClick={onMax}>
+                        <Trans>MAX</Trans>
+                      </StyledBalanceMax>
+                    </TraceEvent>
                   ) : null}
                 </RowFixed>
               ) : (

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro'
-import { Trace } from 'components/AmplitudeAnalytics/Trace'
-import { ModalName } from 'components/AmplitudeAnalytics/constants'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
+import { ModalName } from 'components/AmplitudeAnalytics/constants'
+import { Trace } from 'components/AmplitudeAnalytics/Trace'
 import { ReactNode, useCallback, useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import { tradeMeaningfullyDiffers } from 'utils/tradeMeaningFullyDiffer'
@@ -92,14 +92,14 @@ export default function ConfirmSwapModal({
 
   return (
     <Trace modal={ModalName.CONFIRM_SWAP} shouldLogImpression={isOpen}>
-    <TransactionConfirmationModal
-      isOpen={isOpen}
-      onDismiss={onDismiss}
-      attemptingTxn={attemptingTxn}
-      hash={txHash}
-      content={confirmationContent}
-      pendingText={pendingText}
-      currencyToAdd={trade?.outputAmount.currency}
+      <TransactionConfirmationModal
+        isOpen={isOpen}
+        onDismiss={onDismiss}
+        attemptingTxn={attemptingTxn}
+        hash={txHash}
+        content={confirmationContent}
+        pendingText={pendingText}
+        currencyToAdd={trade?.outputAmount.currency}
       />
     </Trace>
   )

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -1,4 +1,6 @@
 import { Trans } from '@lingui/macro'
+import { Trace } from 'components/AmplitudeAnalytics/Trace'
+import { ModalName } from 'components/AmplitudeAnalytics/constants'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { ReactNode, useCallback, useMemo } from 'react'
@@ -89,6 +91,7 @@ export default function ConfirmSwapModal({
   )
 
   return (
+    <Trace modal={ModalName.CONFIRM_SWAP} shouldLogImpression={isOpen}>
     <TransactionConfirmationModal
       isOpen={isOpen}
       onDismiss={onDismiss}
@@ -97,6 +100,7 @@ export default function ConfirmSwapModal({
       content={confirmationContent}
       pendingText={pendingText}
       currencyToAdd={trade?.outputAmount.currency}
-    />
+      />
+    </Trace>
   )
 }

--- a/src/components/swap/SwapDetailsDropdown.tsx
+++ b/src/components/swap/SwapDetailsDropdown.tsx
@@ -139,6 +139,7 @@ export default function SwapDetailsDropdown({
           events={[Event.onClick]}
           name={EventName.SWAP_DETAILS_EXPANDED}
           element={ElementName.SWAP_DETAILS_DROPDOWN}
+          shouldLogImpression={!showDetails}
         >
           <StyledHeaderRow onClick={() => setShowDetails(!showDetails)} disabled={!trade} open={showDetails}>
             <RowFixed style={{ position: 'relative' }}>

--- a/src/components/swap/SwapDetailsDropdown.tsx
+++ b/src/components/swap/SwapDetailsDropdown.tsx
@@ -1,6 +1,8 @@
 import { Trans } from '@lingui/macro'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
+import { ElementName, Event, EventName } from 'components/AmplitudeAnalytics/constants'
+import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import AnimatedDropdown from 'components/AnimatedDropdown'
 import Card, { OutlineCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
@@ -132,6 +134,11 @@ export default function SwapDetailsDropdown({
   return (
     <Wrapper>
       <AutoColumn gap={'8px'} style={{ width: '100%', marginBottom: '-8px' }}>
+        <TraceEvent
+          events={[Event.onClick]}
+          name={EventName.SWAP_DETAILS_EXPANDED}
+          element={ElementName.SWAP_DETAILS_DROPDOWN}
+        >
         <StyledHeaderRow onClick={() => setShowDetails(!showDetails)} disabled={!trade} open={showDetails}>
           <RowFixed style={{ position: 'relative' }}>
             {loading || syncing ? (
@@ -192,6 +199,7 @@ export default function SwapDetailsDropdown({
             <RotatingArrow stroke={trade ? theme.text3 : theme.bg3} open={Boolean(trade && showDetails)} />
           </RowFixed>
         </StyledHeaderRow>
+        </TraceEvent>
         <AnimatedDropdown open={showDetails}>
           <AutoColumn gap={'8px'} style={{ padding: '0', paddingBottom: '8px' }}>
             {trade ? (

--- a/src/components/swap/SwapDetailsDropdown.tsx
+++ b/src/components/swap/SwapDetailsDropdown.tsx
@@ -140,69 +140,69 @@ export default function SwapDetailsDropdown({
           name={EventName.SWAP_DETAILS_EXPANDED}
           element={ElementName.SWAP_DETAILS_DROPDOWN}
         >
-        <StyledHeaderRow onClick={() => setShowDetails(!showDetails)} disabled={!trade} open={showDetails}>
-          <RowFixed style={{ position: 'relative' }}>
-            {loading || syncing ? (
-              <StyledPolling>
-                <StyledPollingDot>
-                  <Spinner />
-                </StyledPollingDot>
-              </StyledPolling>
-            ) : (
-              <HideSmall>
-                <MouseoverTooltipContent
-                  wrap={false}
-                  content={
-                    <ResponsiveTooltipContainer origin="top right" style={{ padding: '0' }}>
-                      <Card padding="12px">
-                        <AdvancedSwapDetails
-                          trade={trade}
-                          allowedSlippage={allowedSlippage}
-                          syncing={syncing}
-                          hideInfoTooltips={true}
-                        />
-                      </Card>
-                    </ResponsiveTooltipContainer>
-                  }
-                  placement="bottom"
+          <StyledHeaderRow onClick={() => setShowDetails(!showDetails)} disabled={!trade} open={showDetails}>
+            <RowFixed style={{ position: 'relative' }}>
+              {loading || syncing ? (
+                <StyledPolling>
+                  <StyledPollingDot>
+                    <Spinner />
+                  </StyledPollingDot>
+                </StyledPolling>
+              ) : (
+                <HideSmall>
+                  <MouseoverTooltipContent
+                    wrap={false}
+                    content={
+                      <ResponsiveTooltipContainer origin="top right" style={{ padding: '0' }}>
+                        <Card padding="12px">
+                          <AdvancedSwapDetails
+                            trade={trade}
+                            allowedSlippage={allowedSlippage}
+                            syncing={syncing}
+                            hideInfoTooltips={true}
+                          />
+                        </Card>
+                      </ResponsiveTooltipContainer>
+                    }
+                    placement="bottom"
+                    disableHover={showDetails}
+                  >
+                    <StyledInfoIcon color={trade ? theme.deprecated_text3 : theme.deprecated_bg3} />
+                  </MouseoverTooltipContent>
+                </HideSmall>
+              )}
+              {trade ? (
+                <LoadingOpacityContainer $loading={syncing}>
+                  <TradePrice
+                    price={trade.executionPrice}
+                    showInverted={showInverted}
+                    setShowInverted={setShowInverted}
+                  />
+                </LoadingOpacityContainer>
+              ) : loading || syncing ? (
+                <ThemedText.Main fontSize={14}>
+                  <Trans>Fetching best price...</Trans>
+                </ThemedText.Main>
+              ) : null}
+            </RowFixed>
+            <RowFixed>
+              {!trade?.gasUseEstimateUSD ||
+              showDetails ||
+              !chainId ||
+              !SUPPORTED_GAS_ESTIMATE_CHAIN_IDS.includes(chainId) ? null : (
+                <GasEstimateBadge
+                  trade={trade}
+                  loading={syncing || loading}
+                  showRoute={!showDetails}
                   disableHover={showDetails}
-                >
-                  <StyledInfoIcon color={trade ? theme.deprecated_text3 : theme.deprecated_bg3} />
-                </MouseoverTooltipContent>
-              </HideSmall>
-            )}
-            {trade ? (
-              <LoadingOpacityContainer $loading={syncing}>
-                <TradePrice
-                  price={trade.executionPrice}
-                  showInverted={showInverted}
-                  setShowInverted={setShowInverted}
                 />
-              </LoadingOpacityContainer>
-            ) : loading || syncing ? (
-              <ThemedText.Main fontSize={14}>
-                <Trans>Fetching best price...</Trans>
-              </ThemedText.Main>
-            ) : null}
-          </RowFixed>
-          <RowFixed>
-            {!trade?.gasUseEstimateUSD ||
-            showDetails ||
-            !chainId ||
-            !SUPPORTED_GAS_ESTIMATE_CHAIN_IDS.includes(chainId) ? null : (
-              <GasEstimateBadge
-                trade={trade}
-                loading={syncing || loading}
-                showRoute={!showDetails}
-                disableHover={showDetails}
+              )}
+              <RotatingArrow
+                stroke={trade ? theme.deprecated_text3 : theme.deprecated_bg3}
+                open={Boolean(trade && showDetails)}
               />
-            )}
-            <RotatingArrow
-              stroke={trade ? theme.deprecated_text3 : theme.deprecated_bg3}
-              open={Boolean(trade && showDetails)}
-            />
-          </RowFixed>
-        </StyledHeaderRow>
+            </RowFixed>
+          </StyledHeaderRow>
         </TraceEvent>
         <AnimatedDropdown open={showDetails}>
           <AutoColumn gap={'8px'} style={{ padding: '0', paddingBottom: '8px' }}>

--- a/src/components/swap/SwapRoute.tsx
+++ b/src/components/swap/SwapRoute.tsx
@@ -4,6 +4,8 @@ import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { FeeAmount } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
+import { ElementName, Event, EventName } from 'components/AmplitudeAnalytics/constants'
+import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import AnimatedDropdown from 'components/AnimatedDropdown'
 import { AutoColumn } from 'components/Column'
 import { LoadingRows } from 'components/Loader/styled'
@@ -62,13 +64,20 @@ export default memo(function SwapRoute({ trade, syncing, fixedOpen = false, ...r
 
   return (
     <Wrapper {...rest} darkMode={darkMode} fixedOpen={fixedOpen}>
-      <RowBetween onClick={() => setOpen(!open)}>
-        <AutoRow gap="4px" width="auto">
-          <AutoRouterLogo />
-          <AutoRouterLabel />
-        </AutoRow>
-        {fixedOpen ? null : <OpenCloseIcon open={open} />}
-      </RowBetween>
+      <TraceEvent
+        events={[Event.onClick]}
+        name={EventName.SWAP_AUTOROUTER_VISUALIZATION_EXPANDED}
+        element={ElementName.AUTOROUTER_VISUALIZATION_ROW}
+        shouldLogImpression={!open}
+      >
+        <RowBetween onClick={() => setOpen(!open)}>
+          <AutoRow gap="4px" width="auto">
+            <AutoRouterLogo />
+            <AutoRouterLabel />
+          </AutoRow>
+          {fixedOpen ? null : <OpenCloseIcon open={open} />}
+        </RowBetween>
+      </TraceEvent>
       <AnimatedDropdown open={open || fixedOpen}>
         <AutoRow gap="4px" width="auto" style={{ paddingTop: '12px', margin: 0 }}>
           {syncing ? (

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -467,19 +467,19 @@ export default function Swap() {
                     name={EventName.SWAP_TOKENS_REVERSED}
                     element={ElementName.SWAP_TOKENS_REVERSE_ARROW_BUTTON}
                   >
-                  <ArrowDown
-                    size="16"
-                    onClick={() => {
-                      setApprovalSubmitted(false) // reset 2 step UI for approvals
-                      onSwitchTokens()
-                    }}
-                    color={
-                      currencies[Field.INPUT] && currencies[Field.OUTPUT]
-                        ? theme.deprecated_text1
-                        : theme.deprecated_text3
-                    }
+                    <ArrowDown
+                      size="16"
+                      onClick={() => {
+                        setApprovalSubmitted(false) // reset 2 step UI for approvals
+                        onSwitchTokens()
+                      }}
+                      color={
+                        currencies[Field.INPUT] && currencies[Field.OUTPUT]
+                          ? theme.deprecated_text1
+                          : theme.deprecated_text3
+                      }
                     />
-                    </TraceEvent>
+                  </TraceEvent>
                 </ArrowWrapper>
                 <Trace section={SectionName.CURRENCY_OUTPUT_PANEL}>
                   <CurrencyInputPanel

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -462,14 +462,20 @@ export default function Swap() {
                   />
                 </Trace>
                 <ArrowWrapper clickable>
-                  <ArrowDown
-                    size="16"
-                    onClick={() => {
-                      setApprovalSubmitted(false) // reset 2 step UI for approvals
-                      onSwitchTokens()
-                    }}
-                    color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.text1 : theme.text3}
-                  />
+                  <TraceEvent
+                    events={[Event.onClick]}
+                    name={EventName.SWAP_TOKENS_REVERSED}
+                    element={ElementName.SWAP_TOKENS_REVERSE_ARROW_BUTTON}
+                  >
+                    <ArrowDown
+                      size="16"
+                      onClick={() => {
+                        setApprovalSubmitted(false) // reset 2 step UI for approvals
+                        onSwitchTokens()
+                      }}
+                      color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.text1 : theme.text3}
+                      />
+                  </TraceEvent>
                 </ArrowWrapper>
                 <Trace section={SectionName.CURRENCY_OUTPUT_PANEL}>
                   <CurrencyInputPanel


### PR DESCRIPTION
Added "shouldLogImpression" property, defaulting to true, onto TraceEvent component as well, because some events require conditional logging. For example, we want to log when the auto router visualization is opened, but not send the same event again when it is closed.

Events created by this PR: 
1. <img width="497" alt="Screen Shot 2022-07-20 at 4 58 24 PM" src="https://user-images.githubusercontent.com/41491154/180091562-6a3fee26-d0f1-4595-bdb1-edf44ec9b361.png">
2. <img width="468" alt="Screen Shot 2022-07-20 at 4 58 32 PM" src="https://user-images.githubusercontent.com/41491154/180091565-6c9dee8b-e90c-41f2-87d7-f25757adf16f.png">
3. <img width="491" alt="Screen Shot 2022-07-20 at 4 58 38 PM" src="https://user-images.githubusercontent.com/41491154/180091567-e37c451d-30b5-46c6-8501-e5494157db50.png">
4. <img width="656" alt="Screen Shot 2022-07-20 at 9 51 40 PM" src="https://user-images.githubusercontent.com/41491154/180112725-73df1709-bc8b-471e-a5ba-4d6d42ccbbea.png">

