### PR TITLE
fix: remove $ when formatting amounts

### DIFF
--- a/src/utils/formatDollarAmt.tsx
+++ b/src/utils/formatDollarAmt.tsx
@@ -26,7 +26,7 @@ export const formatAmount = (num: number | undefined, digits = 2) => {
   if (num === 0) return '0'
   if (!num) return '-'
   if (num < 0.001) {
-    return '$<0.001'
+    return '<0.001'
   }
   return numbro(num).format({
     average: true,


### PR DESCRIPTION
There is already a method to format dollar amounts, so this must be a mistake.