### PR TITLE
fix: add padding-bottom to TokenDetailsLayout

### DIFF
--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -33,7 +33,7 @@ const Hr = styled.hr`
 `
 export const TokenDetailsLayout = styled.div`
   display: flex;
-  padding: 0 8px;
+  padding: 0 8px 52px;
   justify-content: center;
   width: 100%;
 


### PR DESCRIPTION
Makes sure that the contract address is visible on mobile where the swap button shows up at the bottom.
