### PR TITLE
fix: width of widget and network balances on token details

### DIFF
--- a/src/components/Tokens/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Tokens/TokenDetails/BalanceSummary.tsx
@@ -9,15 +9,14 @@ import styled, { useTheme } from 'styled-components/macro'
 import NetworkBalance from './NetworkBalance'
 
 const BalancesCard = styled.div`
-  width: 284px;
+  width: 320px;
   height: fit-content;
   color: ${({ theme }) => theme.textPrimary};
   font-size: 12px;
-  line-height: 20px;
+  line-height: 16px;
   padding: 20px;
   background-color: ${({ theme }) => theme.backgroundSurface};
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.backgroundOutline};
+  border-radius: 16px;
 `
 const ErrorState = styled.div`
   display: flex;

--- a/src/components/Tokens/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Tokens/TokenDetails/BalanceSummary.tsx
@@ -9,7 +9,7 @@ import styled, { useTheme } from 'styled-components/macro'
 import NetworkBalance from './NetworkBalance'
 
 const BalancesCard = styled.div`
-  width: 320px;
+  width: 100%;
   height: fit-content;
   color: ${({ theme }) => theme.textPrimary};
   font-size: 12px;

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -54,7 +54,7 @@ const RightPanel = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  width: WIDGET_WIDTH + 'px';
+  width: ${WIDGET_WIDTH}px;
 
   @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
     display: none;

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -149,7 +149,7 @@ export default function TokenDetails() {
               routerUrl={ROUTER_URL}
               theme={widgetTheme}
               // tokenList={[]}
-              width={290}
+              width={320}
             />
             {tokenWarning && <TokenSafetyMessage tokenAddress={tokenAddress} warning={tokenWarning} />}
             {!loading && (

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -26,6 +26,7 @@ import styled from 'styled-components/macro'
 import { DARK_THEME, LIGHT_THEME } from 'theme/token-details-widget-theme'
 import { ROUTER_URL, RPC_URL_MAP } from 'utils/token-details-widget-config'
 
+const WIDGET_WIDTH = '320'
 const Footer = styled.div`
   display: none;
   @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
@@ -53,7 +54,7 @@ const RightPanel = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  width: 320px;
+  width: WIDGET_WIDTH + 'px';
 
   @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
     display: none;
@@ -150,7 +151,7 @@ export default function TokenDetails() {
               routerUrl={ROUTER_URL}
               theme={widgetTheme}
               // tokenList={[]}
-              width={320}
+              width={WIDGET_WIDTH}
             />
             {tokenWarning && <TokenSafetyMessage tokenAddress={tokenAddress} warning={tokenWarning} />}
             {!loading && (

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -53,6 +53,7 @@ const RightPanel = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
+  width: 320px;
 
   @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
     display: none;

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -26,7 +26,7 @@ import styled from 'styled-components/macro'
 import { DARK_THEME, LIGHT_THEME } from 'theme/token-details-widget-theme'
 import { ROUTER_URL, RPC_URL_MAP } from 'utils/token-details-widget-config'
 
-const WIDGET_WIDTH = '320'
+const WIDGET_WIDTH = 320
 const Footer = styled.div`
   display: none;
   @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {


### PR DESCRIPTION
fix: widget width and network balances align
<img width="317" alt="Screen Shot 2022-08-17 at 2 46 01 PM" src="https://user-images.githubusercontent.com/62825936/185248900-eb0b317c-64f2-438c-8347-5010e02058c9.png">
 