### PR TITLE
fix: show real balance in footer summary instead of dummy data

### DIFF
--- a/src/components/Tokens/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Tokens/TokenDetails/BalanceSummary.tsx
@@ -1,10 +1,6 @@
 import { Trans } from '@lingui/macro'
-import { useWeb3React } from '@web3-react/core'
-import { formatToDecimal } from 'analytics/utils'
 import { useToken } from 'hooks/Tokens'
 import { useNetworkTokenBalances } from 'hooks/useNetworkTokenBalances'
-import { useStablecoinValue } from 'hooks/useStablecoinPrice'
-import { useTokenBalance } from 'lib/hooks/useCurrencyBalance'
 import { AlertTriangle } from 'react-feather'
 import styled from 'styled-components/macro'
 
@@ -49,15 +45,17 @@ const TotalBalanceItem = styled.div`
   display: flex;
 `
 
-export default function BalanceSummary({ address }: { address: string }) {
+export default function BalanceSummary({
+  address,
+  balanceNumber,
+  balanceUsdNumber,
+}: {
+  address: string
+  balanceNumber?: number
+  balanceUsdNumber?: number
+}) {
   const token = useToken(address)
   const { loading, error } = useNetworkTokenBalances({ address })
-
-  const { account } = useWeb3React()
-  const balance = useTokenBalance(account, token ?? undefined)
-  const balanceNumber = balance ? formatToDecimal(balance, Math.min(balance.currency.decimals, 6)) : undefined
-  const balanceUsd = useStablecoinValue(balance)?.toFixed(2)
-  const balanceUsdNumber = balanceUsd ? parseFloat(balanceUsd) : undefined
 
   if (loading || (!error && !balanceNumber && !balanceUsdNumber)) return null
   return (

--- a/src/components/Tokens/TokenDetails/FooterBalanceSummary.tsx
+++ b/src/components/Tokens/TokenDetails/FooterBalanceSummary.tsx
@@ -132,11 +132,13 @@ const ErrorText = styled.span`
 export default function FooterBalanceSummary({
   address,
   networkBalances,
-  totalBalance,
+  balanceNumber,
+  balanceUsdNumber,
 }: {
   address: string
   networkBalances: (JSX.Element | null)[] | null
-  totalBalance: number
+  balanceNumber?: number
+  balanceUsdNumber?: number
 }) {
   const tokenSymbol = useToken(address)?.symbol
   const [showMultipleBalances, setShowMultipleBalances] = useState(false)
@@ -159,20 +161,23 @@ export default function FooterBalanceSummary({
             </ErrorText>
           </ErrorState>
         ) : (
-          <BalanceInfo>
-            {multipleBalances ? 'Balance on all networks' : `Your balance on ${networkNameIfOneBalance}`}
-            <BalanceTotal>
-              <BalanceValue>
-                {totalBalance} {tokenSymbol}
-              </BalanceValue>
-              <FiatValue>($107, 610.04)</FiatValue>
-            </BalanceTotal>
-            {multipleBalances && (
-              <ViewAll onClick={() => setShowMultipleBalances(!showMultipleBalances)}>
-                <Trans>{showMultipleBalances ? 'Hide' : 'View'} all balances</Trans>
-              </ViewAll>
-            )}
-          </BalanceInfo>
+          !!balanceNumber &&
+          !!balanceUsdNumber && (
+            <BalanceInfo>
+              {multipleBalances ? 'Balance on all networks' : `Your balance on ${networkNameIfOneBalance}`}
+              <BalanceTotal>
+                <BalanceValue>
+                  {balanceNumber} {tokenSymbol}
+                </BalanceValue>
+                <FiatValue>{`$${balanceUsdNumber}`}</FiatValue>
+              </BalanceTotal>
+              {multipleBalances && (
+                <ViewAll onClick={() => setShowMultipleBalances(!showMultipleBalances)}>
+                  <Trans>{showMultipleBalances ? 'Hide' : 'View'} all balances</Trans>
+                </ViewAll>
+              )}
+            </BalanceInfo>
+          )
         )}
         <Link to={`/swap?outputCurrency=${address}`}>
           <SwapButton>


### PR DESCRIPTION
When balance is non zero: 
<img width="652" alt="Screen Shot 2022-09-22 at 11 45 37 PM" src="https://user-images.githubusercontent.com/41491154/191888698-eb595cab-e5dd-44c3-a62f-f4feef57d474.png">


When balance is zero: 
<img width="643" alt="Screen Shot 2022-09-22 at 11 45 56 PM" src="https://user-images.githubusercontent.com/41491154/191888699-8a2ce6f6-97d5-4df3-9388-975fdb740b5d.png">
