### PR TITLE
fix: fix explore table filtering and sorting bugs

### DIFF
--- a/src/components/Tokens/TokenTable/SearchBar.tsx
+++ b/src/components/Tokens/TokenTable/SearchBar.tsx
@@ -59,10 +59,14 @@ const SearchInput = styled.input`
 `
 
 export default function SearchBar() {
-  const currentFilterString = useAtomValue(filterStringAtom)
-  const [localFilterString, setLocalFilterString] = useState(currentFilterString ?? '')
+  const currentString = useAtomValue(filterStringAtom)
+  const [localFilterString, setLocalFilterString] = useState(currentString)
   const setFilterString = useUpdateAtom(filterStringAtom)
   const debouncedLocalFilterString = useDebounce(localFilterString, 300)
+
+  useEffect(() => {
+    setLocalFilterString(currentString)
+  }, [currentString])
 
   useEffect(() => {
     setFilterString(debouncedLocalFilterString)

--- a/src/components/Tokens/TokenTable/SearchBar.tsx
+++ b/src/components/Tokens/TokenTable/SearchBar.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import searchIcon from 'assets/svg/search.svg'
 import xIcon from 'assets/svg/x.svg'
 import useDebounce from 'hooks/useDebounce'
-import { useUpdateAtom } from 'jotai/utils'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components/macro'
 
@@ -59,7 +59,8 @@ const SearchInput = styled.input`
 `
 
 export default function SearchBar() {
-  const [localFilterString, setLocalFilterString] = useState('')
+  const currentFilterString = useAtomValue(filterStringAtom)
+  const [localFilterString, setLocalFilterString] = useState(currentFilterString ?? '')
   const setFilterString = useUpdateAtom(filterStringAtom)
   const debouncedLocalFilterString = useDebounce(localFilterString, 300)
 

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -38,8 +38,6 @@ import {
 import { formatDelta, getDeltaArrow } from '../TokenDetails/PriceChart'
 import { DISPLAYS } from './TimeSelector'
 
-export const MAX_TOKENS_TO_LOAD = 100
-
 const Cell = styled.div`
   display: flex;
   align-items: center;
@@ -520,7 +518,7 @@ export const LoadedRow = forwardRef((props: LoadedRowProps, ref: ForwardedRef<HT
               <FavoriteIcon isFavorited={isFavorited} />
             </ClickFavorited>
           }
-          listNumber={sortAscending ? MAX_TOKENS_TO_LOAD - tokenListIndex : tokenListIndex + 1}
+          listNumber={sortAscending ? tokenListLength - tokenListIndex : tokenListIndex + 1}
           tokenInfo={
             <ClickableName>
               <LogoContainer>

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -70,6 +70,7 @@ export default function TokenTable() {
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
   const { loading, tokens, tokensWithoutPriceHistoryCount, hasMore, loadMoreTokens } = useTopTokens()
+  const showMoreLoadingRows = Boolean(loading && hasMore)
 
   const observer = useRef<IntersectionObserver>()
   const lastTokenRef = useCallback(
@@ -122,7 +123,7 @@ export default function TokenTable() {
                   ref={index + 1 === tokens.length ? lastTokenRef : undefined}
                 />
               ))}
-              {loading && hasMore && LoadingMoreRows}
+              {showMoreLoadingRows && LoadingMoreRows}
             </TokenDataContainer>
           </GridContainer>
         </>

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -1,8 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { showFavoritesAtom } from 'components/Tokens/state'
-import { filterTimeAtom } from 'components/Tokens/state'
 import { PAGE_SIZE, useTopTokens } from 'graphql/data/TopTokens'
-import { toHistoryDuration } from 'graphql/data/util'
 import { useAtomValue } from 'jotai/utils'
 import { ReactNode, useCallback, useRef } from 'react'
 import { AlertTriangle } from 'react-feather'
@@ -72,8 +70,6 @@ export default function TokenTable() {
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
   const { loading, tokens, tokenCount, loadMoreTokens } = useTopTokens()
-  const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
-  console.log('duration', duration)
   const hasMore = !tokens || tokens.length < MAX_TOKENS_TO_LOAD
 
   const observer = useRef<IntersectionObserver>()
@@ -120,7 +116,7 @@ export default function TokenTable() {
             <TokenDataContainer>
               {tokens.map((token, index) => (
                 <LoadedRow
-                  key={token?.name}
+                  key={token?.address}
                   tokenListIndex={index}
                   tokenListLength={tokens?.length ?? 0}
                   token={token}

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { showFavoritesAtom } from 'components/Tokens/state'
 import { filterTimeAtom } from 'components/Tokens/state'
-import { PAGE_SIZE, usePrefetchTopTokens, useTopTokens } from 'graphql/data/TopTokens'
+import { PAGE_SIZE, useTopTokens } from 'graphql/data/TopTokens'
 import { toHistoryDuration } from 'graphql/data/util'
 import { useAtomValue } from 'jotai/utils'
 import { ReactNode, useCallback, useRef } from 'react'
@@ -71,8 +71,7 @@ export default function TokenTable() {
   const showFavorites = useAtomValue<boolean>(showFavoritesAtom)
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
-  const prefetchedTokens = usePrefetchTopTokens()
-  const { loading, tokens, tokenCount, loadMoreTokens } = useTopTokens(prefetchedTokens)
+  const { loading, tokens, tokenCount, loadMoreTokens } = useTopTokens()
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
   console.log('duration', duration)
   const hasMore = !tokens || tokens.length < MAX_TOKENS_TO_LOAD
@@ -94,7 +93,7 @@ export default function TokenTable() {
 
   /* loading and error state */
   if (loading && (!tokens || tokens?.length === 0)) {
-    return <LoadingTokenTable rowCount={tokenCount} />
+    return <LoadingTokenTable rowCount={Math.min(tokenCount, PAGE_SIZE)} />
   } else {
     if (!tokens) {
       return (

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -7,7 +7,7 @@ import { AlertTriangle } from 'react-feather'
 import styled from 'styled-components/macro'
 
 import { MAX_WIDTH_MEDIA_BREAKPOINT } from '../constants'
-import { HeaderRow, LoadedRow, LoadingRow, MAX_TOKENS_TO_LOAD } from './TokenRow'
+import { HeaderRow, LoadedRow, LoadingRow } from './TokenRow'
 
 const LOADING_ROWS_COUNT = 3
 
@@ -69,8 +69,7 @@ export default function TokenTable() {
   const showFavorites = useAtomValue<boolean>(showFavoritesAtom)
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
-  const { loading, tokens, tokenCount, loadMoreTokens } = useTopTokens()
-  const hasMore = !tokens || tokens.length < MAX_TOKENS_TO_LOAD
+  const { loading, tokens, tokenCount, hasMore, loadMoreTokens } = useTopTokens()
 
   const observer = useRef<IntersectionObserver>()
   const lastTokenRef = useCallback(
@@ -120,7 +119,7 @@ export default function TokenTable() {
                   tokenListIndex={index}
                   tokenListLength={tokens?.length ?? 0}
                   token={token}
-                  ref={tokens.length === index + 1 ? lastTokenRef : undefined}
+                  ref={index + 1 === tokens.length ? lastTokenRef : undefined}
                 />
               ))}
               {loading && tokenCount > PAGE_SIZE && LoadingMoreRows}

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -69,7 +69,7 @@ export default function TokenTable() {
   const showFavorites = useAtomValue<boolean>(showFavoritesAtom)
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
-  const { loading, tokens, tokenCount, hasMore, loadMoreTokens } = useTopTokens()
+  const { loading, tokens, tokensWithoutPriceHistoryCount, hasMore, loadMoreTokens } = useTopTokens()
 
   const observer = useRef<IntersectionObserver>()
   const lastTokenRef = useCallback(
@@ -88,7 +88,7 @@ export default function TokenTable() {
 
   /* loading and error state */
   if (loading && (!tokens || tokens?.length === 0)) {
-    return <LoadingTokenTable rowCount={Math.min(tokenCount, PAGE_SIZE)} />
+    return <LoadingTokenTable rowCount={Math.min(tokensWithoutPriceHistoryCount, PAGE_SIZE)} />
   } else {
     if (!tokens) {
       return (
@@ -122,7 +122,7 @@ export default function TokenTable() {
                   ref={index + 1 === tokens.length ? lastTokenRef : undefined}
                 />
               ))}
-              {loading && tokenCount > PAGE_SIZE && LoadingMoreRows}
+              {loading && hasMore && LoadingMoreRows}
             </TokenDataContainer>
           </GridContainer>
         </>

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -18,8 +18,9 @@ import { toHistoryDuration, useCurrentChainName } from './util'
 export function usePrefetchTopTokens() {
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
   const chain = useCurrentChainName()
-  const args = useMemo(() => ({ chain, duration }), [chain, duration])
-  return useLazyLoadQuery<TopTokens100Query>(topTokens100Query, args)
+
+  const top100 = useLazyLoadQuery<TopTokens100Query>(topTokens100Query, { duration, chain })
+  return top100
 }
 
 const topTokens100Query = graphql`
@@ -120,7 +121,7 @@ function useFilteredTokens(tokens: PrefetchedTopToken[]) {
   }, [tokens, showFavorites, lowercaseFilterString, favorites])
 }
 
-const PAGE_SIZE = 20
+export const PAGE_SIZE = 20
 
 function toContractInput(token: PrefetchedTopToken) {
   return {
@@ -130,62 +131,60 @@ function toContractInput(token: PrefetchedTopToken) {
 }
 
 export type TopToken = NonNullable<TopTokens_TokensQuery['response']['tokens']>[number]
-interface UseTopTokensReturnValue {
-  loading: boolean
-  tokens: TopToken[]
-  loadMoreTokens: () => void
-}
-export function useTopTokens(prefetchedData: TopTokens100Query['response']): UseTopTokensReturnValue {
+export function useTopTokens(prefetchedData: TopTokens100Query['response']) {
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
+
   const environment = useRelayEnvironment()
-  const [tokens, setTokens] = useState<TopToken[]>([])
+  const [tokens, setTokens] = useState<TopToken[]>()
 
-  const [page, setPage] = useState(0)
+  const [page, setPage] = useState(1)
+  const prefetchedSelectedTokens = useFilteredTokens(useSortedTokens(prefetchedData.topTokens))
   const [loading, setLoading] = useState(true)
-
-  const appendTokens = useCallback(
-    (newTokens: TopToken[]) => {
-      setTokens(
-        Object.values(
-          tokens
-            .concat(newTokens)
-            .reduce((acc, token) => (token?.address ? { ...acc, [token.address]: token } : acc), {})
-        )
-      )
-    },
-    [tokens]
-  )
-  const loadMoreTokens = useCallback(() => setPage(page + 1), [page])
 
   // TopTokens should ideally be fetched with usePaginationFragment. The backend does not current support graphql cursors;
   // in the meantime, fetchQuery is used, as other relay hooks do not allow the refreshing and lazy loading we need
-  const prefetchedSelectedTokens = useFilteredTokens(useSortedTokens(prefetchedData.topTokens))
-  const contracts: ContractInput[] = useMemo(
-    () => prefetchedSelectedTokens.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map(toContractInput),
-    [page, prefetchedSelectedTokens]
+  const loadTokens = useCallback(
+    (contracts: ContractInput[], onSuccess: (data: TopTokens_TokensQuery['response'] | undefined) => void) => {
+      fetchQuery<TopTokens_TokensQuery>(
+        environment,
+        tokensQuery,
+        { contracts, duration },
+        { fetchPolicy: 'store-or-network' }
+      )
+        .toPromise()
+        .then(onSuccess)
+    },
+    [duration, environment]
   )
 
-  useEffect(() => {
-    const subscription = fetchQuery<TopTokens_TokensQuery>(
-      environment,
-      tokensQuery,
-      { contracts, duration },
-      { fetchPolicy: 'store-or-network' }
-    ).subscribe({
-      start() {
-        setLoading(true)
-      },
-      complete() {
+  const loadMoreTokens = useCallback(() => {
+    setLoading(true)
+    const contracts = prefetchedSelectedTokens.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map(toContractInput)
+    loadTokens(contracts, (data) => {
+      if (data?.tokens) {
+        setTokens([...(tokens ?? []), ...data.tokens])
         setLoading(false)
-      },
-      next(data) {
-        appendTokens(data.tokens as TopToken[])
-      },
+        setPage(page + 1)
+      }
     })
-    return subscription.unsubscribe
-  }, [appendTokens, contracts, duration, environment])
+  }, [loadTokens, page, prefetchedSelectedTokens, tokens])
 
-  return { loading, tokens: useFilteredTokens(useSortedTokens(tokens)) as TopToken[], loadMoreTokens }
+  // Reset count when filters are changed
+  useEffect(() => {
+    setLoading(true)
+    setTokens([])
+    const contracts = prefetchedSelectedTokens.slice(0, PAGE_SIZE).map(toContractInput)
+    loadTokens(contracts, (data) => {
+      if (data?.tokens) {
+        // @ts-ignore prevent typescript from complaining about readonly data
+        setTokens(data.tokens)
+        setLoading(false)
+        setPage(1)
+      }
+    })
+  }, [loadTokens, prefetchedSelectedTokens])
+
+  return { loading, tokens, tokenCount: prefetchedSelectedTokens.length, loadMoreTokens }
 }
 
 export const tokensQuery = graphql`

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -146,7 +146,14 @@ const checkIfAllTokensCached = (prefetchedSelectedTokens: PrefetchedTopToken[]) 
 }
 
 export type TopToken = NonNullable<TopTokens_TokensQuery['response']['tokens']>[number]
-export function useTopTokens() {
+interface UseTopTokensReturnValue {
+  loading: boolean
+  tokens: TopToken[] | undefined
+  tokensWithoutPriceHistoryCount: number
+  hasMore: boolean
+  loadMoreTokens: () => void
+}
+export function useTopTokens(): UseTopTokensReturnValue {
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
   const [loading, setLoading] = useState(true)
   const [tokens, setTokens] = useState<TopToken[]>()

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -131,14 +131,15 @@ function toContractInput(token: PrefetchedTopToken) {
 }
 
 export type TopToken = NonNullable<TopTokens_TokensQuery['response']['tokens']>[number]
-export function useTopTokens(prefetchedData: TopTokens100Query['response']) {
+export function useTopTokens() {
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
+  const prefetchedData = usePrefetchTopTokens()
+  const prefetchedSelectedTokens = useFilteredTokens(useSortedTokens(prefetchedData.topTokens))
 
   const environment = useRelayEnvironment()
   const [tokens, setTokens] = useState<TopToken[]>()
 
   const [page, setPage] = useState(1)
-  const prefetchedSelectedTokens = useFilteredTokens(useSortedTokens(prefetchedData.topTokens))
   const [loading, setLoading] = useState(true)
 
   // TopTokens should ideally be fetched with usePaginationFragment. The backend does not current support graphql cursors;

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -160,7 +160,7 @@ export function useTopTokens() {
 
   // TopTokens should ideally be fetched with usePaginationFragment. The backend does not current support graphql cursors;
   // in the meantime, fetchQuery is used, as other relay hooks do not allow the refreshing and lazy loading we need
-  const loadTokens = useCallback(
+  const loadTokensWithPriceHistory = useCallback(
     (contracts: ContractInput[], onSuccess: (data: TopTokens_TokensQuery['response'] | undefined) => void) => {
       fetchQuery<TopTokens_TokensQuery>(
         environment,
@@ -179,7 +179,7 @@ export function useTopTokens() {
     const contracts = prefetchedSelectedTokensWithoutPriceHistory
       .slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
       .map(toContractInput)
-    loadTokens(contracts, (data) => {
+    loadTokensWithPriceHistory(contracts, (data) => {
       if (data?.tokens) {
         data.tokens.forEach((token) =>
           !!token ? (tokensWithPriceHistoryCache[`${token.chain.toString()}${token.address}`] = token) : null
@@ -189,7 +189,7 @@ export function useTopTokens() {
         setPage(page + 1)
       }
     })
-  }, [prefetchedSelectedTokensWithoutPriceHistory, page, loadTokens, tokens])
+  }, [prefetchedSelectedTokensWithoutPriceHistory, page, loadTokensWithPriceHistory, tokens])
 
   // Reset count when filters are changed
   useLayoutEffect(() => {
@@ -204,7 +204,7 @@ export function useTopTokens() {
       setLoading(true)
       setTokens([])
       const contracts = prefetchedSelectedTokensWithoutPriceHistory.slice(0, PAGE_SIZE).map(toContractInput)
-      loadTokens(contracts, (data) => {
+      loadTokensWithPriceHistory(contracts, (data) => {
         if (data?.tokens) {
           data.tokens.forEach((token) =>
             !!token ? (tokensWithPriceHistoryCache[`${token.chain.toString()}${token.address}`] = token) : null
@@ -216,9 +216,15 @@ export function useTopTokens() {
         }
       })
     }
-  }, [loadTokens, prefetchedSelectedTokensWithoutPriceHistory])
+  }, [loadTokensWithPriceHistory, prefetchedSelectedTokensWithoutPriceHistory])
 
-  return { loading, tokens, hasMore, tokenCount: prefetchedSelectedTokensWithoutPriceHistory.length, loadMoreTokens }
+  return {
+    loading,
+    tokens,
+    hasMore,
+    tokensWithoutPriceHistoryCount: prefetchedSelectedTokensWithoutPriceHistory.length,
+    loadMoreTokens,
+  }
 }
 
 export const tokensQuery = graphql`


### PR DESCRIPTION
1) get rid of data flickering when you change time period 
2) fix search string being ignored if you change the time period you’re viewing
3) make search filter queries reset /disappear when you navigate to a different page and come back. 
4) when user starts typing a search term, show correct number of loading rows (we have this info from prefetched top 100 tokens query), and load actual rows once price history token data becomes available. 
5) add local "cache" of preloaded tokens with price history (if we have already rendered them previously) 
