### PR TITLE
fix: center TimeButton in PriceChart

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -106,6 +106,8 @@ export const TimeOptionsContainer = styled.div`
   width: fit-content;
 `
 const TimeButton = styled.button<{ active: boolean }>`
+  display: flex;
+  align-items: center;
   background-color: ${({ theme, active }) => (active ? theme.backgroundInteractive : 'transparent')};
   font-weight: 600;
   font-size: 16px;


### PR DESCRIPTION
<img width="468" alt="Screen Shot 2022-09-27 at 6 20 56 PM" src="https://user-images.githubusercontent.com/4899429/192647926-ee4a0689-c501-4a33-804f-a5a64c0b7b53.png">
