### PR TITLE
feat: Adding in remaining transactions to transaction history

### DIFF
--- a/src/components/AccountDetailsV2/LogoView.tsx
+++ b/src/components/AccountDetailsV2/LogoView.tsx
@@ -1,11 +1,11 @@
+import { useWeb3React } from '@web3-react/core'
+import { UNI_ADDRESS } from 'constants/addresses'
 import { TransactionInfo, TransactionType } from 'state/transactions/types'
 import styled, { css } from 'styled-components/macro'
-import { UNI_ADDRESS } from 'constants/addresses'
 
+import { nativeOnChain } from '../../constants/tokens'
 import { useCurrency } from '../../hooks/Tokens'
 import CurrencyLogo from '../CurrencyLogo'
-import { nativeOnChain } from '../../constants/tokens'
-import { useWeb3React } from '@web3-react/core'
 
 const CurrencyWrap = styled.div`
   position: relative;
@@ -53,7 +53,7 @@ const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number
       return { currencyId0: unwrapped ? wrappedCurrency : base, currencyId1: unwrapped ? base : wrappedCurrency }
     case TransactionType.COLLECT_FEES:
       const { currencyId0, currencyId1 } = info
-      return { currencyId0: currencyId0, currencyId1: currencyId1 }
+      return { currencyId0, currencyId1 }
     case TransactionType.APPROVAL:
       return { currencyId0: info.tokenAddress, currencyId1: undefined }
     case TransactionType.CLAIM:

--- a/src/components/AccountDetailsV2/LogoView.tsx
+++ b/src/components/AccountDetailsV2/LogoView.tsx
@@ -47,7 +47,6 @@ const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number
       return { currencyId0: inputCurrencyId, currencyId1: outputCurrencyId }
     case TransactionType.WRAP:
       const { unwrapped } = info
-
       const native = info.chainId ? nativeOnChain(info.chainId) : undefined
       const base = 'ETH'
       const wrappedCurrency = native?.wrapped.address ?? 'WETH'

--- a/src/components/AccountDetailsV2/LogoView.tsx
+++ b/src/components/AccountDetailsV2/LogoView.tsx
@@ -35,7 +35,7 @@ interface CurrencyPair {
   currencyId1: string | undefined
 }
 
-const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number }): CurrencyPair => {
+const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number | undefined }): CurrencyPair => {
   switch (info.type) {
     case TransactionType.ADD_LIQUIDITY_V3_POOL:
     case TransactionType.REMOVE_LIQUIDITY_V3:
@@ -57,7 +57,7 @@ const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number
     case TransactionType.APPROVAL:
       return { currencyId0: info.tokenAddress, currencyId1: undefined }
     case TransactionType.CLAIM:
-      const uniAddress = UNI_ADDRESS[chainId]
+      const uniAddress = UNI_ADDRESS[chainId || -1]
       return { currencyId0: uniAddress, currencyId1: undefined }
     default:
       return { currencyId0: undefined, currencyId1: undefined }
@@ -65,7 +65,7 @@ const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number
 }
 
 const LogoView = ({ info }: { info: TransactionInfo }) => {
-  const { chainId = 1 } = useWeb3React()
+  const { chainId } = useWeb3React()
   const { currencyId0, currencyId1 } = getCurrency({ info, chainId })
   const currency0 = useCurrency(currencyId0)
   const currency1 = useCurrency(currencyId1)

--- a/src/components/AccountDetailsV2/LogoView.tsx
+++ b/src/components/AccountDetailsV2/LogoView.tsx
@@ -57,7 +57,7 @@ const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number
     case TransactionType.APPROVAL:
       return { currencyId0: info.tokenAddress, currencyId1: undefined }
     case TransactionType.CLAIM:
-      const uniAddress = UNI_ADDRESS[chainId || -1]
+      const uniAddress = chainId ? UNI_ADDRESS[chainId] : undefined
       return { currencyId0: uniAddress, currencyId1: undefined }
     default:
       return { currencyId0: undefined, currencyId1: undefined }

--- a/src/components/AccountDetailsV2/LogoView.tsx
+++ b/src/components/AccountDetailsV2/LogoView.tsx
@@ -1,8 +1,11 @@
 import { TransactionInfo, TransactionType } from 'state/transactions/types'
 import styled, { css } from 'styled-components/macro'
+import { UNI_ADDRESS } from 'constants/addresses'
 
 import { useCurrency } from '../../hooks/Tokens'
 import CurrencyLogo from '../CurrencyLogo'
+import { nativeOnChain } from '../../constants/tokens'
+import { useWeb3React } from '@web3-react/core'
 
 const CurrencyWrap = styled.div`
   position: relative;
@@ -32,22 +35,39 @@ interface CurrencyPair {
   currencyId1: string | undefined
 }
 
-const getCurrency = ({ info }: { info: TransactionInfo }): CurrencyPair => {
+const getCurrency = ({ info, chainId }: { info: TransactionInfo; chainId: number }): CurrencyPair => {
   switch (info.type) {
     case TransactionType.ADD_LIQUIDITY_V3_POOL:
     case TransactionType.REMOVE_LIQUIDITY_V3:
+    case TransactionType.CREATE_V3_POOL:
       const { baseCurrencyId, quoteCurrencyId } = info
       return { currencyId0: baseCurrencyId, currencyId1: quoteCurrencyId }
     case TransactionType.SWAP:
       const { inputCurrencyId, outputCurrencyId } = info
       return { currencyId0: inputCurrencyId, currencyId1: outputCurrencyId }
+    case TransactionType.WRAP:
+      const { unwrapped } = info
+
+      const native = info.chainId ? nativeOnChain(info.chainId) : undefined
+      const base = 'ETH'
+      const wrappedCurrency = native?.wrapped.address ?? 'WETH'
+      return { currencyId0: unwrapped ? wrappedCurrency : base, currencyId1: unwrapped ? base : wrappedCurrency }
+    case TransactionType.COLLECT_FEES:
+      const { currencyId0, currencyId1 } = info
+      return { currencyId0: currencyId0, currencyId1: currencyId1 }
+    case TransactionType.APPROVAL:
+      return { currencyId0: info.tokenAddress, currencyId1: undefined }
+    case TransactionType.CLAIM:
+      const uniAddress = UNI_ADDRESS[chainId]
+      return { currencyId0: uniAddress, currencyId1: undefined }
     default:
       return { currencyId0: undefined, currencyId1: undefined }
   }
 }
 
 const LogoView = ({ info }: { info: TransactionInfo }) => {
-  const { currencyId0, currencyId1 } = getCurrency({ info })
+  const { chainId = 1 } = useWeb3React()
+  const { currencyId0, currencyId1 } = getCurrency({ info, chainId })
   const currency0 = useCurrency(currencyId0)
   const currency1 = useCurrency(currencyId1)
   const isCentered = !(currency0 && currency1)

--- a/src/components/AccountDetailsV2/TransactionBody.tsx
+++ b/src/components/AccountDetailsV2/TransactionBody.tsx
@@ -15,11 +15,11 @@ import {
 } from 'state/transactions/types'
 import styled from 'styled-components/macro'
 
+import { nativeOnChain } from '../../constants/tokens'
 import { useCurrency, useToken } from '../../hooks/Tokens'
-import { TransactionState } from './index'
 import useENSName from '../../hooks/useENSName'
 import { shortenAddress } from '../../utils'
-import { nativeOnChain } from '../../constants/tokens'
+import { TransactionState } from './index'
 
 const HighlightText = styled.span`
   color: ${({ theme }) => theme.textPrimary};

--- a/src/components/AccountDetailsV2/TransactionBody.tsx
+++ b/src/components/AccountDetailsV2/TransactionBody.tsx
@@ -3,16 +3,23 @@ import { Fraction, TradeType } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 import {
   AddLiquidityV3PoolTransactionInfo,
+  ApproveTransactionInfo,
+  ClaimTransactionInfo,
+  CollectFeesTransactionInfo,
   ExactInputSwapTransactionInfo,
   ExactOutputSwapTransactionInfo,
   RemoveLiquidityV3TransactionInfo,
   TransactionInfo,
   TransactionType,
+  WrapTransactionInfo,
 } from 'state/transactions/types'
 import styled from 'styled-components/macro'
 
-import { useCurrency } from '../../hooks/Tokens'
+import { useCurrency, useToken } from '../../hooks/Tokens'
 import { TransactionState } from './index'
+import useENSName from '../../hooks/useENSName'
+import { shortenAddress } from '../../utils'
+import { nativeOnChain } from '../../constants/tokens'
 
 const HighlightText = styled.span`
   color: ${({ theme }) => theme.textPrimary};
@@ -180,6 +187,128 @@ const CreateV3PoolSummary = ({
   )
 }
 
+const CollectFeesSummary = ({
+  info,
+  transactionState,
+}: {
+  info: CollectFeesTransactionInfo
+  transactionState: TransactionState
+}) => {
+  const { currencyId0, expectedCurrencyOwed0 = '0', expectedCurrencyOwed1 = '0', currencyId1 } = info
+  const actionProps = {
+    transactionState,
+    pending: <Trans>Collecting</Trans>,
+    success: <Trans>Collected</Trans>,
+    failed: <Trans>Collect</Trans>,
+  }
+
+  return (
+    <>
+      <Action {...actionProps} />{' '}
+      <FormattedCurrencyAmount rawAmount={expectedCurrencyOwed0} currencyId={currencyId0} sigFigs={2} />{' '}
+      <Trans>and</Trans>{' '}
+      <FormattedCurrencyAmount rawAmount={expectedCurrencyOwed1} currencyId={currencyId1} sigFigs={2} />{' '}
+      <Trans>fees</Trans> <FailedText transactionState={transactionState} />
+    </>
+  )
+}
+
+const ApprovalSummary = ({
+  info,
+  transactionState,
+}: {
+  info: ApproveTransactionInfo
+  transactionState: TransactionState
+}) => {
+  const token = useToken(info.tokenAddress)
+  const actionProps = {
+    transactionState,
+    pending: <Trans>Approving</Trans>,
+    success: <Trans>Approved</Trans>,
+    failed: <Trans>Approve</Trans>,
+  }
+
+  return (
+    <>
+      <Action {...actionProps} /> <HighlightText>{token?.symbol}</HighlightText>{' '}
+      <FailedText transactionState={transactionState} />
+    </>
+  )
+}
+
+const ClaimSummary = ({
+  info: { recipient, uniAmountRaw },
+  transactionState,
+}: {
+  info: ClaimTransactionInfo
+  transactionState: TransactionState
+}) => {
+  const { ENSName } = useENSName()
+  const actionProps = {
+    transactionState,
+    pending: <Trans>Claiming</Trans>,
+    success: <Trans>Claimed</Trans>,
+    failed: <Trans>Claim</Trans>,
+  }
+
+  return (
+    <>
+      {uniAmountRaw && (
+        <>
+          <Action {...actionProps} />{' '}
+          <HighlightText>
+            {formatAmount(uniAmountRaw, 18, 4)}
+            <Trans>UNI</Trans>{' '}
+          </HighlightText>{' '}
+          <Trans>for</Trans> <HighlightText>{ENSName ?? shortenAddress(recipient)}</HighlightText>
+        </>
+      )}{' '}
+      <FailedText transactionState={transactionState} />
+    </>
+  )
+}
+
+const WrapSummary = ({
+  info: { chainId, currencyAmountRaw, unwrapped },
+  transactionState,
+}: {
+  info: WrapTransactionInfo
+  transactionState: TransactionState
+}) => {
+  const native = chainId ? nativeOnChain(chainId) : undefined
+  const from = unwrapped ? native?.wrapped.symbol ?? 'WETH' : native?.symbol ?? 'ETH'
+  const to = unwrapped ? native?.symbol ?? 'ETH' : native?.wrapped.symbol ?? 'WETH'
+
+  const amount = formatAmount(currencyAmountRaw, 18, 6)
+  const actionProps = unwrapped
+    ? {
+        transactionState,
+        pending: <Trans>Unwrapping</Trans>,
+        success: <Trans>Unwrapped</Trans>,
+        failed: <Trans>Unwrap</Trans>,
+      }
+    : {
+        transactionState,
+        pending: <Trans>Wrapping</Trans>,
+        success: <Trans>Wrapped</Trans>,
+        failed: <Trans>Wrap</Trans>,
+      }
+
+  return (
+    <>
+      <Action {...actionProps} />{' '}
+      <HighlightText>
+        {amount} {from}
+      </HighlightText>{' '}
+      <Trans>to</Trans>{' '}
+      <HighlightText>
+        {amount} {to}
+      </HighlightText>{' '}
+      <FailedText transactionState={transactionState} />
+    </>
+  )
+}
+
 const TransactionBody = ({ info, transactionState }: { info: TransactionInfo; transactionState: TransactionState }) => {
   switch (info.type) {
     case TransactionType.SWAP:
@@ -188,6 +317,14 @@ const TransactionBody = ({ info, transactionState }: { info: TransactionInfo; tr
       return <AddLiquidityV3PoolSummary info={info} transactionState={transactionState} />
     case TransactionType.REMOVE_LIQUIDITY_V3:
       return <RemoveLiquidityV3Summary info={info} transactionState={transactionState} />
+    case TransactionType.WRAP:
+      return <WrapSummary info={info} transactionState={transactionState} />
+    case TransactionType.COLLECT_FEES:
+      return <CollectFeesSummary info={info} transactionState={transactionState} />
+    case TransactionType.APPROVAL:
+      return <ApprovalSummary info={info} transactionState={transactionState} />
+    case TransactionType.CLAIM:
+      return <ClaimSummary info={info} transactionState={transactionState} />
     default:
       return <span />
   }

--- a/src/components/AccountDetailsV2/TransactionBody.tsx
+++ b/src/components/AccountDetailsV2/TransactionBody.tsx
@@ -26,6 +26,10 @@ const HighlightText = styled.span`
   font-weight: 600;
 `
 
+const BodyWrap = styled.div`
+  line-height: 20px;
+`
+
 interface ActionProps {
   pending: JSX.Element
   success: JSX.Element
@@ -92,13 +96,13 @@ const SwapSummary = ({
   const { rawAmountFrom, rawAmountTo } = getRawAmounts(info)
 
   return (
-    <>
+    <BodyWrap>
       <Action {...actionProps} />{' '}
       <FormattedCurrencyAmount rawAmount={rawAmountFrom} currencyId={info.inputCurrencyId} sigFigs={2} />{' '}
       <Trans>for </Trans>{' '}
       <FormattedCurrencyAmount rawAmount={rawAmountTo} currencyId={info.outputCurrencyId} sigFigs={2} />{' '}
       <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -119,7 +123,7 @@ const AddLiquidityV3PoolSummary = ({
   }
 
   return (
-    <>
+    <BodyWrap>
       {createPool ? (
         <CreateV3PoolSummary info={info} transactionState={transactionState} />
       ) : (
@@ -131,7 +135,7 @@ const AddLiquidityV3PoolSummary = ({
         </>
       )}{' '}
       <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -150,13 +154,13 @@ const RemoveLiquidityV3Summary = ({
   }
 
   return (
-    <>
+    <BodyWrap>
       <Action {...actionProps} />{' '}
       <FormattedCurrencyAmount rawAmount={expectedAmountBaseRaw} currencyId={baseCurrencyId} sigFigs={2} />{' '}
       <Trans>and</Trans>{' '}
       <FormattedCurrencyAmount rawAmount={expectedAmountQuoteRaw} currencyId={quoteCurrencyId} sigFigs={2} />{' '}
       <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -177,13 +181,13 @@ const CreateV3PoolSummary = ({
   }
 
   return (
-    <>
+    <BodyWrap>
       <Action {...actionProps} />{' '}
       <HighlightText>
         {baseCurrency?.symbol}/{quoteCurrency?.symbol}{' '}
       </HighlightText>
       <Trans>Pool</Trans> <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -203,13 +207,13 @@ const CollectFeesSummary = ({
   }
 
   return (
-    <>
+    <BodyWrap>
       <Action {...actionProps} />{' '}
       <FormattedCurrencyAmount rawAmount={expectedCurrencyOwed0} currencyId={currencyId0} sigFigs={2} />{' '}
       <Trans>and</Trans>{' '}
       <FormattedCurrencyAmount rawAmount={expectedCurrencyOwed1} currencyId={currencyId1} sigFigs={2} />{' '}
       <Trans>fees</Trans> <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -229,10 +233,10 @@ const ApprovalSummary = ({
   }
 
   return (
-    <>
+    <BodyWrap>
       <Action {...actionProps} /> <HighlightText>{token?.symbol}</HighlightText>{' '}
       <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -252,7 +256,7 @@ const ClaimSummary = ({
   }
 
   return (
-    <>
+    <BodyWrap>
       {uniAmountRaw && (
         <>
           <Action {...actionProps} />{' '}
@@ -264,7 +268,7 @@ const ClaimSummary = ({
         </>
       )}{' '}
       <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 
@@ -295,7 +299,7 @@ const WrapSummary = ({
       }
 
   return (
-    <>
+    <BodyWrap>
       <Action {...actionProps} />{' '}
       <HighlightText>
         {amount} {from}
@@ -305,7 +309,7 @@ const WrapSummary = ({
         {amount} {to}
       </HighlightText>{' '}
       <FailedText transactionState={transactionState} />
-    </>
+    </BodyWrap>
   )
 }
 

--- a/src/components/Popups/PopupItem.tsx
+++ b/src/components/Popups/PopupItem.tsx
@@ -1,9 +1,9 @@
+import { NavBarVariant, useNavBarFlag } from 'featureFlags/flags/navBar'
 import { useCallback, useEffect } from 'react'
 import { X } from 'react-feather'
 import { animated } from 'react-spring'
 import { useSpring } from 'react-spring/web'
 import styled, { useTheme } from 'styled-components/macro'
-import { NavBarVariant, useNavBarFlag } from 'featureFlags/flags/navBar'
 
 import { useRemovePopup } from '../../state/application/hooks'
 import { PopupContent } from '../../state/application/reducer'
@@ -73,6 +73,11 @@ export default function PopupItem({
   }, [removeAfterMs, removeThisPopup])
 
   const theme = useTheme()
+  const faderStyle = useSpring({
+    from: { width: '100%' },
+    to: { width: '0%' },
+    config: { duration: removeAfterMs ?? undefined },
+  })
 
   let popupContent
   if ('txn' in content) {
@@ -85,12 +90,6 @@ export default function PopupItem({
   } else if ('failedSwitchNetwork' in content) {
     popupContent = <FailedNetworkSwitchPopup chainId={content.failedSwitchNetwork} />
   }
-
-  const faderStyle = useSpring({
-    from: { width: '100%' },
-    to: { width: '0%' },
-    config: { duration: removeAfterMs ?? undefined },
-  })
 
   return (
     <Popup>

--- a/src/components/Popups/PopupItem.tsx
+++ b/src/components/Popups/PopupItem.tsx
@@ -3,6 +3,7 @@ import { X } from 'react-feather'
 import { animated } from 'react-spring'
 import { useSpring } from 'react-spring/web'
 import styled, { useTheme } from 'styled-components/macro'
+import { NavBarVariant, useNavBarFlag } from 'featureFlags/flags/navBar'
 
 import { useRemovePopup } from '../../state/application/hooks'
 import { PopupContent } from '../../state/application/reducer'
@@ -57,6 +58,7 @@ export default function PopupItem({
   popKey: string
 }) {
   const removePopup = useRemovePopup()
+  const navbarFlag = useNavBarFlag()
   const removeThisPopup = useCallback(() => removePopup(popKey), [popKey, removePopup])
   useEffect(() => {
     if (removeAfterMs === null) return undefined
@@ -77,6 +79,8 @@ export default function PopupItem({
     const {
       txn: { hash },
     } = content
+    if (navbarFlag === NavBarVariant.Enabled) return null
+
     popupContent = <TransactionPopup hash={hash} />
   } else if ('failedSwitchNetwork' in content) {
     popupContent = <FailedNetworkSwitchPopup chainId={content.failedSwitchNetwork} />

--- a/src/components/WalletDropdown/SlideOutMenu.tsx
+++ b/src/components/WalletDropdown/SlideOutMenu.tsx
@@ -48,6 +48,7 @@ const BackSection = styled.div`
   cursor: default;
   display: flex;
   justify-content: space-between;
+  z-index: 1;
 `
 
 const BackSectionContainer = styled.div`


### PR DESCRIPTION
This is a follow up to this commit
https://github.com/Uniswap/interface/commit/9b07d8ce64878f5becf88cb6d8e77639b3493299

Added the following transactions

Wrap
Collect Fees
Approval
Claim


I tested, this is what it looks like

<img width="339" alt="Screen Shot 2022-08-23 at 4 31 04 PM" src="https://user-images.githubusercontent.com/15934595/186259764-157729c9-e61a-4743-b521-b888dfe7826b.png">
<img width="360" alt="Screen Shot 2022-08-23 at 4 31 10 PM" src="https://user-images.githubusercontent.com/15934595/186259766-6266ea81-36a3-4602-bb9a-0efd8fad4150.png">
<img width="358" alt="Screen Shot 2022-08-23 at 4 31 13 PM" src="https://user-images.githubusercontent.com/15934595/186259767-b8ea1573-aa59-44cb-bdbb-fbe2f9eea731.png">


This is preloaded txs, but what uni and eth look like

<img width="355" alt="Screen Shot 2022-08-23 at 4 38 36 PM" src="https://user-images.githubusercontent.com/15934595/186260996-c3e85fbf-6597-4c96-87cb-5d8e6f3944c3.png">

