### PR TITLE
fix: active state for Token Explore

### DIFF
--- a/src/components/NavBar/Navbar.tsx
+++ b/src/components/NavBar/Navbar.tsx
@@ -87,7 +87,7 @@ const Navbar = () => {
             <MenuItem href="/swap" isActive={pathname.startsWith('/swap')}>
               Swap
             </MenuItem>
-            <MenuItem href="/tokens" isActive={pathname.startsWith('/explore')}>
+            <MenuItem href="/tokens" isActive={pathname.startsWith('/tokens')}>
               Tokens
             </MenuItem>
             {nftFlag === NftVariant.Enabled && (


### PR DESCRIPTION
When we switched from `/explore` to `/tokens` the isActive check was not updated for the desktop navbar
<img width="1504" alt="Screen Shot 2022-08-22 at 13 49 27 " src="https://user-images.githubusercontent.com/11512321/186016314-7b020335-c0d4-4f59-9cca-f246f0551d8f.png">
