### PR TITLE
feat: weth check

### DIFF
--- a/src/analytics/constants.ts
+++ b/src/analytics/constants.ts
@@ -25,6 +25,7 @@ export enum EventName {
   WALLET_CONNECT_TXN_COMPLETED = 'Wallet Connect Transaction Completed',
   WALLET_SELECTED = 'Wallet Selected',
   WEB_VITALS = 'Web Vitals',
+  WRAP_TOKEN_TXN_INVALIDATED = 'Wrap Token Transaction Invalidated',
   WRAP_TOKEN_TXN_SUBMITTED = 'Wrap Token Transaction Submitted',
   // alphabetize additional event names.
 }

--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -108,7 +108,8 @@ export default function useWrapCallback(
                       contract_chain_id: network.chainId,
                       type: WrapType.WRAP,
                     })
-                    const error = new Error('Invalid WETH contract')
+                    const error = new Error(`Invalid WETH contract
+Please file a bug detailing how this happened - https://github.com/Uniswap/interface/issues/new?labels=bug&template=bug-report.md&title=Invalid%20WETH%20contract`)
                     setError(error)
                     throw error
                   }

--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -70,6 +70,8 @@ export default function useWrapCallback(
   )
   const addTransaction = useTransactionAdder()
 
+  // This allows an async error to propagate within the React lifecycle.
+  // Without rethrowing it here, it would not show up in the UI - only the dev console.
   const [error, setError] = useState<Error>()
   if (error) throw error
 


### PR DESCRIPTION
Throw an error before deposits can be made to the wrapped native currency on the wrong chain.
Includes a deep link in the error message for filing a bug, to encourage reporting.