### PR TITLE
fix: left align SearchBar

### DIFF
--- a/src/components/NavBar/SearchBar.css.ts
+++ b/src/components/NavBar/SearchBar.css.ts
@@ -194,23 +194,3 @@ export const visible = style([
     transitionTimingFunction: 'ease-out',
   },
 ])
-
-export const searchContentCentered = style({
-  '@media': {
-    [`screen and (min-width: ${breakpoints.lg}px)`]: {
-      transform: `translateX(${DESKTOP_NAVBAR_WIDTH / 4}px)`,
-      transition: `transform ${vars.time[125]}`,
-      transitionTimingFunction: 'ease-out',
-    },
-  },
-})
-
-export const searchContentLeftAlign = style({
-  '@media': {
-    [`screen and (min-width: ${breakpoints.lg}px)`]: {
-      transform: 'translateX(0)',
-      transition: `transform ${vars.time[125]}`,
-      transitionTimingFunction: 'ease-in',
-    },
-  },
-})

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -410,7 +410,7 @@ export const SearchBar = () => {
               !isOpen && toggleOpen()
               setSearchValue(event.target.value)
             }}
-            className={`${styles.searchBarInput}`}
+            className={styles.searchBarInput}
             value={searchValue}
             ref={inputRef}
             width={phase1Flag === NftVariant.Enabled || isOpen ? 'full' : '160'}

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -372,7 +372,6 @@ export const SearchBar = () => {
 
   const placeholderText = phase1Flag === NftVariant.Enabled ? t`Search tokens and NFT collections` : t`Search tokens`
   const isMobileOrTablet = isMobile || isTablet
-  const showCenteredSearchContent = !isOpen && phase1Flag !== NftVariant.Enabled && !isMobileOrTablet
 
   return (
     <Box position="relative">
@@ -396,7 +395,7 @@ export const SearchBar = () => {
           onClick={() => !isOpen && toggleOpen()}
           gap="12"
         >
-          <Box className={showCenteredSearchContent ? styles.searchContentCentered : styles.searchContentLeftAlign}>
+          <Box>
             <Box display={{ sm: 'none', md: 'flex' }}>
               <MagnifyingGlassIcon />
             </Box>
@@ -411,9 +410,7 @@ export const SearchBar = () => {
               !isOpen && toggleOpen()
               setSearchValue(event.target.value)
             }}
-            className={`${styles.searchBarInput} ${
-              showCenteredSearchContent ? styles.searchContentCentered : styles.searchContentLeftAlign
-            }`}
+            className={`${styles.searchBarInput}`}
             value={searchValue}
             ref={inputRef}
             width={phase1Flag === NftVariant.Enabled || isOpen ? 'full' : '160'}


### PR DESCRIPTION
There is a task to left align the search bar when unfocused while there is a search query. Looking at this code, it looks like we'll left align it when NFT is released. My opinion is it'd be better to remove this center alignment logic so we can be consistent on the NFT launch, and not need further edge casing.