### PR TITLE
fix: Fix to mobile wallet experience

### DIFF
--- a/src/components/WalletDropdown/index.tsx
+++ b/src/components/WalletDropdown/index.tsx
@@ -36,13 +36,13 @@ const WalletDropdownWrapper = styled.div`
   position: absolute;
   top: 65px;
   right: 20px;
+  z-index: 2;
 
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     top: unset;
     left: 0;
     right: 0;
     bottom: 56px;
-    z-index: 1;
   }
 `
 

--- a/src/components/WalletDropdown/index.tsx
+++ b/src/components/WalletDropdown/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import styled from 'styled-components/macro'
+import { Z_INDEX } from 'theme'
 
 import { useModalIsOpen } from '../../state/application/hooks'
 import { ApplicationModal } from '../../state/application/reducer'
@@ -36,7 +37,7 @@ const WalletDropdownWrapper = styled.div`
   position: absolute;
   top: 65px;
   right: 20px;
-  z-index: 2;
+  z-index: ${Z_INDEX.dropdown};
 
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     top: unset;

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -7,7 +7,6 @@ import WalletDropdown from 'components/WalletDropdown'
 import { getConnection } from 'connection/utils'
 import { NavBarVariant, useNavBarFlag } from 'featureFlags/flags/navBar'
 import { Portal } from 'nft/components/common/Portal'
-import { useIsMobile } from 'nft/hooks'
 import { getIsValidSwapQuote } from 'pages/Swap'
 import { darken } from 'polished'
 import { useMemo, useRef } from 'react'
@@ -288,7 +287,6 @@ export default function Web3Status() {
   const walletRef = useRef<HTMLDivElement>(null)
   const closeModal = useCloseModal(ApplicationModal.WALLET_DROPDOWN)
   const isOpen = useIsOpen()
-  const isMobile = useIsMobile()
 
   useOnClickOutside(ref, isOpen ? closeModal : undefined, [walletRef])
 

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -285,11 +285,12 @@ export default function Web3Status() {
 
   const allTransactions = useAllTransactions()
   const ref = useRef<HTMLDivElement>(null)
+  const walletRef = useRef<HTMLDivElement>(null)
   const closeModal = useCloseModal(ApplicationModal.WALLET_DROPDOWN)
   const isOpen = useIsOpen()
   const isMobile = useIsMobile()
 
-  useOnClickOutside(ref, isOpen ? closeModal : undefined)
+  useOnClickOutside(ref, isOpen ? closeModal : undefined, [walletRef])
 
   const sortedRecentTransactions = useMemo(() => {
     const txs = Object.values(allTransactions)
@@ -303,13 +304,11 @@ export default function Web3Status() {
     <span ref={ref}>
       <Web3StatusInner />
       <WalletModal ENSName={ENSName ?? undefined} pendingTransactions={pending} confirmedTransactions={confirmed} />
-      {isMobile ? (
-        <Portal>
+      <Portal>
+        <span ref={walletRef}>
           <WalletDropdown />
-        </Portal>
-      ) : (
-        <WalletDropdown />
-      )}
+        </span>
+      </Portal>
     </span>
   )
 }

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -13,9 +13,10 @@ export function useOnClickOutside<T extends HTMLElement>(
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      const additionalNodeClicked = additionalNodes.length
-        ? additionalNodes.reduce((reducer, val) => reducer || !!val.current?.contains(e.target as Node), false)
-        : false
+      const additionalNodeClicked = additionalNodes.reduce(
+        (reducer, val) => reducer || !!val.current?.contains(e.target as Node),
+        false
+      )
 
       if ((node.current?.contains(e.target as Node) || additionalNodeClicked) ?? false) {
         return

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -13,13 +13,13 @@ export function useOnClickOutside<T extends HTMLElement>(
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      const clickedNode = node.current?.contains(e.target as Node)
+      const nodeClicked = node.current?.contains(e.target as Node)
       const ignoredNodeClicked = ignoredNodes.reduce(
         (reducer, val) => reducer || !!val.current?.contains(e.target as Node),
         false
       )
 
-      if ((clickedNode || ignoredNodeClicked) ?? false) {
+      if ((nodeClicked || ignoredNodeClicked) ?? false) {
         return
       }
 

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -2,18 +2,25 @@ import { RefObject, useEffect, useRef } from 'react'
 
 export function useOnClickOutside<T extends HTMLElement>(
   node: RefObject<T | undefined>,
-  handler: undefined | (() => void)
+  handler: undefined | (() => void),
+  additionalNodes: Array<RefObject<T | undefined>> = []
 ) {
   const handlerRef = useRef<undefined | (() => void)>(handler)
+
   useEffect(() => {
     handlerRef.current = handler
   }, [handler])
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (node.current?.contains(e.target as Node) ?? false) {
+      const additionalNodeClicked = additionalNodes.length
+        ? additionalNodes.reduce((reducer, val) => reducer || !!val.current?.contains(e.target as Node), false)
+        : false
+
+      if ((node.current?.contains(e.target as Node) || additionalNodeClicked) ?? false) {
         return
       }
+
       if (handlerRef.current) handlerRef.current()
     }
 
@@ -22,5 +29,5 @@ export function useOnClickOutside<T extends HTMLElement>(
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [node])
+  }, [node, additionalNodes])
 }

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -13,12 +13,13 @@ export function useOnClickOutside<T extends HTMLElement>(
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
+      const clickedNode = node.current?.contains(e.target as Node)
       const ignoredNodeClicked = ignoredNodes.reduce(
         (reducer, val) => reducer || !!val.current?.contains(e.target as Node),
         false
       )
 
-      if ((node.current?.contains(e.target as Node) || ignoredNodeClicked) ?? false) {
+      if ((clickedNode || ignoredNodeClicked) ?? false) {
         return
       }
 

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useRef } from 'react'
 export function useOnClickOutside<T extends HTMLElement>(
   node: RefObject<T | undefined>,
   handler: undefined | (() => void),
-  additionalNodes: Array<RefObject<T | undefined>> = []
+  ignoredNodes: Array<RefObject<T | undefined>> = []
 ) {
   const handlerRef = useRef<undefined | (() => void)>(handler)
 
@@ -13,12 +13,12 @@ export function useOnClickOutside<T extends HTMLElement>(
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      const additionalNodeClicked = additionalNodes.reduce(
+      const ignoredNodeClicked = ignoredNodes.reduce(
         (reducer, val) => reducer || !!val.current?.contains(e.target as Node),
         false
       )
 
-      if ((node.current?.contains(e.target as Node) || additionalNodeClicked) ?? false) {
+      if ((node.current?.contains(e.target as Node) || ignoredNodeClicked) ?? false) {
         return
       }
 
@@ -30,5 +30,5 @@ export function useOnClickOutside<T extends HTMLElement>(
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [node, additionalNodes])
+  }, [node, ignoredNodes])
 }


### PR DESCRIPTION
The issue

The mobile wallet would close when clicking on or interacting with it.  This occurred because the wallet is coded to close any time a click occurs outside the web3status ref.  In mobile, we were using a portal, so the wallet was technically outside of this ref.  The reason wallet is under the status ref is due to a tricky edge case.  Clicking the status should toggle the wallet close and clicking outside the wallet should also close it.  If the ref only lives on the wallet and not status, this would lead to an edge case that would close and then immediately reopen the wallet.  I put the wallet under status so that when clicking on it, you are not technically clicking outside of wallet.  This results in the proper behavior of closing the wallet when clicking status and closing when clicking outside.


The solution
I made useClickOnOutside a bit more extensible.  It now take as many ref elements as you want for other elements that should not affect if it closes or not
