### PR TITLE
fix: Full range button for both tokens

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -159,6 +159,7 @@ export default function AddLiquidity() {
 
   useEffect(() => {
     if (
+      leftRangeTypedValue !== true &&
       typeof parsedQs.minPrice === 'string' &&
       parsedQs.minPrice !== leftRangeTypedValue &&
       !isNaN(parsedQs.minPrice as any)
@@ -167,6 +168,7 @@ export default function AddLiquidity() {
     }
 
     if (
+      rightRangeTypedValue !== true &&
       typeof parsedQs.maxPrice === 'string' &&
       parsedQs.maxPrice !== rightRangeTypedValue &&
       !isNaN(parsedQs.maxPrice as any)


### PR DESCRIPTION
**Description**
This PR is to fix the issue [3843](https://github.com/Uniswap/interface/issues/3843)

**What was causing the bug?**
When the user clicks on the _Full Range_ button, the action `setFullRange` is dispatched, setting both `leftRangeTypedValue` and `rightRangeTypedValue` to `true`. That causes the useEffect below to execute and since there are always query params of minPrice and maxPrice on first load of the AddLiquidity page
![image](https://user-images.githubusercontent.com/28561817/180598040-f6096eb7-3352-4026-9218-664491102604.png)
The `typeLeftRangeInput` and `typeRightRangeInput` actions will dispatched, therefore setting the min/max price with what's in the query params.