### PR TITLE
fix: Tick collisions on token detail price chart

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -200,7 +200,7 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
         return [
           monthYearFormatter(locale),
           monthYearDayFormatter(locale),
-          timeMonth.range(startDate, endDate, 3).map((x) => x.valueOf() / 1000),
+          timeMonth.range(startDate, endDate, 6).map((x) => x.valueOf() / 1000),
         ]
     }
   }


### PR DESCRIPTION
On the Token Details price chart, when selecting all the x-axis tick intervals were too short causing overlaps in the tick labels: 

Before: 
<img width="818" alt="before" src="https://user-images.githubusercontent.com/224071/190032942-ec20cefc-2652-4942-a4dc-3a6f63fad6bd.png">

After: 
<img width="810" alt="after" src="https://user-images.githubusercontent.com/224071/190032966-7e769ff3-2c3a-4179-832d-0d3266d30ffa.png">
