### PR TITLE
fix: remove refetchOnFocus for routing-api

### DIFF
--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -45,7 +45,6 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
 
   const { isLoading, isError, data, currentData } = useGetQuoteQuery(queryArgs ?? skipToken, {
     pollingInterval: ms`15s`,
-    refetchOnFocus: true,
   })
 
   const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(data?.blockNumber) || 0) ? data : undefined


### PR DESCRIPTION
There shouldn't be a need to refetch on focus as we keep the state in sync regardless. This will reduce a large number of Infura requests we make via the smart-order-router.