### PR TITLE
fix: Token Details chart: adjust curveTension on 1H chart timeframe

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -254,8 +254,8 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
   const crosshairEdgeMax = width * 0.85
   const crosshairAtEdge = !!crosshair && crosshair > crosshairEdgeMax
 
-  /* Default curve doesn't look good for the ALL chart */
-  const curveTension = timePeriod === TimePeriod.ALL ? 0.75 : 0.9
+  /* Default curve doesn't look good for the HOUR/ALL chart */
+  const curveTension = timePeriod === TimePeriod.ALL ? 0.75 : timePeriod === TimePeriod.HOUR ? 1 : 0.9
 
   return (
     <>


### PR DESCRIPTION
- Tweaks curveTension on 1H chart to fix line tapering

Before:
<img width="457" alt="before" src="https://user-images.githubusercontent.com/224071/190375076-3bb5e2cb-b70c-400f-8153-f02ec1acd6b3.png">

After
<img width="298" alt="after" src="https://user-images.githubusercontent.com/224071/190375101-c3993dd2-9587-464a-b324-fb43233ff3fb.png">
