### PR TITLE
fix: change from flex to inline to fix safari bugs

### DIFF
--- a/src/components/NavBar/SearchBar.css.ts
+++ b/src/components/NavBar/SearchBar.css.ts
@@ -27,6 +27,7 @@ export const searchBarContainer = style([
     right: '0',
     top: '0',
     zIndex: '3',
+    display: 'inline-block',
   }),
   {
     '@media': {

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -332,64 +332,62 @@ export const SearchBar = () => {
   const placeholderText = phase1Flag === NftVariant.Enabled ? t`Search tokens and NFT collections` : t`Search tokens`
 
   return (
-    <>
-      <Box position="relative">
-        <Box
-          position={isOpen ? { sm: 'fixed', md: 'absolute' } : 'static'}
-          width={{ sm: isOpen ? 'viewWidth' : 'auto', md: 'auto' }}
-          ref={searchRef}
-          className={styles.searchBarContainer}
+    <Box position="relative">
+      <Box
+        position={isOpen ? { sm: 'fixed', md: 'absolute' } : 'static'}
+        width={{ sm: isOpen ? 'viewWidth' : 'auto', md: 'auto' }}
+        ref={searchRef}
+        className={styles.searchBarContainer}
+      >
+        <Row
+          className={clsx(`${styles.searchBar} ${!isOpen && magicalGradientOnHover}`)}
+          borderRadius={isOpen ? undefined : '12'}
+          borderTopRightRadius={isOpen && !isMobile ? '12' : undefined}
+          borderTopLeftRadius={isOpen && !isMobile ? '12' : undefined}
+          borderBottomWidth={isOpen ? '0px' : '1px'}
+          display={{ sm: isOpen ? 'flex' : 'none', xl: 'flex' }}
+          justifyContent={isOpen || phase1Flag === NftVariant.Enabled ? 'flex-start' : 'center'}
+          onFocus={() => !isOpen && toggleOpen()}
+          onClick={() => !isOpen && toggleOpen()}
+          gap="12"
         >
-          <Row
-            className={clsx(`${styles.searchBar} ${!isOpen && magicalGradientOnHover}`)}
-            borderRadius={isOpen ? undefined : '12'}
-            borderTopRightRadius={isOpen && !isMobile ? '12' : undefined}
-            borderTopLeftRadius={isOpen && !isMobile ? '12' : undefined}
-            borderBottomWidth={isOpen ? '0px' : '1px'}
-            display={{ sm: isOpen ? 'flex' : 'none', xl: 'flex' }}
-            justifyContent={isOpen || phase1Flag === NftVariant.Enabled ? 'flex-start' : 'center'}
-            onFocus={() => !isOpen && toggleOpen()}
-            onClick={() => !isOpen && toggleOpen()}
-            gap="12"
-          >
-            <Box display={{ sm: 'none', md: 'flex' }}>
-              <MagnifyingGlassIcon />
-            </Box>
-            <Box display={{ sm: 'flex', md: 'none' }} color="placeholder" onClick={toggleOpen}>
-              <ChevronLeftIcon />
-            </Box>
-            <Box
-              as="input"
-              placeholder={placeholderText}
-              width={isOpen || phase1Flag === NftVariant.Enabled ? 'full' : '120'}
-              onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                !isOpen && toggleOpen()
-                setSearchValue(event.target.value)
-              }}
-              className={styles.searchBarInput}
-              value={searchValue}
-              ref={inputRef}
-            />
-          </Row>
-          <Box display={{ sm: isOpen ? 'none' : 'flex', xl: 'none' }}>
-            <NavIcon onClick={toggleOpen}>
-              <NavMagnifyingGlassIcon width={28} height={28} />
-            </NavIcon>
+          <Box display={{ sm: 'none', md: 'flex' }}>
+            <MagnifyingGlassIcon />
           </Box>
-          {isOpen &&
-            (debouncedSearchValue.length > 0 && (tokensAreLoading || collectionsAreLoading) ? (
-              <SkeletonRow />
-            ) : (
-              <SearchBarDropdown
-                toggleOpen={toggleOpen}
-                tokens={reducedTokens}
-                collections={reducedCollections}
-                hasInput={debouncedSearchValue.length > 0}
-              />
-            ))}
+          <Box display={{ sm: 'flex', md: 'none' }} color="placeholder" onClick={toggleOpen}>
+            <ChevronLeftIcon />
+          </Box>
+          <Box
+            as="input"
+            placeholder={placeholderText}
+            width={isOpen || phase1Flag === NftVariant.Enabled ? 'full' : '120'}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              !isOpen && toggleOpen()
+              setSearchValue(event.target.value)
+            }}
+            className={styles.searchBarInput}
+            value={searchValue}
+            ref={inputRef}
+          />
+        </Row>
+        <Box display={{ sm: isOpen ? 'none' : 'flex', xl: 'none' }}>
+          <NavIcon onClick={toggleOpen}>
+            <NavMagnifyingGlassIcon width={28} height={28} />
+          </NavIcon>
         </Box>
+        {isOpen &&
+          (debouncedSearchValue.length > 0 && (tokensAreLoading || collectionsAreLoading) ? (
+            <SkeletonRow />
+          ) : (
+            <SearchBarDropdown
+              toggleOpen={toggleOpen}
+              tokens={reducedTokens}
+              collections={reducedCollections}
+              hasInput={debouncedSearchValue.length > 0}
+            />
+          ))}
       </Box>
       {isOpen && <Overlay />}
-    </>
+    </Box>
   )
 }


### PR DESCRIPTION
- Fixes issues seen on Safari desktop and iOS where searchbar and magnifying glass icon would shift around
- Bug was caused by absolute positioning and flexbox being handled differently(and inconsistently) by Safari vs Chrome/Firefox
- Fixed by changing searchbar's container from flex to `inline-block`
- Undoes fix #4556 in favor of this solution

Screenshots:
Safari desktop
![searchBarSafariFixed](https://user-images.githubusercontent.com/11512321/187941432-fdee69e5-e446-4104-b8b7-0c09f69491aa.gif)

Chrome on iOS
https://user-images.githubusercontent.com/11512321/187941529-5c642f33-a865-492c-9f16-f73607f01b9f.MP4
