### PR TITLE
fix: add null check to collection floor price

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -141,7 +141,7 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput }:
         return {
           ...collection,
           collectionAddress: collection.address,
-          floorPrice: formatEthPrice(collection.floor.toString()),
+          floorPrice: formatEthPrice(collection.floor?.toString()),
           stats: {
             total_supply: collection.totalSupply,
             one_day_change: collection.floorChange,

--- a/src/components/NavBar/SuggestionRow.tsx
+++ b/src/components/NavBar/SuggestionRow.tsx
@@ -78,14 +78,14 @@ export const CollectionRow = ({ collection, isHovered, setHoveredIndex, toggleOp
           <Box className={styles.secondaryText}>{putCommas(collection.stats.total_supply)} items</Box>
         </Column>
       </Row>
-      {collection.floorPrice && (
+      {collection.floorPrice ? (
         <Column className={styles.suggestionSecondaryContainer}>
           <Row gap="4">
             <Box className={styles.primaryText}>{ethNumberStandardFormatter(collection.floorPrice)} ETH</Box>
           </Row>
           <Box className={styles.secondaryText}>Floor</Box>
         </Column>
-      )}
+      ) : null}
     </Link>
   )
 }

--- a/src/nft/utils/currency.ts
+++ b/src/nft/utils/currency.ts
@@ -16,7 +16,7 @@ export const formatUSDPriceWithCommas = (price: number) => {
     .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`
 }
 
-export const formatEthPrice = (price: string) => {
+export const formatEthPrice = (price: string | undefined) => {
   if (!price) return 0
 
   const formattedPrice = parseFloat(formatEther(String(price)))


### PR DESCRIPTION
The trending collections endpoint is experiencing a bug and is returning collections with a null floor price. While this is being investigated by data team this allows for more graceful handling.