### PR TITLE
fix: Token Details - move About section below Market Stats

### DIFF
--- a/src/components/Tokens/TokenDetails/LoadingTokenDetail.tsx
+++ b/src/components/Tokens/TokenDetails/LoadingTokenDetail.tsx
@@ -120,16 +120,6 @@ export default function LoadingTokenDetail() {
         </LoadingChartContainer>
         <Space heightSize={32} />
       </ChartHeader>
-      <AboutContainer>
-        <AboutHeader>
-          <SquareLoadingBubble />
-        </AboutHeader>
-        <LongLoadingBubble />
-        <LongLoadingBubble />
-        <HalfLoadingBubble />
-
-        <ResourcesContainer>{null}</ResourcesContainer>
-      </AboutContainer>
       <StatsSection>
         <StatsLoadingContainer>
           <StatPair>
@@ -154,6 +144,16 @@ export default function LoadingTokenDetail() {
           </StatPair>
         </StatsLoadingContainer>
       </StatsSection>
+      <AboutContainer>
+        <AboutHeader>
+          <SquareLoadingBubble />
+        </AboutHeader>
+        <LongLoadingBubble />
+        <LongLoadingBubble />
+        <HalfLoadingBubble />
+
+        <ResourcesContainer>{null}</ResourcesContainer>
+      </AboutContainer>
       <ContractAddressSection>{null}</ContractAddressSection>
     </TopArea>
   )

--- a/src/components/Tokens/TokenDetails/TokenDetail.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDetail.tsx
@@ -238,7 +238,6 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
             <ParentSize>{({ width, height }) => <PriceChart token={token} width={width} height={height} />}</ParentSize>
           </ChartContainer>
         </ChartHeader>
-        <AboutSection address={address} tokenDetailData={relevantTokenDetailData} />
         <StatsSection>
           <StatPair>
             <Stat>
@@ -269,6 +268,7 @@ export default function LoadedTokenDetail({ address }: { address: string }) {
             </Stat>
           </StatPair>
         </StatsSection>
+        <AboutSection address={address} tokenDetailData={relevantTokenDetailData} />
         <ContractAddressSection>
           <Contract>
             Contract address


### PR DESCRIPTION
- Moves About section below Market Stats

![flip-about-and-stats-sections](https://user-images.githubusercontent.com/224071/186665637-d24a800b-e69e-485f-9726-d3293aef85a7.png)

