### PR TITLE
fix: formatted delta on mobile view of token explore

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -518,7 +518,7 @@ export default function LoadedRow({
             <PriceInfoCell>
               {tokenData.price?.value ? formatDollarAmount(tokenData.price?.value) : '-'}
               <PercentChangeInfoCell>
-                {delta}
+                {formattedDelta}
                 {arrow}
               </PercentChangeInfoCell>
             </PriceInfoCell>


### PR DESCRIPTION
fix: formatted delta on mobile view of token explore

before: 
<img width="552" alt="Screen Shot 2022-08-26 at 1 28 23 PM" src="https://user-images.githubusercontent.com/62825936/186985767-0bd6e1a9-fd60-4d77-b8f4-452cac864c08.png">

after:
<img width="519" alt="Screen Shot 2022-08-26 at 1 27 01 PM" src="https://user-images.githubusercontent.com/62825936/186985674-4bc19ed5-deb7-4511-a6ec-2372f5667f9d.png">
