### PR TITLE
build: enforce node/npm versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -227,5 +227,9 @@
     "workbox-precaching": "^6.1.0",
     "workbox-routing": "^6.1.0",
     "zustand": "^4.0.0-rc.1"
+  },
+  "engines": {
+    "npm" : "8",
+    "node" : "14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -229,7 +229,8 @@
     "zustand": "^4.0.0-rc.1"
   },
   "engines": {
-    "npm" : "8",
-    "node" : "14"
+    "npm": "please-use-yarn",
+    "node": "14",
+    "yarn": ">=1.22"
   }
 }


### PR DESCRIPTION
This is the version we use to build on IPFS and is listed in our .nvmrc. Vanilla-extract also doesn't work on anything over 14 properly, so local builds won't work otherwise.