### PR TITLE
feat: show searchbar on tablet size

### DIFF
--- a/src/components/NavBar/Navbar.css.ts
+++ b/src/components/NavBar/Navbar.css.ts
@@ -34,7 +34,6 @@ export const logo = style([
 
 export const baseContainer = style([
   sprinkles({
-    display: 'flex',
     alignItems: 'center',
   }),
 ])
@@ -51,6 +50,7 @@ export const baseMobileContainer = style([
 export const baseSideContainer = style([
   baseContainer,
   sprinkles({
+    display: 'flex',
     width: 'full',
     flex: '1',
     flexShrink: '2',

--- a/src/components/NavBar/Navbar.tsx
+++ b/src/components/NavBar/Navbar.tsx
@@ -45,9 +45,14 @@ const MobileNavbar = () => {
             </Box>
             <ChainSwitcher isMobile={true} />
           </Box>
+          <Box className={styles.middleContainer} display={{ sm: 'none', md: 'flex' }}>
+            <SearchBar />
+          </Box>
           <Box className={styles.rightSideMobileContainer}>
             <Row gap="16">
-              <SearchBar />
+              <Box display={{ sm: 'flex', md: 'none' }}>
+                <SearchBar />
+              </Box>
               <MobileSideBar />
             </Row>
           </Box>
@@ -100,7 +105,7 @@ const Navbar = () => {
             </MenuItem>
           </Row>
         </Box>
-        <Box className={styles.middleContainer}>
+        <Box className={styles.middleContainer} display="flex">
           <SearchBar />
         </Box>
         <Box className={styles.rightSideContainer}>

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -335,7 +335,7 @@ export const SearchBar = () => {
           borderRadius={isOpen ? undefined : '12'}
           borderTopRightRadius={isOpen && !isMobile ? '12' : undefined}
           borderTopLeftRadius={isOpen && !isMobile ? '12' : undefined}
-          display={{ sm: isOpen ? 'flex' : 'none', xxl: 'flex' }}
+          display={{ sm: isOpen ? 'flex' : 'none', md: 'flex' }}
           justifyContent={isOpen || phase1Flag === NftVariant.Enabled ? 'flex-start' : 'center'}
           onFocus={() => !isOpen && toggleOpen()}
           onClick={() => !isOpen && toggleOpen()}
@@ -359,7 +359,7 @@ export const SearchBar = () => {
             value={searchValue}
           />
         </Row>
-        <Box display={{ sm: isOpen ? 'none' : 'flex', xxl: 'none' }}>
+        <Box display={{ sm: isOpen ? 'none' : 'flex', md: 'none' }}>
           <NavIcon onClick={toggleOpen}>
             <NavMagnifyingGlassIcon width={28} height={28} />
           </NavIcon>


### PR DESCRIPTION
As part of the updated mobile spec, full searchbar is shown on tablet (breakpoint md+) before switching to the magnifying glass icon on mobile (sm).

Screenshots:
<img width="1127" alt="Screen Shot 2022-08-25 at 07 34 50 " src="https://user-images.githubusercontent.com/11512321/186694902-9cff8c27-4418-4ce7-acac-f875b0eec2b9.png">
<img width="1147" alt="Screen Shot 2022-08-25 at 07 35 06 " src="https://user-images.githubusercontent.com/11512321/186694913-5400fd1f-f3ce-4b41-9be9-360b422f19a0.png">
![searchbarBreakpoints](https://user-images.githubusercontent.com/11512321/186694947-a0d6c87a-c599-419e-b0b0-ce95d8391cc7.gif)
