### PR TITLE
feat: add time / duration based event properties to swap events

### DIFF
--- a/src/components/AmplitudeAnalytics/constants.ts
+++ b/src/components/AmplitudeAnalytics/constants.ts
@@ -38,6 +38,8 @@ export enum WALLET_CONNECTION_RESULT {
   FAILED = 'Failed',
 }
 
+export const NATIVE_CHAIN_ADDRESS = 'NATIVE'
+
 /**
  * Known pages in the app. Highest order context.
  */
@@ -81,7 +83,6 @@ export const enum ElementName {
   SWAP_BUTTON = 'swap-button',
   SWAP_DETAILS_DROPDOWN = 'swap-details-dropdown',
   SWAP_TOKENS_REVERSE_ARROW_BUTTON = 'swap-tokens-reverse-arrow-button',
-  SWAP_TRADE_PRICE_ROW = 'swap-trade-price-row',
   TOKEN_SELECTOR_ROW = 'token-selector-row',
   WALLET_TYPE_OPTION = 'wallet-type-option',
   // alphabetize additional element names.

--- a/src/components/AmplitudeAnalytics/constants.ts
+++ b/src/components/AmplitudeAnalytics/constants.ts
@@ -38,7 +38,7 @@ export enum WALLET_CONNECTION_RESULT {
   FAILED = 'Failed',
 }
 
-export const NATIVE_CHAIN_ADDRESS = 'NATIVE'
+export const NATIVE_CHAIN_ID = 'NATIVE'
 
 /**
  * Known pages in the app. Highest order context.

--- a/src/components/AmplitudeAnalytics/utils.ts
+++ b/src/components/AmplitudeAnalytics/utils.ts
@@ -6,7 +6,7 @@ export const getDurationTillTimestampSinceEpochSeconds = (futureTimestampSinceEp
 }
 
 export const getDurationFromDateTillNowMilliseconds = (date: Date): number => {
-  return Math.abs(new Date().getUTCMilliseconds() - date.getUTCMilliseconds())
+  return new Date().getUTCMilliseconds() - date.getUTCMilliseconds()
 }
 
 export const getNumberFormattedToDecimalPlace = (

--- a/src/components/AmplitudeAnalytics/utils.ts
+++ b/src/components/AmplitudeAnalytics/utils.ts
@@ -1,8 +1,12 @@
 import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 
-export const getDurationTillTimestampSinceEpoch = (futureTimestampSinceEpoch?: number): number | undefined => {
+export const getDurationTillTimestampSinceEpochSeconds = (futureTimestampSinceEpoch?: number): number | undefined => {
   if (!futureTimestampSinceEpoch) return undefined
   return futureTimestampSinceEpoch - new Date().getTime() / 1000
+}
+
+export const getDurationFromDateTillNowMilliseconds = (date: Date): number => {
+  return Math.abs(new Date().getUTCMilliseconds() - date.getUTCMilliseconds())
 }
 
 export const getNumberFormattedToDecimalPlace = (

--- a/src/components/AmplitudeAnalytics/utils.ts
+++ b/src/components/AmplitudeAnalytics/utils.ts
@@ -2,9 +2,9 @@ import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 
 import { NATIVE_CHAIN_ID } from './constants'
 
-export const getDurationTillTimestampSinceEpochSeconds = (futureTimestampSinceEpoch?: number): number | undefined => {
-  if (!futureTimestampSinceEpoch) return undefined
-  return futureTimestampSinceEpoch - new Date().getTime() / 1000
+export const getDurationTillTimestampSeconds = (futureTimestampInSecondsSinceEpoch?: number): number | undefined => {
+  if (!futureTimestampInSecondsSinceEpoch) return undefined
+  return futureTimestampInSecondsSinceEpoch - new Date().getTime() / 1000
 }
 
 export const getDurationFromDateMilliseconds = (start: Date): number => {

--- a/src/components/AmplitudeAnalytics/utils.ts
+++ b/src/components/AmplitudeAnalytics/utils.ts
@@ -2,7 +2,7 @@ import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 
 import { NATIVE_CHAIN_ID } from './constants'
 
-export const getDurationTillTimestampSeconds = (futureTimestampInSecondsSinceEpoch?: number): number | undefined => {
+export const getDurationUntilTimestampSeconds = (futureTimestampInSecondsSinceEpoch?: number): number | undefined => {
   if (!futureTimestampInSecondsSinceEpoch) return undefined
   return futureTimestampInSecondsSinceEpoch - new Date().getTime() / 1000
 }

--- a/src/components/AmplitudeAnalytics/utils.ts
+++ b/src/components/AmplitudeAnalytics/utils.ts
@@ -1,17 +1,21 @@
 import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 
+import { NATIVE_CHAIN_ID } from './constants'
+
 export const getDurationTillTimestampSinceEpochSeconds = (futureTimestampSinceEpoch?: number): number | undefined => {
   if (!futureTimestampSinceEpoch) return undefined
   return futureTimestampSinceEpoch - new Date().getTime() / 1000
 }
 
-export const getDurationFromDateTillNowMilliseconds = (start: Date): number => {
+export const getDurationFromDateMilliseconds = (start: Date): number => {
   return new Date().getTime() - start.getTime()
 }
 
-export const getNumberFormattedToDecimalPlace = (
+export const formatToDecimal = (
   intialNumberObject: Percent | CurrencyAmount<Token | Currency>,
   decimalPlace: number
 ): number => parseFloat(intialNumberObject.toFixed(decimalPlace))
+
+export const getTokenAddress = (currency: Currency) => (currency.isNative ? NATIVE_CHAIN_ID : currency.address)
 
 export const formatPercentInBasisPointsNumber = (percent: Percent): number => parseFloat(percent.toFixed(2)) * 100

--- a/src/components/AmplitudeAnalytics/utils.ts
+++ b/src/components/AmplitudeAnalytics/utils.ts
@@ -5,8 +5,8 @@ export const getDurationTillTimestampSinceEpochSeconds = (futureTimestampSinceEp
   return futureTimestampSinceEpoch - new Date().getTime() / 1000
 }
 
-export const getDurationFromDateTillNowMilliseconds = (date: Date): number => {
-  return new Date().getUTCMilliseconds() - date.getUTCMilliseconds()
+export const getDurationFromDateTillNowMilliseconds = (start: Date): number => {
+  return new Date().getTime() - start.getTime()
 }
 
 export const getNumberFormattedToDecimalPlace = (

--- a/src/components/SearchModal/CommonBases.tsx
+++ b/src/components/SearchModal/CommonBases.tsx
@@ -1,5 +1,5 @@
-import { Currency, Token } from '@uniswap/sdk-core'
-import { ElementName, Event, EventName } from 'components/AmplitudeAnalytics/constants'
+import { Currency } from '@uniswap/sdk-core'
+import { ElementName, Event, EventName, NATIVE_CHAIN_ADDRESS } from 'components/AmplitudeAnalytics/constants'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
@@ -33,15 +33,10 @@ const BaseWrapper = styled.div<{ disable?: boolean }>`
   filter: ${({ disable }) => disable && 'grayscale(1)'};
 `
 
-const formatAnalyticsEventProperties = (
-  currency: Currency,
-  tokenAddress: string | undefined,
-  searchQuery: string,
-  isAddressSearch: string | false
-) => ({
+const formatAnalyticsEventProperties = (currency: Currency, searchQuery: string, isAddressSearch: string | false) => ({
   token_symbol: currency?.symbol,
   token_chain_id: currency?.chainId,
-  ...(tokenAddress ? { token_address: tokenAddress } : {}),
+  token_address: currency.isNative ? NATIVE_CHAIN_ADDRESS : currency.address,
   is_suggested_token: true,
   is_selected_from_list: false,
   is_imported_by_user: false,
@@ -70,13 +65,12 @@ export default function CommonBases({
       <AutoRow gap="4px">
         {bases.map((currency: Currency) => {
           const isSelected = selectedCurrency?.equals(currency)
-          const tokenAddress = currency instanceof Token ? currency?.address : undefined
 
           return (
             <TraceEvent
               events={[Event.onClick, Event.onKeyPress]}
               name={EventName.TOKEN_SELECTED}
-              properties={formatAnalyticsEventProperties(currency, tokenAddress, searchQuery, isAddressSearch)}
+              properties={formatAnalyticsEventProperties(currency, searchQuery, isAddressSearch)}
               element={ElementName.COMMON_BASES_CURRENCY_BUTTON}
               key={currencyId(currency)}
             >

--- a/src/components/SearchModal/CommonBases.tsx
+++ b/src/components/SearchModal/CommonBases.tsx
@@ -1,6 +1,7 @@
 import { Currency } from '@uniswap/sdk-core'
-import { ElementName, Event, EventName, NATIVE_CHAIN_ADDRESS } from 'components/AmplitudeAnalytics/constants'
+import { ElementName, Event, EventName } from 'components/AmplitudeAnalytics/constants'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
+import { getTokenAddress } from 'components/AmplitudeAnalytics/utils'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { AutoRow } from 'components/Row'
@@ -36,7 +37,7 @@ const BaseWrapper = styled.div<{ disable?: boolean }>`
 const formatAnalyticsEventProperties = (currency: Currency, searchQuery: string, isAddressSearch: string | false) => ({
   token_symbol: currency?.symbol,
   token_chain_id: currency?.chainId,
-  token_address: currency.isNative ? NATIVE_CHAIN_ADDRESS : currency.address,
+  token_address: getTokenAddress(currency),
   is_suggested_token: true,
   is_selected_from_list: false,
   is_imported_by_user: false,

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -191,8 +191,8 @@ export function CurrencySearch({
   }, [])
 
   return (
-    <Trace name={EventName.TOKEN_SELECTOR_OPENED} modal={ModalName.TOKEN_SELECTOR} shouldLogImpression={true}>
-      <ContentWrapper>
+    <ContentWrapper>
+      <Trace name={EventName.TOKEN_SELECTOR_OPENED} modal={ModalName.TOKEN_SELECTOR} shouldLogImpression>
         <PaddedColumn gap="16px">
           <RowBetween>
             <Text fontWeight={500} fontSize={16}>
@@ -270,7 +270,7 @@ export function CurrencySearch({
             </ButtonText>
           </Row>
         </Footer>
-      </ContentWrapper>
-    </Trace>
+      </Trace>
+    </ContentWrapper>
   )
 }

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -26,6 +26,7 @@ export default function ConfirmSwapModal({
   isOpen,
   attemptingTxn,
   txHash,
+  swapQuoteReceivedDate,
 }: {
   isOpen: boolean
   trade: InterfaceTrade<Currency, Currency, TradeType> | undefined
@@ -38,6 +39,7 @@ export default function ConfirmSwapModal({
   onConfirm: () => void
   swapErrorMessage: ReactNode | undefined
   onDismiss: () => void
+  swapQuoteReceivedDate: Date | undefined
 }) {
   const showAcceptChanges = useMemo(
     () => Boolean(trade && originalTrade && tradeMeaningfullyDiffers(trade, originalTrade)),
@@ -65,9 +67,10 @@ export default function ConfirmSwapModal({
         allowedSlippage={allowedSlippage}
         disabledConfirm={showAcceptChanges}
         swapErrorMessage={swapErrorMessage}
+        swapQuoteReceivedDate={swapQuoteReceivedDate}
       />
     ) : null
-  }, [onConfirm, showAcceptChanges, swapErrorMessage, trade, allowedSlippage, txHash])
+  }, [onConfirm, showAcceptChanges, swapErrorMessage, trade, allowedSlippage, txHash, swapQuoteReceivedDate])
 
   // text to show while loading
   const pendingText = (

--- a/src/components/swap/SwapDetailsDropdown.tsx
+++ b/src/components/swap/SwapDetailsDropdown.tsx
@@ -2,13 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { ElementName, Event, EventName } from 'components/AmplitudeAnalytics/constants'
-import { Trace } from 'components/AmplitudeAnalytics/Trace'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
-import {
-  formatPercentInBasisPointsNumber,
-  getDurationFromDateTillNowMilliseconds,
-  getNumberFormattedToDecimalPlace,
-} from 'components/AmplitudeAnalytics/utils'
 import AnimatedDropdown from 'components/AnimatedDropdown'
 import Card, { OutlineCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
@@ -17,15 +11,13 @@ import Row, { RowBetween, RowFixed } from 'components/Row'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { SUPPORTED_GAS_ESTIMATE_CHAIN_IDS } from 'constants/chains'
 import { darken } from 'polished'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { ChevronDown, Info } from 'react-feather'
 import { InterfaceTrade } from 'state/routing/types'
 import styled, { keyframes, useTheme } from 'styled-components/macro'
 import { HideSmall, ThemedText } from 'theme'
-import { computeRealizedLPFeePercent } from 'utils/prices'
 
 import { AdvancedSwapDetails } from './AdvancedSwapDetails'
-import { getPriceImpactPercent } from './AdvancedSwapDetails'
 import GasEstimateBadge from './GasEstimateBadge'
 import { ResponsiveTooltipContainer } from './styleds'
 import SwapRoute from './SwapRoute'
@@ -129,36 +121,6 @@ interface SwapDetailsInlineProps {
   setSwapQuoteReceivedDate: (date: Date) => void
 }
 
-const formatAnalyticsEventProperties = (
-  trade: InterfaceTrade<Currency, Currency, TradeType>,
-  fetchingQuoteStartTime: Date | undefined,
-  setSwapQuoteReceivedDate: (date: Date) => void
-) => {
-  const lpFeePercent = trade ? computeRealizedLPFeePercent(trade) : undefined
-  setSwapQuoteReceivedDate(new Date())
-  return {
-    token_in_symbol: trade.inputAmount.currency.symbol,
-    token_out_symbol: trade.outputAmount.currency.symbol,
-    token_in_address: trade.inputAmount.currency.isToken ? trade.inputAmount.currency.address : undefined,
-    token_out_address: trade.outputAmount.currency.isToken ? trade.outputAmount.currency.address : undefined,
-    price_impact_basis_points: lpFeePercent
-      ? formatPercentInBasisPointsNumber(getPriceImpactPercent(lpFeePercent, trade))
-      : undefined,
-    estimated_network_fee_usd: trade.gasUseEstimateUSD
-      ? getNumberFormattedToDecimalPlace(trade.gasUseEstimateUSD, 2)
-      : undefined,
-    chain_id:
-      trade.inputAmount.currency.chainId === trade.outputAmount.currency.chainId
-        ? trade.inputAmount.currency.chainId
-        : undefined,
-    token_in_amount: getNumberFormattedToDecimalPlace(trade.inputAmount, trade.inputAmount.currency.decimals),
-    token_out_amount: getNumberFormattedToDecimalPlace(trade.outputAmount, trade.outputAmount.currency.decimals),
-    quote_latency_milliseconds: fetchingQuoteStartTime
-      ? getDurationFromDateTillNowMilliseconds(fetchingQuoteStartTime)
-      : undefined,
-  }
-}
-
 export default function SwapDetailsDropdown({
   trade,
   syncing,
@@ -171,13 +133,6 @@ export default function SwapDetailsDropdown({
   const theme = useTheme()
   const { chainId } = useWeb3React()
   const [showDetails, setShowDetails] = useState(false)
-  const [isFirstPriceFetch, setIsFirstPriceFetch] = useState(true)
-  const [fetchingQuoteStartTime, setFetchingQuoteStartTime] = useState<Date | undefined>()
-
-  useEffect(() => {
-    if (loading || syncing) setFetchingQuoteStartTime(new Date())
-    if (isFirstPriceFetch && syncing) setIsFirstPriceFetch(false)
-  }, [isFirstPriceFetch, syncing, loading])
 
   return (
     <Wrapper>
@@ -221,18 +176,11 @@ export default function SwapDetailsDropdown({
               )}
               {trade ? (
                 <LoadingOpacityContainer $loading={syncing}>
-                  <Trace
-                    name={EventName.SWAP_QUOTE_RECEIVED}
-                    element={ElementName.SWAP_TRADE_PRICE_ROW}
-                    properties={formatAnalyticsEventProperties(trade, fetchingQuoteStartTime, setSwapQuoteReceivedDate)}
-                    shouldLogImpression={!loading && !syncing && isFirstPriceFetch}
-                  >
-                    <TradePrice
-                      price={trade.executionPrice}
-                      showInverted={showInverted}
-                      setShowInverted={setShowInverted}
-                    />
-                  </Trace>
+                  <TradePrice
+                    price={trade.executionPrice}
+                    showInverted={showInverted}
+                    setShowInverted={setShowInverted}
+                  />
                 </LoadingOpacityContainer>
               ) : loading || syncing ? (
                 <ThemedText.DeprecatedMain fontSize={14}>

--- a/src/components/swap/SwapDetailsDropdown.tsx
+++ b/src/components/swap/SwapDetailsDropdown.tsx
@@ -118,7 +118,6 @@ interface SwapDetailsInlineProps {
   showInverted: boolean
   setShowInverted: React.Dispatch<React.SetStateAction<boolean>>
   allowedSlippage: Percent
-  setSwapQuoteReceivedDate: (date: Date) => void
 }
 
 export default function SwapDetailsDropdown({
@@ -128,7 +127,6 @@ export default function SwapDetailsDropdown({
   showInverted,
   setShowInverted,
   allowedSlippage,
-  setSwapQuoteReceivedDate,
 }: SwapDetailsInlineProps) {
   const theme = useTheme()
   const { chainId } = useWeb3React()

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
-import { ElementName, EventName } from 'components/AmplitudeAnalytics/constants'
+import { ElementName, EventName, NATIVE_CHAIN_ADDRESS } from 'components/AmplitudeAnalytics/constants'
 import { Event } from 'components/AmplitudeAnalytics/constants'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import {
@@ -54,8 +54,8 @@ const formatAnalyticsEventProperties = ({
   transaction_deadline_seconds: getDurationTillTimestampSinceEpochSeconds(transactionDeadlineSecondsSinceEpoch),
   token_in_amount_usd: tokenInAmountUsd ? parseFloat(tokenInAmountUsd) : undefined,
   token_out_amount_usd: tokenOutAmountUsd ? parseFloat(tokenOutAmountUsd) : undefined,
-  token_in_address: trade.inputAmount.currency.isToken ? trade.inputAmount.currency.address : undefined,
-  token_out_address: trade.outputAmount.currency.isToken ? trade.outputAmount.currency.address : undefined,
+  token_in_address: trade.inputAmount.currency.isNative ? NATIVE_CHAIN_ADDRESS : trade.inputAmount.currency.address,
+  token_out_address: trade.outputAmount.currency.isNative ? NATIVE_CHAIN_ADDRESS : trade.outputAmount.currency.address,
   token_in_symbol: trade.inputAmount.currency.symbol,
   token_out_symbol: trade.outputAmount.currency.symbol,
   token_in_amount: getNumberFormattedToDecimalPlace(trade.inputAmount, trade.inputAmount.currency.decimals),
@@ -71,7 +71,6 @@ const formatAnalyticsEventProperties = ({
   duration_from_first_quote_to_swap_submission_milliseconds: swapQuoteReceivedDate
     ? getDurationFromDateTillNowMilliseconds(swapQuoteReceivedDate)
     : undefined,
-  // TODO(lynnshaoyu): implement duration_from_first_quote_to_swap_submission_seconds
 })
 
 export default function SwapModalFooter({

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -7,7 +7,7 @@ import {
   formatPercentInBasisPointsNumber,
   formatToDecimal,
   getDurationFromDateMilliseconds,
-  getDurationTillTimestampSeconds,
+  getDurationUntilTimestampSeconds,
   getTokenAddress,
 } from 'components/AmplitudeAnalytics/utils'
 import { useStablecoinValue } from 'hooks/useStablecoinPrice'
@@ -50,7 +50,7 @@ const formatAnalyticsEventProperties = ({
 }: AnalyticsEventProps) => ({
   estimated_network_fee_usd: trade.gasUseEstimateUSD ? formatToDecimal(trade.gasUseEstimateUSD, 2) : undefined,
   transaction_hash: txHash,
-  transaction_deadline_seconds: getDurationTillTimestampSeconds(transactionDeadlineSecondsSinceEpoch),
+  transaction_deadline_seconds: getDurationUntilTimestampSeconds(transactionDeadlineSecondsSinceEpoch),
   token_in_amount_usd: tokenInAmountUsd ? parseFloat(tokenInAmountUsd) : undefined,
   token_out_amount_usd: tokenOutAmountUsd ? parseFloat(tokenOutAmountUsd) : undefined,
   token_in_address: getTokenAddress(trade.inputAmount.currency),

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -5,7 +5,8 @@ import { Event } from 'components/AmplitudeAnalytics/constants'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import {
   formatPercentInBasisPointsNumber,
-  getDurationTillTimestampSinceEpoch,
+  getDurationFromDateTillNowMilliseconds,
+  getDurationTillTimestampSinceEpochSeconds,
   getNumberFormattedToDecimalPlace,
 } from 'components/AmplitudeAnalytics/utils'
 import { useStablecoinValue } from 'hooks/useStablecoinPrice'
@@ -31,6 +32,7 @@ interface AnalyticsEventProps {
   tokenInAmountUsd: string | undefined
   tokenOutAmountUsd: string | undefined
   lpFeePercent: Percent
+  swapQuoteReceivedDate: Date | undefined
 }
 
 const formatAnalyticsEventProperties = ({
@@ -43,12 +45,13 @@ const formatAnalyticsEventProperties = ({
   tokenInAmountUsd,
   tokenOutAmountUsd,
   lpFeePercent,
+  swapQuoteReceivedDate,
 }: AnalyticsEventProps) => ({
   estimated_network_fee_usd: trade.gasUseEstimateUSD
     ? getNumberFormattedToDecimalPlace(trade.gasUseEstimateUSD, 2)
     : undefined,
   transaction_hash: txHash,
-  transaction_deadline_seconds: getDurationTillTimestampSinceEpoch(transactionDeadlineSecondsSinceEpoch),
+  transaction_deadline_seconds: getDurationTillTimestampSinceEpochSeconds(transactionDeadlineSecondsSinceEpoch),
   token_in_amount_usd: tokenInAmountUsd ? parseFloat(tokenInAmountUsd) : undefined,
   token_out_amount_usd: tokenOutAmountUsd ? parseFloat(tokenOutAmountUsd) : undefined,
   token_in_address: trade.inputAmount.currency.isToken ? trade.inputAmount.currency.address : undefined,
@@ -65,6 +68,9 @@ const formatAnalyticsEventProperties = ({
     trade.inputAmount.currency.chainId === trade.outputAmount.currency.chainId
       ? trade.inputAmount.currency.chainId
       : undefined,
+  duration_from_first_quote_to_swap_submission_milliseconds: swapQuoteReceivedDate
+    ? getDurationFromDateTillNowMilliseconds(swapQuoteReceivedDate)
+    : undefined,
   // TODO(lynnshaoyu): implement duration_from_first_quote_to_swap_submission_seconds
 })
 
@@ -75,6 +81,7 @@ export default function SwapModalFooter({
   onConfirm,
   swapErrorMessage,
   disabledConfirm,
+  swapQuoteReceivedDate,
 }: {
   trade: InterfaceTrade<Currency, Currency, TradeType>
   txHash: string | undefined
@@ -82,6 +89,7 @@ export default function SwapModalFooter({
   onConfirm: () => void
   swapErrorMessage: ReactNode | undefined
   disabledConfirm: boolean
+  swapQuoteReceivedDate: Date | undefined
 }) {
   const transactionDeadlineSecondsSinceEpoch = useTransactionDeadline()?.toNumber() // in seconds since epoch
   const isAutoSlippage = useUserSlippageTolerance() === 'auto'
@@ -107,6 +115,7 @@ export default function SwapModalFooter({
             tokenInAmountUsd,
             tokenOutAmountUsd,
             lpFeePercent,
+            swapQuoteReceivedDate,
           })}
         >
           <ButtonError

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -5,9 +5,9 @@ import { Event } from 'components/AmplitudeAnalytics/constants'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import {
   formatPercentInBasisPointsNumber,
-  getDurationFromDateTillNowMilliseconds,
+  formatToDecimal,
+  getDurationFromDateMilliseconds,
   getDurationTillTimestampSinceEpochSeconds,
-  getNumberFormattedToDecimalPlace,
 } from 'components/AmplitudeAnalytics/utils'
 import { useStablecoinValue } from 'hooks/useStablecoinPrice'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
@@ -47,9 +47,7 @@ const formatAnalyticsEventProperties = ({
   lpFeePercent,
   swapQuoteReceivedDate,
 }: AnalyticsEventProps) => ({
-  estimated_network_fee_usd: trade.gasUseEstimateUSD
-    ? getNumberFormattedToDecimalPlace(trade.gasUseEstimateUSD, 2)
-    : undefined,
+  estimated_network_fee_usd: trade.gasUseEstimateUSD ? formatToDecimal(trade.gasUseEstimateUSD, 2) : undefined,
   transaction_hash: txHash,
   transaction_deadline_seconds: getDurationTillTimestampSinceEpochSeconds(transactionDeadlineSecondsSinceEpoch),
   token_in_amount_usd: tokenInAmountUsd ? parseFloat(tokenInAmountUsd) : undefined,
@@ -58,8 +56,8 @@ const formatAnalyticsEventProperties = ({
   token_out_address: trade.outputAmount.currency.isNative ? NATIVE_CHAIN_ADDRESS : trade.outputAmount.currency.address,
   token_in_symbol: trade.inputAmount.currency.symbol,
   token_out_symbol: trade.outputAmount.currency.symbol,
-  token_in_amount: getNumberFormattedToDecimalPlace(trade.inputAmount, trade.inputAmount.currency.decimals),
-  token_out_amount: getNumberFormattedToDecimalPlace(trade.outputAmount, trade.outputAmount.currency.decimals),
+  token_in_amount: formatToDecimal(trade.inputAmount, trade.inputAmount.currency.decimals),
+  token_out_amount: formatToDecimal(trade.outputAmount, trade.outputAmount.currency.decimals),
   price_impact_basis_points: formatPercentInBasisPointsNumber(getPriceImpactPercent(lpFeePercent, trade)),
   allowed_slippage_basis_points: formatPercentInBasisPointsNumber(allowedSlippage),
   is_auto_router_api: isAutoRouterApi,
@@ -69,7 +67,7 @@ const formatAnalyticsEventProperties = ({
       ? trade.inputAmount.currency.chainId
       : undefined,
   duration_from_first_quote_to_swap_submission_milliseconds: swapQuoteReceivedDate
-    ? getDurationFromDateTillNowMilliseconds(swapQuoteReceivedDate)
+    ? getDurationFromDateMilliseconds(swapQuoteReceivedDate)
     : undefined,
 })
 

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -1,13 +1,14 @@
 import { Trans } from '@lingui/macro'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
-import { ElementName, EventName, NATIVE_CHAIN_ADDRESS } from 'components/AmplitudeAnalytics/constants'
+import { ElementName, EventName } from 'components/AmplitudeAnalytics/constants'
 import { Event } from 'components/AmplitudeAnalytics/constants'
 import { TraceEvent } from 'components/AmplitudeAnalytics/TraceEvent'
 import {
   formatPercentInBasisPointsNumber,
   formatToDecimal,
   getDurationFromDateMilliseconds,
-  getDurationTillTimestampSinceEpochSeconds,
+  getDurationTillTimestampSeconds,
+  getTokenAddress,
 } from 'components/AmplitudeAnalytics/utils'
 import { useStablecoinValue } from 'hooks/useStablecoinPrice'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
@@ -49,11 +50,11 @@ const formatAnalyticsEventProperties = ({
 }: AnalyticsEventProps) => ({
   estimated_network_fee_usd: trade.gasUseEstimateUSD ? formatToDecimal(trade.gasUseEstimateUSD, 2) : undefined,
   transaction_hash: txHash,
-  transaction_deadline_seconds: getDurationTillTimestampSinceEpochSeconds(transactionDeadlineSecondsSinceEpoch),
+  transaction_deadline_seconds: getDurationTillTimestampSeconds(transactionDeadlineSecondsSinceEpoch),
   token_in_amount_usd: tokenInAmountUsd ? parseFloat(tokenInAmountUsd) : undefined,
   token_out_amount_usd: tokenOutAmountUsd ? parseFloat(tokenOutAmountUsd) : undefined,
-  token_in_address: trade.inputAmount.currency.isNative ? NATIVE_CHAIN_ADDRESS : trade.inputAmount.currency.address,
-  token_out_address: trade.outputAmount.currency.isNative ? NATIVE_CHAIN_ADDRESS : trade.outputAmount.currency.address,
+  token_in_address: getTokenAddress(trade.inputAmount.currency),
+  token_out_address: getTokenAddress(trade.outputAmount.currency),
   token_in_symbol: trade.inputAmount.currency.symbol,
   token_out_symbol: trade.outputAmount.currency.symbol,
   token_in_amount: formatToDecimal(trade.inputAmount, trade.inputAmount.currency.decimals),

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -459,6 +459,7 @@ export default function Swap() {
 
   const priceImpactTooHigh = priceImpactSeverity > 3 && !isExpertMode
 
+  // Handle time based logging events and event properties.
   useEffect(() => {
     const now = new Date()
     // If a trade exists, and we need to log the receipt of this new swap quote:

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -604,7 +604,6 @@ export default function Swap() {
                   showInverted={showInverted}
                   setShowInverted={setShowInverted}
                   allowedSlippage={allowedSlippage}
-                  setSwapQuoteReceivedDate={setSwapQuoteReceivedDate}
                 />
               )}
               <div>

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -350,6 +350,7 @@ export default function Swap() {
 
   // errors
   const [showInverted, setShowInverted] = useState<boolean>(false)
+  const [swapQuoteReceivedDate, setSwapQuoteReceivedDate] = useState<Date | undefined>()
 
   // warnings on the greater of fiat value price impact and execution price impact
   const priceImpactSeverity = useMemo(() => {
@@ -436,6 +437,7 @@ export default function Swap() {
               onConfirm={handleSwap}
               swapErrorMessage={swapErrorMessage}
               onDismiss={handleConfirmDismiss}
+              swapQuoteReceivedDate={swapQuoteReceivedDate}
             />
 
             <AutoColumn gap={'sm'}>
@@ -524,6 +526,7 @@ export default function Swap() {
                   showInverted={showInverted}
                   setShowInverted={setShowInverted}
                   allowedSlippage={allowedSlippage}
+                  setSwapQuoteReceivedDate={setSwapQuoteReceivedDate}
                 />
               )}
               <div>


### PR DESCRIPTION
1. quote_latency_milliseconds
 ![Screen Shot 2022-07-26 at 5 11 34 PM](https://user-images.githubusercontent.com/41491154/181112955-b8ebce09-3c68-49dc-9e17-6a3da27afbb7.png)

2. duration_from_first_quote_to_swap_submission_milliseconds
![Screen Shot 2022-07-27 at 12 17 56 PM](https://user-images.githubusercontent.com/41491154/181298490-29ff0fdf-3700-4000-9de0-6952efe003bc.png)

Also changed native token address (eg: eth) from undefined to constant "NATIVE". 

I also modified where and how swap quote received is being logged. It was being logged twice previously (when there was little to no change in the trade). Now it's only logged when user inputs have changed, and only once (it doesn't log again when price updates/syncing occurs etc). 
