### PR TITLE
fix: update colors on token details page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.formatOnSaveMode": "file",
   "editor.tabCompletion": "on",
   "editor.tabSize": 2,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.inlineSuggest.enabled": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.formatOnSaveMode": "file",
   "editor.tabCompletion": "on",
   "editor.tabSize": 2,
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.inlineSuggest.enabled": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true

--- a/src/components/Explore/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Explore/TokenDetails/BalanceSummary.tsx
@@ -13,20 +13,20 @@ import NetworkBalance from './NetworkBalance'
 const BalancesCard = styled.div`
   width: 284px;
   height: fit-content;
-  color: ${({ theme }) => theme.deprecated_text1};
+  color: ${({ theme }) => theme.textPrimary};
   font-size: 12px;
   line-height: 20px;
   padding: 20px;
-  background-color: ${({ theme }) => theme.deprecated_bg1};
+  background-color: ${({ theme }) => theme.backgroundSurface};
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.deprecated_bg3};
+  border: 1px solid ${({ theme }) => theme.backgroundOutline};
 `
 const NetworkBalancesSection = styled.div`
   height: fit-content;
 `
 const TotalBalanceSection = styled.div`
   height: fit-content;
-  border-bottom: 1px solid ${({ theme }) => theme.deprecated_bg3};
+  border-bottom: 1px solid ${({ theme }) => theme.backgroundOutline};
   margin-bottom: 20px;
   padding-bottom: 20px;
 `
@@ -96,7 +96,7 @@ export default function BalanceSummary({ address }: { address: string }) {
                   tokenSymbol={tokenSymbol ?? 'XXX'}
                   fiatValue={fiatValue.toSignificant(2)}
                   label={chainInfo.label}
-                  networkColor={theme.deprecated_primary1}
+                  networkColor={chainInfo.color}
                 />
               )
             })}
@@ -110,7 +110,7 @@ export default function BalanceSummary({ address }: { address: string }) {
             tokenSymbol={tokenSymbol ?? 'XXX'}
             fiatValue={connectedFiatValue}
             label={connectedLabel}
-            networkColor={theme.deprecated_primary1}
+            networkColor={theme.textPrimary}
           />
         </>
       )}

--- a/src/components/Explore/TokenDetails/NetworkBalance.tsx
+++ b/src/components/Explore/TokenDetails/NetworkBalance.tsx
@@ -1,3 +1,4 @@
+import useTheme from 'hooks/useTheme'
 import styled from 'styled-components/macro'
 
 const Balance = styled.div`
@@ -44,8 +45,9 @@ export default function NetworkBalance({
   tokenSymbol: string
   fiatValue: string | number
   label: string
-  networkColor: string
+  networkColor: string | undefined
 }) {
+  const theme = useTheme()
   return (
     <NetworkBalanceContainer>
       <Logo src={logoUrl} />
@@ -56,7 +58,7 @@ export default function NetworkBalance({
           </BalanceItem>
           <BalanceItem>${fiatValue}</BalanceItem>
         </BalanceRow>
-        <Network color={networkColor}>{label}</Network>
+        <Network color={networkColor ?? theme.textPrimary}>{label}</Network>
       </Balance>
     </NetworkBalanceContainer>
   )

--- a/src/components/Explore/TokenDetails/Resource.tsx
+++ b/src/components/Explore/TokenDetails/Resource.tsx
@@ -4,7 +4,7 @@ import { ExternalLink } from 'theme'
 
 const ResourceLink = styled(ExternalLink)`
   display: flex;
-  color: ${({ theme }) => theme.deprecated_primary1};
+  color: ${({ theme }) => theme.accentAction};
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
@@ -13,7 +13,7 @@ const ResourceLink = styled(ExternalLink)`
 
   &:hover,
   &:focus {
-    color: ${({ theme }) => darken(0.1, theme.deprecated_primary1)};
+    color: ${({ theme }) => darken(0.1, theme.accentAction)};
     text-decoration: none;
   }
 `

--- a/src/components/Explore/TokenDetails/ShareButton.tsx
+++ b/src/components/Explore/TokenDetails/ShareButton.tsx
@@ -8,7 +8,6 @@ import styled, { useTheme } from 'styled-components/macro'
 
 const TWITTER_WIDTH = 560
 const TWITTER_HEIGHT = 480
-const SHADOW = '0px 1px 6px rgba(0, 0, 0, 0.9), 0px 8px 12px rgba(13, 14, 14, 0.8)'
 
 const ShareButtonDisplay = styled.div`
   display: flex;
@@ -30,7 +29,7 @@ const ShareActions = styled.div`
   overflow: auto;
   background-color: ${({ theme }) => theme.backgroundSurface};
   border: 1px solid ${({ theme }) => theme.backgroundOutline};
-  box-shadow: ${SHADOW};
+  box-shadow: ${({ theme }) => theme.flyoutDropShadow};
   border-radius: 12px;
 `
 const ShareAction = styled.div`
@@ -49,13 +48,12 @@ const ShareAction = styled.div`
   }
 `
 
-// TODO: create component in shared location
 const LinkCopied = styled.div<{ show: boolean }>`
   display: ${({ show }) => (show ? 'flex' : 'none')};
   width: 328px;
   height: 72px;
-  color: ${({ theme }) => theme.deprecated_text1};
-  background-color: ${({ theme }) => theme.deprecated_bg0};
+  color: ${({ theme }) => theme.textPrimary};
+  background-color: ${({ theme }) => theme.backgroundBackdrop};
   justify-content: flex-start;
   align-items: center;
   padding: 24px 16px;
@@ -65,7 +63,7 @@ const LinkCopied = styled.div<{ show: boolean }>`
   font-size: 14px;
   gap: 8px;
   border: 1px solid rgba(153, 161, 189, 0.08);
-  box-shadow: ${SHADOW};
+  box-shadow: ${({ theme }) => theme.flyoutDropShadow};
   border-radius: 20px;
   animation: floatIn 0s ease-in 3s forwards;
 
@@ -121,19 +119,19 @@ export default function ShareButton(tokenInfo: TokenInfo) {
         {open && (
           <ShareActions>
             <ShareAction onClick={copyLink}>
-              <Link color={theme.deprecated_text2} size={18} />
+              <Link color={theme.textSecondary} size={18} />
               Copy link
             </ShareAction>
 
             <ShareAction onClick={shareTweet}>
-              <Twitter color={theme.deprecated_text2} size={18} />
+              <Twitter color={theme.textSecondary} size={18} />
               Share to Twitter
             </ShareAction>
           </ShareActions>
         )}
       </ShareButtonDisplay>
       <LinkCopied show={showCopied}>
-        <Check color={theme.deprecated_green1} />
+        <Check color={theme.accentSuccess} />
         Link Copied
       </LinkCopied>
     </>

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -3,6 +3,7 @@ import CurrencyLogo from 'components/CurrencyLogo'
 import { useCurrency, useToken } from 'hooks/Tokens'
 import { TimePeriod } from 'hooks/useTopTokens'
 import { useAtomValue } from 'jotai/utils'
+import { darken } from 'polished'
 import { useState } from 'react'
 import { ArrowDownRight, ArrowLeft, ArrowUpRight, Copy, Heart } from 'react-feather'
 import { Link } from 'react-router-dom'
@@ -70,7 +71,7 @@ const ContractAddress = styled.button`
   cursor: pointer;
 
   &:hover {
-    color: ${({ theme }) => theme.textSecondary};
+    color: ${({ theme }) => darken(0.1, theme.textPrimary)};
   }
 `
 export const ContractAddressSection = styled.div`
@@ -218,8 +219,8 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
             <ClickFavorited onClick={toggleFavorite}>
               <Heart
                 size={15}
-                color={isFavorited ? theme.deprecated_primary1 : theme.deprecated_text2}
-                fill={isFavorited ? theme.deprecated_primary1 : 'transparent'}
+                color={isFavorited ? theme.accentAction : theme.textSecondary}
+                fill={isFavorited ? theme.accentAction : theme.none}
               />
             </ClickFavorited>
           </TokenActions>
@@ -230,9 +231,9 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           {tokenDelta}%
           <ArrowCell>
             {isPositive ? (
-              <ArrowUpRight size={16} color={theme.deprecated_green1} />
+              <ArrowUpRight size={16} color={theme.accentSuccess} />
             ) : (
-              <ArrowDownRight size={16} color={theme.deprecated_red1} />
+              <ArrowDownRight size={16} color={theme.accentFailure} />
             )}
           </ArrowCell>
         </DeltaContainer>
@@ -286,7 +287,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           <ContractAddress onClick={() => navigator.clipboard.writeText(address)}>
             <FullAddress>{address}</FullAddress>
             <TruncatedAddress>{truncatedTokenAddress}</TruncatedAddress>
-            <Copy size={13} color={theme.deprecated_text2} />
+            <Copy size={13} color={theme.textSecondary} />
           </ContractAddress>
         </Contract>
       </ContractAddressSection>

--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -4,6 +4,7 @@ import celoLogo from 'assets/svg/celo_logo.svg'
 import optimismLogoUrl from 'assets/svg/optimistic_ethereum.svg'
 import polygonMaticLogo from 'assets/svg/polygon-matic-logo.svg'
 import ms from 'ms.macro'
+import { colorsDark } from 'theme/colors'
 
 import { SupportedChainId, SupportedL1ChainId, SupportedL2ChainId } from './chains'
 import { ARBITRUM_LIST, CELO_LIST, OPTIMISM_LIST } from './lists'
@@ -28,6 +29,7 @@ interface BaseChainInfo {
     symbol: string // e.g. 'gorETH',
     decimals: number // e.g. 18,
   }
+  readonly color?: string
 }
 
 export interface L1ChainInfo extends BaseChainInfo {
@@ -55,6 +57,7 @@ const CHAIN_INFO: ChainInfoMap = {
     label: 'Ethereum',
     logoUrl: ethereumLogoUrl,
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    color: colorsDark.chain_1,
   },
   [SupportedChainId.RINKEBY]: {
     networkType: NetworkType.L1,
@@ -64,6 +67,7 @@ const CHAIN_INFO: ChainInfoMap = {
     label: 'Rinkeby',
     logoUrl: ethereumLogoUrl,
     nativeCurrency: { name: 'Rinkeby Ether', symbol: 'rETH', decimals: 18 },
+    color: colorsDark.chain_4,
   },
   [SupportedChainId.ROPSTEN]: {
     networkType: NetworkType.L1,
@@ -73,6 +77,7 @@ const CHAIN_INFO: ChainInfoMap = {
     label: 'Ropsten',
     logoUrl: ethereumLogoUrl,
     nativeCurrency: { name: 'Ropsten Ether', symbol: 'ropETH', decimals: 18 },
+    color: colorsDark.chain_3,
   },
   [SupportedChainId.KOVAN]: {
     networkType: NetworkType.L1,
@@ -82,6 +87,7 @@ const CHAIN_INFO: ChainInfoMap = {
     label: 'Kovan',
     logoUrl: ethereumLogoUrl,
     nativeCurrency: { name: 'Kovan Ether', symbol: 'kovETH', decimals: 18 },
+    color: colorsDark.chain_69,
   },
   [SupportedChainId.GOERLI]: {
     networkType: NetworkType.L1,
@@ -91,6 +97,7 @@ const CHAIN_INFO: ChainInfoMap = {
     label: 'Görli',
     logoUrl: ethereumLogoUrl,
     nativeCurrency: { name: 'Görli Ether', symbol: 'görETH', decimals: 18 },
+    color: colorsDark.chain_5,
   },
   [SupportedChainId.OPTIMISM]: {
     networkType: NetworkType.L2,
@@ -105,6 +112,7 @@ const CHAIN_INFO: ChainInfoMap = {
     statusPage: 'https://optimism.io/status',
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137778-uniswap-on-optimistic-ethereum-oξ',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    color: colorsDark.chain_10,
   },
   [SupportedChainId.OPTIMISTIC_KOVAN]: {
     networkType: NetworkType.L2,
@@ -119,6 +127,7 @@ const CHAIN_INFO: ChainInfoMap = {
     statusPage: 'https://optimism.io/status',
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137778-uniswap-on-optimistic-ethereum-oξ',
     nativeCurrency: { name: 'Optimistic Kovan Ether', symbol: 'kovOpETH', decimals: 18 },
+    color: colorsDark.chain_69,
   },
   [SupportedChainId.ARBITRUM_ONE]: {
     networkType: NetworkType.L2,
@@ -132,6 +141,7 @@ const CHAIN_INFO: ChainInfoMap = {
     defaultListUrl: ARBITRUM_LIST,
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137787-uniswap-on-arbitrum',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    color: colorsDark.chain_42,
   },
   [SupportedChainId.ARBITRUM_RINKEBY]: {
     networkType: NetworkType.L2,
@@ -145,6 +155,7 @@ const CHAIN_INFO: ChainInfoMap = {
     defaultListUrl: ARBITRUM_LIST,
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137787-uniswap-on-arbitrum',
     nativeCurrency: { name: 'Rinkeby Arbitrum Ether', symbol: 'rinkArbETH', decimals: 18 },
+    color: colorsDark.chain_421611,
   },
   [SupportedChainId.POLYGON]: {
     networkType: NetworkType.L1,
@@ -156,6 +167,7 @@ const CHAIN_INFO: ChainInfoMap = {
     label: 'Polygon',
     logoUrl: polygonMaticLogo,
     nativeCurrency: { name: 'Polygon Matic', symbol: 'MATIC', decimals: 18 },
+    color: colorsDark.chain_137,
   },
   [SupportedChainId.POLYGON_MUMBAI]: {
     networkType: NetworkType.L1,


### PR DESCRIPTION
Update colors in token detail pages and add colors for network (no more deprecated!)

<img width="1127" alt="Screen Shot 2022-07-27 at 3 29 45 PM" src="https://user-images.githubusercontent.com/62825936/181356157-66adce65-87c0-4f86-9f32-b3f41c8e9f15.png">
s