### PR TITLE
fix: make number of loading rows make more sense when filtering, changing duration etc

### DIFF
--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -95,7 +95,7 @@ export default function TokenTable() {
 
   /* loading and error state */
   if (loading && (!tokens || tokens?.length === 0)) {
-    return <LoadingTokenTable rowCount={PAGE_SIZE} />
+    return <LoadingTokenTable rowCount={Math.min(PAGE_SIZE, maxFetchable)} />
   } else {
     if (error || !tokens) {
       return (

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -95,7 +95,6 @@ export default function TokenTable() {
 
   /* loading and error state */
   if (loading && (!tokens || tokens?.length === 0)) {
-    console.log('loading count', loadingRowsCount)
     return <LoadingTokenTable rowCount={loadingRowsCount} />
   } else {
     if (error || !tokens) {

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -75,7 +75,7 @@ export default function TokenTable() {
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
   const chainName = validateUrlChainParam(useParams<{ chainName?: string }>().chainName)
-  const { error, loading, tokens, hasMore, loadMoreTokens, tokenListLength, loadingRowsCount } = useTopTokens(chainName)
+  const { error, loading, tokens, hasMore, loadMoreTokens, loadingRowsCount } = useTopTokens(chainName)
   const showMoreLoadingRows = Boolean(loading && hasMore)
 
   const observer = useRef<IntersectionObserver>()
@@ -126,7 +126,7 @@ export default function TokenTable() {
                     <LoadedRow
                       key={token?.address}
                       tokenListIndex={index}
-                      tokenListLength={tokenListLength}
+                      tokenListLength={tokens.length}
                       token={token}
                       ref={index + 1 === tokens.length ? lastTokenRef : undefined}
                     />

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -75,7 +75,7 @@ export default function TokenTable() {
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
   const chainName = validateUrlChainParam(useParams<{ chainName?: string }>().chainName)
-  const { error, loading, tokens, hasMore, loadMoreTokens, maxFetchable } = useTopTokens(chainName)
+  const { error, loading, tokens, hasMore, loadMoreTokens, tokenListLength, loadingRowsCount } = useTopTokens(chainName)
   const showMoreLoadingRows = Boolean(loading && hasMore)
 
   const observer = useRef<IntersectionObserver>()
@@ -95,7 +95,8 @@ export default function TokenTable() {
 
   /* loading and error state */
   if (loading && (!tokens || tokens?.length === 0)) {
-    return <LoadingTokenTable rowCount={Math.min(PAGE_SIZE, maxFetchable)} />
+    console.log('loading count', loadingRowsCount)
+    return <LoadingTokenTable rowCount={loadingRowsCount} />
   } else {
     if (error || !tokens) {
       return (
@@ -126,7 +127,7 @@ export default function TokenTable() {
                     <LoadedRow
                       key={token?.address}
                       tokenListIndex={index}
-                      tokenListLength={maxFetchable}
+                      tokenListLength={tokenListLength}
                       token={token}
                       ref={index + 1 === tokens.length ? lastTokenRef : undefined}
                     />

--- a/src/components/Tokens/TokenTable/TokenTable.tsx
+++ b/src/components/Tokens/TokenTable/TokenTable.tsx
@@ -75,7 +75,7 @@ export default function TokenTable() {
 
   // TODO: consider moving prefetched call into app.tsx and passing it here, use a preloaded call & updated on interval every 60s
   const chainName = validateUrlChainParam(useParams<{ chainName?: string }>().chainName)
-  const { error, loading, tokens, hasMore, loadMoreTokens, loadingRowsCount } = useTopTokens(chainName)
+  const { error, loading, tokens, hasMore, loadMoreTokens, loadingRowCount } = useTopTokens(chainName)
   const showMoreLoadingRows = Boolean(loading && hasMore)
 
   const observer = useRef<IntersectionObserver>()
@@ -95,7 +95,7 @@ export default function TokenTable() {
 
   /* loading and error state */
   if (loading && (!tokens || tokens?.length === 0)) {
-    return <LoadingTokenTable rowCount={loadingRowsCount} />
+    return <LoadingTokenTable rowCount={loadingRowCount} />
   } else {
     if (error || !tokens) {
       return (

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -179,7 +179,7 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const [prefetchedData, setPrefetchedData] = useState<PrefetchedTopToken[]>()
   const prefetchedSelectedTokensWithoutPriceHistory = useFilteredTokens(useSortedTokens(prefetchedData))
   const maxFetchable = useMemo(
-    () => (!!prefetchedData ? prefetchedSelectedTokensWithoutPriceHistory.length : 100),
+    () => (prefetchedData ? prefetchedSelectedTokensWithoutPriceHistory.length : 100),
     [prefetchedSelectedTokensWithoutPriceHistory, prefetchedData]
   )
 

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -167,7 +167,6 @@ interface UseTopTokensReturnValue {
   tokens: TopToken[] | undefined
   hasMore: boolean
   loadMoreTokens: () => void
-  tokenListLength: number
   loadingRowsCount: number
 }
 export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
@@ -179,10 +178,7 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const [error, setError] = useState<Error | undefined>()
   const [prefetchedData, setPrefetchedData] = useState<PrefetchedTopToken[]>()
   const prefetchedSelectedTokensWithoutPriceHistory = useFilteredTokens(useSortedTokens(prefetchedData))
-  const tokenListLength = useMemo(
-    () => prefetchedSelectedTokensWithoutPriceHistory.length,
-    [prefetchedSelectedTokensWithoutPriceHistory]
-  )
+  const loading = Boolean(loadingTokensWithPriceHistory || loadingTokensWithoutPriceHistory)
   // loadingRowsCount defaults to PAGE_SIZE when no prefetchedData is available yet because the initial load
   // count will always be PAGE_SIZE.
   const loadingRowsCount = useMemo(
@@ -283,11 +279,10 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
 
   return {
     error,
-    loading: loadingTokensWithPriceHistory || loadingTokensWithoutPriceHistory,
+    loading,
     tokens,
     hasMore,
     loadMoreTokens,
-    tokenListLength,
     loadingRowsCount,
   }
 }

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -167,7 +167,7 @@ interface UseTopTokensReturnValue {
   tokens: TopToken[] | undefined
   hasMore: boolean
   loadMoreTokens: () => void
-  loadingRowsCount: number
+  loadingRowCount: number
 }
 export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
@@ -179,9 +179,9 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const [prefetchedData, setPrefetchedData] = useState<PrefetchedTopToken[]>()
   const prefetchedSelectedTokensWithoutPriceHistory = useFilteredTokens(useSortedTokens(prefetchedData))
   const loading = Boolean(loadingTokensWithPriceHistory || loadingTokensWithoutPriceHistory)
-  // loadingRowsCount defaults to PAGE_SIZE when no prefetchedData is available yet because the initial load
+  // loadingRowCount defaults to PAGE_SIZE when no prefetchedData is available yet because the initial load
   // count will always be PAGE_SIZE.
-  const loadingRowsCount = useMemo(
+  const loadingRowCount = useMemo(
     () => (prefetchedData ? Math.min(prefetchedSelectedTokensWithoutPriceHistory.length, PAGE_SIZE) : PAGE_SIZE),
     [prefetchedSelectedTokensWithoutPriceHistory, prefetchedData]
   )
@@ -283,7 +283,7 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
     tokens,
     hasMore,
     loadMoreTokens,
-    loadingRowsCount,
+    loadingRowCount,
   }
 }
 

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -167,7 +167,8 @@ interface UseTopTokensReturnValue {
   tokens: TopToken[] | undefined
   hasMore: boolean
   loadMoreTokens: () => void
-  maxFetchable: number
+  tokenListLength: number
+  loadingRowsCount: number
 }
 export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const duration = toHistoryDuration(useAtomValue(filterTimeAtom))
@@ -178,8 +179,14 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const [error, setError] = useState<Error | undefined>()
   const [prefetchedData, setPrefetchedData] = useState<PrefetchedTopToken[]>()
   const prefetchedSelectedTokensWithoutPriceHistory = useFilteredTokens(useSortedTokens(prefetchedData))
-  const maxFetchable = useMemo(
-    () => (prefetchedData ? prefetchedSelectedTokensWithoutPriceHistory.length : 100),
+  const tokenListLength = useMemo(
+    () => prefetchedSelectedTokensWithoutPriceHistory.length,
+    [prefetchedSelectedTokensWithoutPriceHistory]
+  )
+  // loadingRowsCount defaults to PAGE_SIZE when no prefetchedData is available yet because the initial load
+  // count will always be PAGE_SIZE.
+  const loadingRowsCount = useMemo(
+    () => (prefetchedData ? Math.min(prefetchedSelectedTokensWithoutPriceHistory.length, PAGE_SIZE) : PAGE_SIZE),
     [prefetchedSelectedTokensWithoutPriceHistory, prefetchedData]
   )
 
@@ -280,7 +287,8 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
     tokens,
     hasMore,
     loadMoreTokens,
-    maxFetchable,
+    tokenListLength,
+    loadingRowsCount,
   }
 }
 

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -59,7 +59,7 @@ export enum TokenSortMethod {
 
 export type PrefetchedTopToken = NonNullable<TopTokens100Query['response']['topTokens']>[number]
 
-function useSortedTokens(tokens: TopTokens100Query['response']['topTokens']) {
+function useSortedTokens(tokens: TopTokens100Query['response']['topTokens'] | undefined) {
   const sortMethod = useAtomValue(sortMethodAtom)
   const sortAscending = useAtomValue(sortAscendingAtom)
 
@@ -176,11 +176,11 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const [tokens, setTokens] = useState<TopToken[]>()
   const [page, setPage] = useState(0)
   const [error, setError] = useState<Error | undefined>()
-  const [prefetchedData, setPrefetchedData] = useState<PrefetchedTopToken[]>([])
+  const [prefetchedData, setPrefetchedData] = useState<PrefetchedTopToken[]>()
   const prefetchedSelectedTokensWithoutPriceHistory = useFilteredTokens(useSortedTokens(prefetchedData))
   const maxFetchable = useMemo(
-    () => prefetchedSelectedTokensWithoutPriceHistory.length,
-    [prefetchedSelectedTokensWithoutPriceHistory]
+    () => (!!prefetchedData ? prefetchedSelectedTokensWithoutPriceHistory.length : 100),
+    [prefetchedSelectedTokensWithoutPriceHistory, prefetchedData]
   )
 
   const hasMore = !tokens || tokens.length < prefetchedSelectedTokensWithoutPriceHistory.length


### PR DESCRIPTION
after fix loom: https://www.loom.com/share/a0f5b0bb59f2435081297f2328571b78

Notice: 
- when you search something, it already knows how many rows there will be, so we show that number of loading rows
- when you change duration (with a filter applied), the same number of rows will exist with new duration. so we show that number of loading rows. 