### PR TITLE
fix: respect padding in cells with proper hover

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -44,7 +44,7 @@ const Cell = styled.div`
   align-items: center;
   justify-content: center;
 `
-const StyledTokenRow = styled.div`
+const StyledTokenRow = styled.div<{ first?: boolean; last?: boolean }>`
   width: 100%;
   height: 60px;
   display: grid;
@@ -54,10 +54,14 @@ const StyledTokenRow = styled.div`
 
   max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT};
   min-width: 390px;
-  padding: 0px 12px;
+  padding-top: ${({ first }) => (first ? '4px' : '0px')};
+  padding-bottom: ${({ last }) => (last ? '4px' : '0px')};
+  padding-left: 12px;
+  padding-right: 12px;
 
   &:hover {
     background-color: ${({ theme }) => theme.accentActionSoft};
+    ${({ last }) => last && 'border-radius: 0px 0px 8px 8px;'}
   }
 
   @media only screen and (max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT}) {
@@ -351,6 +355,8 @@ export function TokenRow({
   marketCap,
   volume,
   sparkLine,
+  first,
+  last,
 }: {
   address: ReactNode
   header: boolean
@@ -362,6 +368,8 @@ export function TokenRow({
   marketCap: ReactNode
   volume: ReactNode
   sparkLine: ReactNode
+  first?: boolean
+  last?: boolean
 }) {
   const rowCells = (
     <>
@@ -376,7 +384,11 @@ export function TokenRow({
     </>
   )
   if (header) return <StyledHeaderRow>{rowCells}</StyledHeaderRow>
-  return <StyledTokenRow>{rowCells}</StyledTokenRow>
+  return (
+    <StyledTokenRow first={first} last={last}>
+      {rowCells}
+    </StyledTokenRow>
+  )
 }
 
 /* Header Row: top header row component for table */
@@ -534,6 +546,8 @@ export default function LoadedRow({
             <ParentSize>{({ width, height }) => <SparklineChart width={width} height={height} />}</ParentSize>
           </SparkLine>
         }
+        first={tokenListIndex === 0}
+        last={tokenListIndex === tokenListLength - 1}
       />
     </StyledLink>
   )

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -44,7 +44,6 @@ const NoTokenDisplay = styled.div`
   gap: 8px;
 `
 const TokenRowsContainer = styled.div`
-  padding: 4px 0px;
   width: 100%;
 `
 


### PR DESCRIPTION
before:
<img width="1079" alt="Screen Shot 2022-08-23 at 12 47 43 PM" src="https://user-images.githubusercontent.com/1307633/186215931-0e4736b6-422f-48bd-a86f-4e9dbfe60245.png">

<img width="1044" alt="Screen Shot 2022-08-23 at 12 47 48 PM" src="https://user-images.githubusercontent.com/1307633/186215958-65af7126-351e-4ae8-8413-cd1465033dec.png">

after:

<img width="1054" alt="Screen Shot 2022-08-23 at 12 45 56 PM" src="https://user-images.githubusercontent.com/1307633/186216011-01c3b7aa-61f8-49c4-b527-54a8120df4c1.png">

<img width="1045" alt="Screen Shot 2022-08-23 at 12 46 02 PM" src="https://user-images.githubusercontent.com/1307633/186216050-4755606f-0de2-4796-9be8-f2c194e9c768.png">

