### PR TITLE
fix: center TimeButton in PriceChart horizontally

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -109,6 +109,7 @@ const TimeButton = styled.button<{ active: boolean }>`
   flex: 1;
   display: flex;
   align-items: center;
+  justify-content: center;
   background-color: ${({ theme, active }) => (active ? theme.backgroundInteractive : 'transparent')};
   font-weight: 600;
   font-size: 16px;


### PR DESCRIPTION
<img width="404" alt="Screen Shot 2022-10-04 at 5 48 44 PM" src="https://user-images.githubusercontent.com/4899429/193936688-0a0b807d-7e5a-474d-9e9b-424f88bde4f5.png">
