### PR TITLE
fix: Making sure all icons are 24px

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -218,7 +218,7 @@ function Web3StatusInner() {
   } else if (account) {
     return (
       <Web3StatusConnected data-testid="web3-status-connected" onClick={toggleWallet} pending={hasPendingTransactions}>
-        {navbarFlagEnabled && !hasPendingTransactions && <StatusIcon connectionType={connectionType} />}
+        {navbarFlagEnabled && !hasPendingTransactions && <StatusIcon size={24} connectionType={connectionType} />}
         {hasPendingTransactions ? (
           <RowBetween>
             <Text>


### PR DESCRIPTION
Per this conversation: https://uniswapteam.slack.com/archives/C02T729PMQE/p1662576603879399?thread_ts=1662576192.202619&cid=C02T729PMQE

We have inconsistent size of avatars on web status.