### PR TITLE
fix: update feature flags on update

### DIFF
--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -1,5 +1,4 @@
-import { useAtom } from 'jotai'
-import { atomWithStorage, useAtomValue } from 'jotai/utils'
+import { atomWithStorage, useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { createContext, ReactNode, useCallback, useContext } from 'react'
 export { FeatureFlag } from './flags/featureFlags'
 
@@ -23,14 +22,16 @@ export function useFeatureFlagsContext(): FeatureFlagsContextType {
 export const featureFlagSettings = atomWithStorage<Record<string, string>>('featureFlags', {})
 
 export function useUpdateFlag() {
-  const [featureFlags, setFeatureFlags] = useAtom(featureFlagSettings)
+  const setFeatureFlags = useUpdateAtom(featureFlagSettings)
 
   return useCallback(
     (featureFlag: string, option: string) => {
-      featureFlags[featureFlag] = option
-      setFeatureFlags(featureFlags)
+      setFeatureFlags((featureFlags) => ({
+        ...featureFlags,
+        [featureFlag]: option,
+      }))
     },
-    [featureFlags, setFeatureFlags]
+    [setFeatureFlags]
   )
 }
 


### PR DESCRIPTION
- Avoids including the set value in the deps - instead uses the current value from the setter
- Sets a new reference for the value, triggering a re-render