### PR TITLE
fix: make token detail chart full width and x axis fixes

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -116,7 +116,6 @@ const TimeButton = styled.button<{ active: boolean }>`
 
 const margin = { top: 100, bottom: 48, crosshair: 72 }
 const timeOptionsHeight = 44
-const crosshairDateOverhang = 80
 
 interface PriceChartProps {
   width: number
@@ -147,14 +146,13 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
   }, [prices, endingPrice])
   const [crosshair, setCrosshair] = useState<number | null>(null)
 
-  const graphWidth = width + crosshairDateOverhang
   const graphHeight = height - timeOptionsHeight > 0 ? height - timeOptionsHeight : 0
   const graphInnerHeight = graphHeight - margin.top - margin.bottom > 0 ? graphHeight - margin.top - margin.bottom : 0
 
   // Defining scales
   // x scale
   const timeScale = useMemo(
-    () => scaleLinear().domain([startingPrice.timestamp, endingPrice.timestamp]).range([0, width]).nice(),
+    () => scaleLinear().domain([startingPrice.timestamp, endingPrice.timestamp]).range([0, width]),
     [startingPrice, endingPrice, width]
   )
   // y scale
@@ -282,7 +280,7 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
         marginTop={margin.top}
         curve={curveCardinal.tension(curveTension)}
         strokeWidth={2}
-        width={graphWidth}
+        width={width}
         height={graphHeight}
       >
         {crosshair !== null ? (

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -220,7 +220,7 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
         return [
           monthYearFormatter(locale),
           monthYearDayFormatter(locale),
-          timeTicks(startDateWithOffset, endDateWithOffset, 5).map((x) => x.valueOf() / 1000),
+          timeTicks(startDateWithOffset, endDateWithOffset, 6).map((x) => x.valueOf() / 1000),
         ]
     }
   }

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -180,7 +180,7 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
     timePeriod: TimePeriod,
     locale: string
   ): [TickFormatter<NumberValue>, (v: number) => string, NumberValue[]] {
-    const offsetTime = (endingPrice.timestamp.valueOf() - startingPrice.timestamp.valueOf()) / 14
+    const offsetTime = (endingPrice.timestamp.valueOf() - startingPrice.timestamp.valueOf()) / 24
     const startDateWithOffset = new Date((startingPrice.timestamp.valueOf() + offsetTime) * 1000)
     const endDateWithOffset = new Date((endingPrice.timestamp.valueOf() - offsetTime) * 1000)
     switch (timePeriod) {
@@ -220,7 +220,7 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
         return [
           monthYearFormatter(locale),
           monthYearDayFormatter(locale),
-          timeTicks(startDateWithOffset, endDateWithOffset, 6).map((x) => x.valueOf() / 1000),
+          timeTicks(startDateWithOffset, endDateWithOffset, 5).map((x) => x.valueOf() / 1000),
         ]
     }
   }

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -304,6 +304,7 @@ export function PriceChart({ width, height, tokenAddress, priceData }: PriceChar
               tickFormat={tickFormatter}
               tickStroke={theme.backgroundOutline}
               tickLength={4}
+              hideTicks={true}
               tickTransform={'translate(0 -5)'}
               tickValues={ticks}
               top={graphHeight - 1}


### PR DESCRIPTION
chart changes:
1) make chart full width as per https://uniswaplabs.atlassian.net/browse/WEB-1181?atlOrigin=eyJpIjoiMzYwN2VmOWYwOGJlNGY1ODlkYTMyNGM5N2M4OWFkM2EiLCJwIjoiaiJ9

2) add offsets to start and end time in x axis so the dates dont get cut off (because chart extends full width now) 

3) Limit to 6 ticks on "All" time chart, which has variable time frame, to avoid situations like this: 
<img width="738" alt="Screen Shot 2022-09-19 at 6 03 04 PM" src="https://user-images.githubusercontent.com/41491154/191127677-151fe3e2-d877-41fd-997c-5af9e50aca6d.png">