### PR TITLE
refactor: move initializing analytics to top level

### DIFF
--- a/src/components/AmplitudeAnalytics/index.ts
+++ b/src/components/AmplitudeAnalytics/index.ts
@@ -7,31 +7,28 @@ import { isProductionEnv } from 'utils/env'
  * Uniswap has two Amplitude projects: test and production. You must be a
  * member of the organization on Amplitude to view details.
  */
-export function initializeAnalytics() {
-  const API_KEY = isProductionEnv() ? process.env.REACT_APP_AMPLITUDE_KEY : process.env.REACT_APP_AMPLITUDE_TEST_KEY
+const API_KEY = isProductionEnv() ? process.env.REACT_APP_AMPLITUDE_KEY : process.env.REACT_APP_AMPLITUDE_TEST_KEY
 
-  if (typeof API_KEY === 'undefined') {
-    const keyName = isProductionEnv() ? 'REACT_APP_AMPLITUDE_KEY' : 'REACT_APP_AMPLITUDE_TEST_KEY'
-    console.error(`${keyName} is undefined, Amplitude analytics will not run.`)
-    return
-  }
-
-  init(
-    API_KEY,
-    /* userId= */ undefined, // User ID should be undefined to let Amplitude default to Device ID
-    /* options= */
-    {
-      // Disable tracking of private user information by Amplitude
-      trackingOptions: {
-        ipAddress: false,
-        carrier: false,
-        city: false,
-        region: false,
-        dma: false, // designated market area
-      },
-    }
-  )
+if (typeof API_KEY === 'undefined') {
+  const keyName = isProductionEnv() ? 'REACT_APP_AMPLITUDE_KEY' : 'REACT_APP_AMPLITUDE_TEST_KEY'
+  throw new Error(`${keyName} is undefined, Amplitude analytics will not run.`)
 }
+
+init(
+  API_KEY,
+  /* userId= */ undefined, // User ID should be undefined to let Amplitude default to Device ID
+  /* options= */
+  {
+    // Disable tracking of private user information by Amplitude
+    trackingOptions: {
+      ipAddress: false,
+      carrier: false,
+      city: false,
+      region: false,
+      dma: false, // designated market area
+    },
+  }
+)
 
 /** Sends an approved (finalized) event to Amplitude production project. */
 export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<string, unknown>) {

--- a/src/components/AmplitudeAnalytics/index.ts
+++ b/src/components/AmplitudeAnalytics/index.ts
@@ -7,11 +7,12 @@ import { isProductionEnv } from 'utils/env'
  * Uniswap has two Amplitude projects: test and production. You must be a
  * member of the organization on Amplitude to view details.
  */
-const API_KEY = isProductionEnv() ? process.env.REACT_APP_AMPLITUDE_KEY : process.env.REACT_APP_AMPLITUDE_TEST_KEY
+
+const AMPLITUDE_KEY_NAME = isProductionEnv() ? 'REACT_APP_AMPLITUDE_KEY' : 'REACT_APP_AMPLITUDE_TEST_KEY'
+const API_KEY = process.env[AMPLITUDE_KEY_NAME]
 
 if (typeof API_KEY === 'undefined') {
-  const keyName = isProductionEnv() ? 'REACT_APP_AMPLITUDE_KEY' : 'REACT_APP_AMPLITUDE_TEST_KEY'
-  throw new Error(`${keyName} is undefined, Amplitude analytics will not run.`)
+  throw new Error(`${AMPLITUDE_KEY_NAME} is undefined, Amplitude analytics will not run.`)
 }
 
 init(

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,4 +1,4 @@
-import { initializeAnalytics, sendAnalyticsEvent, user } from 'components/AmplitudeAnalytics'
+import { sendAnalyticsEvent, user } from 'components/AmplitudeAnalytics'
 import { CUSTOM_USER_PROPERTIES, EventName, PageName } from 'components/AmplitudeAnalytics/constants'
 import { Trace } from 'components/AmplitudeAnalytics/Trace'
 import Loader from 'components/Loader'
@@ -122,7 +122,6 @@ export default function App() {
   const isExpertMode = useIsExpertMode()
 
   useAnalyticsReporter()
-  initializeAnalytics()
 
   useEffect(() => {
     window.scrollTo(0, 0)


### PR DESCRIPTION
Initializing amplitude is required for setting up amplitude experiment. We will use the key returned by `init` to set up the experiment module. Make sure that we error out if the key is undefined.