### PR TITLE
feat: fix visual bugs on truncate token description

### DIFF
--- a/src/components/Tokens/TokenDetails/TokenDetail.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDetail.tsx
@@ -124,6 +124,7 @@ export const TopArea = styled.div`
 `
 export const ResourcesContainer = styled.div`
   display: flex;
+  padding-top: 12px;
   gap: 14px;
 `
 const NetworkBadge = styled.div<{ networkColor?: string; backgroundColor?: string }>`
@@ -188,7 +189,7 @@ const TruncateDescriptionButton = styled.div`
   color: ${({ theme }) => theme.textSecondary};
   font-weight: 400;
   font-size: 14px;
-  padding: 14px 0px;
+  padding-top: 14px;
 
   &:hover,
   &:focus {
@@ -234,16 +235,18 @@ export function AboutSection({ address, tokenDetailData }: { address: string; to
       <AboutHeader>
         <Trans>About</Trans>
       </AboutHeader>
-      {(!tokenDetailData || !tokenDetailData.description) && (
-        <NoInfoAvailable>
-          <Trans>No token information available</Trans>
-        </NoInfoAvailable>
-      )}
       <TokenDescriptionContainer>
+        {(!tokenDetailData || !tokenDetailData.description) && (
+          <NoInfoAvailable>
+            <Trans>No token information available</Trans>
+          </NoInfoAvailable>
+        )}
         {tokenDescription}
-        <TruncateDescriptionButton onClick={() => setIsDescriptionTruncated(!isDescriptionTruncated)}>
-          {isDescriptionTruncated ? <Trans>Read more</Trans> : <Trans>Hide</Trans>}
-        </TruncateDescriptionButton>
+        {shouldTruncate && (
+          <TruncateDescriptionButton onClick={() => setIsDescriptionTruncated(!isDescriptionTruncated)}>
+            {isDescriptionTruncated ? <Trans>Read more</Trans> : <Trans>Hide</Trans>}
+          </TruncateDescriptionButton>
+        )}
       </TokenDescriptionContainer>
       <ResourcesContainer>
         <Resource name={'Etherscan'} link={`https://etherscan.io/address/${address}`} />


### PR DESCRIPTION
1. Fix styling when no token info available
![Screen Shot 2022-08-24 at 12 12 31 PM](https://user-images.githubusercontent.com/41491154/186470158-9a5ce84a-2a49-46da-83e8-1b5617794fd6.png)

2. Make sure Read more button doesn't display when token description is short enough (sub 400 char)
![Screen Shot 2022-08-24 at 12 12 54 PM](https://user-images.githubusercontent.com/41491154/186470203-44097807-bf02-4bd4-b53a-b96a8c2a36b1.png)

