### PR TITLE
fix: make token details loading state responsive

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.formatOnSaveMode": "file",
   "editor.tabCompletion": "on",
   "editor.tabSize": 2,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.inlineSuggest.enabled": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.formatOnSaveMode": "file",
   "editor.tabCompletion": "on",
   "editor.tabSize": 2,
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.inlineSuggest.enabled": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true

--- a/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
@@ -69,15 +69,15 @@ const ChartAnimation = styled.div`
     }
   }
 `
-const Space = styled.div<{ heightSize: string }>`
-  height: ${({ heightSize }) => heightSize};
+const Space = styled.div<{ heightSize: number }>`
+  height: ${({ heightSize }) => `${heightSize}px`};
 `
 /* Loading State: row component with loading bubbles */
 export default function LoadingTokenDetail() {
   return (
     <TopArea>
       <BreadcrumbNavLink to="/explore">
-        <Space heightSize="20px" />
+        <Space heightSize={20} />
       </BreadcrumbNavLink>
       <ChartHeader>
         <TokenInfoContainer>
@@ -90,7 +90,7 @@ export default function LoadingTokenDetail() {
           <PriceLoadingBubble />
         </TokenPrice>
         <DeltaContainer>
-          <Space heightSize="20px" />
+          <Space heightSize={20} />
         </DeltaContainer>
         <ChartContainer>
           <ChartAnimation>
@@ -112,7 +112,7 @@ export default function LoadingTokenDetail() {
           </ChartAnimation>
         </ChartContainer>
         <TimeOptionsContainer>
-          <Space heightSize="32px" />
+          <Space heightSize={32} />
         </TimeOptionsContainer>
       </ChartHeader>
       <AboutSection>

--- a/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
@@ -69,9 +69,6 @@ const ChartAnimation = styled.div`
     }
   }
 `
-const ChartWrapper = styled.div`
-  width: inherit;
-`
 const TimeSpace = styled.div`
   height: 36px;
 `
@@ -95,27 +92,25 @@ export default function LoadingTokenDetail() {
         <DeltaContainer>
           <br></br>
         </DeltaContainer>
-        <ChartWrapper>
-          <ChartContainer>
-            <ChartAnimation>
-              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-              </svg>
-              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-              </svg>
-              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-              </svg>
-              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-              </svg>
-              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-              </svg>
-            </ChartAnimation>
-          </ChartContainer>
-        </ChartWrapper>
+        <ChartContainer>
+          <ChartAnimation>
+            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+            </svg>
+            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+            </svg>
+            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+            </svg>
+            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+            </svg>
+            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+            </svg>
+          </ChartAnimation>
+        </ChartContainer>
         <TimeOptionsContainer>
           <TimeSpace></TimeSpace>
         </TimeOptionsContainer>

--- a/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
@@ -69,15 +69,15 @@ const ChartAnimation = styled.div`
     }
   }
 `
-const TimeSpace = styled.div`
-  height: 36px;
+const Space = styled.div<{ heightSize: string }>`
+  height: ${({ heightSize }) => heightSize};
 `
 /* Loading State: row component with loading bubbles */
 export default function LoadingTokenDetail() {
   return (
     <TopArea>
       <BreadcrumbNavLink to="/explore">
-        <br></br>
+        <Space heightSize="20px" />
       </BreadcrumbNavLink>
       <ChartHeader>
         <TokenInfoContainer>
@@ -90,7 +90,7 @@ export default function LoadingTokenDetail() {
           <PriceLoadingBubble />
         </TokenPrice>
         <DeltaContainer>
-          <br></br>
+          <Space heightSize="20px" />
         </DeltaContainer>
         <ChartContainer>
           <ChartAnimation>
@@ -112,7 +112,7 @@ export default function LoadingTokenDetail() {
           </ChartAnimation>
         </ChartContainer>
         <TimeOptionsContainer>
-          <TimeSpace></TimeSpace>
+          <Space heightSize="32px" />
         </TimeOptionsContainer>
       </ChartHeader>
       <AboutSection>

--- a/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
@@ -72,11 +72,16 @@ const ChartAnimation = styled.div`
 const ChartWrapper = styled.div`
   width: inherit;
 `
+const TimeSpace = styled.div`
+  height: 36px;
+`
 /* Loading State: row component with loading bubbles */
 export default function LoadingTokenDetail() {
   return (
     <TopArea>
-      <BreadcrumbNavLink to="/explore">{null}</BreadcrumbNavLink>
+      <BreadcrumbNavLink to="/explore">
+        <br></br>
+      </BreadcrumbNavLink>
       <ChartHeader>
         <TokenInfoContainer>
           <TokenNameCell>
@@ -87,7 +92,9 @@ export default function LoadingTokenDetail() {
         <TokenPrice>
           <PriceLoadingBubble />
         </TokenPrice>
-        <DeltaContainer>{null}</DeltaContainer>
+        <DeltaContainer>
+          <br></br>
+        </DeltaContainer>
         <ChartWrapper>
           <ChartContainer>
             <ChartAnimation>
@@ -109,7 +116,9 @@ export default function LoadingTokenDetail() {
             </ChartAnimation>
           </ChartContainer>
         </ChartWrapper>
-        <TimeOptionsContainer>{null}</TimeOptionsContainer>
+        <TimeOptionsContainer>
+          <TimeSpace></TimeSpace>
+        </TimeOptionsContainer>
       </ChartHeader>
       <AboutSection>
         <AboutHeader>

--- a/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/LoadingTokenDetail.tsx
@@ -10,6 +10,7 @@ import {
   DeltaContainer,
   ResourcesContainer,
   Stat,
+  StatPair,
   StatsSection,
   TimeOptionsContainer,
   TokenInfoContainer,
@@ -53,6 +54,7 @@ const StatLoadingBubble = styled(SquareLoadingBubble)`
 const StatsLoadingContainer = styled.div`
   display: flex;
   gap: 24px;
+  flex-wrap: wrap;
 `
 const ChartAnimation = styled.div`
   display: flex;
@@ -67,7 +69,9 @@ const ChartAnimation = styled.div`
     }
   }
 `
-
+const ChartWrapper = styled.div`
+  width: inherit;
+`
 /* Loading State: row component with loading bubbles */
 export default function LoadingTokenDetail() {
   return (
@@ -84,25 +88,27 @@ export default function LoadingTokenDetail() {
           <PriceLoadingBubble />
         </TokenPrice>
         <DeltaContainer>{null}</DeltaContainer>
-        <ChartContainer>
-          <ChartAnimation>
-            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-            </svg>
-            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-            </svg>
-            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-            </svg>
-            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-            </svg>
-            <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
-              <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
-            </svg>
-          </ChartAnimation>
-        </ChartContainer>
+        <ChartWrapper>
+          <ChartContainer>
+            <ChartAnimation>
+              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+              </svg>
+              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+              </svg>
+              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+              </svg>
+              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+              </svg>
+              <svg width="416" height="160" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 80 Q 104 10, 208 80 T 416 80" stroke="#2e3138" fill="transparent" strokeWidth="2" />
+              </svg>
+            </ChartAnimation>
+          </ChartContainer>
+        </ChartWrapper>
         <TimeOptionsContainer>{null}</TimeOptionsContainer>
       </ChartHeader>
       <AboutSection>
@@ -117,22 +123,26 @@ export default function LoadingTokenDetail() {
       </AboutSection>
       <StatsSection>
         <StatsLoadingContainer>
-          <Stat>
-            <HalfLoadingBubble />
-            <StatLoadingBubble />
-          </Stat>
-          <Stat>
-            <HalfLoadingBubble />
-            <StatLoadingBubble />
-          </Stat>
-          <Stat>
-            <HalfLoadingBubble />
-            <StatLoadingBubble />
-          </Stat>
-          <Stat>
-            <HalfLoadingBubble />
-            <StatLoadingBubble />
-          </Stat>
+          <StatPair>
+            <Stat>
+              <HalfLoadingBubble />
+              <StatLoadingBubble />
+            </Stat>
+            <Stat>
+              <HalfLoadingBubble />
+              <StatLoadingBubble />
+            </Stat>
+          </StatPair>
+          <StatPair>
+            <Stat>
+              <HalfLoadingBubble />
+              <StatLoadingBubble />
+            </Stat>
+            <Stat>
+              <HalfLoadingBubble />
+              <StatLoadingBubble />
+            </Stat>
+          </StatPair>
         </StatsLoadingContainer>
       </StatsSection>
       <ContractAddressSection>{null}</ContractAddressSection>

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -112,7 +112,7 @@ export const StatsSection = styled.div`
   display: flex;
   flex-wrap: wrap;
 `
-const StatPair = styled.div`
+export const StatPair = styled.div`
   display: flex;
   flex: 1;
   flex-wrap: wrap;
@@ -158,6 +158,7 @@ const TokenSymbol = styled.span`
 `
 export const TopArea = styled.div`
   max-width: 832px;
+  overflow: hidden;
 `
 export const ResourcesContainer = styled.div`
   display: flex;

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -93,7 +93,6 @@ export const ChartContainer = styled.div`
 export const DeltaContainer = styled.div`
   display: flex;
   align-items: center;
-  height: ;
 `
 export const Stat = styled.div`
   display: flex;

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -93,6 +93,7 @@ export const ChartContainer = styled.div`
 export const DeltaContainer = styled.div`
   display: flex;
   align-items: center;
+  height: ;
 `
 export const Stat = styled.div`
   display: flex;

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -15,6 +15,8 @@ const TokenDetailsLayout = styled.div`
   display: flex;
   gap: 80px;
   padding: 0px 20px;
+  width: 100%;
+  justify-content: center;
 
   @media only screen and (max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT}) {
     gap: 40px;
@@ -45,6 +47,7 @@ const Widget = styled.div`
 export default function TokenDetails() {
   const { tokenAddress } = useParams<{ tokenAddress?: string }>()
   const [loading, setLoading] = useState(true)
+
   setTimeout(() => {
     setLoading(false)
   }, 1000)


### PR DESCRIPTION
make the loading state for token details page responsive based on screen width (to match loaded token details)

https://user-images.githubusercontent.com/62825936/181374884-243e42b3-268c-4885-b7b2-49f7d7d9382b.mov


