### PR TITLE
fix: update TokenDetails layout sizing

### DIFF
--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -10,7 +10,7 @@ import { useSyncWidgetInputs } from './inputs'
 import { useSyncWidgetSettings } from './settings'
 import { useSyncWidgetTransactions } from './transactions'
 
-export const WIDGET_WIDTH = 320
+export const WIDGET_WIDTH = 360
 
 const WIDGET_ROUTER_URL = 'https://api.uniswap.org/v1/'
 

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -45,7 +45,7 @@ export const Footer = styled.div`
 `
 export const TokenDetailsLayout = styled.div`
   display: flex;
-  gap: 80px;
+  gap: 60px;
   padding: 68px 20px;
   width: 100%;
   justify-content: center;
@@ -77,7 +77,7 @@ export const TokenDetailsLayout = styled.div`
   }
 `
 export const LeftPanel = styled.div`
-  max-width: 832px;
+  max-width: 780px;
   overflow: hidden;
 `
 export const RightPanel = styled.div`


### PR DESCRIPTION
before:
<img width="1476" alt="Screen Shot 2022-09-28 at 2 36 03 PM" src="https://user-images.githubusercontent.com/4899429/192862037-4c2196e7-8716-432c-95e3-0ad763c8c6aa.png">

after:
<img width="1475" alt="Screen Shot 2022-09-28 at 2 36 48 PM" src="https://user-images.githubusercontent.com/4899429/192862039-75b4c143-a4e8-401d-9515-9e19a969a574.png">
