### PR TITLE
feat: optimize AlphaRouter usage

### DIFF
--- a/src/hooks/useBestTrade.test.ts
+++ b/src/hooks/useBestTrade.test.ts
@@ -1,7 +1,9 @@
 import { renderHook } from '@testing-library/react'
 import { CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { DAI, USDC_MAINNET } from 'constants/tokens'
+import { RouterPreference } from 'state/routing/slice'
 import { TradeState } from 'state/routing/types'
+import { useClientSideRouter } from 'state/user/hooks'
 
 import { useRoutingAPITrade } from '../state/routing/useRoutingAPITrade'
 import useAutoRouterSupported from './useAutoRouterSupported'
@@ -25,6 +27,7 @@ const mockUseAutoRouterSupported = useAutoRouterSupported as jest.MockedFunction
 const mockUseIsWindowVisible = useIsWindowVisible as jest.MockedFunction<typeof useIsWindowVisible>
 
 const mockUseRoutingAPITrade = useRoutingAPITrade as jest.MockedFunction<typeof useRoutingAPITrade>
+const mockUseClientSideRouter = useClientSideRouter as jest.MockedFunction<typeof useClientSideRouter>
 const mockUseClientSideV3Trade = useClientSideV3Trade as jest.MockedFunction<typeof useClientSideV3Trade>
 
 // helpers to set mock expectations
@@ -42,6 +45,7 @@ beforeEach(() => {
 
   mockUseIsWindowVisible.mockReturnValue(true)
   mockUseAutoRouterSupported.mockReturnValue(true)
+  mockUseClientSideRouter.mockReturnValue([true, () => undefined])
 })
 
 describe('#useBestV3Trade ExactIn', () => {
@@ -52,7 +56,7 @@ describe('#useBestV3Trade ExactIn', () => {
 
     const { result } = renderHook(() => useBestTrade(TradeType.EXACT_INPUT, USDCAmount, DAI))
 
-    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(TradeType.EXACT_INPUT, undefined, DAI)
+    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(TradeType.EXACT_INPUT, undefined, DAI, RouterPreference.CLIENT)
     expect(mockUseClientSideV3Trade).toHaveBeenCalledWith(TradeType.EXACT_INPUT, USDCAmount, DAI)
     expect(result.current).toEqual({ state: TradeState.VALID, trade: undefined })
   })
@@ -64,7 +68,7 @@ describe('#useBestV3Trade ExactIn', () => {
 
     const { result } = renderHook(() => useBestTrade(TradeType.EXACT_INPUT, USDCAmount, DAI))
 
-    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(TradeType.EXACT_INPUT, undefined, DAI)
+    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(TradeType.EXACT_INPUT, undefined, DAI, RouterPreference.CLIENT)
     expect(mockUseClientSideV3Trade).toHaveBeenCalledWith(TradeType.EXACT_INPUT, USDCAmount, DAI)
     expect(result.current).toEqual({ state: TradeState.VALID, trade: undefined })
   })
@@ -128,7 +132,12 @@ describe('#useBestV3Trade ExactOut', () => {
 
     const { result } = renderHook(() => useBestTrade(TradeType.EXACT_OUTPUT, DAIAmount, USDC_MAINNET))
 
-    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(TradeType.EXACT_OUTPUT, undefined, USDC_MAINNET)
+    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(
+      TradeType.EXACT_OUTPUT,
+      undefined,
+      USDC_MAINNET,
+      RouterPreference.CLIENT
+    )
     expect(mockUseClientSideV3Trade).toHaveBeenCalledWith(TradeType.EXACT_OUTPUT, DAIAmount, USDC_MAINNET)
     expect(result.current).toEqual({ state: TradeState.VALID, trade: undefined })
   })
@@ -140,7 +149,12 @@ describe('#useBestV3Trade ExactOut', () => {
 
     const { result } = renderHook(() => useBestTrade(TradeType.EXACT_OUTPUT, DAIAmount, USDC_MAINNET))
 
-    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(TradeType.EXACT_OUTPUT, undefined, USDC_MAINNET)
+    expect(mockUseRoutingAPITrade).toHaveBeenCalledWith(
+      TradeType.EXACT_OUTPUT,
+      undefined,
+      USDC_MAINNET,
+      RouterPreference.CLIENT
+    )
     expect(mockUseClientSideV3Trade).toHaveBeenCalledWith(TradeType.EXACT_OUTPUT, DAIAmount, USDC_MAINNET)
     expect(result.current).toEqual({ state: TradeState.VALID, trade: undefined })
   })

--- a/src/hooks/useBestTrade.ts
+++ b/src/hooks/useBestTrade.ts
@@ -1,7 +1,9 @@
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
+import { RouterPreference } from 'state/routing/slice'
 import { InterfaceTrade, TradeState } from 'state/routing/types'
 import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
+import { useClientSideRouter } from 'state/user/hooks'
 
 import useAutoRouterSupported from './useAutoRouterSupported'
 import { useClientSideV3Trade } from './useClientSideV3Trade'
@@ -30,10 +32,12 @@ export function useBestTrade(
     200
   )
 
+  const [clientSideRouter] = useClientSideRouter()
   const routingAPITrade = useRoutingAPITrade(
     tradeType,
     autoRouterSupported && isWindowVisible ? debouncedAmount : undefined,
-    debouncedOtherCurrency
+    debouncedOtherCurrency,
+    clientSideRouter ? RouterPreference.CLIENT : RouterPreference.API
   )
 
   const isLoading = routingAPITrade.state === TradeState.LOADING

--- a/src/hooks/useStablecoinPrice.ts
+++ b/src/hooks/useStablecoinPrice.ts
@@ -27,7 +27,7 @@ export default function useStablecoinPrice(currency?: Currency): Price<Currency,
   const amountOut = chainId ? STABLECOIN_AMOUNT_OUT[chainId] : undefined
   const stablecoin = amountOut?.currency
 
-  const { trade } = useRoutingAPITrade(TradeType.EXACT_OUTPUT, amountOut, currency, RouterPreference.CLIENT)
+  const { trade } = useRoutingAPITrade(TradeType.EXACT_OUTPUT, amountOut, currency, RouterPreference.PRICE)
   const price = useMemo(() => {
     if (!currency || !stablecoin) {
       return undefined

--- a/src/hooks/useStablecoinPrice.ts
+++ b/src/hooks/useStablecoinPrice.ts
@@ -2,7 +2,8 @@ import { Currency, CurrencyAmount, Price, Token, TradeType } from '@uniswap/sdk-
 import { useWeb3React } from '@web3-react/core'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useMemo, useRef } from 'react'
-import { RouterPreference, useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
+import { RouterPreference } from 'state/routing/slice'
+import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
 
 import { SupportedChainId } from '../constants/chains'
 import { CUSD_CELO, DAI_OPTIMISM, USDC_ARBITRUM, USDC_MAINNET, USDC_POLYGON } from '../constants/tokens'

--- a/src/lib/hooks/routing/clientSideSmartOrderRouter.ts
+++ b/src/lib/hooks/routing/clientSideSmartOrderRouter.ts
@@ -1,7 +1,7 @@
 import { BigintIsh, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 // This file is lazy-loaded, so the import of smart-order-router is intentional.
 // eslint-disable-next-line no-restricted-imports
-import { AlphaRouter, AlphaRouterConfig, AlphaRouterParams, ChainId } from '@uniswap/smart-order-router'
+import { AlphaRouter, AlphaRouterConfig, ChainId } from '@uniswap/smart-order-router'
 import { SupportedChainId } from 'constants/chains'
 import JSBI from 'jsbi'
 import { GetQuoteResult } from 'state/routing/types'
@@ -29,11 +29,9 @@ async function getQuote(
     tokenOut: { address: string; chainId: number; decimals: number; symbol?: string }
     amount: BigintIsh
   },
-  routerParams: AlphaRouterParams,
-  routerConfig: Partial<AlphaRouterConfig>
+  router: AlphaRouter,
+  config: Partial<AlphaRouterConfig>
 ): Promise<{ data: GetQuoteResult; error?: unknown }> {
-  const router = new AlphaRouter(routerParams)
-
   const currencyIn = new Token(tokenIn.chainId, tokenIn.address, tokenIn.decimals, tokenIn.symbol)
   const currencyOut = new Token(tokenOut.chainId, tokenOut.address, tokenOut.decimals, tokenOut.symbol)
 
@@ -46,7 +44,7 @@ async function getQuote(
     quoteCurrency,
     type === 'exactIn' ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT,
     /*swapConfig=*/ undefined,
-    routerConfig
+    config
   )
 
   if (!swapRoute) throw new Error('Failed to generate client side quote')
@@ -80,8 +78,8 @@ export async function getClientSideQuote(
     amount,
     type,
   }: QuoteArguments,
-  routerParams: AlphaRouterParams,
-  routerConfig: Partial<AlphaRouterConfig>
+  router: AlphaRouter,
+  config: Partial<AlphaRouterConfig>
 ) {
   return getQuote(
     {
@@ -100,7 +98,7 @@ export async function getClientSideQuote(
       },
       amount,
     },
-    routerParams,
-    routerConfig
+    router,
+    config
   )
 }

--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -1,5 +1,6 @@
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
+import { RouterPreference } from 'state/routing/slice'
 
 /**
  * Returns query arguments for the Routing API query or undefined if the
@@ -11,13 +12,13 @@ export function useRoutingAPIArguments({
   tokenOut,
   amount,
   tradeType,
-  useClientSideRouter,
+  routerPreference,
 }: {
   tokenIn: Currency | undefined
   tokenOut: Currency | undefined
   amount: CurrencyAmount<Currency> | undefined
   tradeType: TradeType
-  useClientSideRouter: boolean
+  routerPreference: RouterPreference
 }) {
   return useMemo(
     () =>
@@ -33,9 +34,9 @@ export function useRoutingAPIArguments({
             tokenOutChainId: tokenOut.wrapped.chainId,
             tokenOutDecimals: tokenOut.wrapped.decimals,
             tokenOutSymbol: tokenOut.wrapped.symbol,
-            useClientSideRouter,
+            routerPreference,
             type: (tradeType === TradeType.EXACT_INPUT ? 'exactIn' : 'exactOut') as 'exactIn' | 'exactOut',
           },
-    [amount, tokenIn, tokenOut, tradeType, useClientSideRouter]
+    [amount, routerPreference, tokenIn, tokenOut, tradeType]
   )
 }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -42,6 +42,26 @@ const CLIENT_QUERY_PARAMS = {
 }
 const PRICE_QUERY_PARAMS = {
   protocols,
+  v2PoolSelection: {
+    topN: 2,
+    topNDirectSwaps: 1,
+    topNTokenInOut: 2,
+    topNSecondHop: 1,
+    topNWithEachBaseToken: 2,
+    topNWithBaseToken: 2,
+  },
+  v3PoolSelection: {
+    topN: 2,
+    topNDirectSwaps: 1,
+    topNTokenInOut: 2,
+    topNSecondHop: 1,
+    topNWithEachBaseToken: 2,
+    topNWithBaseToken: 2,
+  },
+  maxSwapsPerPath: 2,
+  minSplits: 1,
+  maxSplits: 1,
+  distributionPercent: 100,
 }
 
 export const routingApi = createApi({

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -40,6 +40,7 @@ const API_QUERY_PARAMS = {
 const CLIENT_QUERY_PARAMS = {
   protocols,
 }
+// Price queries are tuned down to minimize the required RPCs to respond to them.
 const PRICE_QUERY_PARAMS = {
   protocols,
   v2PoolSelection: {

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -39,6 +39,8 @@ const CLIENT_PARAMS = {
   protocols: [Protocol.V2, Protocol.V3, Protocol.MIXED],
 }
 // Price queries are tuned down to minimize the required RPCs to respond to them.
+// TODO(zzmp): This will be used after testing router caching.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const PRICE_PARAMS = {
   protocols: [Protocol.V2, Protocol.V3],
   v2PoolSelection: {
@@ -108,7 +110,9 @@ export const routingApi = createApi({
             result = await getClientSideQuote(
               args,
               router,
-              routerPreference === RouterPreference.PRICE ? PRICE_PARAMS : CLIENT_PARAMS
+              // TODO(zzmp): Use PRICE_PARAMS for RouterPreference.PRICE.
+              // This change is intentionally being deferred to first see what effect router caching has.
+              CLIENT_PARAMS
             )
           }
 

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -31,18 +31,16 @@ function getRouter(chainId: ChainId): AlphaRouter {
   throw new Error(`Router does not support this chain (chainId: ${chainId}).`)
 }
 
-const protocols: Protocol[] = [Protocol.V2, Protocol.V3, Protocol.MIXED]
-
-// routing API quote query params: https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/schema/quote-schema.ts
+// routing API quote params: https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/schema/quote-schema.ts
 const API_QUERY_PARAMS = {
-  protocols: protocols.map((p) => p.toLowerCase()).join(','),
+  protocols: 'v2,v3,mixed',
 }
-const CLIENT_QUERY_PARAMS = {
-  protocols,
+const CLIENT_PARAMS = {
+  protocols: [Protocol.V2, Protocol.V3, Protocol.MIXED],
 }
 // Price queries are tuned down to minimize the required RPCs to respond to them.
-const PRICE_QUERY_PARAMS = {
-  protocols,
+const PRICE_PARAMS = {
+  protocols: [Protocol.V2, Protocol.V3],
   v2PoolSelection: {
     topN: 2,
     topNDirectSwaps: 1,
@@ -110,7 +108,7 @@ export const routingApi = createApi({
             result = await getClientSideQuote(
               args,
               router,
-              routerPreference === RouterPreference.PRICE ? PRICE_QUERY_PARAMS : CLIENT_QUERY_PARAMS
+              routerPreference === RouterPreference.PRICE ? PRICE_PARAMS : CLIENT_PARAMS
             )
           }
 

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -32,11 +32,9 @@ function getRouterProvider(chainId: ChainId): BaseProvider {
 
 const protocols: Protocol[] = [Protocol.V2, Protocol.V3, Protocol.MIXED]
 
+// routing API quote query params: https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/schema/quote-schema.ts
 const API_QUERY_PARAMS = {
   protocols: protocols.map((p) => p.toLowerCase()).join(','),
-  // example other params
-  // forceCrossProtocol: 'true',
-  // minSplits: '5',
 }
 const CLIENT_QUERY_PARAMS = {}
 const PRICE_QUERY_PARAMS = {}

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -7,16 +7,10 @@ import { useRoutingAPIArguments } from 'lib/hooks/routing/useRoutingAPIArguments
 import useIsValidBlock from 'lib/hooks/useIsValidBlock'
 import ms from 'ms.macro'
 import { useMemo } from 'react'
-import { useGetQuoteQuery } from 'state/routing/slice'
-import { useClientSideRouter } from 'state/user/hooks'
+import { RouterPreference, useGetQuoteQuery } from 'state/routing/slice'
 
 import { GetQuoteResult, InterfaceTrade, TradeState } from './types'
 import { computeRoutes, transformRoutesToTrade } from './utils'
-
-export enum RouterPreference {
-  CLIENT = 'client',
-  API = 'api',
-}
 
 /**
  * Returns the best trade by invoking the routing api or the smart order router on the client
@@ -26,9 +20,9 @@ export enum RouterPreference {
  */
 export function useRoutingAPITrade<TTradeType extends TradeType>(
   tradeType: TTradeType,
-  amountSpecified?: CurrencyAmount<Currency>,
-  otherCurrency?: Currency,
-  routerPreference?: RouterPreference
+  amountSpecified: CurrencyAmount<Currency> | undefined,
+  otherCurrency: Currency | undefined,
+  routerPreference: RouterPreference
 ): {
   state: TradeState
   trade: InterfaceTrade<Currency, Currency, TTradeType> | undefined
@@ -41,17 +35,12 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     [amountSpecified, otherCurrency, tradeType]
   )
 
-  const [clientSideRouterStoredPreference] = useClientSideRouter()
-  const clientSideRouter = routerPreference
-    ? routerPreference === RouterPreference.CLIENT
-    : clientSideRouterStoredPreference
-
   const queryArgs = useRoutingAPIArguments({
     tokenIn: currencyIn,
     tokenOut: currencyOut,
     amount: amountSpecified,
     tradeType,
-    useClientSideRouter: clientSideRouter,
+    routerPreference,
   })
 
   const { isLoading, isError, data, currentData } = useGetQuoteQuery(queryArgs ?? skipToken, {


### PR DESCRIPTION
- Cache AlphaRouter (instead of the BaseProvider passed to the router), to prevent router re-instantiation
- Adds a new RouterPreference: PRICE
- Adds the ability to explicitly tune each preference: API, CLIENT, PRICE
  -  A PRICE tuning is defined, but unused - this will be activated after determining the performance of router caching