### PR TITLE
fix: keep search history synced with trending

### DIFF
--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -106,7 +106,7 @@ interface SearchBarDropdownProps {
 
 export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput, isLoading }: SearchBarDropdownProps) => {
   const [hoveredIndex, setHoveredIndex] = useState<number | undefined>(0)
-  const searchHistory = useSearchHistory((state: { history: (FungibleToken | GenieCollection)[] }) => state.history)
+  const { history: searchHistory, updateItem: updateSearchHistory } = useSearchHistory()
   const shortenedHistory = useMemo(() => searchHistory.slice(0, 2), [searchHistory])
   const { pathname } = useLocation()
   const isNFTPage = pathname.includes('/nfts')
@@ -146,9 +146,11 @@ export const SearchBarDropdown = ({ toggleOpen, tokens, collections, hasInput, i
       refetchOnReconnect: false,
     }
   )
+  useEffect(() => {
+    trendingTokenResults?.forEach(updateSearchHistory)
+  }, [trendingTokenResults, updateSearchHistory])
 
   const trendingTokensLength = phase1Flag === NftVariant.Enabled ? (isTokenPage ? 3 : 2) : 4
-
   const trendingTokens = useMemo(
     () =>
       trendingTokenResults

--- a/src/nft/hooks/useSearchHistory.ts
+++ b/src/nft/hooks/useSearchHistory.ts
@@ -5,6 +5,7 @@ import { devtools, persist } from 'zustand/middleware'
 interface SearchHistoryProps {
   history: (FungibleToken | GenieCollection)[]
   addItem: (item: FungibleToken | GenieCollection) => void
+  updateItem: (update: FungibleToken | GenieCollection) => void
 }
 
 export const useSearchHistory = create<SearchHistoryProps>()(
@@ -15,6 +16,16 @@ export const useSearchHistory = create<SearchHistoryProps>()(
         set(({ history }) => {
           const historyCopy = [...history]
           if (historyCopy.length === 0 || historyCopy[0].address !== item.address) historyCopy.unshift(item)
+          return { history: historyCopy }
+        })
+      },
+      updateItem: (update: FungibleToken | GenieCollection) => {
+        set(({ history }) => {
+          const index = history.findIndex((item) => item.address === update.address)
+          if (index === -1) return { history }
+
+          const historyCopy = [...history]
+          historyCopy[index] = update
           return { history: historyCopy }
         })
       },


### PR DESCRIPTION
Syncs searchHistory with trendingTokenResults, which were otherwise (potentially) fetching more updated results than the searchHistory cache.

WEB-1508