### PR TITLE
fix: updated color definitions for backgroundModule, add scrolledSurface

### DIFF
--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -21,7 +21,7 @@ const GridContainer = styled.div`
   display: flex;
   flex-direction: column;
   max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT};
-  background-color: ${({ theme }) => theme.backgroundModule};
+  background-color: ${({ theme }) => theme.backgroundSurface};
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
     0px 24px 32px rgba(0, 0, 0, 0.01);
   margin-left: auto;

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -178,6 +178,7 @@ export interface Palette {
   backgroundModule: Color
   backgroundOutline: Color
   backgroundScrim: Color
+  backgroundScrolledSurface: Color
 
   textPrimary: Color
   textSecondary: Color
@@ -237,6 +238,7 @@ export const colorsLight: Palette = {
   backgroundFloating: opacify(8, colors.gray700),
   backgroundOutline: opacify(24, colors.gray500),
   backgroundScrim: opacify(60, colors.gray900),
+  backgroundScrolledSurface: opacify(72, colors.white),
 
   textPrimary: colors.gray900,
   textSecondary: colors.gray500,
@@ -293,11 +295,12 @@ export const colorsDark: Palette = {
 
   backgroundBackdrop: colors.black,
   backgroundSurface: colors.gray900,
-  backgroundModule: opacify(8, colors.gray300),
+  backgroundModule: colors.gray800,
   backgroundInteractive: colors.gray700,
   backgroundFloating: opacify(12, colors.black),
   backgroundOutline: opacify(24, colors.gray300),
   backgroundScrim: opacify(72, colors.gray900),
+  backgroundScrolledSurface: opacify(72, colors.gray900),
 
   textPrimary: colors.white,
   textSecondary: colors.gray300,

--- a/src/theme/widget.ts
+++ b/src/theme/widget.ts
@@ -22,7 +22,7 @@ export const DARK_THEME = {
   // surface
   container: colorsDark.backgroundSurface,
   interactive: colorsDark.backgroundInteractive,
-  module: colorsDark.backgroundInteractive,
+  module: colorsDark.backgroundModule,
   accent: colorsDark.accentAction,
   dialog: colorsDark.backgroundBackdrop,
   outline: colorsDark.backgroundOutline,


### PR DESCRIPTION
Update Dark Mode BackgroundModule to Grey800 to match new design spec

Update Widgets theme to use BackgroundModule for Module

Update Token List in Explore page to use Surface instead of Module

Add Scrolled Surface color definition
<img width="1552" alt="Screen Shot 2022-08-29 at 4 05 49 PM" src="https://user-images.githubusercontent.com/111304124/187306033-7a2925e3-46bd-4483-934d-fc85b5ba5b9e.png">
<img width="1552" alt="Screen Shot 2022-08-29 at 4 05 20 PM" src="https://user-images.githubusercontent.com/111304124/187306035-08354e80-f908-4b37-a69b-030c25cc687c.png">
<img width="1552" alt="Screen Shot 2022-08-29 at 5 56 59 PM" src="https://user-images.githubusercontent.com/111304124/187306222-f633b8d8-dad9-4faa-bc23-a3762dbbe696.png">
<img width="1552" alt="Screen Shot 2022-08-29 at 5 56 56 PM" src="https://user-images.githubusercontent.com/111304124/187306224-c2234681-a4e0-4f64-9363-3399d032760c.png">
<img width="1552" alt="Screen Shot 2022-08-29 at 5 56 51 PM" src="https://user-images.githubusercontent.com/111304124/187306225-ff373278-cd17-499d-9489-19d791b5d754.png">
<img width="1552" alt="Screen Shot 2022-08-29 at 5 56 46 PM" src="https://user-images.githubusercontent.com/111304124/187306226-3dda28c2-ebf1-4409-b1c3-dc74d55c9a9c.png">
