### PR TITLE
feat: network badge on token details page

### DIFF
--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -1,5 +1,7 @@
 import { Trans } from '@lingui/macro'
+import { useWeb3React } from '@web3-react/core'
 import CurrencyLogo from 'components/CurrencyLogo'
+import { getChainInfo } from 'constants/chainInfo'
 import { useCurrency, useToken } from 'hooks/Tokens'
 import { TimePeriod } from 'hooks/useTopTokens'
 import { useAtomValue } from 'jotai/utils'
@@ -176,6 +178,17 @@ const TruncatedAddress = styled.span`
     display: flex;
   }
 `
+const NetworkBadge = styled.div<{ networkColor?: string }>`
+  display: flex;
+  border-radius: 5px;
+  padding: 4px 6px;
+  align-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 12px;
+  color: ${({ theme, networkColor }) => networkColor ?? theme.textPrimary};
+  background-color: ${({ theme }) => theme.backgroundSurface};
+`
 
 export default function LoadedTokenDetail({ address }: { address: string }) {
   const theme = useTheme()
@@ -185,6 +198,8 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
   const [activeTimePeriod, setTimePeriod] = useState(TimePeriod.hour)
   const isFavorited = favoriteTokens.includes(address)
   const toggleFavorite = useToggleFavorite(address)
+  const { chainId: connectedChainId } = useWeb3React()
+  const chainInfo = getChainInfo(connectedChainId)
 
   // catch token error and loading state
   if (!token || !token.name || !token.symbol) {
@@ -214,6 +229,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           <TokenNameCell>
             <CurrencyLogo currency={currency} size={'32px'} />
             {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
+            <NetworkBadge networkColor={chainInfo?.color}>{chainInfo?.label}</NetworkBadge>
           </TokenNameCell>
           <TokenActions>
             <ShareButton tokenName={tokenName} tokenSymbol={tokenSymbol} />

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -197,7 +197,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
   const toggleFavorite = useToggleFavorite(address)
   const chainInfo = getChainInfo(token?.chainId)
   const networkLabel = chainInfo?.label
-  const backgroundColor = chainInfo?.background_color
+  const networkBadgebackgroundColor = chainInfo?.backgroundColor
 
   // catch token error and loading state
   if (!token || !token.name || !token.symbol) {
@@ -227,8 +227,8 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           <TokenNameCell>
             <CurrencyLogo currency={currency} size={'32px'} />
             {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
-            {backgroundColor && (
-              <NetworkBadge networkColor={chainInfo?.color} backgroundColor={backgroundColor}>
+            {networkBadgebackgroundColor && (
+              <NetworkBadge networkColor={chainInfo?.color} backgroundColor={networkBadgebackgroundColor}>
                 {networkLabel}
               </NetworkBadge>
             )}

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -192,11 +192,6 @@ const NetworkBadge = styled.div<{ networkColor?: string; backgroundColor?: strin
 
 export default function LoadedTokenDetail({ address }: { address: string }) {
   const theme = useTheme()
-  const NETWORK_BADGE_COLORS: Record<string, string> = {
-    Polygon: theme.polygon_background,
-    Optimism: theme.optimism_background,
-    Arbitrum: theme.arbitrum_background,
-  }
   const token = useToken(address)
   const currency = useCurrency(address)
   const favoriteTokens = useAtomValue<string[]>(favoritesAtom)
@@ -206,6 +201,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
   const { chainId: connectedChainId } = useWeb3React()
   const chainInfo = getChainInfo(connectedChainId)
   const networkLabel = chainInfo?.label
+  const networkBadgeBackgroundColor = chainInfo?.background_color
 
   // catch token error and loading state
   if (!token || !token.name || !token.symbol) {
@@ -235,11 +231,8 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           <TokenNameCell>
             <CurrencyLogo currency={currency} size={'32px'} />
             {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
-            {networkLabel && NETWORK_BADGE_COLORS.hasOwnProperty(networkLabel) && (
-              <NetworkBadge
-                networkColor={chainInfo?.color}
-                backgroundColor={networkLabel && NETWORK_BADGE_COLORS[networkLabel]}
-              >
+            {networkBadgeBackgroundColor && (
+              <NetworkBadge networkColor={chainInfo?.color} backgroundColor={networkBadgeBackgroundColor}>
                 {networkLabel}
               </NetworkBadge>
             )}

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -178,10 +178,8 @@ const TruncatedAddress = styled.span`
   }
 `
 const NetworkBadge = styled.div<{ networkColor?: string; backgroundColor?: string }>`
-  display: flex;
   border-radius: 5px;
-  padding: 4px 6px;
-  align-items: center;
+  padding: 4px 8px;
   font-weight: 600;
   font-size: 12px;
   line-height: 12px;
@@ -199,7 +197,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
   const toggleFavorite = useToggleFavorite(address)
   const chainInfo = getChainInfo(token?.chainId)
   const networkLabel = chainInfo?.label
-  const networkBadgeBackgroundColor = chainInfo?.background_color
+  const backgroundColor = chainInfo?.background_color
 
   // catch token error and loading state
   if (!token || !token.name || !token.symbol) {
@@ -229,8 +227,8 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           <TokenNameCell>
             <CurrencyLogo currency={currency} size={'32px'} />
             {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
-            {networkBadgeBackgroundColor && (
-              <NetworkBadge networkColor={chainInfo?.color} backgroundColor={networkBadgeBackgroundColor}>
+            {backgroundColor && (
+              <NetworkBadge networkColor={chainInfo?.color} backgroundColor={backgroundColor}>
                 {networkLabel}
               </NetworkBadge>
             )}

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -178,7 +178,7 @@ const TruncatedAddress = styled.span`
     display: flex;
   }
 `
-const NetworkBadge = styled.div<{ networkColor?: string }>`
+const NetworkBadge = styled.div<{ networkColor?: string; backgroundColor?: string }>`
   display: flex;
   border-radius: 5px;
   padding: 4px 6px;
@@ -187,11 +187,16 @@ const NetworkBadge = styled.div<{ networkColor?: string }>`
   font-size: 12px;
   line-height: 12px;
   color: ${({ theme, networkColor }) => networkColor ?? theme.textPrimary};
-  background-color: ${({ theme }) => theme.backgroundSurface};
+  background-color: ${({ theme, backgroundColor }) => backgroundColor ?? theme.backgroundSurface};
 `
 
 export default function LoadedTokenDetail({ address }: { address: string }) {
   const theme = useTheme()
+  const NETWORK_BADGE_COLORS: Record<string, string> = {
+    Polygon: theme.polygon_background,
+    Optimism: theme.optimism_background,
+    Arbitrum: theme.arbitrum_background,
+  }
   const token = useToken(address)
   const currency = useCurrency(address)
   const favoriteTokens = useAtomValue<string[]>(favoritesAtom)
@@ -200,6 +205,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
   const toggleFavorite = useToggleFavorite(address)
   const { chainId: connectedChainId } = useWeb3React()
   const chainInfo = getChainInfo(connectedChainId)
+  const networkLabel = chainInfo?.label
 
   // catch token error and loading state
   if (!token || !token.name || !token.symbol) {
@@ -229,7 +235,14 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
           <TokenNameCell>
             <CurrencyLogo currency={currency} size={'32px'} />
             {tokenName} <TokenSymbol>{tokenSymbol}</TokenSymbol>
-            <NetworkBadge networkColor={chainInfo?.color}>{chainInfo?.label}</NetworkBadge>
+            {networkLabel && NETWORK_BADGE_COLORS.hasOwnProperty(networkLabel) && (
+              <NetworkBadge
+                networkColor={chainInfo?.color}
+                backgroundColor={networkLabel && NETWORK_BADGE_COLORS[networkLabel]}
+              >
+                {networkLabel}
+              </NetworkBadge>
+            )}
           </TokenNameCell>
           <TokenActions>
             <ShareButton tokenName={tokenName} tokenSymbol={tokenSymbol} />

--- a/src/components/Explore/TokenDetails/TokenDetail.tsx
+++ b/src/components/Explore/TokenDetails/TokenDetail.tsx
@@ -1,5 +1,4 @@
 import { Trans } from '@lingui/macro'
-import { useWeb3React } from '@web3-react/core'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { getChainInfo } from 'constants/chainInfo'
 import { useCurrency, useToken } from 'hooks/Tokens'
@@ -198,8 +197,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
   const [activeTimePeriod, setTimePeriod] = useState(TimePeriod.hour)
   const isFavorited = favoriteTokens.includes(address)
   const toggleFavorite = useToggleFavorite(address)
-  const { chainId: connectedChainId } = useWeb3React()
-  const chainInfo = getChainInfo(connectedChainId)
+  const chainInfo = getChainInfo(token?.chainId)
   const networkLabel = chainInfo?.label
   const networkBadgeBackgroundColor = chainInfo?.background_color
 

--- a/src/components/Explore/loading.tsx
+++ b/src/components/Explore/loading.tsx
@@ -1,5 +1,4 @@
 import { loadingAnimation } from 'components/Loader/styled'
-import { darken } from 'polished'
 import styled from 'styled-components/macro'
 
 /* Loading state bubbles (animation style from: src/components/Loader/styled.tsx) */
@@ -11,9 +10,9 @@ export const LoadingBubble = styled.div`
   animation-fill-mode: both;
   background: linear-gradient(
     to left,
-    ${({ theme }) => theme.backgroundContainer} 25%,
-    ${({ theme }) => darken(0.8, theme.backgroundContainer)} 50%,
-    ${({ theme }) => theme.backgroundContainer} 75%
+    ${({ theme }) => theme.backgroundAction} 25%,
+    ${({ theme }) => theme.backgroundOutline} 50%,
+    ${({ theme }) => theme.backgroundAction} 75%
   );
   will-change: background-position;
   background-size: 400%;

--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -30,6 +30,7 @@ interface BaseChainInfo {
     decimals: number // e.g. 18,
   }
   readonly color?: string
+  readonly background_color?: string
 }
 
 export interface L1ChainInfo extends BaseChainInfo {
@@ -113,6 +114,7 @@ const CHAIN_INFO: ChainInfoMap = {
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137778-uniswap-on-optimistic-ethereum-oξ',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     color: colorsDark.chain_10,
+    background_color: colorsDark.optimism_background,
   },
   [SupportedChainId.OPTIMISTIC_KOVAN]: {
     networkType: NetworkType.L2,
@@ -142,6 +144,7 @@ const CHAIN_INFO: ChainInfoMap = {
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137787-uniswap-on-arbitrum',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     color: colorsDark.chain_42,
+    background_color: colorsDark.arbitrum_background,
   },
   [SupportedChainId.ARBITRUM_RINKEBY]: {
     networkType: NetworkType.L2,
@@ -168,6 +171,7 @@ const CHAIN_INFO: ChainInfoMap = {
     logoUrl: polygonMaticLogo,
     nativeCurrency: { name: 'Polygon Matic', symbol: 'MATIC', decimals: 18 },
     color: colorsDark.chain_137,
+    background_color: colorsDark.polygon_background,
   },
   [SupportedChainId.POLYGON_MUMBAI]: {
     networkType: NetworkType.L1,

--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -30,7 +30,7 @@ interface BaseChainInfo {
     decimals: number // e.g. 18,
   }
   readonly color?: string
-  readonly background_color?: string
+  readonly backgroundColor?: string
 }
 
 export interface L1ChainInfo extends BaseChainInfo {
@@ -114,7 +114,7 @@ const CHAIN_INFO: ChainInfoMap = {
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137778-uniswap-on-optimistic-ethereum-oξ',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     color: colorsDark.chain_10,
-    background_color: colorsDark.optimism_background,
+    backgroundColor: colorsDark.optimism_background,
   },
   [SupportedChainId.OPTIMISTIC_KOVAN]: {
     networkType: NetworkType.L2,
@@ -144,7 +144,7 @@ const CHAIN_INFO: ChainInfoMap = {
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137787-uniswap-on-arbitrum',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     color: colorsDark.chain_42,
-    background_color: colorsDark.arbitrum_background,
+    backgroundColor: colorsDark.arbitrum_background,
   },
   [SupportedChainId.ARBITRUM_RINKEBY]: {
     networkType: NetworkType.L2,
@@ -171,7 +171,7 @@ const CHAIN_INFO: ChainInfoMap = {
     logoUrl: polygonMaticLogo,
     nativeCurrency: { name: 'Polygon Matic', symbol: 'MATIC', decimals: 18 },
     color: colorsDark.chain_137,
-    background_color: colorsDark.polygon_background,
+    backgroundColor: colorsDark.polygon_background,
   },
   [SupportedChainId.POLYGON_MUMBAI]: {
     networkType: NetworkType.L1,

--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -114,7 +114,7 @@ const CHAIN_INFO: ChainInfoMap = {
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137778-uniswap-on-optimistic-ethereum-oξ',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     color: colorsDark.chain_10,
-    backgroundColor: colorsDark.optimism_background,
+    backgroundColor: colorsDark.chain_10_background,
   },
   [SupportedChainId.OPTIMISTIC_KOVAN]: {
     networkType: NetworkType.L2,
@@ -144,7 +144,7 @@ const CHAIN_INFO: ChainInfoMap = {
     helpCenterUrl: 'https://help.uniswap.org/en/collections/3137787-uniswap-on-arbitrum',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     color: colorsDark.chain_42,
-    backgroundColor: colorsDark.arbitrum_background,
+    backgroundColor: colorsDark.chain_42161_background,
   },
   [SupportedChainId.ARBITRUM_RINKEBY]: {
     networkType: NetworkType.L2,
@@ -171,7 +171,7 @@ const CHAIN_INFO: ChainInfoMap = {
     logoUrl: polygonMaticLogo,
     nativeCurrency: { name: 'Polygon Matic', symbol: 'MATIC', decimals: 18 },
     color: colorsDark.chain_137,
-    backgroundColor: colorsDark.polygon_background,
+    backgroundColor: colorsDark.chain_137_background,
   },
   [SupportedChainId.POLYGON_MUMBAI]: {
     networkType: NetworkType.L1,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -74,6 +74,7 @@ export interface GlobalPalette {
   blue900: Color
   blueVibrant: Color
   magentaVibrant: Color
+  purple900: Color
   networkEthereum: Color
   networkOptimism: Color
   networkOptimismSoft: Color
@@ -156,6 +157,7 @@ export const colors: GlobalPalette = {
   blueVibrant: '#587BFF',
   // TODO: add magenta 50-900
   magentaVibrant: '#FC72FF',
+  purple900: '#1C0337',
   // TODO: add all other vibrant variations
   networkEthereum: '#627EEA',
   networkOptimism: '#FF0420',
@@ -215,6 +217,10 @@ export interface Palette {
   chain_42161: Color
   chain_421611: Color
   chain_80001: Color
+
+  polygon_background: Color
+  optimism_background: Color
+  arbitrum_background: Color
 }
 
 export const colorsLight: Palette = {
@@ -267,6 +273,10 @@ export const colorsLight: Palette = {
   chain_42161: colors.networkEthereum,
   chain_421611: colors.networkEthereum,
   chain_80001: colors.networkPolygon,
+
+  polygon_background: colors.purple900,
+  optimism_background: colors.red900,
+  arbitrum_background: colors.blue900,
 }
 
 export const colorsDark: Palette = {
@@ -318,4 +328,8 @@ export const colorsDark: Palette = {
   chain_42161: colors.networkEthereum,
   chain_421611: colors.networkEthereum,
   chain_80001: colors.networkPolygon,
+
+  polygon_background: colors.purple900,
+  optimism_background: colors.red900,
+  arbitrum_background: colors.blue900,
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -217,10 +217,9 @@ export interface Palette {
   chain_42161: Color
   chain_421611: Color
   chain_80001: Color
-
-  polygon_background: Color
-  optimism_background: Color
-  arbitrum_background: Color
+  chain_137_background: Color
+  chain_10_background: Color
+  chain_42161_background: Color
 }
 
 export const colorsLight: Palette = {
@@ -273,10 +272,9 @@ export const colorsLight: Palette = {
   chain_42161: colors.networkEthereum,
   chain_421611: colors.networkEthereum,
   chain_80001: colors.networkPolygon,
-
-  polygon_background: colors.purple900,
-  optimism_background: colors.red900,
-  arbitrum_background: colors.blue900,
+  chain_137_background: colors.purple900,
+  chain_10_background: colors.red900,
+  chain_42161_background: colors.blue900,
 }
 
 export const colorsDark: Palette = {
@@ -328,8 +326,7 @@ export const colorsDark: Palette = {
   chain_42161: colors.networkEthereum,
   chain_421611: colors.networkEthereum,
   chain_80001: colors.networkPolygon,
-
-  polygon_background: colors.purple900,
-  optimism_background: colors.red900,
-  arbitrum_background: colors.blue900,
+  chain_137_background: colors.purple900,
+  chain_10_background: colors.red900,
+  chain_42161_background: colors.blue900,
 }

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -166,9 +166,9 @@ function colors(darkMode: boolean): Colors {
     chain_42161: colorsDark.chain_42161,
     chain_421611: colorsDark.chain_421611,
     chain_80001: colorsDark.chain_80001,
-    polygon_background: colorsDark.polygon_background,
-    optimism_background: colorsDark.optimism_background,
-    arbitrum_background: colorsDark.arbitrum_background,
+    chain_137_background: ColorsPalette.purple900,
+    chain_10_background: ColorsPalette.red900,
+    chain_42161_background: ColorsPalette.blue900,
 
     blue200: ColorsPalette.blue200,
     flyoutDropShadow:

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -166,6 +166,9 @@ function colors(darkMode: boolean): Colors {
     chain_42161: colorsDark.chain_42161,
     chain_421611: colorsDark.chain_421611,
     chain_80001: colorsDark.chain_80001,
+    polygon_background: colorsDark.polygon_background,
+    optimism_background: colorsDark.optimism_background,
+    arbitrum_background: colorsDark.arbitrum_background,
 
     blue200: ColorsPalette.blue200,
     flyoutDropShadow:

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -107,9 +107,9 @@ export interface Colors {
   chain_42161: Color
   chain_421611: Color
   chain_80001: Color
-  polygon_background: Color
-  optimism_background: Color
-  arbitrum_background: Color
+  chain_10_background: Color
+  chain_137_background: Color
+  chain_42161_background: Color
 
   blue200: Color
   flyoutDropShadow: Color

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -107,6 +107,9 @@ export interface Colors {
   chain_42161: Color
   chain_421611: Color
   chain_80001: Color
+  polygon_background: Color
+  optimism_background: Color
+  arbitrum_background: Color
 
   blue200: Color
   flyoutDropShadow: Color


### PR DESCRIPTION
added network badge to token details page for Polygon, Optimism, and Arbitrum AND change loading state bubble color

<img width="461" alt="Screen Shot 2022-07-29 at 12 02 06 PM" src="https://user-images.githubusercontent.com/62825936/181799213-72181ce9-39f8-416c-8f3a-4a372cb5beba.png">


