### PR TITLE
fix: allows SwapDetailsDropdown to be opened

### DIFF
--- a/src/components/swap/SwapDetailsDropdown.tsx
+++ b/src/components/swap/SwapDetailsDropdown.tsx
@@ -28,7 +28,7 @@ const Wrapper = styled(Row)<{ redesignFlag: boolean }>`
   justify-content: center;
   border-radius: ${({ redesignFlag }) => redesignFlag && 'inherit'};
   padding: ${({ redesignFlag }) => redesignFlag && '8px 12px'};
-  margin-top: ${({ redesignFlag }) => (redesignFlag ? '0px' : '4px')} !important;
+  margin-top: ${({ redesignFlag }) => (redesignFlag ? '0px' : '4px')};
   min-height: ${({ redesignFlag }) => redesignFlag && '32px'};
 `
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -106,6 +106,7 @@ const SwapSection = styled.div<{ redesignFlag: boolean }>`
 
         width: 100%;
         height: 100%;
+        pointer-events: none;
         content: '';
         border: 1px solid ${({ theme }) => theme.backgroundModule};
       }


### PR DESCRIPTION
This allows the dropdown to be clicked by making sure the :before element doesn't swallow the click event.
