### PR TITLE
fix: no hover on price estimate in swap

### DIFF
--- a/src/components/CurrencyInputPanel/FiatValue.tsx
+++ b/src/components/CurrencyInputPanel/FiatValue.tsx
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
-import HoverInlineText from 'components/HoverInlineText'
 import { useMemo } from 'react'
 import { useTheme } from 'styled-components/macro'
 
@@ -32,17 +31,7 @@ export function FiatValue({
 
   return (
     <ThemedText.DeprecatedBody fontSize={14} color={fiatValue ? theme.deprecated_text3 : theme.deprecated_text4}>
-      {fiatValue ? (
-        <Trans>
-          $
-          <HoverInlineText
-            text={fiatValue?.toFixed(visibleDecimalPlaces, { groupSeparator: ',' })}
-            textColor={fiatValue ? theme.deprecated_text3 : theme.deprecated_text4}
-          />
-        </Trans>
-      ) : (
-        ''
-      )}
+      {fiatValue && <>${fiatValue?.toFixed(visibleDecimalPlaces, { groupSeparator: ',' })}</>}
       {priceImpact ? (
         <span style={{ color: priceImpactColor }}>
           {' '}


### PR DESCRIPTION
After:
https://user-images.githubusercontent.com/4899429/192635111-1efd48d9-66d2-4aa2-a807-fcdb9711ccf9.mov

Before:
https://user-images.githubusercontent.com/4899429/192635523-379f6167-0d78-40fb-8f0d-9fc11aa45c77.mov

Discussed with Fred that this isn't worth gating since it's more of a bug than part of a re-design.
