### PR TITLE
fix: Bump height on LineNumberCell and pass header boolean

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -149,10 +149,11 @@ const StyledHeaderRow = styled(StyledTokenRow)`
     justify-content: space-between;
   }
 `
-const ListNumberCell = styled(Cell)`
+
+const ListNumberCell = styled(Cell)<{ header: boolean }>`
   color: ${({ theme }) => theme.textSecondary};
   min-width: 32px;
-  height: 48px;
+  height: ${({ header }) => (header ? '48px' : '60px')};
 
   @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
     display: none;
@@ -389,7 +390,7 @@ export function TokenRow({
 }) {
   const rowCells = (
     <>
-      <ListNumberCell>{listNumber}</ListNumberCell>
+      <ListNumberCell header={header}>{listNumber}</ListNumberCell>
       <NameCell>{tokenInfo}</NameCell>
       <PriceCell sortable={header}>{price}</PriceCell>
       <PercentChangeCell sortable={header}>{percentChange}</PercentChangeCell>


### PR DESCRIPTION
- On TokenRows the line number cell had a different height than the rest of the row causing misalignment. This PR bumps the height to match (conditionally, based on a header boolean flag so the header row does not change). 

Before
<img width="426" alt="before" src="https://user-images.githubusercontent.com/224071/187660427-a2ad88d7-6a1d-4278-8748-e2d90587d88e.png">

After
<img width="412" alt="after" src="https://user-images.githubusercontent.com/224071/187660432-d1599b1b-2f5a-4a99-9164-26b88cd80548.png">
