### PR TITLE
chore: updating navbar padding

### DIFF
--- a/src/components/swap/styleds.tsx
+++ b/src/components/swap/styleds.tsx
@@ -9,7 +9,7 @@ import { Z_INDEX } from 'theme'
 import { AutoColumn } from '../Column'
 
 export const PageWrapper = styled.div<{ redesignFlag: boolean }>`
-  padding: 0 8px;
+  padding: 48px 8px 0px;
   max-width: ${({ redesignFlag }) => (redesignFlag ? '420px' : '480px')};
   width: 100%;
 `

--- a/src/pages/AddLiquidity/styled.tsx
+++ b/src/pages/AddLiquidity/styled.tsx
@@ -33,10 +33,14 @@ export const ScrollablePage = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
+  padding: 68px 0px 0px;
   ${({ theme }) => theme.mediaWidth.upToMedium`
     max-width: 480px;
     margin: 0 auto;
-    padding: 0px 8px;
+    padding: 32px 8px 0px;
+  `};
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 12px 8px 0px;
   `};
 `
 

--- a/src/pages/CreateProposal/index.tsx
+++ b/src/pages/CreateProposal/index.tsx
@@ -34,6 +34,7 @@ import { ProposalEditor } from './ProposalEditor'
 import { ProposalSubmissionModal } from './ProposalSubmissionModal'
 
 const PageWrapper = styled(AutoColumn)`
+  padding: 48px 0px 0px;
   ${({ theme }) => theme.mediaWidth.upToMedium`
     padding: 0px 8px;
   `};

--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -31,6 +31,7 @@ import { currencyId } from '../../utils/currencyId'
 const PageWrapper = styled(AutoColumn)`
   max-width: 640px;
   width: 100%;
+  padding: 48px 0px 0px;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 0px 8px;
   `};

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -17,6 +17,7 @@ import { Countdown } from './Countdown'
 const PageWrapper = styled(AutoColumn)`
   max-width: 640px;
   width: 100%;
+  padding: 48px 0px 0px;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 0px 8px;
   `};

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -51,20 +51,24 @@ import { LoadingRows } from './styleds'
 const PageWrapper = styled.div`
   min-width: 800px;
   max-width: 960px;
+  padding: 68px 0px 0px;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
     min-width: 680px;
     max-width: 680px;
+    padding: 32px 8px 0px;
   `};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     min-width: 600px;
     max-width: 600px;
+    padding: 12px 8px 0px;
   `};
 
   @media only screen and (max-width: 620px) {
     min-width: 500px;
     max-width: 500px;
+    padding: 12px 8px 0px;
   }
 
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -27,13 +27,15 @@ import { LoadingRows } from './styleds'
 const PageWrapper = styled(AutoColumn)`
   max-width: 870px;
   width: 100%;
+  padding: 68px 0px 0px;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
     max-width: 800px;
-    padding: 0px 8px;
+    padding: 32px 8px 0px;
   `};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 12px 8px 0px;
     max-width: 500px;
   `};
 `

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -36,18 +36,21 @@ const Footer = styled.div`
 const TokenDetailsLayout = styled.div`
   display: flex;
   gap: 80px;
-  padding: 0px 20px;
+  padding: 68px 20px 0px;
   width: 100%;
   justify-content: center;
 
   @media only screen and (max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT}) {
     gap: 40px;
   }
+  @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
+    padding: 32px 20px 0px;
+  }
   @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
-    padding: 0px 16px;
+    padding: 32px 16px 0px;
   }
   @media only screen and (max-width: ${MOBILE_MEDIA_BREAKPOINT}) {
-    padding: 0px 8px;
+    padding: 32px 8px 0px;
   }
 `
 const RightPanel = styled.div`

--- a/src/pages/Tokens/index.tsx
+++ b/src/pages/Tokens/index.tsx
@@ -1,7 +1,11 @@
 import { Trans } from '@lingui/macro'
 import { PageName } from 'components/AmplitudeAnalytics/constants'
 import { Trace } from 'components/AmplitudeAnalytics/Trace'
-import { MAX_WIDTH_MEDIA_BREAKPOINT, MEDIUM_MEDIA_BREAKPOINT } from 'components/Tokens/constants'
+import {
+  LARGE_MEDIA_BREAKPOINT,
+  MAX_WIDTH_MEDIA_BREAKPOINT,
+  MEDIUM_MEDIA_BREAKPOINT,
+} from 'components/Tokens/constants'
 import { favoritesAtom, filterStringAtom } from 'components/Tokens/state'
 import FavoriteButton from 'components/Tokens/TokenTable/FavoriteButton'
 import NetworkFilter from 'components/Tokens/TokenTable/NetworkFilter'
@@ -18,7 +22,11 @@ import { ThemedText } from 'theme'
 const ExploreContainer = styled.div`
   width: 100%;
   min-width: 320px;
-  padding: 0px 12px;
+  padding: 60px 12px 0px;
+
+  @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
+    padding: 32px 12px 0px;
+  } ;
 `
 const TokenTableContainer = styled.div`
   padding: 16px 0px;

--- a/src/pages/Vote/Landing.tsx
+++ b/src/pages/Vote/Landing.tsx
@@ -33,6 +33,7 @@ import { UNI } from '../../constants/tokens'
 import { ProposalStatus } from './styled'
 
 const PageWrapper = styled(AutoColumn)`
+  padding: 48px 0px 0px;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 0px 8px;
   `};

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -57,6 +57,8 @@ import { ProposalStatus } from './styled'
 
 const PageWrapper = styled(AutoColumn)`
   width: 100%;
+  padding: 48px 0px 0px;
+
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 0px 8px;
   `};


### PR DESCRIPTION
- updating navbar padding across token pages
- following figma guideline when available. If no figma guidelines available defaulting to 120px padding on page and none for mobile