### PR TITLE
test: skip fetchTokenList tests

### DIFF
--- a/src/lib/hooks/useTokenList/fetchTokenList.test.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.test.ts
@@ -1,6 +1,6 @@
 import fetchTokenList, { DEFAULT_TOKEN_LIST } from './fetchTokenList'
 
-describe('fetchTokenList', () => {
+describe.skip('fetchTokenList', () => {
   const resolver = jest.fn()
 
   it('throws on an invalid list url', async () => {


### PR DESCRIPTION
The tests are not comprehensive and are also using actual fetches to validate responses.

I'd be open to mocking the fetch calls (there are a few) and testing the other error cases if we feel that's a good use of time.