### PR TITLE
fix: networkProvider error

### DIFF
--- a/src/components/Web3Provider/index.tsx
+++ b/src/components/Web3Provider/index.tsx
@@ -33,12 +33,12 @@ function Tracer() {
     if (shouldTrace) {
       provider?.on('debug', trace)
       if (provider !== networkProvider) {
-        networkProvider.on('debug', trace)
+        networkProvider?.on('debug', trace)
       }
     }
     return () => {
       provider?.off('debug', trace)
-      networkProvider.off('debug', trace)
+      networkProvider?.off('debug', trace)
     }
   }, [networkProvider, provider, shouldTrace])
 


### PR DESCRIPTION
Added optional chaining to networkProvider to fix an error that causes the interface to crash when the user while being connected switches the network from an unsupported one to a supported one.