### PR TITLE
fix: change background color on Explore table

### DIFF
--- a/src/components/Explore/TokenTable/TokenTable.tsx
+++ b/src/components/Explore/TokenTable/TokenTable.tsx
@@ -21,7 +21,7 @@ const GridContainer = styled.div`
   display: flex;
   flex-direction: column;
   max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT};
-  background-color: ${({ theme }) => theme.backgroundSurface};
+  background-color: ${({ theme }) => theme.backgroundContainer};
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
     0px 24px 32px rgba(0, 0, 0, 0.01);
   margin-left: auto;


### PR DESCRIPTION
fix background color on explore table

<img width="938" alt="Screen Shot 2022-08-10 at 3 13 06 PM" src="https://user-images.githubusercontent.com/62825936/183999373-e455696e-9617-4ae9-9ca0-01d005996672.png">
