### PR TITLE
feat: add error state for network balance summary

### DIFF
--- a/src/components/Explore/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Explore/TokenDetails/BalanceSummary.tsx
@@ -5,6 +5,7 @@ import { L1_CHAIN_IDS, L2_CHAIN_IDS, SupportedChainId, TESTNET_CHAIN_IDS } from 
 import { useToken } from 'hooks/Tokens'
 import { useNetworkTokenBalances } from 'hooks/useNetworkTokenBalances'
 import { useMemo } from 'react'
+import { AlertTriangle } from 'react-feather'
 import styled, { useTheme } from 'styled-components/macro'
 import { isChainAllowed } from 'utils/switchChain'
 
@@ -20,6 +21,19 @@ const BalancesCard = styled.div`
   background-color: ${({ theme }) => theme.backgroundSurface};
   border-radius: 12px;
   border: 1px solid ${({ theme }) => theme.backgroundOutline};
+`
+const ErrorState = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: ${({ theme }) => theme.textSecondary};
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+`
+const ErrorText = styled.span`
+  display: flex;
+  flex-wrap: wrap;
 `
 const NetworkBalancesSection = styled.div`
   height: fit-content;
@@ -63,14 +77,16 @@ export default function BalanceSummary({ address }: { address: string }) {
     return chainIds
   }, [connectedChainId])
 
+  if (loading) return null
   return (
     <BalancesCard>
-      {loading ? (
-        <span>loading...</span>
-      ) : error ? (
-        <p>
-          <Trans>Error fetching user balances</Trans>
-        </p>
+      {error ? (
+        <ErrorState>
+          <AlertTriangle size={24} />
+          <ErrorText>
+            <Trans>There was an error loading your {tokenSymbol} balance</Trans>
+          </ErrorText>
+        </ErrorState>
       ) : multipleBalances ? (
         <>
           <TotalBalanceSection>


### PR DESCRIPTION
Add error state for network balance summary and do not display anything during loading state of network balances

<img width="1118" alt="Screen Shot 2022-07-29 at 12 45 43 PM" src="https://user-images.githubusercontent.com/62825936/181806476-60c920f2-6676-4221-bc91-a507588f923a.png">

