### PR TITLE
feat: amplitude logs is_reconnect

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -6,6 +6,7 @@ import { Context, useCallback, useContext } from 'react'
 import { ExternalLink as LinkIcon } from 'react-feather'
 import { useAppDispatch } from 'state/hooks'
 import { updateSelectedWallet } from 'state/user/reducer'
+import { removeConnectedWallet } from 'state/wallets/reducer'
 import { DefaultTheme } from 'styled-components/macro'
 import styled, { ThemeContext } from 'styled-components/macro'
 import { isMobile } from 'utils/userAgent'
@@ -245,6 +246,7 @@ export default function AccountDetails({
                       <WalletAction
                         style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
                         onClick={() => {
+                          const walletType = getConnectionName(getConnection(connector).type, getIsMetaMask())
                           if (connector.deactivate) {
                             connector.deactivate()
                           } else {
@@ -252,6 +254,7 @@ export default function AccountDetails({
                           }
 
                           dispatch(updateSelectedWallet({ wallet: undefined }))
+                          dispatch(removeConnectedWallet({ account, walletType }))
                           openOptions()
                         }}
                       >

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -171,13 +171,6 @@ export default function WalletModal({
   }, [walletModalOpen, setWalletView, account])
 
   useEffect(() => {
-    if (connectedWallets) {
-      console.log('connected:')
-      console.log(connectedWallets)
-    }
-  }, [connectedWallets])
-
-  useEffect(() => {
     if (pendingConnector && walletView !== WALLET_VIEWS.PENDING) {
       updateConnectionError({ connectionType: getConnection(pendingConnector).type, error: undefined })
       setPendingConnector(undefined)
@@ -199,7 +192,7 @@ export default function WalletModal({
       }
     }
     setLastActiveWalletAddress(account)
-  }, [lastActiveWalletAddress, account, connector, chainId])
+  }, [connectedWallets, updateConnectedWallets, lastActiveWalletAddress, account, connector, chainId])
 
   const tryActivation = useCallback(
     async (connector: Connector) => {

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -126,7 +126,6 @@ const sendAnalyticsEventAndUserInfo = (
     wallet_address: account,
     wallet_type: walletType,
     is_reconnect: isReconnect,
-    // TODO(lynnshaoyu): Send correct is_reconnect value after modifying user state.
   })
   user.set(CUSTOM_USER_PROPERTIES.WALLET_ADDRESS, account)
   user.set(CUSTOM_USER_PROPERTIES.WALLET_TYPE, walletType)

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -17,6 +17,7 @@ import { routingApi } from './routing/slice'
 import swap from './swap/reducer'
 import transactions from './transactions/reducer'
 import user from './user/reducer'
+import wallets from './wallets/reducer'
 
 const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
 
@@ -26,6 +27,7 @@ const store = configureStore({
     user,
     connection,
     transactions,
+    wallets,
     swap,
     mint,
     mintV3,

--- a/src/state/wallets/hooks.tsx
+++ b/src/state/wallets/hooks.tsx
@@ -1,0 +1,17 @@
+import { useCallback } from 'react'
+import { useAppDispatch, useAppSelector } from 'state/hooks'
+
+import { addConnectedWallet } from './reducer'
+import { Wallet } from './types'
+
+export function useConnectedWallets(): [Wallet[], (wallet: Wallet) => void] {
+  const dispatch = useAppDispatch()
+  const connectedWallets = useAppSelector((state) => state.wallets.connectedWallets)
+  const addWallet = useCallback(
+    (wallet: Wallet) => {
+      dispatch(addConnectedWallet(wallet))
+    },
+    [dispatch]
+  )
+  return [connectedWallets, addWallet]
+}

--- a/src/state/wallets/reducer.ts
+++ b/src/state/wallets/reducer.ts
@@ -3,8 +3,8 @@ import { shallowEqual } from 'react-redux'
 
 import { Wallet } from './types'
 
-// const currentTimestamp = () => new Date().getTime()
-
+/* Used to track wallets that have been connected by the user in current session, and remove them when deliberately disconnected. 
+  Used to compute is_reconnect event property for analytics */
 export interface WalletState {
   connectedWallets: Wallet[]
 }

--- a/src/state/wallets/reducer.ts
+++ b/src/state/wallets/reducer.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { shallowEqual } from 'react-redux'
+
+import { Wallet } from './types'
+
+// const currentTimestamp = () => new Date().getTime()
+
+export interface WalletState {
+  connectedWallets: Wallet[]
+}
+
+export const initialState: WalletState = {
+  connectedWallets: [],
+}
+
+const walletsSlice = createSlice({
+  name: 'wallets',
+  initialState,
+  reducers: {
+    addConnectedWallet(state, { payload }) {
+      state.connectedWallets = state.connectedWallets.concat(payload)
+    },
+    removeConnectedWallet(state, { payload }) {
+      state.connectedWallets = state.connectedWallets.filter((wallet) => !shallowEqual(wallet, payload))
+    },
+  },
+})
+
+export const { addConnectedWallet, removeConnectedWallet } = walletsSlice.actions
+export default walletsSlice.reducer

--- a/src/state/wallets/types.ts
+++ b/src/state/wallets/types.ts
@@ -1,0 +1,6 @@
+import { Connector } from '@web3-react/types'
+
+export interface Wallet {
+  walletType: string
+  account: string
+}

--- a/src/state/wallets/types.ts
+++ b/src/state/wallets/types.ts
@@ -1,5 +1,3 @@
-import { Connector } from '@web3-react/types'
-
 export interface Wallet {
   walletType: string
   account: string


### PR DESCRIPTION
Added functionality for amplitude wallet connect events to include is_reconnect field, which is true if the user's wallet is disconnected and reconnected without them pressing the disconnect button