### PR TITLE
fix: center SearchBar vertically

### DIFF
--- a/src/components/NavBar/SearchBar.css.ts
+++ b/src/components/NavBar/SearchBar.css.ts
@@ -34,7 +34,7 @@ export const searchBarContainer = style([
     '@media': {
       [`screen and (min-width: ${breakpoints.lg}px)`]: {
         right: `-${DESKTOP_NAVBAR_WIDTH / 2 - MAGNIFYING_GLASS_ICON_WIDTH}px`,
-        top: -'5px',
+        top: '-5px',
       },
     },
   },

--- a/src/components/NavBar/SearchBar.css.ts
+++ b/src/components/NavBar/SearchBar.css.ts
@@ -34,6 +34,7 @@ export const searchBarContainer = style([
     '@media': {
       [`screen and (min-width: ${breakpoints.lg}px)`]: {
         right: `-${DESKTOP_NAVBAR_WIDTH / 2 - MAGNIFYING_GLASS_ICON_WIDTH}px`,
+        top: -'5px',
       },
     },
   },


### PR DESCRIPTION
after:
<img width="1257" alt="Screen Shot 2022-09-20 at 3 37 02 PM" src="https://user-images.githubusercontent.com/4899429/191349509-0a3ddf58-5207-4b46-97b2-129b9b54c4b8.png">

before:
<img width="1260" alt="Screen Shot 2022-09-20 at 3 37 07 PM" src="https://user-images.githubusercontent.com/4899429/191349511-bcbae3e7-77a9-4e8b-9a01-6c470147c4a8.png">

Honestly, not sure why this is necessary. I think longer term we'll want to handle this horizontal centering within Nav via `justify-self: center` rather than fixed positioning.
