### PR TITLE
fix: hide text cursor on network selector hover

### DIFF
--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -114,6 +114,7 @@ const Logo = styled.img`
 `
 const NetworkLabel = styled.div`
   flex: 1 1 auto;
+  cursor: default;
 `
 const SelectorLabel = styled(NetworkLabel)`
   display: none;


### PR DESCRIPTION
At present, if you hover over the network selector to open the dropdown, the currently selected network text shows the text cursor.  This isn't text you'd want to copy, so the text cursor is inappropriate.  The default cursor is probably best.

Effects the cursor when hovering over this area:
<img width="497" alt="NetworkText" src="https://user-images.githubusercontent.com/46655/182277693-c76904ed-e24d-4bb7-a839-bbd9060c4087.png">

