### PR TITLE
fix: Fixing border overlap and reducing button size

### DIFF
--- a/src/components/WalletDropdown/DefaultMenu.tsx
+++ b/src/components/WalletDropdown/DefaultMenu.tsx
@@ -27,7 +27,7 @@ const ConnectButton = styled(ButtonPrimary)`
 `
 
 const Divider = styled.div`
-  border: 0.5px solid ${({ theme }) => theme.backgroundOutline};
+  border-bottom: 1px solid ${({ theme }) => theme.backgroundOutline};
   margin-top: 16px;
   margin-bottom: 16px;
 `

--- a/src/components/WalletDropdown/DefaultMenu.tsx
+++ b/src/components/WalletDropdown/DefaultMenu.tsx
@@ -27,7 +27,7 @@ const ConnectButton = styled(ButtonPrimary)`
 `
 
 const Divider = styled.div`
-  border: 1px solid ${({ theme }) => theme.backgroundOutline};
+  border: 0.5px solid ${({ theme }) => theme.backgroundOutline};
   margin-top: 16px;
   margin-bottom: 16px;
 `

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -67,7 +67,7 @@ const Web3StatusConnectNavbar = styled.button<{ faded?: boolean }>`
   border-radius: 12px;
   border: none;
   cursor: pointer;
-  padding: 10px 12px;
+  padding: 8px 12px;
 
   :hover,
   :active,


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-988

1. The divider border top/bottom were overlapping causing it to be too big.  Setting only border-bottom fixes this
2. Request for button size to be reduced slightly

<img width="401" alt="Screen Shot 2022-08-29 at 6 26 29 PM" src="https://user-images.githubusercontent.com/15934595/187309860-2dd2aec1-1d9d-4e5a-84bb-a6095ae410c5.png">
<img width="388" alt="Screen Shot 2022-08-29 at 6 26 34 PM" src="https://user-images.githubusercontent.com/15934595/187309861-825a5363-b9e1-4476-af46-73c63ce4b5e4.png">






