### PR TITLE
fix: scroll to top only when pathname changes

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -6,7 +6,7 @@ import TopLevelModals from 'components/TopLevelModals'
 import ApeModeQueryParamReader from 'hooks/useApeModeQueryParamReader'
 import { lazy, Suspense } from 'react'
 import { useEffect } from 'react'
-import { Redirect, Route, Switch, useHistory, useLocation } from 'react-router-dom'
+import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { useAnalyticsReporter } from '../components/analytics'
@@ -80,20 +80,15 @@ function getCurrentPageFromLocation(locationPathname: string): PageName | undefi
 }
 
 export default function App() {
-  const history = useHistory()
   const location = useLocation()
+  const { pathname } = location
   const currentPage = getCurrentPageFromLocation(location.pathname)
   useAnalyticsReporter()
   initializeAnalytics()
 
   useEffect(() => {
-    const unlisten = history.listen(() => {
-      window.scrollTo(0, 0)
-    })
-    return () => {
-      unlisten()
-    }
-  }, [history])
+    window.scrollTo(0, 0)
+  }, [pathname])
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
When I was adding liquidity on my cellphone through the in-app browser of metamask, I noticed that every time I click the +/- buttons, the page would scroll to top:

<img src='https://user-images.githubusercontent.com/1091472/180636182-f7f1f95b-b023-4c55-b438-f8993ab3c04e.png' width='300' />

Here's why it happens: when we click the +/- buttons, the url would change, e.g.,

from: `/#/add/ETH/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/3000?chain=mainnet&maxPrice=3261.7&minPrice=919.71`
to: `/#/add/ETH/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/3000?chain=mainnet&maxPrice=3261.7&minPrice=919.71`

I.e., the `history` object changes, hence `scrollTo` would get called every time I click the +/- buttons.

Which is obviously wrong, we shouldn't call `scrollTo` when query strings change because we are still on the same page.