### PR TITLE
feat: adds ethers provider tracing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,6 +81,18 @@
           }
         ]
       }
+    ],
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@ethersproject/providers",
+            "message": "Please only use Providers instantiated in constants/providers to improve traceability.",
+            "allowTypeImports": true
+          }
+        ]
+      }
     ]
   }
 }

--- a/cypress/support/ethereum.ts
+++ b/cypress/support/ethereum.ts
@@ -3,6 +3,7 @@
  */
 
 import { Eip1193Bridge } from '@ethersproject/experimental/lib/eip1193-bridge'
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
 

--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -5,6 +5,7 @@ import { RedesignVariant, useRedesignFlag } from 'featureFlags/flags/redesign'
 import { TokensVariant, useTokensFlag } from 'featureFlags/flags/tokens'
 import { TokenSafetyVariant, useTokenSafetyFlag } from 'featureFlags/flags/tokenSafety'
 import { TokensNetworkFilterVariant, useTokensNetworkFilterFlag } from 'featureFlags/flags/tokensNetworkFilter'
+import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { Children, PropsWithChildren, ReactElement, ReactNode, useCallback, useState } from 'react'
 import { X } from 'react-feather'
@@ -240,6 +241,14 @@ export default function FeatureFlagModal() {
       </FeatureFlagGroup>
       <FeatureFlagGroup name="Phase 1">
         <FeatureFlagOption variant={NftVariant} value={useNftFlag()} featureFlag={FeatureFlag.nft} label="NFTs" />
+      </FeatureFlagGroup>
+      <FeatureFlagGroup name="Debug">
+        <FeatureFlagOption
+          variant={TraceJsonRpcVariant}
+          value={useTraceJsonRpcFlag()}
+          featureFlag={FeatureFlag.traceJsonRpc}
+          label="Enables JSON-RPC tracing"
+        />
       </FeatureFlagGroup>
       <SaveButton onClick={() => window.location.reload()}>Reload</SaveButton>
     </Modal>

--- a/src/components/earn/ClaimRewardModal.tsx
+++ b/src/components/earn/ClaimRewardModal.tsx
@@ -1,4 +1,4 @@
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import StakingRewardsJson from '@uniswap/liquidity-staker/build/StakingRewards.json'
 import { useWeb3React } from '@web3-react/core'

--- a/src/components/earn/StakingModal.tsx
+++ b/src/components/earn/StakingModal.tsx
@@ -1,4 +1,4 @@
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import StakingRewardsJson from '@uniswap/liquidity-staker/build/StakingRewards.json'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'

--- a/src/components/earn/UnstakingModal.tsx
+++ b/src/components/earn/UnstakingModal.tsx
@@ -1,4 +1,4 @@
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import StakingRewardsJson from '@uniswap/liquidity-staker/build/StakingRewards.json'
 import { useWeb3React } from '@web3-react/core'

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -8,7 +8,8 @@ import { WalletConnect } from '@web3-react/walletconnect'
 import { SupportedChainId } from 'constants/chains'
 
 import UNISWAP_LOGO_URL from '../assets/svg/logo.svg'
-import { RPC_PROVIDERS, RPC_URLS } from '../constants/networks'
+import { RPC_URLS } from '../constants/networks'
+import { RPC_PROVIDERS } from '../constants/providers'
 
 export enum ConnectionType {
   INJECTED = 'INJECTED',

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -74,7 +74,7 @@ const [web3CoinbaseWallet, web3CoinbaseWalletHooks] = initializeConnector<Coinba
     new CoinbaseWallet({
       actions,
       options: {
-        url: RPC_URLS[SupportedChainId.MAINNET],
+        url: RPC_URLS[SupportedChainId.MAINNET][0],
         appName: 'Uniswap',
         appLogoUrl: UNISWAP_LOGO_URL,
         reloadOnDisconnect: false,

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -6,20 +6,132 @@ if (typeof INFURA_KEY === 'undefined') {
 }
 
 /**
- * These are the network URLs used by the interface when there is not another available source of chain data
+ * Fallback JSON-RPC endpoints.
+ * These are used if the integrator does not provide an endpoint, or if the endpoint does not work.
+ *
+ * MetaMask allows switching to any URL, but displays a warning if it is not on the "Safe" list:
+ * https://github.com/MetaMask/metamask-mobile/blob/bdb7f37c90e4fc923881a07fca38d4e77c73a579/app/core/RPCMethods/wallet_addEthereumChain.js#L228-L235
+ * https://chainid.network/chains.json
+ *
+ * These "Safe" URLs are listed first, followed by other fallback URLs, which are taken from chainlist.org.
  */
-export const RPC_URLS: { [key in SupportedChainId]: string } = {
-  [SupportedChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.RINKEBY]: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.ROPSTEN]: `https://ropsten.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.GOERLI]: `https://goerli.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.KOVAN]: `https://kovan.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.OPTIMISM]: `https://optimism-mainnet.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.OPTIMISTIC_KOVAN]: `https://optimism-kovan.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.ARBITRUM_ONE]: `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.ARBITRUM_RINKEBY]: `https://arbitrum-rinkeby.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.POLYGON]: `https://polygon-mainnet.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.POLYGON_MUMBAI]: `https://polygon-mumbai.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.CELO]: `https://forno.celo.org`,
-  [SupportedChainId.CELO_ALFAJORES]: `https://alfajores-forno.celo-testnet.org`,
+export const FALLBACK_URLS: { [key in SupportedChainId]: string[] } = {
+  [SupportedChainId.MAINNET]: [
+    // "Safe" URLs
+    'https://api.mycryptoapi.com/eth',
+    'https://cloudflare-eth.com',
+    // "Fallback" URLs
+    'https://rpc.ankr.com/eth',
+    'https://eth-mainnet.public.blastapi.io',
+  ],
+  [SupportedChainId.ROPSTEN]: [
+    // "Fallback" URLs
+    'https://rpc.ankr.com/eth_ropsten',
+  ],
+  [SupportedChainId.RINKEBY]: [
+    // "Fallback" URLs
+    'https://rinkeby-light.eth.linkpool.io/',
+  ],
+  [SupportedChainId.GOERLI]: [
+    // "Safe" URLs
+    'https://rpc.goerli.mudit.blog/',
+    // "Fallback" URLs
+    'https://rpc.ankr.com/eth_goerli',
+  ],
+  [SupportedChainId.KOVAN]: [
+    // "Safe" URLs
+    'https://kovan.poa.network',
+    // "Fallback" URLs
+    'https://eth-kovan.public.blastapi.io',
+  ],
+  [SupportedChainId.POLYGON]: [
+    // "Safe" URLs
+    'https://polygon-rpc.com/',
+    'https://rpc-mainnet.matic.network',
+    'https://matic-mainnet.chainstacklabs.com',
+    'https://rpc-mainnet.maticvigil.com',
+    'https://rpc-mainnet.matic.quiknode.pro',
+    'https://matic-mainnet-full-rpc.bwarelabs.com',
+  ],
+  [SupportedChainId.POLYGON_MUMBAI]: [
+    // "Safe" URLs
+    'https://matic-mumbai.chainstacklabs.com',
+    'https://rpc-mumbai.maticvigil.com',
+    'https://matic-testnet-archive-rpc.bwarelabs.com',
+  ],
+  [SupportedChainId.ARBITRUM_ONE]: [
+    // "Safe" URLs
+    'https://arb1.arbitrum.io/rpc',
+    // "Fallback" URLs
+    'https://arbitrum.public-rpc.com',
+  ],
+  [SupportedChainId.ARBITRUM_RINKEBY]: [
+    // "Safe" URLs
+    'https://rinkeby.arbitrum.io/rpc',
+  ],
+  [SupportedChainId.OPTIMISM]: [
+    // "Safe" URLs
+    'https://mainnet.optimism.io/',
+    // "Fallback" URLs
+    'https://rpc.ankr.com/optimism',
+  ],
+  [SupportedChainId.OPTIMISTIC_KOVAN]: [
+    // "Safe" URLs
+    'https://kovan.optimism.io',
+  ],
+  [SupportedChainId.CELO]: [
+    // "Safe" URLs
+    `https://forno.celo.org`,
+  ],
+  [SupportedChainId.CELO_ALFAJORES]: [
+    // "Safe" URLs
+    `https://alfajores-forno.celo-testnet.org`,
+  ],
+}
+
+/**
+ * Known JSON-RPC endpoints.
+ * These are the URLs used by the interface when there is not another available source of chain data.
+ */
+export const RPC_URLS: { [key in SupportedChainId]: string[] } = {
+  [SupportedChainId.MAINNET]: [
+    `https://mainnet.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.MAINNET],
+  ],
+  [SupportedChainId.RINKEBY]: [
+    `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.RINKEBY],
+  ],
+  [SupportedChainId.ROPSTEN]: [
+    `https://ropsten.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.ROPSTEN],
+  ],
+  [SupportedChainId.GOERLI]: [`https://goerli.infura.io/v3/${INFURA_KEY}`, ...FALLBACK_URLS[SupportedChainId.GOERLI]],
+  [SupportedChainId.KOVAN]: [`https://kovan.infura.io/v3/${INFURA_KEY}`, ...FALLBACK_URLS[SupportedChainId.KOVAN]],
+  [SupportedChainId.OPTIMISM]: [
+    `https://optimism-mainnet.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.OPTIMISM],
+  ],
+  [SupportedChainId.OPTIMISTIC_KOVAN]: [
+    `https://optimism-kovan.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.OPTIMISTIC_KOVAN],
+  ],
+  [SupportedChainId.ARBITRUM_ONE]: [
+    `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.ARBITRUM_ONE],
+  ],
+  [SupportedChainId.ARBITRUM_RINKEBY]: [
+    `https://arbitrum-rinkeby.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.ARBITRUM_RINKEBY],
+  ],
+  [SupportedChainId.POLYGON]: [
+    `https://polygon-mainnet.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.POLYGON],
+  ],
+  [SupportedChainId.POLYGON_MUMBAI]: [
+    `https://polygon-mumbai.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.POLYGON_MUMBAI],
+  ],
+  [SupportedChainId.CELO]: FALLBACK_URLS[SupportedChainId.CELO],
+  [SupportedChainId.CELO_ALFAJORES]: FALLBACK_URLS[SupportedChainId.CELO_ALFAJORES],
 }

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -1,5 +1,3 @@
-import { StaticJsonRpcProvider } from '@ethersproject/providers'
-
 import { SupportedChainId } from './chains'
 
 const INFURA_KEY = process.env.REACT_APP_INFURA_KEY
@@ -24,20 +22,4 @@ export const RPC_URLS: { [key in SupportedChainId]: string } = {
   [SupportedChainId.POLYGON_MUMBAI]: `https://polygon-mumbai.infura.io/v3/${INFURA_KEY}`,
   [SupportedChainId.CELO]: `https://forno.celo.org`,
   [SupportedChainId.CELO_ALFAJORES]: `https://alfajores-forno.celo-testnet.org`,
-}
-
-export const RPC_PROVIDERS: { [key in SupportedChainId]: StaticJsonRpcProvider } = {
-  [SupportedChainId.MAINNET]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
-  [SupportedChainId.RINKEBY]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
-  [SupportedChainId.ROPSTEN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
-  [SupportedChainId.GOERLI]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
-  [SupportedChainId.KOVAN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
-  [SupportedChainId.OPTIMISM]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
-  [SupportedChainId.OPTIMISTIC_KOVAN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISTIC_KOVAN]),
-  [SupportedChainId.ARBITRUM_ONE]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
-  [SupportedChainId.ARBITRUM_RINKEBY]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
-  [SupportedChainId.POLYGON]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
-  [SupportedChainId.POLYGON_MUMBAI]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
-  [SupportedChainId.CELO]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
-  [SupportedChainId.CELO_ALFAJORES]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
 }

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -5,21 +5,29 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { SupportedChainId } from './chains'
 import { RPC_URLS } from './networks'
 
+class FallbackJsonRpcProvider extends StaticJsonRpcProvider {
+  constructor(urls: string[]) {
+    super(urls[0])
+
+    // TODO(vm): Implement fallback logic.
+  }
+}
+
 /**
  * These are the only JsonRpcProviders used directly by the interface.
  */
 export const RPC_PROVIDERS: { [key in SupportedChainId]: StaticJsonRpcProvider } = {
-  [SupportedChainId.MAINNET]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
-  [SupportedChainId.RINKEBY]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
-  [SupportedChainId.ROPSTEN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
-  [SupportedChainId.GOERLI]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
-  [SupportedChainId.KOVAN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
-  [SupportedChainId.OPTIMISM]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
-  [SupportedChainId.OPTIMISTIC_KOVAN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISTIC_KOVAN]),
-  [SupportedChainId.ARBITRUM_ONE]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
-  [SupportedChainId.ARBITRUM_RINKEBY]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
-  [SupportedChainId.POLYGON]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
-  [SupportedChainId.POLYGON_MUMBAI]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
-  [SupportedChainId.CELO]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
-  [SupportedChainId.CELO_ALFAJORES]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
+  [SupportedChainId.MAINNET]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
+  [SupportedChainId.RINKEBY]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
+  [SupportedChainId.ROPSTEN]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
+  [SupportedChainId.GOERLI]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
+  [SupportedChainId.KOVAN]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
+  [SupportedChainId.OPTIMISM]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
+  [SupportedChainId.OPTIMISTIC_KOVAN]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISTIC_KOVAN]),
+  [SupportedChainId.ARBITRUM_ONE]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
+  [SupportedChainId.ARBITRUM_RINKEBY]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
+  [SupportedChainId.POLYGON]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
+  [SupportedChainId.POLYGON_MUMBAI]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
+  [SupportedChainId.CELO]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
+  [SupportedChainId.CELO_ALFAJORES]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
 }

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -5,11 +5,9 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { SupportedChainId } from './chains'
 import { RPC_URLS } from './networks'
 
-class FallbackJsonRpcProvider extends StaticJsonRpcProvider {
+class AppJsonRpcProvider extends StaticJsonRpcProvider {
   constructor(urls: string[]) {
     super(urls[0])
-
-    // TODO(vm): Implement fallback logic.
   }
 }
 
@@ -17,17 +15,17 @@ class FallbackJsonRpcProvider extends StaticJsonRpcProvider {
  * These are the only JsonRpcProviders used directly by the interface.
  */
 export const RPC_PROVIDERS: { [key in SupportedChainId]: StaticJsonRpcProvider } = {
-  [SupportedChainId.MAINNET]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
-  [SupportedChainId.RINKEBY]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
-  [SupportedChainId.ROPSTEN]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
-  [SupportedChainId.GOERLI]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
-  [SupportedChainId.KOVAN]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
-  [SupportedChainId.OPTIMISM]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
-  [SupportedChainId.OPTIMISTIC_KOVAN]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISTIC_KOVAN]),
-  [SupportedChainId.ARBITRUM_ONE]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
-  [SupportedChainId.ARBITRUM_RINKEBY]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
-  [SupportedChainId.POLYGON]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
-  [SupportedChainId.POLYGON_MUMBAI]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
-  [SupportedChainId.CELO]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
-  [SupportedChainId.CELO_ALFAJORES]: new FallbackJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
+  [SupportedChainId.MAINNET]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
+  [SupportedChainId.RINKEBY]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
+  [SupportedChainId.ROPSTEN]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
+  [SupportedChainId.GOERLI]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
+  [SupportedChainId.KOVAN]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
+  [SupportedChainId.OPTIMISM]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
+  [SupportedChainId.OPTIMISTIC_KOVAN]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISTIC_KOVAN]),
+  [SupportedChainId.ARBITRUM_ONE]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
+  [SupportedChainId.ARBITRUM_RINKEBY]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
+  [SupportedChainId.POLYGON]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
+  [SupportedChainId.POLYGON_MUMBAI]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
+  [SupportedChainId.CELO]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
+  [SupportedChainId.CELO_ALFAJORES]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
 }

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -1,0 +1,23 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
+
+import { SupportedChainId } from './chains'
+import { RPC_URLS } from './networks'
+
+/**
+ * These are the only JsonRpcProviders used directly by the interface.
+ */
+export const RPC_PROVIDERS: { [key in SupportedChainId]: StaticJsonRpcProvider } = {
+  [SupportedChainId.MAINNET]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
+  [SupportedChainId.RINKEBY]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
+  [SupportedChainId.ROPSTEN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
+  [SupportedChainId.GOERLI]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
+  [SupportedChainId.KOVAN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
+  [SupportedChainId.OPTIMISM]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
+  [SupportedChainId.OPTIMISTIC_KOVAN]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISTIC_KOVAN]),
+  [SupportedChainId.ARBITRUM_ONE]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
+  [SupportedChainId.ARBITRUM_RINKEBY]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
+  [SupportedChainId.POLYGON]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
+  [SupportedChainId.POLYGON_MUMBAI]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
+  [SupportedChainId.CELO]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
+  [SupportedChainId.CELO_ALFAJORES]: new StaticJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
+}

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -1,3 +1,5 @@
+// This is the only file which should instantiate new Providers.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 
 import { SupportedChainId } from './chains'

--- a/src/featureFlags/flags/featureFlags.ts
+++ b/src/featureFlags/flags/featureFlags.ts
@@ -5,4 +5,5 @@ export enum FeatureFlag {
   tokens = 'tokens',
   tokensNetworkFilter = 'tokensNetworkFilter',
   tokenSafety = 'tokenSafety',
+  traceJsonRpc = 'traceJsonRpc',
 }

--- a/src/featureFlags/flags/traceJsonRpc.ts
+++ b/src/featureFlags/flags/traceJsonRpc.ts
@@ -1,0 +1,7 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+export function useTraceJsonRpcFlag(): BaseVariant {
+  return useBaseFlag(FeatureFlag.traceJsonRpc)
+}
+
+export { BaseVariant as TraceJsonRpcVariant }

--- a/src/hooks/useFetchListCallback.ts
+++ b/src/hooks/useFetchListCallback.ts
@@ -1,7 +1,7 @@
 import { nanoid } from '@reduxjs/toolkit'
 import { TokenList } from '@uniswap/token-lists'
 import { SupportedChainId } from 'constants/chains'
-import { RPC_PROVIDERS } from 'constants/networks'
+import { RPC_PROVIDERS } from 'constants/providers'
 import getTokenList from 'lib/hooks/useTokenList/fetchTokenList'
 import resolveENSContentHash from 'lib/utils/resolveENSContentHash'
 import { useCallback } from 'react'

--- a/src/lib/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/lib/hooks/swap/useSendSwapTransaction.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers'
+import type { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers'
 // eslint-disable-next-line no-restricted-imports
 import { t, Trans } from '@lingui/macro'
 import { Trade } from '@uniswap/router-sdk'

--- a/src/lib/hooks/swap/useSwapCallback.tsx
+++ b/src/lib/hooks/swap/useSwapCallback.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import { BigNumber } from '@ethersproject/bignumber'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'

--- a/src/lib/hooks/useApproval.ts
+++ b/src/lib/hooks/useApproval.ts
@@ -1,5 +1,5 @@
 import { MaxUint256 } from '@ethersproject/constants'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { sendAnalyticsEvent } from 'components/AmplitudeAnalytics'

--- a/src/nft/hooks/useSendTransaction.ts
+++ b/src/nft/hooks/useSendTransaction.ts
@@ -2,7 +2,7 @@ import { Interface } from '@ethersproject/abi'
 import { BigNumber } from '@ethersproject/bignumber'
 import { hexStripZeros } from '@ethersproject/bytes'
 import { ContractReceipt } from '@ethersproject/contracts'
-import { JsonRpcSigner } from '@ethersproject/providers'
+import type { JsonRpcSigner } from '@ethersproject/providers'
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 

--- a/src/nft/hooks/useWalletBalance.ts
+++ b/src/nft/hooks/useWalletBalance.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { Web3Provider } from '@ethersproject/providers'
+import type { Web3Provider } from '@ethersproject/providers'
 import { parseEther } from '@ethersproject/units'
 import { useWeb3React } from '@web3-react/core'
 import { useNativeCurrencyBalances } from 'state/connection/hooks'

--- a/src/nft/utils/claimLooks.ts
+++ b/src/nft/utils/claimLooks.ts
@@ -1,6 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { Contract } from '@ethersproject/contracts'
-import { BaseProvider } from '@ethersproject/providers'
+import type { BaseProvider } from '@ethersproject/providers'
 
 const looksRareContract = new Contract('0xea37093ce161f090e443f304e1bf3a8f14d7bb40', [
   {

--- a/src/nft/utils/listNfts.ts
+++ b/src/nft/utils/listNfts.ts
@@ -1,7 +1,7 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
+import type { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
 import { parseEther } from '@ethersproject/units'
 import { addressesByNetwork, MakerOrder, signMakerOrder, SupportedChainId } from '@looksrare/sdk'
 import { Seaport } from '@opensea/seaport-js'

--- a/src/nft/utils/x2y2.ts
+++ b/src/nft/utils/x2y2.ts
@@ -3,7 +3,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { hexZeroPad } from '@ethersproject/bytes'
 import { AddressZero } from '@ethersproject/constants'
 import { keccak256 } from '@ethersproject/keccak256'
-import { Web3Provider } from '@ethersproject/providers'
+import type { Web3Provider } from '@ethersproject/providers'
 import { randomBytes } from '@ethersproject/random'
 
 const dataParamType = `tuple(address token, uint256 tokenId)[]`

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { FeeAmount, NonfungiblePositionManager } from '@uniswap/v3-sdk'

--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'

--- a/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -1,5 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { CurrencyAmount, Fraction, Percent, Price, Token } from '@uniswap/sdk-core'
 import { FeeAmount, Pool, Position, priceToClosestTick, TickMath } from '@uniswap/v3-sdk'

--- a/src/pages/Pool/CTACards.test.tsx
+++ b/src/pages/Pool/CTACards.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@web3-react/core', () => {
   return {
     ...web3React,
     useWeb3React: () => ({
-      chainId: 99999,
+      chainId: 42,
     }),
   }
 })

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Fraction, Percent, Price, Token } from '@uniswap/sdk-core'
 import { NonfungiblePositionManager, Pool, Position } from '@uniswap/v3-sdk'

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { NonfungiblePositionManager } from '@uniswap/v3-sdk'

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
 import { Currency, Percent } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'

--- a/src/state/claim/hooks.ts
+++ b/src/state/claim/hooks.ts
@@ -1,4 +1,4 @@
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { abi as MERKLE_DISTRIBUTOR_ABI } from '@uniswap/merkle-distributor/build/MerkleDistributor.json'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -2,7 +2,7 @@ import { defaultAbiCoder, Interface } from '@ethersproject/abi'
 import { isAddress } from '@ethersproject/address'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { toUtf8String, Utf8ErrorFuncs, Utf8ErrorReason } from '@ethersproject/strings'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'

--- a/src/state/logs/hooks.ts
+++ b/src/state/logs/hooks.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@ethersproject/providers'
+import type { Filter } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { useEffect, useMemo } from 'react'

--- a/src/state/logs/slice.ts
+++ b/src/state/logs/slice.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@ethersproject/providers'
+import type { Filter } from '@ethersproject/providers'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { filterToKey, Log } from './utils'

--- a/src/state/logs/updater.ts
+++ b/src/state/logs/updater.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@ethersproject/providers'
+import type { Filter } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { useEffect, useMemo } from 'react'

--- a/src/state/logs/utils.ts
+++ b/src/state/logs/utils.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@ethersproject/providers'
+import type { Filter } from '@ethersproject/providers'
 
 export interface Log {
   topics: Array<string>

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 import { Protocol } from '@uniswap/router-sdk'
 import { AlphaRouter, ChainId } from '@uniswap/smart-order-router'
-import { RPC_PROVIDERS } from 'constants/networks'
+import { RPC_PROVIDERS } from 'constants/providers'
 import { getClientSideQuote, toSupportedChainId } from 'lib/hooks/routing/clientSideSmartOrderRouter'
 import ms from 'ms.macro'
 import qs from 'qs'

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -1,4 +1,4 @@
-import { TransactionResponse } from '@ethersproject/providers'
+import type { TransactionResponse } from '@ethersproject/providers'
 import { Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { useCallback, useMemo } from 'react'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { getAddress } from '@ethersproject/address'
 import { AddressZero } from '@ethersproject/constants'
 import { Contract } from '@ethersproject/contracts'
-import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
+import type { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 import { Token } from '@uniswap/sdk-core'
 import { ChainTokenMap } from 'lib/hooks/useTokenList/utils'
 

--- a/src/utils/switchChain.ts
+++ b/src/utils/switchChain.ts
@@ -14,7 +14,7 @@ function getRpcUrl(chainId: SupportedChainId): string {
       return RPC_URLS[chainId][0]
     // Attempting to add a chain using an infura URL will not work, as the URL will be unreachable from the MetaMask background page.
     // MetaMask allows switching to any publicly reachable URL, but for novel chains, it will display a warning if it is not on the "Safe" list.
-    // FALLBACK_URLS are explicitly selected from the "Safe" list to avoid this quirk.
+    // See the definition of FALLBACK_URLS for more details.
     default:
       return FALLBACK_URLS[chainId][0]
   }

--- a/src/utils/switchChain.ts
+++ b/src/utils/switchChain.ts
@@ -2,36 +2,22 @@ import { Connector } from '@web3-react/types'
 import { networkConnection, walletConnectConnection } from 'connection'
 import { getChainInfo } from 'constants/chainInfo'
 import { isSupportedChain, SupportedChainId } from 'constants/chains'
-import { RPC_URLS } from 'constants/networks'
+import { FALLBACK_URLS, RPC_URLS } from 'constants/networks'
 
-function getRpcUrls(chainId: SupportedChainId): [string] {
+function getRpcUrl(chainId: SupportedChainId): string {
   switch (chainId) {
     case SupportedChainId.MAINNET:
     case SupportedChainId.RINKEBY:
     case SupportedChainId.ROPSTEN:
     case SupportedChainId.KOVAN:
     case SupportedChainId.GOERLI:
-      return [RPC_URLS[chainId]]
-    case SupportedChainId.OPTIMISM:
-      return ['https://mainnet.optimism.io']
-    case SupportedChainId.OPTIMISTIC_KOVAN:
-      return ['https://kovan.optimism.io']
-    case SupportedChainId.ARBITRUM_ONE:
-      return ['https://arb1.arbitrum.io/rpc']
-    case SupportedChainId.ARBITRUM_RINKEBY:
-      return ['https://rinkeby.arbitrum.io/rpc']
-    case SupportedChainId.POLYGON:
-      return ['https://polygon-rpc.com/']
-    case SupportedChainId.POLYGON_MUMBAI:
-      return ['https://rpc-endpoints.superfluid.dev/mumbai']
-    case SupportedChainId.CELO:
-      return ['https://forno.celo.org']
-    case SupportedChainId.CELO_ALFAJORES:
-      return ['https://alfajores-forno.celo-testnet.org']
+      return RPC_URLS[chainId][0]
+    // Attempting to add a chain using an infura URL will not work, as the URL will be unreachable from the MetaMask background page.
+    // MetaMask allows switching to any publicly reachable URL, but for novel chains, it will display a warning if it is not on the "Safe" list.
+    // FALLBACK_URLS are explicitly selected from the "Safe" list to avoid this quirk.
     default:
+      return FALLBACK_URLS[chainId][0]
   }
-  // Our API-keyed URLs will fail security checks when used with external wallets.
-  throw new Error('RPC URLs must use public endpoints')
 }
 
 export const switchChain = async (connector: Connector, chainId: SupportedChainId) => {
@@ -44,7 +30,7 @@ export const switchChain = async (connector: Connector, chainId: SupportedChainI
     const addChainParameter = {
       chainId,
       chainName: info.label,
-      rpcUrls: getRpcUrls(chainId),
+      rpcUrls: [getRpcUrl(chainId)],
       nativeCurrency: info.nativeCurrency,
       blockExplorerUrls: [info.explorer],
     }


### PR DESCRIPTION
Refactors all JsonRpcProviders to be instantiated in the same file, and adds tracing under the `traceJsonRpc` flag.
- Moves JsonRpcProvider instantiations to constants/providers.ts
- Guards against other instantiations with a new type-only lint rule
- Adds explicit fallback URLs, and includes them in instantiation
- Adds a flag-guarded console log for all calls to the Provider