### PR TITLE
fix: Fixing token modal warning to match figma design

### DIFF
--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -11,7 +11,6 @@ import { Text } from 'rebass'
 import { useAddUserToken } from 'state/user/hooks'
 import styled from 'styled-components/macro'
 import { ButtonText, CopyLinkIcon, ExternalLink } from 'theme'
-import { Color } from 'theme/styled'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 
 const Wrapper = styled.div`

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -79,7 +79,7 @@ const Buttons = ({
   onContinue: () => void
   onCancel: () => void
 }) => {
-  return warning.canProceed ? (
+  return !warning.canProceed ? (
     <>
       <StyledButton onClick={onContinue}>
         <Trans>I understand</Trans>
@@ -179,6 +179,10 @@ function ExplorerView({ token }: { token: Token }) {
   }
 }
 
+const StyledExternalLink = styled(ExternalLink)`
+  font-weight: 600;
+`
+
 interface TokenSafetyProps {
   tokenAddress: string | null
   secondTokenAddress?: string
@@ -243,9 +247,9 @@ export default function TokenSafety({ tokenAddress, secondTokenAddress, onContin
           <ShortColumn>
             <InfoText>
               {description}{' '}
-              <ExternalLink style={{ fontWeight: 600 }} href={TOKEN_SAFETY_ARTICLE}>
+              <StyledExternalLink href={TOKEN_SAFETY_ARTICLE}>
                 <Trans>Learn more</Trans>
-              </ExternalLink>
+              </StyledExternalLink>
             </InfoText>
           </ShortColumn>
           <LinkColumn>{urls}</LinkColumn>

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -4,12 +4,12 @@ import { ButtonPrimary } from 'components/Button'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
 import TokenSafetyLabel from 'components/TokenSafety/TokenSafetyLabel'
-import { checkWarning, getWarningCopy, TOKEN_SAFETY_ARTICLE, Warning, WARNING_LEVEL } from 'constants/tokenSafety'
+import { checkWarning, getWarningCopy, TOKEN_SAFETY_ARTICLE, Warning } from 'constants/tokenSafety'
 import { useToken } from 'hooks/Tokens'
 import { ExternalLink as LinkIconFeather } from 'react-feather'
 import { Text } from 'rebass'
 import { useAddUserToken } from 'state/user/hooks'
-import styled, { useTheme } from 'styled-components/macro'
+import styled from 'styled-components/macro'
 import { ButtonText, CopyLinkIcon, ExternalLink } from 'theme'
 import { Color } from 'theme/styled'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
@@ -46,19 +46,28 @@ const InfoText = styled(Text)`
   text-align: center;
 `
 
-const StyledButton = styled(ButtonPrimary)<{ buttonColor: Color; textColor: Color }>`
-  color: ${({ textColor }) => textColor};
-  background-color: ${({ buttonColor }) => buttonColor};
+const StyledButton = styled(ButtonPrimary)`
   margin-top: 24px;
   width: 100%;
-  :hover {
-    background-color: ${({ buttonColor, theme }) => buttonColor ?? theme.accentAction};
+  font-weight: 600;
+`
+
+const StyledCloseButton = styled(StyledButton)`
+  background-color: ${({ theme }) => theme.backgroundInteractive};
+  color: ${({ theme }) => theme.textPrimary};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.backgroundInteractive};
+    opacity: 0.6;
+    transition: opacity 250ms ease;
   }
 `
 
 const StyledCancelButton = styled(ButtonText)<{ color?: Color }>`
   margin-top: 16px;
-  color: ${({ color, theme }) => color ?? theme.accentAction};
+  color: ${({ color, theme }) => color ?? theme.textSecondary};
+  font-weight: 600;
+  font-size: 14px;
 `
 
 const Buttons = ({
@@ -70,37 +79,17 @@ const Buttons = ({
   onContinue: () => void
   onCancel: () => void
 }) => {
-  const theme = useTheme()
-  let textColor, buttonColor, cancelColor
-  switch (warning.level) {
-    case WARNING_LEVEL.MEDIUM:
-      textColor = theme.white
-      buttonColor = theme.accentAction
-      cancelColor = theme.accentAction
-      break
-    case WARNING_LEVEL.UNKNOWN:
-      textColor = theme.accentFailure
-      buttonColor = theme.accentFailureSoft
-      cancelColor = theme.textPrimary
-      break
-    case WARNING_LEVEL.BLOCKED:
-      textColor = theme.textPrimary
-      buttonColor = theme.backgroundInteractive
-      break
-  }
   return warning.canProceed ? (
     <>
-      <StyledButton buttonColor={buttonColor} textColor={textColor} onClick={onContinue}>
+      <StyledButton onClick={onContinue}>
         <Trans>I understand</Trans>
       </StyledButton>
-      <StyledCancelButton color={cancelColor} onClick={onCancel}>
-        Cancel
-      </StyledCancelButton>
+      <StyledCancelButton onClick={onCancel}>Cancel</StyledCancelButton>
     </>
   ) : (
-    <StyledButton buttonColor={buttonColor} textColor={textColor} onClick={onCancel}>
+    <StyledCloseButton onClick={onCancel}>
       <Trans>Close</Trans>
-    </StyledButton>
+    </StyledCloseButton>
   )
 }
 
@@ -124,8 +113,8 @@ const ExplorerContainer = styled.div`
   height: 32px;
   margin-top: 10px;
   font-size: 20px;
-  background-color: ${({ theme }) => theme.accentActiveSoft};
-  color: ${({ theme }) => theme.accentActive};
+  background-color: ${({ theme }) => theme.accentActionSoft};
+  color: ${({ theme }) => theme.accentAction};
   border-radius: 8px;
   padding: 2px 12px;
   display: flex;
@@ -254,7 +243,7 @@ export default function TokenSafety({ tokenAddress, secondTokenAddress, onContin
           <ShortColumn>
             <InfoText>
               {description}{' '}
-              <ExternalLink href={TOKEN_SAFETY_ARTICLE}>
+              <ExternalLink style={{ fontWeight: 600 }} href={TOKEN_SAFETY_ARTICLE}>
                 <Trans>Learn more</Trans>
               </ExternalLink>
             </InfoText>

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -79,7 +79,7 @@ const Buttons = ({
   onContinue: () => void
   onCancel: () => void
 }) => {
-  return !warning.canProceed ? (
+  return warning.canProceed ? (
     <>
       <StyledButton onClick={onContinue}>
         <Trans>I understand</Trans>

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -63,9 +63,9 @@ const StyledCloseButton = styled(StyledButton)`
   }
 `
 
-const StyledCancelButton = styled(ButtonText)<{ color?: Color }>`
+const StyledCancelButton = styled(ButtonText)`
   margin-top: 16px;
-  color: ${({ color, theme }) => color ?? theme.textSecondary};
+  color: ${({ theme }) => theme.textSecondary};
   font-weight: 600;
   font-size: 14px;
 `

--- a/src/theme/components.tsx
+++ b/src/theme/components.tsx
@@ -131,7 +131,7 @@ const CopyIcon = styled(Copy)`
   ${IconStyle}
   ${ClickableStyle}
   ${LinkStyle}
-  stroke: ${({ theme }) => theme.accentActive};
+  stroke: ${({ theme }) => theme.accentAction};
 `
 
 export const TrashIcon = styled(Trash)`


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-879

I'd refer to the ticket for the before view and figma spec for what it's supposed to look like now

For the close only render, I couldn't find a token that met the criteria, so the copy isn't correct but the color scheme is  



Screen Shots
<img width="563" alt="Screen Shot 2022-08-24 at 5 17 11 PM" src="https://user-images.githubusercontent.com/15934595/186525304-21366ca5-d300-4d93-b257-ffa8b5576d9f.png">
<img width="545" alt="Screen Shot 2022-08-24 at 4 56 06 PM" src="https://user-images.githubusercontent.com/15934595/186524762-bbb56ff0-b229-4cbd-8361-fe84bb85589f.png">
<img width="546" alt="Screen Shot 2022-08-24 at 4 55 02 PM" src="https://user-images.githubusercontent.com/15934595/186524756-4cdc16be-e354-4099-9686-1ac86507b3a6.png">
<img width="554" alt="Screen Shot 2022-08-24 at 4 55 11 PM" src="https://user-images.githubusercontent.com/15934595/186524760-12023fc3-e1c1-42b6-b4e3-864f1af1922b.png">


