### PR TITLE
fix: rm right padding on token details

### DIFF
--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -46,6 +46,10 @@ const TokenDetailsLayout = styled.div`
     padding-top: 20px;
   }
 
+  @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
+    gap: 0px;
+  }
+
   @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
     padding-left: 16px;
     padding-right: 16px;


### PR DESCRIPTION
rm right side padding on token details - https://uniswaplabs.atlassian.net/browse/WEB-989

before:
![image](https://user-images.githubusercontent.com/62825936/186984860-a55f973c-8539-4af0-afe7-bcbdfdbf622f.png)

after:
<img width="559" alt="Screen Shot 2022-08-26 at 1 20 11 PM" src="https://user-images.githubusercontent.com/62825936/186984835-b89ab5f4-8f42-4480-90dd-adab42c93497.png">
