### PR TITLE
fix: Swaps icons for light theme and dark theme

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -278,7 +278,7 @@ export default function Menu() {
                     </ToggleMenuItem>
                     <ToggleMenuItem onClick={() => toggleDarkMode()}>
                       <div>{darkMode ? <Trans>Light Theme</Trans> : <Trans>Dark Theme</Trans>}</div>
-                      {darkMode ? <Moon opacity={0.6} size={16} /> : <Sun opacity={0.6} size={16} />}
+                      {darkMode ? <Sun opacity={0.6} size={16} /> : <Moon opacity={0.6} size={16} />}
                     </ToggleMenuItem>
                     <MenuItem href="https://docs.uniswap.org/">
                       <div>


### PR DESCRIPTION
- Swaps icons for light mode and dark mode

Currently the UI displays the Moon icon for Light theme and Sun icon for Dark theme. These should be switched.