### PR TITLE
fix: wallet mobile ui changes

### DIFF
--- a/src/components/WalletDropdown/DefaultMenu.tsx
+++ b/src/components/WalletDropdown/DefaultMenu.tsx
@@ -20,6 +20,10 @@ const ConnectButton = styled(ButtonPrimary)`
   font-size: 16px;
   margin-left: auto;
   margin-right: auto;
+
+  @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
+    width: 100%;
+  }
 `
 
 const Divider = styled.div`

--- a/src/components/WalletDropdown/SlideOutMenu.tsx
+++ b/src/components/WalletDropdown/SlideOutMenu.tsx
@@ -67,7 +67,7 @@ const StyledChevron = styled(ChevronLeft)`
 const BackSection = styled.div`
   position: absolute;
   background-color: ${({ theme }) => theme.backgroundSurface};
-  width: 100%;
+  width: 99%;
   padding: 0 16px 16px 16px;
   color: ${({ theme }) => theme.textSecondary};
   cursor: default;

--- a/src/components/WalletDropdown/index.tsx
+++ b/src/components/WalletDropdown/index.tsx
@@ -24,6 +24,9 @@ const WalletWrapper = styled.div`
 
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     width: 100%;
+    border-bottom-right-radius: 0px;
+    border-bottom-left-radius: 0px;
+    box-shadow: unset;
   }
 `
 


### PR DESCRIPTION
1. no border  radius on bottom of wallet for  mobile ui
2. no box shadow for mobile ui
3. Increased connect button width on mobile for disconnect
3. Stick back section was sticking out on language and transaction history menu.  I will come up with a better solution, but want this fixed for bug bash so I set width to 99% for now