### PR TITLE
fix: vertically center the explore table header text

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -139,6 +139,7 @@ const StyledHeaderRow = styled(StyledTokenRow)`
   line-height: 16px;
   padding: 0px 12px;
   width: 100%;
+  justify-content: center;
 
   &:hover {
     background-color: transparent;
@@ -151,6 +152,7 @@ const StyledHeaderRow = styled(StyledTokenRow)`
 const ListNumberCell = styled(Cell)`
   color: ${({ theme }) => theme.textSecondary};
   min-width: 32px;
+  height: 48px;
 
   @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
     display: none;


### PR DESCRIPTION
center the header text - https://uniswaplabs.atlassian.net/browse/WEB-983

before: 
![image](https://user-images.githubusercontent.com/62825936/186968329-d784dc40-81bf-45a2-86f4-3ed0b6267210.png)

after:
<img width="457" alt="Screen Shot 2022-08-26 at 11 23 55 AM" src="https://user-images.githubusercontent.com/62825936/186968292-89a15bd1-3fa6-44b3-bb6e-3d6260469423.png">
