### PR TITLE
fix: undo polygon auto-slippage changes

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -3,7 +3,7 @@ import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { Pool } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
-import { SUPPORTED_GAS_ESTIMATE_CHAIN_IDS, SupportedChainId } from 'constants/chains'
+import { SUPPORTED_GAS_ESTIMATE_CHAIN_IDS } from 'constants/chains'
 import { L2_CHAIN_IDS } from 'constants/chains'
 import JSBI from 'jsbi'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
@@ -68,7 +68,6 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
 }
 
 const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 1000) // 0.5%
-const POLYGON_MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(1, 100) // 1%
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(25, 100) // 25%
 
 /**
@@ -115,13 +114,8 @@ export default function useAutoSlippageTolerance(
         return MAX_AUTO_SLIPPAGE_TOLERANCE
       }
 
-      // TODO(vm): Added because ~30% of Polygon swaps were failing due to exceeding slippage.
-      // The root cause is likely elsewhere, but added for now to reduce failure rate on production.
-      const isPolygon = chainId && [SupportedChainId.POLYGON, SupportedChainId.POLYGON_MUMBAI].includes(chainId)
-      const minAutoSlippageTolerance = isPolygon ? POLYGON_MIN_AUTO_SLIPPAGE_TOLERANCE : MIN_AUTO_SLIPPAGE_TOLERANCE
-
-      if (result.lessThan(minAutoSlippageTolerance)) {
-        return minAutoSlippageTolerance
+      if (result.lessThan(MIN_AUTO_SLIPPAGE_TOLERANCE)) {
+        return MIN_AUTO_SLIPPAGE_TOLERANCE
       }
 
       return result


### PR DESCRIPTION
Turns out the Polygon slippage issues were coming from specifically the v3 router and not the new swap router. We're going to make the interface only use the latest router and monitor.
