### PR TITLE
chore: remove selectedWalletBackfilled

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -35,6 +35,7 @@ Cypress.Commands.overwrite(
         onBeforeLoad(win) {
           options?.onBeforeLoad?.(win)
           win.localStorage.clear()
+          win.localStorage.setItem('redux_localstorage_simple_user', '{"selectedWallet":"INJECTED"}')
           win.ethereum = injected
         },
       })

--- a/src/hooks/useEagerlyConnect.ts
+++ b/src/hooks/useEagerlyConnect.ts
@@ -2,7 +2,6 @@ import { Connector } from '@web3-react/types'
 import { gnosisSafeConnection, networkConnection } from 'connection'
 import { getConnection } from 'connection/utils'
 import { useEffect } from 'react'
-import { BACKFILLABLE_WALLETS } from 'state/connection/constants'
 import { useAppSelector } from 'state/hooks'
 
 async function connect(connector: Connector) {
@@ -18,7 +17,6 @@ async function connect(connector: Connector) {
 }
 
 export default function useEagerlyConnect() {
-  const selectedWalletBackfilled = useAppSelector((state) => state.user.selectedWalletBackfilled)
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
 
   useEffect(() => {
@@ -27,11 +25,6 @@ export default function useEagerlyConnect() {
 
     if (selectedWallet) {
       connect(getConnection(selectedWallet).connector)
-    } else if (!selectedWalletBackfilled) {
-      BACKFILLABLE_WALLETS.map(getConnection)
-        .map((connection) => connection.connector)
-        .forEach(connect)
-    }
-    // The dependency list is empty so this is only run once on mount
+    } // The dependency list is empty so this is only run once on mount
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/src/hooks/useOrderedConnections.ts
+++ b/src/hooks/useOrderedConnections.ts
@@ -1,10 +1,14 @@
 import { ConnectionType } from 'connection'
 import { getConnection } from 'connection/utils'
 import { useMemo } from 'react'
-import { BACKFILLABLE_WALLETS } from 'state/connection/constants'
 import { useAppSelector } from 'state/hooks'
 
-const SELECTABLE_WALLETS = [...BACKFILLABLE_WALLETS, ConnectionType.FORTMATIC]
+const SELECTABLE_WALLETS = [
+  ConnectionType.INJECTED,
+  ConnectionType.COINBASE_WALLET,
+  ConnectionType.WALLET_CONNECT,
+  ConnectionType.FORTMATIC,
+]
 
 export default function useOrderedConnections() {
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)

--- a/src/state/connection/constants.ts
+++ b/src/state/connection/constants.ts
@@ -1,7 +1,0 @@
-import { ConnectionType } from 'connection'
-
-export const BACKFILLABLE_WALLETS = [
-  ConnectionType.INJECTED,
-  ConnectionType.COINBASE_WALLET,
-  ConnectionType.WALLET_CONNECT,
-]

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -9,11 +9,6 @@ import { SerializedPair, SerializedToken } from './types'
 const currentTimestamp = () => new Date().getTime()
 
 export interface UserState {
-  // We want the user to be able to define which wallet they want to use, even if there are multiple connected wallets via web3-react.
-  // If a user had previously connected a wallet but didn't have a wallet override set (because they connected prior to this field being added),
-  // we want to handle that case by backfilling them manually. Once we backfill, we set the backfilled field to `true`.
-  // After some period of time, our active users will have this property set so we can likely remove the backfilling logic.
-  selectedWalletBackfilled: boolean
   selectedWallet?: ConnectionType
 
   // the timestamp of the last updateVersion action
@@ -66,7 +61,6 @@ function pairKey(token0Address: string, token1Address: string) {
 
 export const initialState: UserState = {
   selectedWallet: undefined,
-  selectedWalletBackfilled: false,
   matchesDarkMode: false,
   userDarkMode: null,
   userExpertMode: false,
@@ -90,7 +84,6 @@ const userSlice = createSlice({
   reducers: {
     updateSelectedWallet(state, { payload: { wallet } }) {
       state.selectedWallet = wallet
-      state.selectedWalletBackfilled = true
     },
     updateUserDarkMode(state, action) {
       state.userDarkMode = action.payload.userDarkMode


### PR DESCRIPTION
Removes the backfilling logic. Now that we've had the code merged in main for 2 months our active users will have had their `selectedWallet` properties set. This means that we only need to lazily load the various connectors after this is merged for new users, which should reduce load time.

We want to remove Fortmatic in a separate PR still, which has a very large load time and is not lazily loaded currency.