### PR TITLE
feat: Placeholder NFT Details and NFT Sell Pages

### DIFF
--- a/src/components/NavBar/MenuDropdown.tsx
+++ b/src/components/NavBar/MenuDropdown.tsx
@@ -9,6 +9,7 @@ import {
   EllipsisIcon,
   GithubIconMenu,
   GovernanceIcon,
+  ThinTagIcon,
   TwitterIconMenu,
 } from 'nft/components/icons'
 import { body, bodySmall } from 'nft/css/common.css'
@@ -129,6 +130,12 @@ export const MenuDropdown = () => {
           <NavDropdown top={60}>
             <Column gap="12">
               <Column paddingX="16" gap="4">
+                <PrimaryMenuRow to="/nft/sell" close={toggleOpen}>
+                  <Icon>
+                    <ThinTagIcon width={24} height={24} />
+                  </Icon>
+                  <PrimaryMenuRow.Text>Sell NFTs</PrimaryMenuRow.Text>
+                </PrimaryMenuRow>
                 <PrimaryMenuRow to="/vote" close={toggleOpen}>
                   <Icon>
                     <GovernanceIcon width={24} height={24} />

--- a/src/components/NavBar/MenuDropdown.tsx
+++ b/src/components/NavBar/MenuDropdown.tsx
@@ -1,5 +1,6 @@
 import FeatureFlagModal from 'components/FeatureFlagModal/FeatureFlagModal'
 import { PrivacyPolicyModal } from 'components/PrivacyPolicy'
+import { NftVariant, useNftFlag } from 'featureFlags/flags/nft'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { Box } from 'nft/components/Box'
 import { Column, Row } from 'nft/components/Flex'
@@ -115,6 +116,7 @@ export const MenuDropdown = () => {
   const [isOpen, toggleOpen] = useReducer((s) => !s, false)
   const togglePrivacyPolicy = useToggleModal(ApplicationModal.PRIVACY_POLICY)
   const openFeatureFlagsModal = useToggleModal(ApplicationModal.FEATURE_FLAGS)
+  const nftFlag = useNftFlag()
 
   const ref = useRef<HTMLDivElement>(null)
   useOnClickOutside(ref, isOpen ? toggleOpen : undefined)
@@ -130,12 +132,14 @@ export const MenuDropdown = () => {
           <NavDropdown top={60}>
             <Column gap="12">
               <Column paddingX="16" gap="4">
-                <PrimaryMenuRow to="/nft/sell" close={toggleOpen}>
-                  <Icon>
-                    <ThinTagIcon width={24} height={24} />
-                  </Icon>
-                  <PrimaryMenuRow.Text>Sell NFTs</PrimaryMenuRow.Text>
-                </PrimaryMenuRow>
+                {nftFlag === NftVariant.Enabled && (
+                  <PrimaryMenuRow to="/nft/sell" close={toggleOpen}>
+                    <Icon>
+                      <ThinTagIcon width={24} height={24} />
+                    </Icon>
+                    <PrimaryMenuRow.Text>Sell NFTs</PrimaryMenuRow.Text>
+                  </PrimaryMenuRow>
+                )}
                 <PrimaryMenuRow to="/vote" close={toggleOpen}>
                   <Icon>
                     <GovernanceIcon width={24} height={24} />

--- a/src/components/NavBar/MobileSidebar.tsx
+++ b/src/components/NavBar/MobileSidebar.tsx
@@ -176,12 +176,14 @@ export const MobileSideBar = () => {
               </Column>
               <Seperator />
               <Column gap="4">
-                <ExtraLinkRow to="/nft/sell" close={toggleOpen}>
-                  <Icon>
-                    <ThinTagIconMobile width={24} height={24} />
-                  </Icon>
-                  Sell NFTs
-                </ExtraLinkRow>
+                {nftFlag === NftVariant.Enabled && (
+                  <ExtraLinkRow to="/nft/sell" close={toggleOpen}>
+                    <Icon>
+                      <ThinTagIconMobile width={24} height={24} />
+                    </Icon>
+                    Sell NFTs
+                  </ExtraLinkRow>
+                )}
                 <ExtraLinkRow to="/vote" close={toggleOpen}>
                   <Icon>
                     <GovernanceIconMobile width={24} height={24} />

--- a/src/components/NavBar/MobileSidebar.tsx
+++ b/src/components/NavBar/MobileSidebar.tsx
@@ -12,6 +12,7 @@ import {
   GithubIconMenuMobile,
   GovernanceIconMobile,
   HamburgerIcon,
+  ThinTagIconMobile,
   TwitterIconMenuMobile,
 } from 'nft/components/icons'
 import { themeVars } from 'nft/css/sprinkles.css'
@@ -175,6 +176,12 @@ export const MobileSideBar = () => {
               </Column>
               <Seperator />
               <Column gap="4">
+                <ExtraLinkRow to="/nft/sell" close={toggleOpen}>
+                  <Icon>
+                    <ThinTagIconMobile width={24} height={24} />
+                  </Icon>
+                  Sell NFTs
+                </ExtraLinkRow>
                 <ExtraLinkRow to="/vote" close={toggleOpen}>
                   <Icon>
                     <GovernanceIconMobile width={24} height={24} />

--- a/src/nft/pages/asset/Asset.tsx
+++ b/src/nft/pages/asset/Asset.tsx
@@ -1,0 +1,5 @@
+const Asset = () => {
+  return <div>NFT Details Page</div>
+}
+
+export default Asset

--- a/src/nft/pages/sell/sell.tsx
+++ b/src/nft/pages/sell/sell.tsx
@@ -1,0 +1,5 @@
+const Sell = () => {
+  return <div>Sell NFTs</div>
+}
+
+export default Sell

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -44,6 +44,8 @@ import Tokens from './Tokens'
 const TokenDetails = lazy(() => import('./TokenDetails'))
 const Vote = lazy(() => import('./Vote'))
 const Collection = lazy(() => import('nft/pages/collection'))
+const Sell = lazy(() => import('nft/pages/sell/sell'))
+const Asset = lazy(() => import('nft/pages/asset/Asset'))
 
 const AppWrapper = styled.div`
   display: flex;
@@ -211,7 +213,11 @@ export default function App() {
                   <Route path="*" element={<RedirectPathToSwapOnly />} />
 
                   {nftFlag === NftVariant.Enabled && (
-                    <Route path="/nfts/collection/:contractAddress" element={<Collection />} />
+                    <>
+                      <Route path="/nfts/collection/:contractAddress" element={<Collection />} />
+                      <Route path="/nft/sell" element={<Sell />} />
+                      <Route path="/nft/asset/:contractAddress/:tokenId" element={<Asset />} />
+                    </>
                   )}
                 </Routes>
               ) : (


### PR DESCRIPTION
- I'll be working on migrating these two pages to the main app this week, this creates the placeholder files and routes in App.tsx behind the NFt feature flag
- Also added feature flagged routing to Sell page in the Navbar
Screenshots:
Blank Sell Page with Correct Pathing
<img width="1035" alt="Screen Shot 2022-08-22 at 07 11 55 " src="https://user-images.githubusercontent.com/11512321/185942596-145d6309-a1a3-4d6c-961a-aeb2687bb577.png">
Blank Details Page with correct Pathing
<img width="1024" alt="Screen Shot 2022-08-22 at 07 12 00 " src="https://user-images.githubusercontent.com/11512321/185942623-e383359c-6681-4677-a0cf-b07e9f582b66.png">
Desktop and Mobile Navbar w/o NFT Feature Flag
<img width="486" alt="Screen Shot 2022-08-22 at 07 09 06 " src="https://user-images.githubusercontent.com/11512321/185942754-4547f3d1-0b3b-4401-a746-c236d1ec26b0.png">
<img width="395" alt="Screen Shot 2022-08-22 at 07 09 19 " src="https://user-images.githubusercontent.com/11512321/185942760-0db4274a-c203-4b61-8376-f4b04d4ab301.png">
Desktop and Mobile Navbar w/ NFT Feature Flag
<img width="553" alt="Screen Shot 2022-08-22 at 07 09 32 " src="https://user-images.githubusercontent.com/11512321/185942693-f8289d06-c5e2-4db7-8104-b88dd31839cd.png">
<img width="527" alt="Screen Shot 2022-08-22 at 07 09 40 " src="https://user-images.githubusercontent.com/11512321/185942697-babea4aa-745c-4105-bad8-52cbfd72a133.png">