### PR TITLE
fix(token-details): make breakpoints more consistent and use only theme.breakpoint values

### DIFF
--- a/src/components/Tokens/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Tokens/TokenDetails/BalanceSummary.tsx
@@ -91,6 +91,7 @@ export default function BalanceSummary({ tokenAmount, nativeCurrencyAmount, isNa
     tokenAmount.currency.address.toLowerCase() === nativeCurrencyAmount.currency.wrapped.address.toLowerCase()
 
   if (
+    (!tokenAmount && !nativeCurrencyAmount) ||
     (!tokenAmount && !tokenIsWrappedNative && !isNative) ||
     (!isNative && !tokenIsWrappedNative && tokenAmount?.equalTo(0)) ||
     (isNative && tokenAmount?.equalTo(0) && nativeCurrencyAmount?.equalTo(0))

--- a/src/components/Tokens/TokenDetails/BalanceSummary.tsx
+++ b/src/components/Tokens/TokenDetails/BalanceSummary.tsx
@@ -130,8 +130,8 @@ export default function BalanceSummary({ tokenAmount, nativeCurrencyAmount, isNa
     <BalancesCard>
       <TotalBalanceSection>
         <Trans>Your balance</Trans>
-        {currencies.map((props) => (
-          <BalanceRow {...props} key={props.currency.wrapped.address} />
+        {currencies.map((props, i) => (
+          <BalanceRow {...props} key={props.currency.wrapped.address + i} />
         ))}
       </TotalBalanceSection>
     </BalancesCard>

--- a/src/components/Tokens/TokenDetails/MobileBalanceSummaryFooter.tsx
+++ b/src/components/Tokens/TokenDetails/MobileBalanceSummaryFooter.tsx
@@ -76,11 +76,6 @@ const SwapButton = styled(StyledInternalLink)`
   justify-content: center;
   margin: auto;
   max-width: 100vw;
-  transition: 250ms ease max-width;
-
-  @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
-    max-width: 50vw;
-  }
 `
 
 export default function MobileBalanceSummaryFooter({

--- a/src/components/Tokens/TokenDetails/MobileBalanceSummaryFooter.tsx
+++ b/src/components/Tokens/TokenDetails/MobileBalanceSummaryFooter.tsx
@@ -1,24 +1,26 @@
 import { Trans } from '@lingui/macro'
 import { formatToDecimal } from 'analytics/utils'
 import { useStablecoinValue } from 'hooks/useStablecoinPrice'
-import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
+import { StyledInternalLink } from 'theme'
 import { currencyAmountToPreciseFloat, formatDollar } from 'utils/formatDollarAmt'
 
 import { BalanceSummaryProps } from './BalanceSummary'
 
 const Wrapper = styled.div`
   align-content: center;
+  align-items: center;
   border: 1px solid ${({ theme }) => theme.backgroundOutline};
   background-color: ${({ theme }) => theme.backgroundSurface};
   border-radius: 20px 20px 0px 0px;
   bottom: 56px;
   color: ${({ theme }) => theme.textSecondary};
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   font-weight: 500;
   font-size: 14px;
   height: fit-content;
+  justify-content: space-between;
   left: 0;
   line-height: 20px;
   padding: 12px 16px;
@@ -33,51 +35,52 @@ const Wrapper = styled.div`
   }
 `
 const BalanceValue = styled.div`
+  color: ${({ theme }) => theme.textPrimary};
   font-size: 20px;
   line-height: 28px;
   display: flex;
   gap: 8px;
 `
 const BalanceTotal = styled.div`
+  align-items: center;
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   gap: 8px;
-  color: ${({ theme }) => theme.textPrimary};
 `
 const BalanceInfo = styled.div`
   display: flex;
-  justify-content: flex-start;
+  flex: 10 1 auto;
   flex-direction: column;
+  justify-content: flex-start;
 `
 const FiatValue = styled.span`
-  align-self: flex-end;
-  display: flex;
   font-size: 12px;
   line-height: 16px;
 
-  @media screen and (min-width: ${({ theme }) => theme.breakpoint.sm}) {
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.sm}px) {
     line-height: 24px;
   }
 `
-const SwapButton = styled.button`
-  align-items: center;
+const SwapButton = styled(StyledInternalLink)`
   background-color: ${({ theme }) => theme.accentAction};
   border: none;
   border-radius: 12px;
   color: ${({ theme }) => theme.accentTextLightPrimary};
   display: flex;
+  flex: 1 1 auto;
   padding: 12px 16px;
-  font-size: 16px;
+  font-size: 1em;
   font-weight: 600;
   height: 44px;
   justify-content: center;
-  width: 120px;
-`
-const TotalBalancesSection = styled.div`
-  align-items: center;
-  display: flex;
-  color: ${({ theme }) => theme.textSecondary};
-  justify-content: space-between;
+  margin: auto;
+  max-width: 100vw;
+  transition: 250ms ease max-width;
+
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
+    max-width: 50vw;
+  }
 `
 
 export default function MobileBalanceSummaryFooter({
@@ -99,43 +102,35 @@ export default function MobileBalanceSummaryFooter({
     : undefined
   const nativeBalanceUsd = nativeBalanceUsdValue ? currencyAmountToPreciseFloat(nativeBalanceUsdValue) : undefined
 
-  if ((!tokenAmount && !nativeCurrencyAmount) || (nativeCurrencyAmount?.equalTo(0) && tokenAmount?.equalTo(0))) {
-    return null
-  }
-
   const outputTokenAddress = tokenAmount?.currency.address ?? nativeCurrencyAmount?.wrapped.currency.address
 
   return (
     <Wrapper>
-      <TotalBalancesSection>
-        {Boolean(formattedBalance !== undefined && !isNative) && (
-          <BalanceInfo>
-            <Trans>Your {tokenAmount?.currency?.symbol} balance</Trans>
-            <BalanceTotal>
-              <BalanceValue>
-                {formattedBalance} {tokenAmount?.currency?.symbol}
-              </BalanceValue>
-              <FiatValue>{formatDollar(balanceUsd, true)}</FiatValue>
-            </BalanceTotal>
-          </BalanceInfo>
-        )}
-        {isNative && (
-          <BalanceInfo>
-            <Trans>Your {nativeCurrencyAmount?.currency?.symbol} balance</Trans>
-            <BalanceTotal>
-              <BalanceValue>
-                {formattedNativeBalance} {nativeCurrencyAmount?.currency?.symbol}
-              </BalanceValue>
-              <FiatValue>{formatDollar(nativeBalanceUsd, true)}</FiatValue>
-            </BalanceTotal>
-          </BalanceInfo>
-        )}
-        <Link to={`/swap?outputCurrency=${outputTokenAddress}`}>
-          <SwapButton>
-            <Trans>Swap</Trans>
-          </SwapButton>
-        </Link>
-      </TotalBalancesSection>
+      {Boolean(formattedBalance !== undefined && !isNative && tokenAmount?.greaterThan(0)) && (
+        <BalanceInfo>
+          <Trans>Your {tokenAmount?.currency?.symbol} balance</Trans>
+          <BalanceTotal>
+            <BalanceValue>
+              {formattedBalance} {tokenAmount?.currency?.symbol}
+            </BalanceValue>
+            <FiatValue>{formatDollar(balanceUsd, true)}</FiatValue>
+          </BalanceTotal>
+        </BalanceInfo>
+      )}
+      {Boolean(isNative && nativeCurrencyAmount?.greaterThan(0)) && (
+        <BalanceInfo>
+          <Trans>Your {nativeCurrencyAmount?.currency?.symbol} balance</Trans>
+          <BalanceTotal>
+            <BalanceValue>
+              {formattedNativeBalance} {nativeCurrencyAmount?.currency?.symbol}
+            </BalanceValue>
+            <FiatValue>{formatDollar(nativeBalanceUsd, true)}</FiatValue>
+          </BalanceTotal>
+        </BalanceInfo>
+      )}
+      <SwapButton to={`/swap?outputCurrency=${outputTokenAddress}`}>
+        <Trans>Swap</Trans>
+      </SwapButton>
     </Wrapper>
   )
 }

--- a/src/components/Tokens/TokenDetails/MobileBalanceSummaryFooter.tsx
+++ b/src/components/Tokens/TokenDetails/MobileBalanceSummaryFooter.tsx
@@ -5,33 +5,31 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { currencyAmountToPreciseFloat, formatDollar } from 'utils/formatDollarAmt'
 
-import { SMALLEST_MOBILE_MEDIA_BREAKPOINT } from '../constants'
 import { BalanceSummaryProps } from './BalanceSummary'
 
 const Wrapper = styled.div`
-  height: fit-content;
+  align-content: center;
   border: 1px solid ${({ theme }) => theme.backgroundOutline};
   background-color: ${({ theme }) => theme.backgroundSurface};
   border-radius: 20px 20px 0px 0px;
-  display: flex;
-  padding: 12px 16px;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 20px;
-  width: 100%;
-  color: ${({ theme }) => theme.textSecondary};
-  position: fixed;
-  left: 0;
   bottom: 56px;
+  color: ${({ theme }) => theme.textSecondary};
   display: flex;
   flex-direction: column;
-  align-content: center;
+  font-weight: 500;
+  font-size: 14px;
+  height: fit-content;
+  left: 0;
+  line-height: 20px;
+  padding: 12px 16px;
+  position: fixed;
+  width: 100%;
 
-  // 768 hardcoded to match NFT-redesign navbar breakpoints
-  // src/nft/css/sprinkles.css.ts
-  // change to match theme breakpoints when this navbar is updated
-  @media screen and (min-width: 768px) {
-    display: none !important;
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
+    bottom: 0px;
+  }
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.lg}px) {
+    display: none;
   }
 `
 const BalanceValue = styled.div`
@@ -52,34 +50,34 @@ const BalanceInfo = styled.div`
   flex-direction: column;
 `
 const FiatValue = styled.span`
-  display: flex;
   align-self: flex-end;
+  display: flex;
   font-size: 12px;
-  line-height: 24px;
+  line-height: 16px;
 
-  @media only screen and (max-width: ${SMALLEST_MOBILE_MEDIA_BREAKPOINT}) {
-    line-height: 16px;
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.sm}) {
+    line-height: 24px;
   }
 `
 const SwapButton = styled.button`
-  background-color: ${({ theme }) => theme.accentAction};
-  border-radius: 12px;
-  display: flex;
   align-items: center;
+  background-color: ${({ theme }) => theme.accentAction};
   border: none;
+  border-radius: 12px;
   color: ${({ theme }) => theme.accentTextLightPrimary};
+  display: flex;
   padding: 12px 16px;
-  width: 120px;
-  height: 44px;
   font-size: 16px;
   font-weight: 600;
+  height: 44px;
   justify-content: center;
+  width: 120px;
 `
 const TotalBalancesSection = styled.div`
+  align-items: center;
   display: flex;
   color: ${({ theme }) => theme.textSecondary};
   justify-content: space-between;
-  align-items: center;
 `
 
 export default function MobileBalanceSummaryFooter({

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -1,11 +1,5 @@
 import { Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import {
-  LARGE_MEDIA_BREAKPOINT,
-  MAX_WIDTH_MEDIA_BREAKPOINT,
-  MOBILE_MEDIA_BREAKPOINT,
-  SMALL_MEDIA_BREAKPOINT,
-} from 'components/Tokens/constants'
 import { filterTimeAtom } from 'components/Tokens/state'
 import { AboutSection } from 'components/Tokens/TokenDetails/About'
 import AddressSection from 'components/Tokens/TokenDetails/AddressSection'
@@ -39,35 +33,20 @@ const Hr = styled.hr`
 `
 export const TokenDetailsLayout = styled.div`
   display: flex;
-  gap: 60px;
-  padding: 68px 20px;
-  width: 100%;
+  padding: 0 8px;
   justify-content: center;
+  width: 100%;
 
-  @media only screen and (max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT}) {
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.sm}px) {
+    gap: 16px;
+    padding: 0 16px;
+  }
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
+    gap: 20px;
+    padding: 48px 20px;
+  }
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.xl}px) {
     gap: 40px;
-  }
-
-  @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.md}px`}) {
-    padding-top: 48px;
-  }
-
-  @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
-    padding-top: 20px;
-  }
-
-  @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
-    gap: 0px;
-  }
-
-  @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
-  @media only screen and (max-width: ${MOBILE_MEDIA_BREAKPOINT}) {
-    padding-left: 8px;
-    padding-right: 8px;
   }
 `
 export const LeftPanel = styled.div`
@@ -76,13 +55,13 @@ export const LeftPanel = styled.div`
   overflow: hidden;
 `
 export const RightPanel = styled.div`
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 20px;
   width: ${WIDGET_WIDTH}px;
 
-  @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
-    display: none;
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.lg}px) {
+    display: flex;
   }
 `
 


### PR DESCRIPTION
There's some inconsistency with the nft codebase's use of breakpoints that don't match those in `src/theme/index.ts`. I've tried to get as close to the figma's spec as I can without touching the nft team's navbar code, as I don't feel confident adjusting their work there w/o a significant amount of debugging/communications work. 

<img width="527" alt="image" src="https://user-images.githubusercontent.com/5773490/194593808-869d498a-f3e4-4a3b-8876-35b49b77356f.png">

<img width="587" alt="image" src="https://user-images.githubusercontent.com/5773490/194593832-d267b616-8325-4e8f-83ec-dba96d8ffe67.png">

<img width="568" alt="image" src="https://user-images.githubusercontent.com/5773490/194593868-f484b8c4-05e4-4022-bcba-a821597a2495.png">

<img width="658" alt="image" src="https://user-images.githubusercontent.com/5773490/194593939-f42271f3-d00e-4364-8706-2579d7ed68c0.png">

<img width="741" alt="image" src="https://user-images.githubusercontent.com/5773490/194593969-1706531d-1c7e-47ab-95a7-d5af512f9199.png">
