### PR TITLE
fix: chart size responsiveness issue

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -143,7 +143,7 @@ function tickFormat(
   }
 }
 
-const margin = { top: 86, bottom: 48, crosshair: 72 }
+const margin = { top: 100, bottom: 48, crosshair: 72 }
 const timeOptionsHeight = 44
 const crosshairDateOverhang = 80
 
@@ -223,7 +223,7 @@ export function PriceChart({ width, height, token }: PriceChartProps) {
     locale
   )
   const [delta, arrow] = getDelta(startingPrice.value, displayPrice.value)
-  const crosshairEdgeMax = width * 0.97
+  const crosshairEdgeMax = width * 0.85
   const crosshairAtEdge = !!crosshair && crosshair > crosshairEdgeMax
 
   return (

--- a/src/components/Tokens/TokenDetails/TokenDetail.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDetail.tsx
@@ -124,6 +124,7 @@ const TokenSymbol = styled.span`
 `
 export const TopArea = styled.div`
   max-width: 832px;
+  overflow: hidden;
 `
 export const ResourcesContainer = styled.div`
   display: flex;


### PR DESCRIPTION
Turned overflow off for TokenDetail's TopArea so that the chart would resize correctly