### PR TITLE
fix: time selector updated to align with price chart 

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -27,7 +27,7 @@ import {
 import LineChart from '../../Charts/LineChart'
 
 // TODO: This should be combined with the logic in TimeSelector.
-const TIME_DISPLAYS: [TimePeriod, string][] = [
+export const TIME_DISPLAYS: [TimePeriod, string][] = [
   [TimePeriod.HOUR, '1H'],
   [TimePeriod.DAY, '1D'],
   [TimePeriod.WEEK, '1W'],

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -25,16 +25,9 @@ import {
 } from 'utils/formatChartTimes'
 
 import LineChart from '../../Charts/LineChart'
+import { DISPLAYS, ORDERED_TIMES } from '../TokenTable/TimeSelector'
 
 // TODO: This should be combined with the logic in TimeSelector.
-export const TIME_DISPLAYS: [TimePeriod, string][] = [
-  [TimePeriod.HOUR, '1H'],
-  [TimePeriod.DAY, '1D'],
-  [TimePeriod.WEEK, '1W'],
-  [TimePeriod.MONTH, '1M'],
-  [TimePeriod.YEAR, '1Y'],
-  [TimePeriod.ALL, 'All'],
-]
 
 type PricePoint = { value: number; timestamp: number }
 
@@ -307,9 +300,9 @@ export function PriceChart({ width, height, token }: PriceChartProps) {
       </LineChart>
       <TimeOptionsWrapper>
         <TimeOptionsContainer>
-          {TIME_DISPLAYS.map(([value, display]) => (
-            <TimeButton key={display} active={timePeriod === value} onClick={() => setTimePeriod(value)}>
-              {display}
+          {ORDERED_TIMES.map((time) => (
+            <TimeButton key={DISPLAYS[time]} active={timePeriod === time} onClick={() => setTimePeriod(time)}>
+              {DISPLAYS[time]}
             </TimeButton>
           ))}
         </TimeOptionsContainer>

--- a/src/components/Tokens/TokenTable/TimeSelector.tsx
+++ b/src/components/Tokens/TokenTable/TimeSelector.tsx
@@ -1,3 +1,4 @@
+import { TimePeriod } from 'hooks/useExplorePageQuery'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { useAtom } from 'jotai'
 import { useRef } from 'react'
@@ -8,7 +9,24 @@ import styled, { useTheme } from 'styled-components/macro'
 
 import { MOBILE_MEDIA_BREAKPOINT, SMALL_MEDIA_BREAKPOINT } from '../constants'
 import { filterTimeAtom } from '../state'
-import { TIME_DISPLAYS } from '../TokenDetails/PriceChart'
+
+export const DISPLAYS: Record<TimePeriod, string> = {
+  [TimePeriod.HOUR]: '1H',
+  [TimePeriod.DAY]: '1D',
+  [TimePeriod.WEEK]: '1W',
+  [TimePeriod.MONTH]: '1M',
+  [TimePeriod.YEAR]: '1Y',
+  [TimePeriod.ALL]: 'All',
+}
+
+export const ORDERED_TIMES = [
+  TimePeriod.HOUR,
+  TimePeriod.DAY,
+  TimePeriod.WEEK,
+  TimePeriod.MONTH,
+  TimePeriod.YEAR,
+  TimePeriod.ALL,
+]
 
 const InternalMenuItem = styled.div`
   flex: 1;
@@ -126,7 +144,7 @@ export default function TimeSelector() {
     <StyledMenu ref={node}>
       <StyledMenuButton onClick={toggleMenu} aria-label={`timeSelector`} open={open}>
         <StyledMenuContent>
-          {TIME_DISPLAYS[activeTime][1]}
+          {DISPLAYS[activeTime]}
           <Chevron open={open}>
             {open ? <ChevronUp size={15} viewBox="0 0 24 20" /> : <ChevronDown size={15} viewBox="0 0 24 20" />}
           </Chevron>
@@ -134,16 +152,16 @@ export default function TimeSelector() {
       </StyledMenuButton>
       {open && (
         <MenuTimeFlyout>
-          {TIME_DISPLAYS.map((time) => (
+          {ORDERED_TIMES.map((time) => (
             <InternalLinkMenuItem
-              key={time[1]}
+              key={DISPLAYS[time]}
               onClick={() => {
-                setTime(time[0])
+                setTime(time)
                 toggleMenu()
               }}
             >
-              <div>{time[1]}</div>
-              {time[0] === activeTime && <Check color={theme.accentAction} size={16} />}
+              <div>{DISPLAYS[time]}</div>
+              {time === activeTime && <Check color={theme.accentAction} size={16} />}
             </InternalLinkMenuItem>
           ))}
         </MenuTimeFlyout>

--- a/src/components/Tokens/TokenTable/TimeSelector.tsx
+++ b/src/components/Tokens/TokenTable/TimeSelector.tsx
@@ -1,4 +1,3 @@
-import { TimePeriod } from 'hooks/useExplorePageQuery'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { useAtom } from 'jotai'
 import { useRef } from 'react'
@@ -9,16 +8,7 @@ import styled, { useTheme } from 'styled-components/macro'
 
 import { MOBILE_MEDIA_BREAKPOINT, SMALL_MEDIA_BREAKPOINT } from '../constants'
 import { filterTimeAtom } from '../state'
-
-export const TIME_DISPLAYS: { [key: string]: string } = {
-  hour: '1H',
-  day: '1D',
-  week: '1W',
-  month: '1M',
-  year: '1Y',
-}
-
-const TIMES = [TimePeriod.HOUR, TimePeriod.DAY, TimePeriod.WEEK, TimePeriod.MONTH, TimePeriod.YEAR]
+import { TIME_DISPLAYS } from '../TokenDetails/PriceChart'
 
 const InternalMenuItem = styled.div`
   flex: 1;
@@ -136,7 +126,7 @@ export default function TimeSelector() {
     <StyledMenu ref={node}>
       <StyledMenuButton onClick={toggleMenu} aria-label={`timeSelector`} open={open}>
         <StyledMenuContent>
-          {TIME_DISPLAYS[activeTime]}
+          {TIME_DISPLAYS[activeTime][1]}
           <Chevron open={open}>
             {open ? <ChevronUp size={15} viewBox="0 0 24 20" /> : <ChevronDown size={15} viewBox="0 0 24 20" />}
           </Chevron>
@@ -144,16 +134,16 @@ export default function TimeSelector() {
       </StyledMenuButton>
       {open && (
         <MenuTimeFlyout>
-          {TIMES.map((time) => (
+          {TIME_DISPLAYS.map((time) => (
             <InternalLinkMenuItem
-              key={time}
+              key={time[1]}
               onClick={() => {
-                setTime(time)
+                setTime(time[0])
                 toggleMenu()
               }}
             >
-              <div>{TIME_DISPLAYS[time]}</div>
-              {time === activeTime && <Check color={theme.accentAction} size={16} />}
+              <div>{time[1]}</div>
+              {time[0] === activeTime && <Check color={theme.accentAction} size={16} />}
             </InternalLinkMenuItem>
           ))}
         </MenuTimeFlyout>

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -32,8 +32,8 @@ import {
   useSetSortCategory,
   useToggleFavorite,
 } from '../state'
-import { TIME_DISPLAYS } from '../TokenDetails/PriceChart'
 import { Category, SortDirection } from '../types'
+import { DISPLAYS } from './TimeSelector'
 
 const ArrowCell = styled.div`
   padding-left: 2px;
@@ -294,7 +294,7 @@ const LogoContainer = styled.div`
 
 /* formatting for volume with timeframe header display */
 function getHeaderDisplay(category: string, timeframe: TimePeriod): string {
-  if (category === Category.volume) return `${TIME_DISPLAYS[timeframe][1]} ${category}`
+  if (category === Category.volume) return `${DISPLAYS[timeframe]} ${category}`
   return category
 }
 

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -32,8 +32,8 @@ import {
   useSetSortCategory,
   useToggleFavorite,
 } from '../state'
+import { TIME_DISPLAYS } from '../TokenDetails/PriceChart'
 import { Category, SortDirection } from '../types'
-import { TIME_DISPLAYS } from './TimeSelector'
 
 const ArrowCell = styled.div`
   padding-left: 2px;
@@ -294,7 +294,7 @@ const LogoContainer = styled.div`
 
 /* formatting for volume with timeframe header display */
 function getHeaderDisplay(category: string, timeframe: TimePeriod): string {
-  if (category === Category.volume) return `${TIME_DISPLAYS[timeframe]} ${category}`
+  if (category === Category.volume) return `${TIME_DISPLAYS[timeframe][1]} ${category}`
   return category
 }
 


### PR DESCRIPTION
fix time selector on Explore page to be accurate and also use PriceChart logic

Before: 
<img width="423" alt="Screen Shot 2022-08-19 at 4 08 42 PM" src="https://user-images.githubusercontent.com/62825936/185717940-973434ba-2b3c-46a5-99a8-8bee81e916f6.png">

After:
<img width="613" alt="Screen Shot 2022-08-19 at 4 07 49 PM" src="https://user-images.githubusercontent.com/62825936/185717908-71669a39-4579-4038-a36d-72ad2d57f0f1.png">