### PR TITLE
fix: search flash of no tokens found when typing

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -141,7 +141,7 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput }:
         return {
           ...collection,
           collectionAddress: collection.address,
-          floorPrice: formatEthPrice(collection.floor.toString()),
+          floorPrice: formatEthPrice(collection.floor?.toString()),
           stats: {
             total_supply: collection.totalSupply,
             one_day_change: collection.floorChange,

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -367,14 +367,14 @@ export const SearchBar = () => {
           </NavIcon>
         </Box>
         {isOpen &&
-          (searchValue.length > 0 && (tokensAreLoading || collectionsAreLoading) ? (
+          (debouncedSearchValue.length > 0 && (tokensAreLoading || collectionsAreLoading) ? (
             <SkeletonRow />
           ) : (
             <SearchBarDropdown
               toggleOpen={toggleOpen}
               tokens={reducedTokens}
               collections={reducedCollections}
-              hasInput={searchValue.length > 0}
+              hasInput={debouncedSearchValue.length > 0}
             />
           ))}
       </Box>

--- a/src/components/NavBar/SuggestionRow.tsx
+++ b/src/components/NavBar/SuggestionRow.tsx
@@ -78,14 +78,14 @@ export const CollectionRow = ({ collection, isHovered, setHoveredIndex, toggleOp
           <Box className={styles.secondaryText}>{putCommas(collection.stats.total_supply)} items</Box>
         </Column>
       </Row>
-      {collection.floorPrice && (
+      {collection.floorPrice ? (
         <Column className={styles.suggestionSecondaryContainer}>
           <Row gap="4">
             <Box className={styles.primaryText}>{ethNumberStandardFormatter(collection.floorPrice)} ETH</Box>
           </Row>
           <Box className={styles.secondaryText}>Floor</Box>
         </Column>
-      )}
+      ) : null}
     </Link>
   )
 }


### PR DESCRIPTION
Use `debouncedSearchValue` to prevent a flash of 'no tokens found' while typing
Dependent on #4528 

Screenshot:
![debouncedSearch](https://user-images.githubusercontent.com/11512321/187249612-541f7a96-f75b-4bbc-806e-f1462ac4f10e.gif)
