### PR TITLE
fix: bug with network with no info

### DIFF
--- a/src/components/NavBar/ChainSwitcher.tsx
+++ b/src/components/NavBar/ChainSwitcher.tsx
@@ -73,7 +73,7 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
   const selectChain = useSelectChain()
   useSyncChainQuery()
 
-  if (!chainId || !info) {
+  if (!chainId) {
     return null
   }
 
@@ -83,7 +83,7 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
     <NavDropdown top={54} leftAligned={leftAlign} paddingBottom={8} paddingTop={8}>
       <Column marginX="8">
         {NETWORK_SELECTOR_CHAINS.map((chainId: SupportedChainId) =>
-          isSupported ? (
+          isChainAllowed(chainId) ? (
             <ChainRow
               onSelectChain={async (targetChainId: SupportedChainId) => {
                 await selectChain(targetChainId)
@@ -107,7 +107,7 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
         background={isOpen ? 'accentActiveSoft' : 'none'}
         onClick={toggleOpen}
       >
-        {!isSupported ? (
+        {!isSupported || !info ? (
           <>
             <TokenWarningRedIcon fill={themeVars.colors.darkGray} width={24} height={24} />
             <Box as="span" className={subhead} display={{ sm: 'none', xl: 'flex' }} style={{ lineHeight: '20px' }}>

--- a/src/components/NavBar/ChainSwitcher.tsx
+++ b/src/components/NavBar/ChainSwitcher.tsx
@@ -12,7 +12,6 @@ import { subhead } from 'nft/css/common.css'
 import { themeVars, vars } from 'nft/css/sprinkles.css'
 import { useIsMobile } from 'nft/hooks'
 import { ReactNode, useReducer, useRef } from 'react'
-import { isChainAllowed } from 'utils/switchChain'
 
 import * as styles from './ChainSwitcher.css'
 import { NavDropdown } from './NavDropdown'
@@ -77,7 +76,7 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
     return null
   }
 
-  const isSupported = isChainAllowed(chainId)
+  const isSupported = !!info
 
   const dropdown = (
     <NavDropdown top={54} leftAligned={leftAlign} paddingBottom={8} paddingTop={8}>
@@ -109,14 +108,14 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
           <>
             <TokenWarningRedIcon fill={themeVars.colors.darkGray} width={24} height={24} />
             <Box as="span" className={subhead} display={{ sm: 'none', xl: 'flex' }} style={{ lineHeight: '20px' }}>
-              {info?.label ?? 'Unsupported'}
+              Unsupported
             </Box>
           </>
         ) : (
           <>
-            <img src={info?.logoUrl} alt={info?.label} className={styles.Image} />
+            <img src={info.logoUrl} alt={info.label} className={styles.Image} />
             <Box as="span" className={subhead} display={{ sm: 'none', xl: 'flex' }} style={{ lineHeight: '20px' }}>
-              {info?.label}
+              {info.label}
             </Box>
           </>
         )}

--- a/src/components/NavBar/ChainSwitcher.tsx
+++ b/src/components/NavBar/ChainSwitcher.tsx
@@ -82,18 +82,16 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
   const dropdown = (
     <NavDropdown top={54} leftAligned={leftAlign} paddingBottom={8} paddingTop={8}>
       <Column marginX="8">
-        {NETWORK_SELECTOR_CHAINS.map((chainId: SupportedChainId) =>
-          isChainAllowed(chainId) ? (
-            <ChainRow
-              onSelectChain={async (targetChainId: SupportedChainId) => {
-                await selectChain(targetChainId)
-                toggleOpen()
-              }}
-              targetChain={chainId}
-              key={chainId}
-            />
-          ) : null
-        )}
+        {NETWORK_SELECTOR_CHAINS.map((chainId: SupportedChainId) => (
+          <ChainRow
+            onSelectChain={async (targetChainId: SupportedChainId) => {
+              await selectChain(targetChainId)
+              toggleOpen()
+            }}
+            targetChain={chainId}
+            key={chainId}
+          />
+        ))}
       </Column>
     </NavDropdown>
   )

--- a/src/components/NavBar/ChainSwitcher.tsx
+++ b/src/components/NavBar/ChainSwitcher.tsx
@@ -105,7 +105,7 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
         background={isOpen ? 'accentActiveSoft' : 'none'}
         onClick={toggleOpen}
       >
-        {!isSupported || !info ? (
+        {!isSupported ? (
           <>
             <TokenWarningRedIcon fill={themeVars.colors.darkGray} width={24} height={24} />
             <Box as="span" className={subhead} display={{ sm: 'none', xl: 'flex' }} style={{ lineHeight: '20px' }}>
@@ -114,9 +114,9 @@ export const ChainSwitcher = ({ leftAlign }: ChainSwitcherProps) => {
           </>
         ) : (
           <>
-            <img src={info.logoUrl} alt={info.label} className={styles.Image} />
+            <img src={info?.logoUrl} alt={info?.label} className={styles.Image} />
             <Box as="span" className={subhead} display={{ sm: 'none', xl: 'flex' }} style={{ lineHeight: '20px' }}>
-              {info.label}
+              {info?.label}
             </Box>
           </>
         )}


### PR DESCRIPTION
Previously if a network had no info, nothing would be shown. Now it is treated as Unsupported.

Before:
<img width="757" alt="Screen Shot 2022-08-25 at 09 45 02 " src="https://user-images.githubusercontent.com/11512321/186723007-56c1659d-4fa7-4976-b552-5ebbc9cde115.png">

After:
<img width="1512" alt="Screen Shot 2022-08-25 at 09 41 30 " src="https://user-images.githubusercontent.com/11512321/186722924-f57b0502-8fce-4a72-bbfd-54c6eed7e1cd.png">
