### PR TITLE
fix: double Polygon auto-slippage again

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -68,7 +68,7 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
 }
 
 const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 1000) // 0.5%
-const POLYGON_MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(1, 100) // 1%
+const POLYGON_MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(2, 100) // 2%
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(25, 100) // 25%
 
 /**


### PR DESCRIPTION
Doubles Polygon auto-slippage again for now as transaction are still failing at 30% rate. We will look into whether Infura has an issue with updating blocks as well.























