### PR TITLE
fix: update Token table headers to match latest Figma

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -314,7 +314,7 @@ const LogoContainer = styled.div`
 
 /* formatting for volume with timeframe header display */
 function getHeaderDisplay(category: string, timeframe: TimePeriod): string {
-  if (category === Category.volume) return `${DISPLAYS[timeframe]} ${category}`
+  if (category === Category.volume || category === Category.percentChange) return `${DISPLAYS[timeframe]} ${category}`
   return category
 }
 

--- a/src/components/Tokens/types.ts
+++ b/src/components/Tokens/types.ts
@@ -1,5 +1,5 @@
 export enum Category {
-  percentChange = '% Change',
+  percentChange = 'Change',
   marketCap = 'Market Cap',
   price = 'Price',
   volume = 'Volume',


### PR DESCRIPTION
- Changes copy text on '% change' column to include selected timeperiod, ie: '1D change'

Before
![before](https://user-images.githubusercontent.com/224071/186885458-bbefd3fc-785e-4323-a725-858f974e73d5.png)

After
![after](https://user-images.githubusercontent.com/224071/186885492-2ede4385-fbc9-4f4c-a05a-2048f43463c0.png)


