### PR TITLE
fix: handle backspace out of /tokens

### DIFF
--- a/src/components/Tokens/TokensBanner.tsx
+++ b/src/components/Tokens/TokensBanner.tsx
@@ -9,9 +9,10 @@ import { Z_INDEX } from 'theme/zIndex'
 import tokensPromoDark from '../../assets/images/tokensPromoDark.png'
 import tokensPromoLight from '../../assets/images/tokensPromoLight.png'
 
-const PopupContainer = styled.div<{ show: boolean }>`
+const PopupContainer = styled(Link)<{ show: boolean }>`
   position: fixed;
   display: ${({ show }) => (show ? 'flex' : 'none')};
+  text-decoration: none;
   flex-direction: column;
   padding: 12px 16px 12px 20px;
   gap: 8px;
@@ -41,14 +42,15 @@ const Header = styled.div`
   align-items: center;
   justify-content: space-between;
 `
-const HeaderText = styled(Link)`
+const HeaderText = styled.span`
   font-weight: 600;
   font-size: 14px;
   line-height: 20px;
   text-decoration: none;
   color: ${({ theme }) => theme.textPrimary};
 `
-const Description = styled(Link)`
+
+const Description = styled.span`
   font-weight: 400;
   font-size: 12px;
   line-height: 16px;
@@ -66,11 +68,10 @@ export default function TokensBanner() {
   }
 
   return (
-    <PopupContainer show={showTokensPromoBanner}>
+    <PopupContainer show={showTokensPromoBanner} to="/tokens" onClick={closeBanner}>
       <Header>
-        <HeaderText to={'/tokens'} onClick={closeBanner}>
+        <HeaderText>
           <Trans>Explore Top Tokens on Uniswap</Trans>
-          Explore Top Tokens
         </HeaderText>
         <X
           size={20}
@@ -84,7 +85,7 @@ export default function TokensBanner() {
         />
       </Header>
 
-      <Description to={'/tokens'} onClick={closeBanner}>
+      <Description>
         <Trans>Sort and filter assets across networks on the new Tokens page.</Trans>
       </Description>
     </PopupContainer>

--- a/src/components/Tokens/TokensBanner.tsx
+++ b/src/components/Tokens/TokensBanner.tsx
@@ -1,8 +1,6 @@
 import { Trans } from '@lingui/macro'
-import { useWeb3React } from '@web3-react/core'
-import { chainIdToBackendName } from 'graphql/data/util'
 import { X } from 'react-feather'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useShowTokensPromoBanner } from 'state/user/hooks'
 import styled, { useTheme } from 'styled-components/macro'
 import { opacify } from 'theme/utils'
@@ -62,19 +60,17 @@ const Description = styled(Link)`
 export default function TokensBanner() {
   const theme = useTheme()
   const [showTokensPromoBanner, setShowTokensPromoBanner] = useShowTokensPromoBanner()
-  const navigate = useNavigate()
-  const { chainId: connectedChainId } = useWeb3React()
-  const chainName = chainIdToBackendName(connectedChainId).toLowerCase()
 
-  const navigateToExplorePage = () => {
-    navigate(`/tokens/${chainName}`)
+  const closeBanner = () => {
+    setShowTokensPromoBanner(false)
   }
 
   return (
-    <PopupContainer show={showTokensPromoBanner} onClick={navigateToExplorePage}>
+    <PopupContainer show={showTokensPromoBanner}>
       <Header>
-        <HeaderText to={'/tokens'}>
+        <HeaderText to={'/tokens'} onClick={closeBanner}>
           <Trans>Explore Top Tokens on Uniswap</Trans>
+          Explore Top Tokens
         </HeaderText>
         <X
           size={20}
@@ -82,13 +78,13 @@ export default function TokensBanner() {
           onClick={(e) => {
             e.preventDefault()
             e.stopPropagation()
-            setShowTokensPromoBanner(false)
+            closeBanner()
           }}
           style={{ cursor: 'pointer' }}
         />
       </Header>
 
-      <Description to={'/tokens'}>
+      <Description to={'/tokens'} onClick={closeBanner}>
         <Trans>Sort and filter assets across networks on the new Tokens page.</Trans>
       </Description>
     </PopupContainer>

--- a/src/components/Tokens/TokensBanner.tsx
+++ b/src/components/Tokens/TokensBanner.tsx
@@ -46,8 +46,6 @@ const HeaderText = styled.span`
   font-weight: 600;
   font-size: 14px;
   line-height: 20px;
-  text-decoration: none;
-  color: ${({ theme }) => theme.textPrimary};
 `
 
 const Description = styled.span`
@@ -55,8 +53,6 @@ const Description = styled.span`
   font-size: 12px;
   line-height: 16px;
   width: 75%;
-  text-decoration: none;
-  color: ${({ theme }) => theme.textPrimary};
 `
 
 export default function TokensBanner() {

--- a/src/pages/Tokens/index.tsx
+++ b/src/pages/Tokens/index.tsx
@@ -85,13 +85,13 @@ const Tokens = () => {
 
   useEffect(() => {
     if (!chainNameParam) {
-      navigate(`/tokens/${connectedChainName.toLowerCase()}`)
+      navigate(`/tokens/${connectedChainName.toLowerCase()}`, { replace: true })
     }
   }, [chainNameParam, connectedChainName, navigate])
 
   useOnGlobalChainSwitch((chain) => {
     if (isValidBackendChainName(chain)) {
-      navigate(`/tokens/${chain.toLowerCase()}`)
+      navigate(`/tokens/${chain.toLowerCase()}`, { replace: true })
     }
   })
 


### PR DESCRIPTION
We don't need the logic to specifically route to the chain in the /tokens url as the redirect happens in Tokens page component.

We also need to replace the url instead of redirecting, so that backspace will work.
