### PR TITLE
fix: Revert "feat: fix padding"

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -55,11 +55,11 @@ const BodyWrapper = styled.div<{ navBarFlag: NavBarVariant }>`
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: ${({ navBarFlag }) => (navBarFlag === NavBarVariant.Enabled ? `120px 16px 0px 16px` : `72px 16px 0px 16px`)};
+  padding: ${({ navBarFlag }) => (navBarFlag === NavBarVariant.Enabled ? `72px 0px 0px 0px` : `120px 0px 0px 0px`)};
   align-items: center;
   flex: 1;
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    padding: 52px 8px 16px 8px;
+    padding: 52px 0px 16px 0px;
   `};
 `
 


### PR DESCRIPTION
Reverts Uniswap/interface#4400

The expected behavior was already correct. Under phase1, the padding-top should be 72px. Under control, it should be 120px. If there is any further misunderstanding here we should resolve it separately.