### PR TITLE
fix: makes sure wallet error is visible

### DIFF
--- a/src/components/Popups/index.tsx
+++ b/src/components/Popups/index.tsx
@@ -41,7 +41,7 @@ const StopOverflowQuery = `@media screen and (min-width: ${MEDIA_WIDTHS.deprecat
 
 const FixedPopupColumn = styled(AutoColumn)<{ extraPadding: boolean; xlPadding: boolean }>`
   position: fixed;
-  top: ${({ extraPadding }) => (extraPadding ? '64px' : '56px')};
+  top: ${({ extraPadding }) => (extraPadding ? '72px' : '64px')};
   right: 1rem;
   max-width: 355px !important;
   width: 100%;
@@ -52,7 +52,7 @@ const FixedPopupColumn = styled(AutoColumn)<{ extraPadding: boolean; xlPadding: 
   `};
 
   ${StopOverflowQuery} {
-    top: ${({ extraPadding, xlPadding }) => (xlPadding ? '64px' : extraPadding ? '64px' : '56px')};
+    top: ${({ extraPadding, xlPadding }) => (xlPadding ? '72px' : extraPadding ? '72px' : '64px')};
   }
 `
 


### PR DESCRIPTION
Since the header height changed we want to make sure the error is always visible. Ideally, this should be done more dynamically but that's outside the scope of this fix.
<img width="394" alt="Screen Shot 2022-09-20 at 3 12 05 PM" src="https://user-images.githubusercontent.com/4899429/191344286-524f2b2e-26a1-4bf0-bdf8-7d56bd7778cc.png">
