### PR TITLE
fix: fix favorites button responsiveness on tokens explore

### DIFF
--- a/src/components/Tokens/TokenTable/FavoriteButton.tsx
+++ b/src/components/Tokens/TokenTable/FavoriteButton.tsx
@@ -3,7 +3,7 @@ import { useAtom } from 'jotai'
 import { Heart } from 'react-feather'
 import styled, { useTheme } from 'styled-components/macro'
 
-import { SMALL_MEDIA_BREAKPOINT } from '../constants'
+import { SMALLEST_MOBILE_MEDIA_BREAKPOINT } from '../constants'
 import { showFavoritesAtom } from '../state'
 
 const FavoriteButtonContent = styled.div`
@@ -27,7 +27,7 @@ const StyledFavoriteButton = styled.button<{ active: boolean }>`
   }
 `
 const FavoriteText = styled.span`
-  @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
+  @media only screen and (max-width: ${SMALLEST_MOBILE_MEDIA_BREAKPOINT}) {
     display: none;
   }
 `


### PR DESCRIPTION
favorites button should only change to heart on 320px 

before:
<img width="200" alt="Screen Shot 2022-08-26 at 1 31 51 PM" src="https://user-images.githubusercontent.com/62825936/186986715-2d986ad3-5ffb-4c17-8bc4-09cbdda28b6f.png">

after:
<img width="200" alt="Screen Shot 2022-08-26 at 1 33 23 PM" src="https://user-images.githubusercontent.com/62825936/186986685-111226d2-4248-41b0-81e5-56f23b05ef52.png">
<img width="200" alt="Screen Shot 2022-08-26 at 1 33 15 PM" src="https://user-images.githubusercontent.com/62825936/186986695-60fc3034-543c-4809-8405-346b8b84e510.png">

