### PR TITLE
fix: fetch the usd price from parsed amount

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -243,11 +243,8 @@ export default function Swap() {
     [trade, tradeState]
   )
 
-  // show price estimates based on wrap trade
-  const inputValue = showWrap ? parsedAmount : trade?.inputAmount
-  const outputValue = showWrap ? parsedAmount : trade?.outputAmount
-  const fiatValueInput = useStablecoinValue(inputValue)
-  const fiatValueOutput = useStablecoinValue(outputValue)
+  const fiatValueInput = useStablecoinValue(parsedAmounts[Field.INPUT])
+  const fiatValueOutput = useStablecoinValue(parsedAmounts[Field.OUTPUT])
   const stablecoinPriceImpact = useMemo(
     () => (routeIsSyncing ? undefined : computeFiatValuePriceImpact(fiatValueInput, fiatValueOutput)),
     [fiatValueInput, fiatValueOutput, routeIsSyncing]


### PR DESCRIPTION
Fetches the stablecoin price without waiting for the quote API to resolve.