### PR TITLE
fix: rm underline for token details

### DIFF
--- a/src/components/Explore/TokenTable/TokenRow.tsx
+++ b/src/components/Explore/TokenTable/TokenRow.tsx
@@ -233,6 +233,9 @@ const SparkLineImg = styled(Cell)<{ isPositive: boolean }>`
     stroke: ${({ theme, isPositive }) => (isPositive ? theme.accentSuccess : theme.accentFailure)};
   }
 `
+const StyledLink = styled(Link)`
+  text-decoration: none;
+`
 const TokenInfoCell = styled(Cell)`
   gap: 8px;
   line-height: 24px;
@@ -466,7 +469,7 @@ export default function LoadedRow({
   const heartColor = isFavorited ? theme.accentActive : undefined
   // TODO: currency logo sizing mobile (32px) vs. desktop (24px)
   return (
-    <Link
+    <StyledLink
       to={`tokens/${tokenAddress}`}
       onClick={() => sendAnalyticsEvent(EventName.EXPLORE_TOKEN_ROW_SELECTED, exploreTokenSelectedEventProperties)}
     >
@@ -506,6 +509,6 @@ export default function LoadedRow({
         volume={<ClickableContent>{formatAmount(tokenData.volume[timePeriod]).toUpperCase()}</ClickableContent>}
         sparkLine={<SparkLineImg dangerouslySetInnerHTML={{ __html: tokenData.sparkline }} isPositive={isPositive} />}
       />
-    </Link>
+    </StyledLink>
   )
 }

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -48,7 +48,6 @@ export default function TokenDetails() {
   const { tokenAddress } = useParams<{ tokenAddress?: string }>()
   const { data, error, loading } = useTokenDetailPageQuery(tokenAddress)
 
-
   let tokenDetail
   if (!tokenAddress) {
     // TODO: handle no address / invalid address cases


### PR DESCRIPTION
remove underline for clickable link for Explore page

BEFORE: 
<img width="951" alt="Screen Shot 2022-08-02 at 4 30 44 PM" src="https://user-images.githubusercontent.com/62825936/182467677-4e3dca45-f0db-45fa-96ee-ac680c8ed725.png">

AFTER: 
<img width="973" alt="Screen Shot 2022-08-02 at 4 29 17 PM" src="https://user-images.githubusercontent.com/62825936/182467500-52695f7b-fb24-4dbc-a318-bfe56e180c0e.png">

