### PR TITLE
fix: /pool position second icon zindex issue

### DIFF
--- a/src/components/DoubleLogo/index.tsx
+++ b/src/components/DoubleLogo/index.tsx
@@ -18,7 +18,7 @@ interface DoubleCurrencyLogoProps {
 }
 
 const HigherLogo = styled(CurrencyLogo)`
-  z-index: 2;
+  z-index: 1;
 `
 const CoveredLogo = styled(CurrencyLogo)<{ sizeraw: number }>`
   position: absolute;


### PR DESCRIPTION
The secondary icon on pool positions had a high zindex which caused it to display over navbar on scroll.

Before:
![Screen Shot 2022-08-23 at 18 05 13 ](https://user-images.githubusercontent.com/11512321/186295211-b2db081a-fac2-4660-894f-7a87715501f9.png)

After:
![Screen Shot 2022-08-23 at 18 05 03 ](https://user-images.githubusercontent.com/11512321/186295227-a4a57336-3fea-4385-a7fd-d0e8be3e1658.png)
