### PR TITLE
fix: display 0 percent change on explore

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -69,8 +69,6 @@ export function formatDelta(delta: number | null | undefined) {
   // Null-check not including zero
   if (delta === null || delta === undefined) {
     return '-'
-  } else if ((delta < 0.01 && delta > 0) || (delta > -0.01 && delta < 0)) {
-    return '0.00%'
   }
   let formattedDelta = delta.toFixed(2) + '%'
   if (Math.sign(delta) > 0) {

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -59,8 +59,7 @@ export function getDeltaArrow(delta: number | null | undefined) {
   // Null-check not including zero
   if (delta === null || delta === undefined) {
     return null
-  }
-  if (Math.sign(delta) < 0) {
+  } else if (Math.sign(delta) < 0) {
     return <StyledDownArrow size={16} key="arrow-down" />
   }
   return <StyledUpArrow size={16} key="arrow-up" />

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -55,17 +55,24 @@ export function calculateDelta(start: number, current: number) {
   return (current / start - 1) * 100
 }
 
-export function getDeltaArrow(delta: number) {
-  if (Math.sign(delta) > 0) {
-    return <StyledUpArrow size={16} key="arrow-up" />
-  } else if (delta === 0) {
+export function getDeltaArrow(delta: number | null | undefined) {
+  // Null-check not including zero
+  if (delta === null || delta === undefined) {
     return null
-  } else {
+  }
+  if (Math.sign(delta) < 0) {
     return <StyledDownArrow size={16} key="arrow-down" />
   }
+  return <StyledUpArrow size={16} key="arrow-up" />
 }
 
-export function formatDelta(delta: number) {
+export function formatDelta(delta: number | null | undefined) {
+  // Null-check not including zero
+  if (delta === null || delta === undefined) {
+    return '-'
+  } else if ((delta < 0.01 && delta > 0) || (delta > -0.01 && delta < 0)) {
+    return '0.00%'
+  }
   let formattedDelta = delta.toFixed(2) + '%'
   if (Math.sign(delta) > 0) {
     formattedDelta = '+' + formattedDelta

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -485,8 +485,8 @@ export const LoadedRow = forwardRef((props: LoadedRowProps, ref: ForwardedRef<HT
   const L2Icon = getChainInfo(CHAIN_NAME_TO_CHAIN_ID[filterNetwork]).circleLogoUrl
   const timePeriod = useAtomValue(filterTimeAtom)
   const delta = token.market?.pricePercentChange?.value
-  const arrow = delta ? getDeltaArrow(delta) : null
-  const formattedDelta = delta ? formatDelta(delta) : null
+  const arrow = getDeltaArrow(delta)
+  const formattedDelta = formatDelta(delta)
   const sortAscending = useAtomValue(sortAscendingAtom)
 
   const exploreTokenSelectedEventProperties = {
@@ -544,7 +544,7 @@ export const LoadedRow = forwardRef((props: LoadedRowProps, ref: ForwardedRef<HT
           }
           percentChange={
             <ClickableContent>
-              {formattedDelta ?? '-'}
+              {formattedDelta}
               {arrow}
             </ClickableContent>
           }


### PR DESCRIPTION
before:
<img width="570" alt="image" src="https://user-images.githubusercontent.com/39385577/192838288-b6c2580c-5256-4e4a-af23-9ea5992bf6c9.png">

after:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/39385577/192838440-19cecf9b-f36b-4719-9186-12160b90d6a0.png">
