### PR TITLE
fix: load correct initial display price and % delta w/o need for scrubbing on token detail chart

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -10,7 +10,7 @@ import { useTokenPricesCached } from 'graphql/data/Token'
 import { PricePoint, TimePeriod } from 'graphql/data/Token'
 import { useActiveLocale } from 'hooks/useActiveLocale'
 import { useAtom } from 'jotai'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowDownRight, ArrowUpRight } from 'react-feather'
 import styled, { useTheme } from 'styled-components/macro'
 import {
@@ -127,15 +127,26 @@ interface PriceChartProps {
 
 export function PriceChart({ width, height, tokenAddress, priceData }: PriceChartProps) {
   const [timePeriod, setTimePeriod] = useAtom(filterTimeAtom)
+  const [firstLoadedPriceDisplayed, setFirstLoadedPriceDisplayed] = useState(false)
   const locale = useActiveLocale()
   const theme = useTheme()
 
   const { priceMap } = useTokenPricesCached(priceData, tokenAddress, 'ETHEREUM', timePeriod)
   const prices = priceMap.get(timePeriod)
 
+  // first price point on the x-axis of the current time period's chart
   const startingPrice = prices?.[0] ?? DATA_EMPTY
+  // last price point on the x-axis of the current time period's chart
   const endingPrice = prices?.[prices.length - 1] ?? DATA_EMPTY
   const [displayPrice, setDisplayPrice] = useState(startingPrice)
+
+  // set display price to ending price once first set of prices is loaded.
+  useEffect(() => {
+    if (prices && !firstLoadedPriceDisplayed) {
+      setDisplayPrice(endingPrice)
+      setFirstLoadedPriceDisplayed(true)
+    }
+  }, [prices, firstLoadedPriceDisplayed, endingPrice])
   const [crosshair, setCrosshair] = useState<number | null>(null)
 
   const graphWidth = width + crosshairDateOverhang

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -127,7 +127,6 @@ interface PriceChartProps {
 
 export function PriceChart({ width, height, tokenAddress, priceData }: PriceChartProps) {
   const [timePeriod, setTimePeriod] = useAtom(filterTimeAtom)
-  const [firstLoadedPriceDisplayed, setFirstLoadedPriceDisplayed] = useState(false)
   const locale = useActiveLocale()
   const theme = useTheme()
 
@@ -140,13 +139,12 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
   const endingPrice = prices?.[prices.length - 1] ?? DATA_EMPTY
   const [displayPrice, setDisplayPrice] = useState(startingPrice)
 
-  // set display price to ending price once first set of prices is loaded.
+  // set display price to ending price when prices have changed.
   useEffect(() => {
-    if (prices && !firstLoadedPriceDisplayed) {
+    if (prices) {
       setDisplayPrice(endingPrice)
-      setFirstLoadedPriceDisplayed(true)
     }
-  }, [prices, firstLoadedPriceDisplayed, endingPrice])
+  }, [prices, endingPrice])
   const [crosshair, setCrosshair] = useState<number | null>(null)
 
   const graphWidth = width + crosshairDateOverhang


### PR DESCRIPTION
before: display price and % delta only loads after scrubbing

after: display price and % delta correctly set to ending price upon first load of token detail page. 

https://uniswaplabs.atlassian.net/browse/WEB-1113?atlOrigin=eyJpIjoiMDg0NzNlNjI3NjM5NDcxYThhYjA5NWFlNzJlNzBmZTEiLCJwIjoiaiJ9