### PR TITLE
fix: Fix unresponsive image in vote page

### DIFF
--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -62,14 +62,6 @@ const PageWrapper = styled(AutoColumn)`
   `};
 `
 
-const MarkDownDescription = styled(ReactMarkdown)`
-  & > p > img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-`
-
 const ProposalInfo = styled(AutoColumn)`
   background: ${({ theme }) => theme.deprecated_bg0};
   border-radius: 12px;
@@ -266,6 +258,10 @@ export default function VotePage() {
       )
     }
     return <span>{content}</span>
+  }
+
+  function MarkdownImage({ ...rest }) {
+    return <img {...rest} style={{ width: '100%', height: '100$', objectFit: 'cover' }} alt="" />
   }
 
   return (
@@ -476,7 +472,12 @@ export default function VotePage() {
                 <Trans>Description</Trans>
               </ThemedText.DeprecatedMediumHeader>
               <MarkDownWrapper>
-                <MarkDownDescription source={proposalData?.description} />
+                <ReactMarkdown
+                  source={proposalData?.description}
+                  renderers={{
+                    image: MarkdownImage,
+                  }}
+                />
               </MarkDownWrapper>
             </AutoColumn>
             <AutoColumn gap="md">

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -62,6 +62,14 @@ const PageWrapper = styled(AutoColumn)`
   `};
 `
 
+const MarkDownDescription = styled(ReactMarkdown)`
+  & > p > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`
+
 const ProposalInfo = styled(AutoColumn)`
   background: ${({ theme }) => theme.deprecated_bg0};
   border-radius: 12px;
@@ -468,7 +476,7 @@ export default function VotePage() {
                 <Trans>Description</Trans>
               </ThemedText.DeprecatedMediumHeader>
               <MarkDownWrapper>
-                <ReactMarkdown source={proposalData?.description} />
+                <MarkDownDescription source={proposalData?.description} />
               </MarkDownWrapper>
             </AutoColumn>
             <AutoColumn gap="md">


### PR DESCRIPTION
Fixes unresponsive image in description section of the vote page

<img width="867" alt="before" src="https://user-images.githubusercontent.com/90815042/185538288-718aa2de-31e7-4f8a-8e6b-80f940ab56e4.png">
<img width="873" alt="after" src="https://user-images.githubusercontent.com/90815042/185538296-bc4ee8cf-2d1f-4805-a361-b41c010deafe.png">

