### PR TITLE
fix: fix swap small layout shifts when clicking reverse tokens button

### DIFF
--- a/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
+++ b/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
@@ -156,7 +156,7 @@ const NoBalanceState = styled.div`
   color: ${({ theme }) => theme.textTertiary};
   font-weight: 400;
   justify-content: space-between;
-  padding: 0px 4px;
+  padding: 0px 4px 1px 4px;
 `
 const NoBalanceDash = styled.span`
   color: ${({ theme }) => theme.textTertiary};


### PR DESCRIPTION
after this fix, clicking the reverse arrow doesn't cause the layout to move around subtly. 