### PR TITLE
fix: update critical red HEX

### DIFF
--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -111,7 +111,7 @@ export const colors: GlobalPalette = {
   red100: '#FFD9CE',
   red200: '#FDA799',
   red300: '#FF776D',
-  red400: '#FD4040',
+  red400: '#FA2B39',
   red500: '#C52533',
   red600: '#891E20',
   red700: '#530F10',


### PR DESCRIPTION
Update theme color (critical red) HEX

<img width="191" alt="Screen Shot 2022-07-26 at 1 20 41 PM" src="https://user-images.githubusercontent.com/62825936/181070690-4c0dfe0f-0175-43ba-83fa-800cec888f3d.png">
 