### PR TITLE
fix: Ensure proper cursor for network dropdown

### DIFF
--- a/src/components/Header/NetworkSelector.tsx
+++ b/src/components/Header/NetworkSelector.tsx
@@ -50,6 +50,7 @@ const ActiveRowWrapper = styled.div`
 `
 const FlyoutHeader = styled.div`
   color: ${({ theme }) => theme.deprecated_text2};
+  cursor: default;
   font-weight: 400;
 `
 const FlyoutMenu = styled.div`
@@ -114,7 +115,6 @@ const Logo = styled.img`
 `
 const NetworkLabel = styled.div`
   flex: 1 1 auto;
-  cursor: default;
 `
 const SelectorLabel = styled(NetworkLabel)`
   display: none;
@@ -153,6 +153,7 @@ const SelectorControls = styled.div<{ supportedChain: boolean }>`
     background-color: ${theme.deprecated_red1};
     border: 2px solid ${theme.deprecated_red1};
   `}
+  cursor: default;
   :focus {
     background-color: ${({ theme }) => darken(0.1, theme.deprecated_red1)};
   }


### PR DESCRIPTION
My previous PR was a bit aggressive.  The intention of the PR can be verified as follows:

1.  Hover over the Network Selector's currently selected network -- see default cursor
2.  Hover over "Select a Network" -- see default cursor
3.  Hover over each network name in the list -- see pointer cursor, signaling that clicking would change something.