### PR TITLE
fix: network filter container shouldn't expand on mobile

### DIFF
--- a/src/components/Tokens/TokenTable/NetworkFilter.tsx
+++ b/src/components/Tokens/TokenTable/NetworkFilter.tsx
@@ -8,7 +8,6 @@ import { useModalIsOpen, useToggleModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
 import styled, { useTheme } from 'styled-components/macro'
 
-import { MEDIUM_MEDIA_BREAKPOINT } from '../constants'
 import FilterOption from './FilterOption'
 
 const InternalMenuItem = styled.div`
@@ -58,10 +57,6 @@ const StyledMenu = styled.div`
   position: relative;
   border: none;
   text-align: left;
-
-  @media only screen and (max-width: ${MEDIUM_MEDIA_BREAKPOINT}) {
-    flex: 1;
-  }
 `
 const StyledMenuContent = styled.div`
   display: flex;


### PR DESCRIPTION
after:
<img width="380" alt="Screen Shot 2022-09-27 at 6 00 20 PM" src="https://user-images.githubusercontent.com/4899429/192644691-fa6e220f-5a8f-41a8-99aa-69293b19eb00.png">

before:
<img width="375" alt="Screen Shot 2022-09-27 at 6 00 30 PM" src="https://user-images.githubusercontent.com/4899429/192644694-b3881e47-d99a-4da0-b372-439429111c79.png">
