### PR TITLE
fix: modify chart axis to to match crosshairs in year view

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -18,7 +18,7 @@ import {
   dayHourFormatter,
   hourFormatter,
   monthDayFormatter,
-  monthFormatter,
+  monthTickFormatter,
   monthYearDayFormatter,
   monthYearFormatter,
   weekFormatter,
@@ -124,22 +124,6 @@ function getTicks(startTimestamp: number, endTimestamp: number, numTicks = 5) {
   )
 }
 
-function getStartOfMonthTicks(startTimestamp: number, endTimestamp: number, numTicks = 5) {
-  const ticks = getTicks(startTimestamp, endTimestamp, numTicks)
-
-  // when a tick maps to a date not on the first of the month, modify the tick to the closest
-  // first of month date. For example, Dec 31 becomes Jan 1, and Dec 5 becomes Dec 1.
-  return ticks.map((tick) => {
-    const date = new Date(tick.valueOf() * 1000)
-    if (date.getDate() !== 1) {
-      return date.getDate() >= 15
-        ? new Date(date.getFullYear(), date.getMonth() + 1, 1).getTime() / 1000
-        : new Date(date.getFullYear(), date.getMonth(), 1).getTime() / 1000
-    }
-    return tick
-  })
-}
-
 function tickFormat(
   startTimestamp: number,
   endTimestamp: number,
@@ -156,7 +140,7 @@ function tickFormat(
     case TimePeriod.MONTH:
       return [monthDayFormatter(locale), dayHourFormatter(locale), getTicks(startTimestamp, endTimestamp)]
     case TimePeriod.YEAR:
-      return [monthFormatter(locale), monthYearDayFormatter(locale), getStartOfMonthTicks(startTimestamp, endTimestamp)]
+      return [monthTickFormatter(locale), monthYearDayFormatter(locale), getTicks(startTimestamp, endTimestamp)]
     case TimePeriod.ALL:
       return [monthYearFormatter(locale), monthYearDayFormatter(locale), getTicks(startTimestamp, endTimestamp)]
   }

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -117,12 +117,15 @@ const TimeButton = styled.button<{ active: boolean }>`
   }
 `
 
-function getTicks(startTimestamp: number, endTimestamp: number, forceStartOfMonthTicks = false, numTicks = 5) {
-  const ticks = Array.from(
+function getTicks(startTimestamp: number, endTimestamp: number, numTicks = 5) {
+  return Array.from(
     { length: numTicks },
     (v, i) => endTimestamp - ((endTimestamp - startTimestamp) / (numTicks + 1)) * (i + 1)
   )
-  if (!forceStartOfMonthTicks) return ticks
+}
+
+function getStartOfMonthTicks(startTimestamp: number, endTimestamp: number, numTicks = 5) {
+  const ticks = getTicks(startTimestamp, endTimestamp, numTicks)
 
   // when a tick maps to a date not on the first of the month, modify the tick to the closest
   // first of month date. For example, Dec 31 becomes Jan 1, and Dec 5 becomes Dec 1.
@@ -149,11 +152,11 @@ function tickFormat(
     case TimePeriod.DAY:
       return [hourFormatter(locale), dayHourFormatter(locale), getTicks(startTimestamp, endTimestamp)]
     case TimePeriod.WEEK:
-      return [weekFormatter(locale), dayHourFormatter(locale), getTicks(startTimestamp, endTimestamp, false, 6)]
+      return [weekFormatter(locale), dayHourFormatter(locale), getTicks(startTimestamp, endTimestamp, 6)]
     case TimePeriod.MONTH:
       return [monthDayFormatter(locale), dayHourFormatter(locale), getTicks(startTimestamp, endTimestamp)]
     case TimePeriod.YEAR:
-      return [monthFormatter(locale), monthYearDayFormatter(locale), getTicks(startTimestamp, endTimestamp, true)]
+      return [monthFormatter(locale), monthYearDayFormatter(locale), getStartOfMonthTicks(startTimestamp, endTimestamp)]
     case TimePeriod.ALL:
       return [monthYearFormatter(locale), monthYearDayFormatter(locale), getTicks(startTimestamp, endTimestamp)]
   }

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -129,11 +129,9 @@ function getTicks(startTimestamp: number, endTimestamp: number, forceStartOfMont
   return ticks.map((tick) => {
     const date = new Date(tick.valueOf() * 1000)
     if (date.getDate() !== 1) {
-      if (date.getDate() >= 15) {
-        return new Date(date.getFullYear(), date.getMonth() + 1, 1).getTime() / 1000
-      } else {
-        return new Date(date.getFullYear(), date.getMonth(), 1).getTime() / 1000
-      }
+      return date.getDate() >= 15
+        ? new Date(date.getFullYear(), date.getMonth() + 1, 1).getTime() / 1000
+        : new Date(date.getFullYear(), date.getMonth(), 1).getTime() / 1000
     }
     return tick
   })

--- a/src/utils/formatChartTimes.ts
+++ b/src/utils/formatChartTimes.ts
@@ -41,8 +41,19 @@ export const monthYearDayFormatter = (locale: string) => (timestamp: NumberValue
     day: 'numeric',
   })
 
-export const monthFormatter = (locale: string) => (timestamp: NumberValue) =>
-  createDateFormatter(timestamp, locale, { month: 'long' })
+export const monthTickFormatter = (locale: string) => (timestamp: NumberValue) => {
+  let date = new Date(timestamp.valueOf() * 1000)
+
+  // when a tick maps to a date not on the first of the month, modify the tick to the closest
+  // first of month date. For example, Dec 31 becomes Jan 1, and Dec 5 becomes Dec 1.
+  if (date.getDate() !== 1) {
+    date =
+      date.getDate() >= 15
+        ? new Date(date.getFullYear(), date.getMonth() + 1, 1)
+        : new Date(date.getFullYear(), date.getMonth(), 1)
+  }
+  return date.toLocaleTimeString(locale, { month: 'long' })
+}
 
 export const weekFormatter = (locale: string) => (timestamp: NumberValue) =>
   createDateFormatter(timestamp, locale, { weekday: 'long' })

--- a/src/utils/formatChartTimes.ts
+++ b/src/utils/formatChartTimes.ts
@@ -52,7 +52,7 @@ export const monthTickFormatter = (locale: string) => (timestamp: NumberValue) =
         ? new Date(date.getFullYear(), date.getMonth() + 1, 1)
         : new Date(date.getFullYear(), date.getMonth(), 1)
   }
-  return date.toLocaleTimeString(locale, { month: 'long' })
+  return date.toLocaleDateString(locale, { month: 'long' })
 }
 
 export const weekFormatter = (locale: string) => (timestamp: NumberValue) =>


### PR DESCRIPTION
for year view we want to consistently show the 1st of the month, not vary between 1st and end of month on diff ticks. 

before:
<img width="916" alt="Screen Shot 2022-08-31 at 2 12 49 AM" src="https://user-images.githubusercontent.com/41491154/187606730-91c771c6-e919-4748-a29b-469c86f6773e.png">

after:
<img width="993" alt="Screen Shot 2022-08-31 at 2 06 15 AM" src="https://user-images.githubusercontent.com/41491154/187606641-1d91296b-4cec-422f-a613-ee36bc3c4794.png">
