### PR TITLE
feat: Adjust gas estimates for auto slippage

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -24,11 +24,14 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
   if (!!trade) {
     let gas = 0
     for (const { route } of trade.swaps) {
-      if (route.protocol == Protocol.V2) {
+      if (route.protocol === Protocol.V2) {
         gas += 135000 + route.pools.length * 50_000
-      } else {
+      } else if (route.protocol === Protocol.V3) {
         // V3 gas costs scale on initialized ticks being crossed, but we don't have that data here.
         // We bake in some tick crossings into the base 100k cost.
+        gas += 100_000 + route.pools.length * 70_000
+      } else {
+        // TODO: Update with better estimates once we have interleaved routes.
         gas += 100_000 + route.pools.length * 70_000
       }
     }


### PR DESCRIPTION
Updates the local gas estimation algorithm used to compute auto slippage to be more similar to the one used in the Auto Router.
Adds a 10% buffer to the gas estimates overall. Gas estimates from the routing API sometimes under-estimate which can lead to very tight auto-slippage being set, especially on L2s where gas costs are low anyway