### PR TITLE
fix: missing segments of price chart

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -5,7 +5,7 @@ import { EventType } from '@visx/event/lib/types'
 import { GlyphCircle } from '@visx/glyph'
 import { Line } from '@visx/shape'
 import { filterTimeAtom } from 'components/Tokens/state'
-import { bisect, curveCardinalOpen, NumberValue, scaleLinear } from 'd3'
+import { bisect, curveCardinal, NumberValue, scaleLinear } from 'd3'
 import { useTokenPriceQuery } from 'graphql/data/TokenPriceQuery'
 import { TimePeriod } from 'graphql/data/TopTokenQuery'
 import { useActiveLocale } from 'hooks/useActiveLocale'
@@ -249,7 +249,7 @@ export function PriceChart({ width, height, token }: PriceChartProps) {
         getX={(p: PricePoint) => timeScale(p.timestamp)}
         getY={(p: PricePoint) => rdScale(p.value)}
         marginTop={margin.top}
-        curve={curveCardinalOpen.tension(curveTension)}
+        curve={curveCardinal.tension(curveTension)}
         strokeWidth={2}
         width={graphWidth}
         height={graphHeight}


### PR DESCRIPTION
before:
<img width="767" alt="Screen Shot 2022-08-30 at 9 42 28 AM" src="https://user-images.githubusercontent.com/39385577/187454768-7011c1a7-d86f-46ec-94fb-205c7d63b2ec.png">
after:
<img width="769" alt="Screen Shot 2022-08-30 at 9 42 52 AM" src="https://user-images.githubusercontent.com/39385577/187454802-9d1c2ebb-fce1-49c9-ba50-edaf415a160d.png">
