### PR TITLE
fix: fixes show more not showing on long collection description

### DIFF
--- a/src/nft/components/collection/CollectionStats.css.ts
+++ b/src/nft/components/collection/CollectionStats.css.ts
@@ -134,6 +134,9 @@ export const statsLabelLoading = style([
 
 export const descriptionLoading = style([
   loadingAsset,
+  sprinkles({
+    height: '20',
+  }),
   {
     maxWidth: 'min(calc(100% - 112px), 600px)',
   },

--- a/src/nft/components/collection/CollectionStats.tsx
+++ b/src/nft/components/collection/CollectionStats.tsx
@@ -208,7 +208,7 @@ const CollectionDescription = ({ description }: { description: string }) => {
         descriptionRef.current.getBoundingClientRect().width >= 590)
     )
       setShowReadMore(true)
-  }, [descriptionRef, baseRef])
+  }, [descriptionRef, baseRef, isCollectionStatsLoading])
 
   return isCollectionStatsLoading ? (
     <Box marginTop={{ sm: '12', md: '16' }} className={styles.descriptionLoading}></Box>
@@ -326,14 +326,10 @@ export const CollectionStats = ({ stats, isMobile }: { stats: GenieCollection; i
           collectionSocialsIsOpen={collectionSocialsIsOpen}
           toggleCollectionSocials={toggleCollectionSocials}
         />
-        {!isMobile && (
-          <>
-            {(stats.description || isCollectionStatsLoading) && (
-              <CollectionDescription description={stats.description} />
-            )}
-            <StatsRow stats={stats} marginTop="20" />
-          </>
-        )}
+        <>
+          {(stats.description || isCollectionStatsLoading) && <CollectionDescription description={stats.description} />}
+          <StatsRow stats={stats} marginTop="20" />
+        </>
       </Box>
       {isMobile && (
         <>

--- a/src/nft/components/collection/CollectionStats.tsx
+++ b/src/nft/components/collection/CollectionStats.tsx
@@ -326,10 +326,14 @@ export const CollectionStats = ({ stats, isMobile }: { stats: GenieCollection; i
           collectionSocialsIsOpen={collectionSocialsIsOpen}
           toggleCollectionSocials={toggleCollectionSocials}
         />
-        <>
-          {(stats.description || isCollectionStatsLoading) && <CollectionDescription description={stats.description} />}
-          <StatsRow stats={stats} marginTop="20" />
-        </>
+        {!isMobile && (
+          <>
+            {(stats.description || isCollectionStatsLoading) && (
+              <CollectionDescription description={stats.description} />
+            )}
+            <StatsRow stats={stats} marginTop="20" />
+          </>
+        )}
       </Box>
       {isMobile && (
         <>


### PR DESCRIPTION
1. I noticed a loading state wasn't showing properly b/c it is missing a height.  
2. It wasn't working because it wasn't showing due to the loading state.  I added it as a hook dependency to recheck once the state loads