### PR TITLE
fix: don't translate UNI

### DIFF
--- a/src/components/AccountDetailsV2/TransactionBody.tsx
+++ b/src/components/AccountDetailsV2/TransactionBody.tsx
@@ -262,7 +262,7 @@ const ClaimSummary = ({
           <Action {...actionProps} />{' '}
           <HighlightText>
             {formatAmount(uniAmountRaw, 18, 4)}
-            <Trans>UNI</Trans>{' '}
+            UNI{' '}
           </HighlightText>{' '}
           <Trans>for</Trans> <HighlightText>{ENSName ?? shortenAddress(recipient)}</HighlightText>
         </>


### PR DESCRIPTION
Noticed this while reviewing the most recent Crowdin PR.
