### PR TITLE
fix: center Web3StatusConnectButton

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -62,6 +62,7 @@ const Web3StatusError = styled(Web3StatusGeneric)`
 
 const Web3StatusConnectButton = styled.button<{ faded?: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap}
+  align-items: center;
   background-color: ${({ theme }) => theme.accentActionSoft};
   border-radius: 12px;
   border: none;


### PR DESCRIPTION
Before:
<img width="160" alt="Screen Shot 2022-09-19 at 3 26 48 PM" src="https://user-images.githubusercontent.com/4899429/191101416-008cd874-6db9-441e-9b3a-320aa2b63792.png">

After:
<img width="149" alt="Screen Shot 2022-09-19 at 3 38 52 PM" src="https://user-images.githubusercontent.com/4899429/191101434-a50a26e4-5a84-4dea-9f27-9b0afa751cd7.png">