### PR TITLE
ci: add .vercel to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ package-lock.json
 cypress/videos
 cypress/screenshots
 
+.vercel


### PR DESCRIPTION
Adds `.vercel` folder to gitignore. Only used when using vercel to build and deploy locally