### PR TITLE
feat: token details for inactive chain

### DIFF
--- a/src/components/SearchModal/CurrencySearchModal.tsx
+++ b/src/components/SearchModal/CurrencySearchModal.tsx
@@ -24,6 +24,7 @@ interface CurrencySearchModalProps {
   showCommonBases?: boolean
   showCurrencyAmount?: boolean
   disableNonToken?: boolean
+  chainId?: number
 }
 
 export enum CurrencyModalView {
@@ -43,6 +44,7 @@ export default memo(function CurrencySearchModal({
   showCommonBases = false,
   showCurrencyAmount = true,
   disableNonToken = false,
+  chainId,
 }: CurrencySearchModalProps) {
   const [modalView, setModalView] = useState<CurrencyModalView>(CurrencyModalView.manage)
   const lastOpen = useLast(isOpen)
@@ -118,6 +120,7 @@ export default memo(function CurrencySearchModal({
           showCurrencyAmount={showCurrencyAmount}
           disableNonToken={disableNonToken}
           showManageView={showManageView}
+          chainId={chainId}
         />
       )
       break

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -19,7 +19,7 @@ export const WIDGET_WIDTH = 360
 const WIDGET_ROUTER_URL = 'https://api.uniswap.org/v1/'
 
 export interface WidgetProps {
-  defaultToken?: Currency
+  defaultToken: Currency
   onReviewSwapClick?: OnReviewSwapClick
 }
 

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -65,6 +65,7 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
       selectedCurrency={selectingToken}
       otherSelectedCurrency={otherToken}
       onCurrencySelect={onTokenSelect}
+      chainId={tokens.INPUT?.chainId ?? tokens.OUTPUT?.chainId}
     />
   )
 

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -13,9 +13,14 @@ import { useUserAddedTokens, useUserAddedTokensOnChain } from '../state/user/hoo
 import { TokenAddressMap, useUnsupportedTokenList } from './../state/lists/hooks'
 
 // reduce token map into standard address <-> Token mapping, optionally include user added tokens
-function useTokensFromMap(tokenMap: TokenAddressMap, includeUserAdded: boolean): { [address: string]: Token } {
-  const { chainId } = useWeb3React()
-  const userAddedTokens = useUserAddedTokens()
+function useTokensFromMap(
+  tokenMap: TokenAddressMap,
+  includeUserAdded: boolean,
+  tokenChainId?: number
+): { [address: string]: Token } {
+  const { chainId: activeChainId } = useWeb3React()
+  const chainId = tokenChainId ?? activeChainId
+  const userAddedTokens = useUserAddedTokens(chainId)
 
   return useMemo(() => {
     if (!chainId) return {}
@@ -49,9 +54,9 @@ function useTokensFromMap(tokenMap: TokenAddressMap, includeUserAdded: boolean):
   }, [chainId, userAddedTokens, tokenMap, includeUserAdded])
 }
 
-export function useAllTokens(): { [address: string]: Token } {
+export function useAllTokens(chainId?: number): { [address: string]: Token } {
   const allTokens = useCombinedActiveList()
-  return useTokensFromMap(allTokens, true)
+  return useTokensFromMap(allTokens, true, chainId)
 }
 
 type BridgeInfo = Record<

--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -56,9 +56,10 @@ export function useTokenBalancesWithLoadingIndicator(
   address?: string,
   tokens?: (Token | undefined)[]
 ): [{ [tokenAddress: string]: CurrencyAmount<Token> | undefined }, boolean] {
+  const { chainId } = useWeb3React() // we cannot fetch balances cross-chain
   const validatedTokens: Token[] = useMemo(
-    () => tokens?.filter((t?: Token): t is Token => isAddress(t?.address) !== false) ?? [],
-    [tokens]
+    () => tokens?.filter((t?: Token): t is Token => isAddress(t?.address) !== false && t?.chainId === chainId) ?? [],
+    [chainId, tokens]
   )
   const validatedTokenAddresses = useMemo(() => validatedTokens.map((vt) => vt.address), [validatedTokens])
 

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -257,8 +257,10 @@ export function useUserAddedTokensOnChain(chainId: number | undefined | null): T
   }, [serializedTokensMap, chainId])
 }
 
-export function useUserAddedTokens(): Token[] {
-  return useUserAddedTokensOnChain(useWeb3React().chainId)
+export function useUserAddedTokens(tokenChainId?: number): Token[] {
+  const { chainId: activeChainId } = useWeb3React()
+  const chainId = tokenChainId ?? activeChainId
+  return useUserAddedTokensOnChain(chainId)
 }
 
 function serializePair(pair: Pair): SerializedPair {


### PR DESCRIPTION
Together, these changes make the TokenDetails page (and its Widget) functional when displaying a token for an inactive chain.

- Prevents balances from being fetched for tokens on an inactive chain, as they will be invalid
- Allows CurrencySearch to be restricted to a non-active chain, to maintain validity in the widget
- Instantiates the token in TokenDetails by _only_ fetching decimals, so it can easily/cheaply be fetched on an inactive chain
- [ ] This PR is currently untested

NB: After speaking with design, the only UX change will be to require user action to switch networks in the widget, and to have the widget always match the global chain. This PR should now be considered a draft - its commits will be frankensteined into future PRs.