### PR TITLE
style: Extend hover on secondary dropdown menu links

### DIFF
--- a/src/components/NavBar/MenuDropdown.css.ts
+++ b/src/components/NavBar/MenuDropdown.css.ts
@@ -41,9 +41,11 @@ export const SecondaryText = style([
     paddingY: '8',
     paddingX: '8',
     color: 'darkGray',
+    width: 'full',
   }),
   {
     lineHeight: '20px',
+    //width: '100%',
   },
 ])
 

--- a/src/components/NavBar/MenuDropdown.css.ts
+++ b/src/components/NavBar/MenuDropdown.css.ts
@@ -45,7 +45,6 @@ export const SecondaryText = style([
   }),
   {
     lineHeight: '20px',
-    //width: '100%',
   },
 ])
 


### PR DESCRIPTION
- add full width to secondary menu links

<img width="280" alt="hover" src="https://user-images.githubusercontent.com/224071/190394035-bff96aad-4fef-4dbc-ae12-d25185f3282e.png">
