### PR TITLE
fix: Update input placeholder text color

### DIFF
--- a/src/components/NumericalInput/index.tsx
+++ b/src/components/NumericalInput/index.tsx
@@ -36,7 +36,7 @@ const StyledInput = styled.input<{ error?: boolean; fontSize?: string; align?: s
   }
 
   ::placeholder {
-    color: ${({ theme, redesignFlag }) => (redesignFlag ? theme.textSecondary : theme.deprecated_text4)};
+    color: ${({ theme, redesignFlag }) => (redesignFlag ? theme.textTertiary : theme.deprecated_text4)};
   }
 `
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -300,7 +300,7 @@ export const colorsDark: Palette = {
   backgroundModule: colors.gray800,
   backgroundInteractive: colors.gray700,
   backgroundFloating: opacify(12, colors.black),
-  backgroundOutline: opacify(24, colors.gray300),
+  backgroundOutline: opacify(14, colors.gray300),
   backgroundScrim: opacify(72, colors.gray900),
   backgroundScrolledSurface: opacify(72, colors.gray900),
 


### PR DESCRIPTION
Swap input placeholder text color was textSecondary when it should be textTertiary.

Before:
<img width="262" alt="Screen Shot 2022-10-10 at 12 23 47 PM" src="https://user-images.githubusercontent.com/1355319/194912031-bc543506-5485-4b0c-8158-66857393ce3a.png">

After:
<img width="294" alt="Screen Shot 2022-10-10 at 12 23 35 PM" src="https://user-images.githubusercontent.com/1355319/194912076-032f780e-0a37-4a96-b61e-0d21597f419f.png">

Also fix border-radius color to be more minimal.
