### PR TITLE
fix: update network warning styling

### DIFF
--- a/src/components/Header/ChainConnectivityWarning.tsx
+++ b/src/components/Header/ChainConnectivityWarning.tsx
@@ -2,16 +2,24 @@ import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
 import { getChainInfoOrDefault, L2ChainInfo } from 'constants/chainInfo'
 import { SupportedChainId } from 'constants/chains'
-import { AlertOctagon } from 'react-feather'
+import { RedesignVariant, useRedesignFlag } from 'featureFlags/flags/redesign'
+import { AlertOctagon, AlertTriangle } from 'react-feather'
 import styled from 'styled-components/macro'
 import { ExternalLink, MEDIA_WIDTHS } from 'theme'
 
-const BodyRow = styled.div`
-  color: ${({ theme }) => theme.deprecated_black};
+const BodyRow = styled.div<{ redesignFlag?: boolean }>`
+  color: ${({ theme, redesignFlag }) => (redesignFlag ? theme.textPrimary : theme.black)};
   font-size: 12px;
+  font-weight: ${({ redesignFlag }) => redesignFlag && '400'};
+  font-size: ${({ redesignFlag }) => (redesignFlag ? '14px' : '12px')};
+  line-height: ${({ redesignFlag }) => redesignFlag && '20px'};
 `
-const CautionIcon = styled(AlertOctagon)`
+const CautionOctagon = styled(AlertOctagon)`
   color: ${({ theme }) => theme.deprecated_black};
+`
+
+const CautionTriangle = styled(AlertTriangle)`
+  color: ${({ theme }) => theme.accentWarning};
 `
 const Link = styled(ExternalLink)`
   color: ${({ theme }) => theme.deprecated_black};
@@ -23,21 +31,22 @@ const TitleRow = styled.div`
   justify-content: flex-start;
   margin-bottom: 8px;
 `
-const TitleText = styled.div`
-  color: black;
-  font-weight: 600;
+const TitleText = styled.div<{ redesignFlag?: boolean }>`
+  color: ${({ theme, redesignFlag }) => (redesignFlag ? theme.textPrimary : theme.black)};
+  font-weight: ${({ redesignFlag }) => (redesignFlag ? '500' : '600')};
   font-size: 16px;
-  line-height: 20px;
+  line-height: ${({ redesignFlag }) => (redesignFlag ? '24px' : '20px')};
   margin: 0px 12px;
 `
-const Wrapper = styled.div`
-  background-color: ${({ theme }) => theme.deprecated_yellow3};
+const Wrapper = styled.div<{ redesignFlag?: boolean }>`
+  background-color: ${({ theme, redesignFlag }) => (redesignFlag ? theme.backgroundSurface : theme.deprecated_yellow3)};
   border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.backgroundOutline};
   bottom: 60px;
   display: none;
   max-width: 348px;
   padding: 16px 20px;
-  position: absolute;
+  position: fixed;
   right: 16px;
   @media screen and (min-width: ${MEDIA_WIDTHS.deprecated_upToMedium}px) {
     display: block;
@@ -48,20 +57,21 @@ export function ChainConnectivityWarning() {
   const { chainId } = useWeb3React()
   const info = getChainInfoOrDefault(chainId)
   const label = info?.label
+  const redesignFlag = useRedesignFlag() === RedesignVariant.Enabled
 
   return (
-    <Wrapper>
+    <Wrapper redesignFlag={redesignFlag}>
       <TitleRow>
-        <CautionIcon />
-        <TitleText>
+        {redesignFlag ? <CautionTriangle /> : <CautionOctagon />}
+        <TitleText redesignFlag={redesignFlag}>
           <Trans>Network Warning</Trans>
         </TitleText>
       </TitleRow>
-      <BodyRow>
+      <BodyRow redesignFlag={redesignFlag}>
         {chainId === SupportedChainId.MAINNET ? (
           <Trans>You may have lost your network connection.</Trans>
         ) : (
-          <Trans>You may have lost your network connection, or {label} might be down right now.</Trans>
+          <Trans>{label} might be down right now, or you may have lost your network connection.</Trans>
         )}{' '}
         {(info as L2ChainInfo).statusPage !== undefined && (
           <span>

--- a/src/components/Header/ChainConnectivityWarning.tsx
+++ b/src/components/Header/ChainConnectivityWarning.tsx
@@ -7,12 +7,12 @@ import { AlertOctagon, AlertTriangle } from 'react-feather'
 import styled from 'styled-components/macro'
 import { ExternalLink, MEDIA_WIDTHS } from 'theme'
 
-const BodyRow = styled.div<{ redesignFlag?: boolean }>`
-  color: ${({ theme, redesignFlag }) => (redesignFlag ? theme.textPrimary : theme.black)};
+const BodyRow = styled.div<{ $redesignFlag?: boolean }>`
+  color: ${({ theme, $redesignFlag }) => ($redesignFlag ? theme.textPrimary : theme.black)};
   font-size: 12px;
-  font-weight: ${({ redesignFlag }) => redesignFlag && '400'};
-  font-size: ${({ redesignFlag }) => (redesignFlag ? '14px' : '12px')};
-  line-height: ${({ redesignFlag }) => redesignFlag && '20px'};
+  font-weight: ${({ $redesignFlag }) => $redesignFlag && '400'};
+  font-size: ${({ $redesignFlag }) => ($redesignFlag ? '14px' : '12px')};
+  line-height: ${({ $redesignFlag }) => $redesignFlag && '20px'};
 `
 const CautionOctagon = styled(AlertOctagon)`
   color: ${({ theme }) => theme.deprecated_black};
@@ -67,7 +67,7 @@ export function ChainConnectivityWarning() {
           <Trans>Network Warning</Trans>
         </TitleText>
       </TitleRow>
-      <BodyRow redesignFlag={redesignFlag}>
+      <BodyRow $redesignFlag={redesignFlag}>
         {chainId === SupportedChainId.MAINNET ? (
           <Trans>You may have lost your network connection.</Trans>
         ) : (


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-1324?atlOrigin=eyJpIjoiNWM3OTFjYzVjY2Q2NDg3NWIyODI2N2M3M2ZmN2ZlOWQiLCJwIjoiaiJ9

i got these screenshots by forcing the connectivity warning to always be displayed temporarily: 
<img width="409" alt="Screen Shot 2022-09-30 at 12 42 27 AM" src="https://user-images.githubusercontent.com/41491154/193192154-153ffdfc-4801-4e89-ba7b-73cb88c884ac.png">
<img width="397" alt="Screen Shot 2022-09-30 at 12 43 04 AM" src="https://user-images.githubusercontent.com/41491154/193192156-0f2a614c-a1dc-4a98-b358-5a14ef440e4c.png">
