### PR TITLE
fix: no hover on balance text in swap

### DIFF
--- a/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
+++ b/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
@@ -373,11 +373,10 @@ export default function SwapCurrencyInputPanel({
               {account ? (
                 <RowFixed style={{ height: '17px' }}>
                   <ThemedText.DeprecatedBody
-                    onClick={onMax}
                     color={theme.deprecated_text3}
                     fontWeight={500}
                     fontSize={14}
-                    style={{ display: 'inline', cursor: 'pointer' }}
+                    style={{ display: 'inline' }}
                   >
                     {!hideBalance && currency && selectedCurrencyBalance ? (
                       renderBalance ? (


### PR DESCRIPTION
Also essentially a bug fix so it's not behind redesign flag.

After:
https://user-images.githubusercontent.com/4899429/192634591-1ecdb66d-52e9-44cf-9e4b-dc1eaa72fd89.mov

Before:
https://user-images.githubusercontent.com/4899429/192635523-379f6167-0d78-40fb-8f0d-9fc11aa45c77.mov
