### PR TITLE
fix: makes SearchBar focus border-width consistent

### DIFF
--- a/src/components/Tokens/TokenTable/SearchBar.tsx
+++ b/src/components/Tokens/TokenTable/SearchBar.tsx
@@ -32,8 +32,9 @@ const SearchInput = styled.input`
   :focus {
     outline: none;
     background-color: ${({ theme }) => theme.backgroundSurface};
-    border: 1.5px solid ${({ theme }) => theme.accentActionSoft};
+    border-color: ${({ theme }) => theme.accentActionSoft};
   }
+
   ::placeholder {
     color: ${({ theme }) => theme.textTertiary};
   }


### PR DESCRIPTION
The border-width for the non-focused state is 1.5px, so we should not change that on focus.

Avoids this case:
https://user-images.githubusercontent.com/4899429/186234237-8f7c20cc-2ede-442c-8252-4e8e431867ae.mov

