### PR TITLE
fix: reset Widget amount on URL change

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -22,6 +22,7 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
     setTokens({
       [Field.OUTPUT]: defaultToken,
     })
+    setAmount('')
   }, [defaultToken])
 
   const onSwitchTokens = useCallback(() => {


### PR DESCRIPTION
Resets the amount on URL change. When the default token changes we should also clear the state fully.
