### PR TITLE
fix: pointing nft links to the right url hash

### DIFF
--- a/src/components/NavBar/MenuDropdown.tsx
+++ b/src/components/NavBar/MenuDropdown.tsx
@@ -134,7 +134,7 @@ export const MenuDropdown = () => {
             <Column gap="16">
               <Column paddingX="8" gap="4">
                 {nftFlag === NftVariant.Enabled && (
-                  <PrimaryMenuRow to="/nft/sell" close={toggleOpen}>
+                  <PrimaryMenuRow to="/nfts/sell" close={toggleOpen}>
                     <Icon>
                       <ThinTagIcon width={24} height={24} />
                     </Icon>

--- a/src/nft/components/collection/Card.tsx
+++ b/src/nft/components/collection/Card.tsx
@@ -38,7 +38,7 @@ const useCardContext = () => {
   return context
 }
 
-const baseHref = (asset: GenieAsset) => `/#/nft/asset/${asset.address}/${asset.tokenId}?origin=collection`
+const baseHref = (asset: GenieAsset) => `/#/nfts/asset/${asset.address}/${asset.tokenId}?origin=collection`
 
 /* -------- ASSET CARD -------- */
 interface CardProps {

--- a/src/nft/components/details/Traits.tsx
+++ b/src/nft/components/details/Traits.tsx
@@ -64,7 +64,7 @@ export const Traits = ({
           return (
             <a
               key={`${item.trait_type}-${item.value}`}
-              href={`#/nft/collection/${collectionAddress}?${params}`}
+              href={`#/nfts/collection/${collectionAddress}?${params}`}
               style={{ textDecoration: 'none' }}
             >
               <Trait label={item.trait_type} value={item.value} />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -233,8 +233,8 @@ export default function App() {
                     <>
                       <Route path="/nfts/collection/:contractAddress" element={<Collection />} />
                       <Route path="/nfts" element={<NftExplore />} />
-                      <Route path="/nft/sell" element={<Sell />} />
-                      <Route path="/nft/asset/:contractAddress/:tokenId" element={<Asset />} />
+                      <Route path="/nfts/sell" element={<Sell />} />
+                      <Route path="/nfts/asset/:contractAddress/:tokenId" element={<Asset />} />
                     </>
                   )}
                 </Routes>


### PR DESCRIPTION
* fix pointing nft links to `/nfts` vs. `/nft`