### PR TITLE
fix: adjust search input width

### DIFF
--- a/src/components/NavBar/SearchBar.css.ts
+++ b/src/components/NavBar/SearchBar.css.ts
@@ -57,7 +57,6 @@ export const searchBarInput = style([
     color: { default: 'blackBlue', placeholder: 'placeholder' },
     border: 'none',
     background: 'none',
-    width: 'full',
   }),
   {
     lineHeight: '24px',

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -418,6 +418,7 @@ export const SearchBar = () => {
             }`}
             value={searchValue}
             ref={inputRef}
+            width={phase1Flag === NftVariant.Enabled || isOpen ? 'full' : '160'}
           />
         </Row>
         <Box className={clsx(isOpen ? styles.visible : styles.hidden)}>


### PR DESCRIPTION
Previously, when the universal search input was shifted to the center in the unopened state for phase 0, the width would not change and the user could click or hover to the right of the searchbar and trigger the open search or hover state respectively. This bug adjusts the width of the input to fix this.

Screenshots:
![searchHoverBug](https://user-images.githubusercontent.com/11512321/189740950-81ae519f-366b-41e6-b6de-5d25dbef710e.gif)
