### PR TITLE
style: increase name column width in token table

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -199,7 +199,7 @@ const MarketCapCell = styled(DataCell)`
 const NameCell = styled(Cell)`
   justify-content: flex-start;
   padding: 0px 8px;
-  min-width: 200px;
+  min-width: 240px;
   gap: 8px;
 `
 const PriceCell = styled(DataCell)`


### PR DESCRIPTION
Before:
<img width="1002" alt="CleanShot 2022-10-07 at 08 25 12@2x" src="https://user-images.githubusercontent.com/3887562/194590861-fe23f511-25fe-41c4-84f7-0e216ee10f6d.png">

After:
<img width="979" alt="CleanShot 2022-10-07 at 08 24 56@2x" src="https://user-images.githubusercontent.com/3887562/194590872-d44fc00e-1e8a-45d3-8357-80bdfdb155db.png">
