### PR TITLE
fix: remove ignore exhaustive deps in SearchBarDropdown

### DIFF
--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -94,38 +94,6 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput, i
   const phase1Flag = useNftFlag()
   const [resultsState, setResultsState] = useState<ReactNode>()
 
-  const tokenSearchResults =
-    tokens.length > 0 ? (
-      <SearchBarDropdownSection
-        hoveredIndex={hoveredIndex}
-        startingIndex={isNFTPage ? collections.length : 0}
-        setHoveredIndex={setHoveredIndex}
-        toggleOpen={toggleOpen}
-        suggestions={tokens}
-        header={<Trans>Tokens</Trans>}
-      />
-    ) : (
-      <Box className={styles.notFoundContainer}>
-        <Trans>No tokens found.</Trans>
-      </Box>
-    )
-
-  const collectionSearchResults =
-    phase1Flag === NftVariant.Enabled ? (
-      collections.length > 0 ? (
-        <SearchBarDropdownSection
-          hoveredIndex={hoveredIndex}
-          startingIndex={isNFTPage ? 0 : tokens.length}
-          setHoveredIndex={setHoveredIndex}
-          toggleOpen={toggleOpen}
-          suggestions={collections}
-          header={<Trans>NFT Collections</Trans>}
-        />
-      ) : (
-        <Box className={styles.notFoundContainer}>No NFT collections found.</Box>
-      )
-    ) : null
-
   const { data: trendingCollectionResults, isLoading: trendingCollectionsAreLoading } = useQuery(
     ['trendingCollections', 'eth', 'twenty_four_hours'],
     () => fetchTrendingCollections({ volumeType: 'eth', timePeriod: 'ONE_DAY' as TimePeriod, size: 3 })
@@ -204,6 +172,38 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput, i
 
   useEffect(() => {
     if (!isLoading) {
+      const tokenSearchResults =
+        tokens.length > 0 ? (
+          <SearchBarDropdownSection
+            hoveredIndex={hoveredIndex}
+            startingIndex={isNFTPage ? collections.length : 0}
+            setHoveredIndex={setHoveredIndex}
+            toggleOpen={toggleOpen}
+            suggestions={tokens}
+            header={<Trans>Tokens</Trans>}
+          />
+        ) : (
+          <Box className={styles.notFoundContainer}>
+            <Trans>No tokens found.</Trans>
+          </Box>
+        )
+
+      const collectionSearchResults =
+        phase1Flag === NftVariant.Enabled ? (
+          collections.length > 0 ? (
+            <SearchBarDropdownSection
+              hoveredIndex={hoveredIndex}
+              startingIndex={isNFTPage ? 0 : tokens.length}
+              setHoveredIndex={setHoveredIndex}
+              toggleOpen={toggleOpen}
+              suggestions={collections}
+              header={<Trans>NFT Collections</Trans>}
+            />
+          ) : (
+            <Box className={styles.notFoundContainer}>No NFT collections found.</Box>
+          )
+        ) : null
+
       const currentState = () =>
         hasInput ? (
           // Empty or Up to 8 combined tokens and nfts
@@ -267,8 +267,6 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput, i
     isLoading,
     tokens,
     collections,
-    collectionSearchResults,
-    tokenSearchResults,
     trendingCollections,
     trendingCollectionsAreLoading,
     trendingTokens,

--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -263,11 +263,12 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput, i
 
       setResultsState(currentState)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isLoading,
     tokens,
     collections,
+    collectionSearchResults,
+    tokenSearchResults,
     trendingCollections,
     trendingCollectionsAreLoading,
     trendingTokens,


### PR DESCRIPTION
Generally, we should not be ignoring exhaustive deps checks as it can lead to subtle bugs. I believe the component is working still while adding this back in.

The core issue is we should not be storing React elements in state from a useEffect. We should be caching just the data and re-rendering the components as needed. If that is expensive then we should be memoizing the component. I think for now we can do this, but should re-think the architecture a bit potentially.