### PR TITLE
fix: fix decimal formatting of token price on details page

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -218,14 +218,11 @@ export function PriceChart({ width, height, token }: PriceChartProps) {
   const [delta, arrow] = getDelta(startingPrice.value, displayPrice.value)
   const crosshairEdgeMax = width * 0.85
   const crosshairAtEdge = !!crosshair && crosshair > crosshairEdgeMax
-  const priceNumDecimalPlaces = displayPrice.value < 1.05 ? 4 : 2
 
   return (
     <>
       <ChartHeader>
-        <TokenPrice>
-          {displayPrice.value < 0.0001 ? '$<0.0001' : displayPrice.value.toFixed(priceNumDecimalPlaces)}
-        </TokenPrice>
+        <TokenPrice>{displayPrice.value < 0.000001 ? '$<0.000001' : displayPrice.value.toFixed(6)}</TokenPrice>
         <DeltaContainer>
           {delta}
           <ArrowCell>{arrow}</ArrowCell>

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -218,11 +218,14 @@ export function PriceChart({ width, height, token }: PriceChartProps) {
   const [delta, arrow] = getDelta(startingPrice.value, displayPrice.value)
   const crosshairEdgeMax = width * 0.85
   const crosshairAtEdge = !!crosshair && crosshair > crosshairEdgeMax
+  const priceNumDecimalPlaces = displayPrice.value < 1.05 ? 4 : 2
 
   return (
     <>
       <ChartHeader>
-        <TokenPrice>${displayPrice.value.toFixed(2)}</TokenPrice>
+        <TokenPrice>
+          {displayPrice.value < 0.0001 ? '$<0.0001' : displayPrice.value.toFixed(priceNumDecimalPlaces)}
+        </TokenPrice>
         <DeltaContainer>
           {delta}
           <ArrowCell>{arrow}</ArrowCell>

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -222,7 +222,7 @@ export function PriceChart({ width, height, token }: PriceChartProps) {
   return (
     <>
       <ChartHeader>
-        <TokenPrice>{displayPrice.value < 0.000001 ? '$<0.000001' : displayPrice.value.toFixed(6)}</TokenPrice>
+        <TokenPrice>${displayPrice.value < 0.000001 ? '<0.000001' : displayPrice.value.toFixed(6)}</TokenPrice>
         <DeltaContainer>
           {delta}
           <ArrowCell>{arrow}</ArrowCell>

--- a/src/utils/formatDollarAmt.tsx
+++ b/src/utils/formatDollarAmt.tsx
@@ -6,7 +6,7 @@ export const formatDollarAmount = (num: number | undefined, digits = 2, round = 
   if (num === 0) return '0'
   if (!num) return '-'
   if (num < 0.001 && digits <= 3) {
-    return '<0.001'
+    return '$<0.001'
   }
 
   return numbro(num)
@@ -26,7 +26,7 @@ export const formatAmount = (num: number | undefined, digits = 2) => {
   if (num === 0) return '0'
   if (!num) return '-'
   if (num < 0.001) {
-    return '<0.001'
+    return '$<0.001'
   }
   return numbro(num).format({
     average: true,


### PR DESCRIPTION
Fix price formatting on token details page: Show 6 decimal points or <0.000001 (i.e. shouldn't show $0.00) - https://uniswaplabs.atlassian.net/browse/WEB-881

before:
![image](https://user-images.githubusercontent.com/62825936/186486541-cf97d105-cb13-4863-8053-7a768f3833d0.png)

after:
<img width="940" alt="Screen Shot 2022-08-26 at 10 18 53 AM" src="https://user-images.githubusercontent.com/62825936/186958358-0e228b1b-f70a-45fa-a57b-d1862a581aa2.png">