### PR TITLE
fix: hide right and left border on mobile dropdown

### DIFF
--- a/src/components/NavBar/NavDropdown.css.ts
+++ b/src/components/NavBar/NavDropdown.css.ts
@@ -38,4 +38,8 @@ export const mobileNavDropdown = style([
     right: '0',
     width: 'full',
   }),
+  {
+    borderRightWidth: '0px',
+    borderLeftWidth: '0px',
+  },
 ])


### PR DESCRIPTION
Hide's left and right border on mobile dropdowns as requested by https://uniswaplabs.atlassian.net/browse/WEB-1001

Screenshots:
<img width="552" alt="Screen Shot 2022-08-30 at 05 31 39 " src="https://user-images.githubusercontent.com/11512321/187437563-b9d55a87-2e62-4b8a-aa46-e922daa682b4.png">
