### PR TITLE
fix: UniIcon bug, missing z-index

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -183,6 +183,7 @@ const UniIcon = styled.div`
   }
 
   position: relative;
+  z-index: 10;
 `
 
 // can't be customized under react-router-dom v6


### PR DESCRIPTION
Adding z-index to UniIcon to fix logo hiding under header underlay. Fixes: #4273