### PR TITLE
fix: remove UNI currency logo from swap widget approval button

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -39,7 +39,6 @@ import { ButtonConfirmed, ButtonError, ButtonLight, ButtonPrimary } from '../../
 import { GreyCard } from '../../components/Card'
 import { AutoColumn } from '../../components/Column'
 import SwapCurrencyInputPanel from '../../components/CurrencyInputPanel/SwapCurrencyInputPanel'
-import CurrencyLogo from '../../components/CurrencyLogo'
 import Loader from '../../components/Loader'
 import { AutoRow } from '../../components/Row'
 import confirmPriceImpactWithoutFee from '../../components/swap/confirmPriceImpactWithoutFee'
@@ -702,11 +701,6 @@ export default function Swap() {
                           >
                             <AutoRow justify="space-between" style={{ flexWrap: 'nowrap' }}>
                               <span style={{ display: 'flex', alignItems: 'center' }}>
-                                <CurrencyLogo
-                                  currency={currencies[Field.INPUT]}
-                                  size={'20px'}
-                                  style={{ marginRight: '8px', flexShrink: 0 }}
-                                />
                                 {/* we need to shorten this string on mobile */}
                                 {approvalState === ApprovalState.APPROVED ||
                                 signatureState === UseERC20PermitState.SIGNED ? (


### PR DESCRIPTION
removes UNI currency logo from swap widget approval button - https://uniswaplabs.atlassian.net/browse/WEB-920

before:
![image](https://user-images.githubusercontent.com/62825936/186479122-70a075e9-046a-4d2d-989b-4af34677b7ba.png)


expected:
![image](https://user-images.githubusercontent.com/62825936/186479151-dbbe5464-2eb2-47fe-b73c-1ea6ee10fe18.png)
