### PR TITLE
fix: grow left panel in token details

### DIFF
--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -77,6 +77,7 @@ export const TokenDetailsLayout = styled.div`
   }
 `
 export const LeftPanel = styled.div`
+  flex: 1;
   max-width: 780px;
   overflow: hidden;
 `


### PR DESCRIPTION
When the text doesn't take up the full space of the container, the max-width won't be reached by the left panel. Instead, we want to expand fully up until we hit the max-width.
