### PR TITLE
fix: updates Widget defaultToken on URL change

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -1,6 +1,5 @@
 import { Currency, Field, SwapController, SwapEventHandlers, TradeType } from '@uniswap/widgets'
 import CurrencySearchModal from 'components/SearchModal/CurrencySearchModal'
-import usePrevious from 'hooks/usePrevious'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 /**
@@ -19,14 +18,11 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
     [Field.OUTPUT]: defaultToken,
   })
 
-  const previousDefaultToken = usePrevious(defaultToken)
   useEffect(() => {
-    if (previousDefaultToken && previousDefaultToken !== defaultToken) {
-      setTokens({
-        [Field.OUTPUT]: defaultToken,
-      })
-    }
-  }, [previousDefaultToken, defaultToken])
+    setTokens({
+      [Field.OUTPUT]: defaultToken,
+    })
+  }, [defaultToken])
 
   const onSwitchTokens = useCallback(() => {
     setType((type) => invertTradeType(type))

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -1,6 +1,7 @@
 import { Currency, Field, SwapController, SwapEventHandlers, TradeType } from '@uniswap/widgets'
 import CurrencySearchModal from 'components/SearchModal/CurrencySearchModal'
-import { useCallback, useMemo, useState } from 'react'
+import usePrevious from 'hooks/usePrevious'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 /**
  * Integrates the Widget's inputs.
@@ -17,6 +18,16 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
   const [tokens, setTokens] = useState<{ [Field.INPUT]?: Currency; [Field.OUTPUT]?: Currency }>({
     [Field.OUTPUT]: defaultToken,
   })
+
+  const previousDefaultToken = usePrevious(defaultToken)
+  useEffect(() => {
+    if (previousDefaultToken && previousDefaultToken !== defaultToken) {
+      setTokens({
+        [Field.OUTPUT]: defaultToken,
+      })
+    }
+  }, [previousDefaultToken, defaultToken])
+
   const onSwitchTokens = useCallback(() => {
     setType((type) => invertTradeType(type))
     setTokens((tokens) => ({


### PR DESCRIPTION
When the URL of a page changes the defaultToken of the Widget should change. Right now that state doesn't get reset on re-renders, so you may see a stale token input.