### PR TITLE
fix: support wETH withdraw for smart contract wallets

### DIFF
--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -120,7 +120,9 @@ export default function useWrapCallback(
           sufficientBalance && inputAmount
             ? async () => {
                 try {
-                  const txReceipt = await wethContract.withdraw(`0x${inputAmount.quotient.toString(16)}`)
+                  const txReceipt = await wethContract.withdraw(`0x${inputAmount.quotient.toString(16)}`, {
+                    gasLimit: 300000,
+                  })
                   addTransaction(txReceipt, {
                     type: TransactionType.WRAP,
                     unwrapped: true,


### PR DESCRIPTION
Fixes the withdraw wETH feature for smart contract wallets like Gnosis Safe. Without a gas limit, the `wethContract.withdraw` call fails with the error `Error: cannot estimate gas; transaction may fail or may require manual gas limit`.