### PR TITLE
fix: handle tiny numbers

### DIFF
--- a/src/utils/formatDollarAmt.test.ts
+++ b/src/utils/formatDollarAmt.test.ts
@@ -4,6 +4,14 @@ import { USDC_MAINNET } from 'constants/tokens'
 import { currencyAmountToPreciseFloat, formatDollar } from './formatDollarAmt'
 
 describe('currencyAmountToPreciseFloat', () => {
+  it('small number', () => {
+    const currencyAmount = CurrencyAmount.fromFractionalAmount(USDC_MAINNET, '20000', '7')
+    expect(currencyAmountToPreciseFloat(currencyAmount)).toEqual(0.00285)
+  })
+  it('tiny number', () => {
+    const currencyAmount = CurrencyAmount.fromFractionalAmount(USDC_MAINNET, '2', '7')
+    expect(currencyAmountToPreciseFloat(currencyAmount)).toEqual(0.000000285)
+  })
   it('lots of decimals', () => {
     const currencyAmount = CurrencyAmount.fromFractionalAmount(USDC_MAINNET, '200000000', '7')
     expect(currencyAmountToPreciseFloat(currencyAmount)).toEqual(28.571)

--- a/src/utils/formatDollarAmt.ts
+++ b/src/utils/formatDollarAmt.ts
@@ -6,7 +6,6 @@ import numbro from 'numbro'
 export const currencyAmountToPreciseFloat = (currencyAmount: CurrencyAmount<Currency>) => {
   const floatForLargerNumbers = parseFloat(currencyAmount.toFixed(3))
   if (floatForLargerNumbers < 0.1) {
-    console.log('parsed')
     return parseFloat(currencyAmount.toSignificant(3))
   }
   return floatForLargerNumbers

--- a/src/utils/formatDollarAmt.ts
+++ b/src/utils/formatDollarAmt.ts
@@ -4,7 +4,12 @@ import numbro from 'numbro'
 
 // Convert [CurrencyAmount] to number with necessary precision for price formatting.
 export const currencyAmountToPreciseFloat = (currencyAmount: CurrencyAmount<Currency>) => {
-  return parseFloat(currencyAmount.toFixed(3))
+  const floatForLargerNumbers = parseFloat(currencyAmount.toFixed(3))
+  if (floatForLargerNumbers < 0.1) {
+    console.log('parsed')
+    return parseFloat(currencyAmount.toSignificant(3))
+  }
+  return floatForLargerNumbers
 }
 
 // Using a currency library here in case we want to add more in future.


### PR DESCRIPTION
when numbers r tiny (< 0.1), we want precision to 3 sig figs. otherwise, we want up to 3 decimals. 