### PR TITLE
fix: phaseflagging token import modals

### DIFF
--- a/src/components/SearchModal/CurrencySearchModal.tsx
+++ b/src/components/SearchModal/CurrencySearchModal.tsx
@@ -1,13 +1,16 @@
 import { Currency, Token } from '@uniswap/sdk-core'
 import { TokenList } from '@uniswap/token-lists'
 import TokenSafety from 'components/TokenSafety'
+import { Phase0Variant, usePhase0Flag } from 'featureFlags/flags/phase0'
 import usePrevious from 'hooks/usePrevious'
 import { useCallback, useEffect, useState } from 'react'
+import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 import useLast from '../../hooks/useLast'
 import Modal from '../Modal'
 import { CurrencySearch } from './CurrencySearch'
 import { ImportList } from './ImportList'
+import { ImportToken } from './ImportToken'
 import Manage from './Manage'
 
 interface CurrencySearchModalProps {
@@ -72,6 +75,8 @@ export default function CurrencySearchModal({
     [setModalView, prevView]
   )
 
+  const phase0Flag = usePhase0Flag()
+
   // change min height if not searching
   let minHeight: number | undefined = 80
   let content = null
@@ -96,13 +101,22 @@ export default function CurrencySearchModal({
     case CurrencyModalView.importToken:
       if (importToken) {
         minHeight = undefined
-        content = (
-          <TokenSafety
-            tokenAddress={importToken.address}
-            onContinue={() => handleCurrencySelect(importToken)}
-            onCancel={handleBackImport}
-          />
-        )
+        content =
+          phase0Flag === Phase0Variant.Enabled ? (
+            <TokenSafety
+              tokenAddress={importToken.address}
+              onContinue={() => handleCurrencySelect(importToken)}
+              onCancel={handleBackImport}
+            />
+          ) : (
+            <ImportToken
+              tokens={[importToken]}
+              onDismiss={onDismiss}
+              list={importToken instanceof WrappedTokenInfo ? importToken.list : undefined}
+              onBack={handleBackImport}
+              handleCurrencySelect={handleCurrencySelect}
+            />
+          )
       }
       break
     case CurrencyModalView.importList:

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -22,6 +22,7 @@ import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter
 import TokenSafetyModal from 'components/TokenSafety/TokenSafetyModal'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { isSupportedChain } from 'constants/chains'
+import { Phase0Variant, usePhase0Flag } from 'featureFlags/flags/phase0'
 import { useSwapCallback } from 'hooks/useSwapCallback'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
 import JSBI from 'jsbi'
@@ -48,6 +49,7 @@ import ConfirmSwapModal from '../../components/swap/ConfirmSwapModal'
 import { ArrowWrapper, SwapCallbackError, Wrapper } from '../../components/swap/styleds'
 import SwapHeader from '../../components/swap/SwapHeader'
 import { SwitchLocaleLink } from '../../components/SwitchLocaleLink'
+import TokenWarningModal from '../../components/TokenWarningModal'
 import { TOKEN_SHORTHANDS } from '../../constants/tokens'
 import { useAllTokens, useCurrency } from '../../hooks/Tokens'
 import { ApprovalState, useApprovalOptimizedTrade, useApproveCallbackFromTrade } from '../../hooks/useApproveCallback'
@@ -125,6 +127,7 @@ export default function Swap() {
   const loadedUrlParams = useDefaultsFromURLSearch()
   const [newSwapQuoteNeedsLogging, setNewSwapQuoteNeedsLogging] = useState(true)
   const [fetchingSwapQuoteStartTime, setFetchingSwapQuoteStartTime] = useState<Date | undefined>()
+  const phase0Flag = usePhase0Flag()
 
   // token warning stuff
   const [loadedInputCurrency, loadedOutputCurrency] = [
@@ -491,13 +494,22 @@ export default function Swap() {
   return (
     <Trace page={PageName.SWAP_PAGE} shouldLogImpression>
       <>
-        <TokenSafetyModal
-          isOpen={importTokensNotInDefault.length > 0 && !dismissTokenWarning}
-          tokenAddress={importTokensNotInDefault[0]?.address}
-          secondTokenAddress={importTokensNotInDefault[1]?.address}
-          onContinue={handleConfirmTokenWarning}
-          onCancel={handleDismissTokenWarning}
-        />
+        {phase0Flag === Phase0Variant.Enabled ? (
+          <TokenSafetyModal
+            isOpen={importTokensNotInDefault.length > 0 && !dismissTokenWarning}
+            tokenAddress={importTokensNotInDefault[0]?.address}
+            secondTokenAddress={importTokensNotInDefault[1]?.address}
+            onContinue={handleConfirmTokenWarning}
+            onCancel={handleDismissTokenWarning}
+          />
+        ) : (
+          <TokenWarningModal
+            isOpen={importTokensNotInDefault.length > 0 && !dismissTokenWarning}
+            tokens={importTokensNotInDefault}
+            onConfirm={handleConfirmTokenWarning}
+            onDismiss={handleDismissTokenWarning}
+          />
+        )}
         <AppBody>
           <SwapHeader allowedSlippage={allowedSlippage} />
           <Wrapper id="swap-page">


### PR DESCRIPTION
The new token safety components were exposed; added old token import component back in to be shown under phase0flag control