### PR TITLE
feat: load token from query data

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@uniswap/v3-core": "1.0.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-sdk": "^3.9.0",
-    "@uniswap/widgets": "^2.14.1",
+    "@uniswap/widgets": "^2.15.1",
     "@vanilla-extract/css": "^1.7.2",
     "@vanilla-extract/css-utils": "^0.1.2",
     "@vanilla-extract/dynamic": "^2.0.2",

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -2,13 +2,20 @@
 // eslint-disable-next-line no-restricted-imports
 import '@uniswap/widgets/dist/fonts.css'
 
-import { Currency, EMPTY_TOKEN_LIST, OnReviewSwapClick, SwapWidget, SwapWidgetSkeleton } from '@uniswap/widgets'
+import {
+  AddEthereumChainParameter,
+  Currency,
+  EMPTY_TOKEN_LIST,
+  OnReviewSwapClick,
+  SwapWidget,
+  SwapWidgetSkeleton,
+} from '@uniswap/widgets'
 import { useWeb3React } from '@web3-react/core'
-import { networkConnection } from 'connection'
-import { RPC_PROVIDERS } from 'constants/providers'
 import { useActiveLocale } from 'hooks/useActiveLocale'
+import { useCallback } from 'react'
 import { useIsDarkMode } from 'state/user/hooks'
 import { DARK_THEME, LIGHT_THEME } from 'theme/widget'
+import { switchChain } from 'utils/switchChain'
 
 import { useSyncWidgetInputs } from './inputs'
 import { useSyncWidgetSettings } from './settings'
@@ -32,19 +39,28 @@ export default function Widget({ defaultToken, onReviewSwapClick }: WidgetProps)
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
 
+  const onSwitchChain = useCallback(
+    ({ chainId }: AddEthereumChainParameter) => switchChain(connector, Number(chainId)),
+    [connector]
+  )
+
+  if (!inputs.value.INPUT && !inputs.value.OUTPUT) {
+    return <WidgetSkeleton />
+  }
+
   return (
     <>
       <SwapWidget
         disableBranding
         hideConnectionUI
-        jsonRpcUrlMap={RPC_PROVIDERS}
         routerUrl={WIDGET_ROUTER_URL}
         width={WIDGET_WIDTH}
         locale={locale}
         theme={theme}
         onReviewSwapClick={onReviewSwapClick}
         // defaultChainId is excluded - it is always inferred from the passed provider
-        provider={connector === networkConnection.connector ? null : provider} // use jsonRpcUrlMap for network providers
+        provider={provider}
+        onSwitchChain={onSwitchChain}
         tokenList={EMPTY_TOKEN_LIST} // prevents loading the default token list, as we use our own token selector UI
         {...inputs}
         {...settings}

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -40,7 +40,8 @@ export default function Widget({ defaultToken, onReviewSwapClick }: WidgetProps)
   const { transactions } = useSyncWidgetTransactions()
 
   const onSwitchChain = useCallback(
-    ({ chainId }: AddEthereumChainParameter) => switchChain(connector, Number(chainId)),
+    // TODO: Widget should not break if this rejects - upstream the catch to ignore it.
+    ({ chainId }: AddEthereumChainParameter) => switchChain(connector, Number(chainId)).catch(() => undefined),
     [connector]
   )
 

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -21,10 +21,13 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
   })
 
   useEffect(() => {
-    setTokens({
-      [Field.OUTPUT]: defaultToken,
-    })
-    setAmount(EMPTY_AMOUNT)
+    // Add some hysteresis - if there is no new default, do not update the display.
+    if (defaultToken) {
+      setTokens({
+        [Field.OUTPUT]: defaultToken,
+      })
+      setAmount(EMPTY_AMOUNT)
+    }
   }, [defaultToken])
 
   const onSwitchTokens = useCallback(() => {

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -21,13 +21,12 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
   })
 
   useEffect(() => {
-    // Add some hysteresis - if there is no new default, do not update the display.
-    if (defaultToken) {
-      setTokens({
-        [Field.OUTPUT]: defaultToken,
-      })
-      setAmount(EMPTY_AMOUNT)
-    }
+    // Avoid overwriting tokens if none are specified, so that a loading token does not cause layout flashing.
+    if (!defaultToken) return
+    setTokens({
+      [Field.OUTPUT]: defaultToken,
+    })
+    setAmount(EMPTY_AMOUNT)
   }, [defaultToken])
 
   const onSwitchTokens = useCallback(() => {

--- a/src/lib/hooks/useCurrency.ts
+++ b/src/lib/hooks/useCurrency.ts
@@ -30,11 +30,11 @@ export function useTokenFromQuery({
   project,
 }: {
   address?: string
-  chainId: SupportedChainId
+  chainId?: SupportedChainId
   symbol?: string | null
   name?: string | null
   project?: { logoUrl?: string | null } | null
-}): Token | null | undefined {
+} = {}): Token | null | undefined {
   const { chainId: activeChainId } = useWeb3React()
   const address = isAddress(tokenAddress)
   const [decimals, setDecimals] = useState<number | null | undefined>(null)

--- a/src/lib/hooks/useCurrency.ts
+++ b/src/lib/hooks/useCurrency.ts
@@ -103,7 +103,7 @@ function parseStringOrBytes32(str: string | undefined, bytes32: string | undefin
  * Returns null if token is loading or null was passed.
  * Returns undefined if tokenAddress is invalid or token does not exist.
  */
-export function useTokenFromNetwork(tokenAddress: string | undefined): Token | null | undefined {
+export function useTokenFromActiveNetwork(tokenAddress: string | undefined): Token | null | undefined {
   const { chainId } = useWeb3React()
 
   const formattedAddress = isAddress(tokenAddress)
@@ -153,7 +153,7 @@ export function useTokenFromMapOrNetwork(tokens: TokenMap, tokenAddress?: string
   const address = isAddress(tokenAddress)
   const token: Token | undefined = address ? tokens[address] : undefined
 
-  const tokenFromNetwork = useTokenFromNetwork(token ? undefined : address ? address : undefined)
+  const tokenFromNetwork = useTokenFromActiveNetwork(token ? undefined : address ? address : undefined)
 
   return tokenFromNetwork ?? token
 }

--- a/src/lib/hooks/useCurrency.ts
+++ b/src/lib/hooks/useCurrency.ts
@@ -2,15 +2,89 @@ import { arrayify } from '@ethersproject/bytes'
 import { parseBytes32String } from '@ethersproject/strings'
 import { Currency, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { isSupportedChain } from 'constants/chains'
+import ERC20_ABI from 'abis/erc20.json'
+import { Erc20 } from 'abis/types'
+import { isSupportedChain, SupportedChainId } from 'constants/chains'
+import { RPC_PROVIDERS } from 'constants/providers'
 import { useBytes32TokenContract, useTokenContract } from 'hooks/useContract'
 import { NEVER_RELOAD, useSingleCallResult } from 'lib/hooks/multicall'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 import { TOKEN_SHORTHANDS } from '../../constants/tokens'
-import { isAddress } from '../../utils'
+import { getContract, isAddress } from '../../utils'
 import { supportedChainId } from '../../utils/supportedChainId'
+
+/**
+ * Returns a Token from query data.
+ * Data should already include all fields except decimals, or it will be considered invalid.
+ * Returns null if the token is loading or null was passed.
+ * Returns undefined if invalid or the token does not exist.
+ */
+export function useTokenFromQuery({
+  address: tokenAddress,
+  chainId,
+  symbol,
+  name,
+  project,
+}: {
+  address?: string
+  chainId: SupportedChainId
+  symbol?: string | null
+  name?: string | null
+  project?: { logoUrl?: string | null } | null
+}): Token | null | undefined {
+  const { chainId: activeChainId } = useWeb3React()
+  const address = isAddress(tokenAddress)
+  const [decimals, setDecimals] = useState<number | null | undefined>(null)
+
+  const tokenContract = useTokenContract(chainId === activeChainId ? (address ? address : undefined) : undefined, false)
+  const { loading, result: [decimalsResult] = [] } = useSingleCallResult(
+    tokenContract,
+    'decimals',
+    undefined,
+    NEVER_RELOAD
+  )
+
+  useEffect(() => {
+    if (loading) {
+      setDecimals(null)
+    } else if (decimalsResult) {
+      setDecimals(decimalsResult)
+    } else if (!address || !chainId || chainId === activeChainId) {
+      setDecimals(undefined)
+    } else {
+      setDecimals(null)
+
+      // Load decimals from a cross-chain RPC provider.
+      const provider = RPC_PROVIDERS[chainId]
+      const contract = getContract(address, ERC20_ABI, provider) as Erc20
+      contract
+        .decimals()
+        .then((value) => {
+          if (!stale) setDecimals(value)
+        })
+        .catch(() => undefined)
+    }
+
+    let stale = false
+    return () => {
+      stale = true
+    }
+  }, [activeChainId, address, chainId, decimalsResult, loading])
+
+  return useMemo(() => {
+    if (!chainId || !address) return undefined
+    if (decimals === null || decimals === undefined) return decimals
+    if (!symbol || !name) {
+      return new Token(chainId, address, decimals, symbol ?? undefined, name ?? undefined)
+    } else {
+      const logoURI = project?.logoUrl ?? undefined
+      return new WrappedTokenInfo({ chainId, address, decimals, symbol, name, logoURI })
+    }
+  }, [address, chainId, decimals, name, project?.logoUrl, symbol])
+}
 
 // parse a name or symbol from a token response
 const BYTES32_REGEX = /^0x[a-fA-F0-9]{64}$/
@@ -29,10 +103,7 @@ function parseStringOrBytes32(str: string | undefined, bytes32: string | undefin
  * Returns null if token is loading or null was passed.
  * Returns undefined if tokenAddress is invalid or token does not exist.
  */
-export function useTokenFromNetwork(
-  tokenAddress: string | null | undefined,
-  tokenChainId?: number
-): Token | null | undefined {
+export function useTokenFromNetwork(tokenAddress: string | undefined): Token | null | undefined {
   const { chainId } = useWeb3React()
 
   const formattedAddress = isAddress(tokenAddress)
@@ -62,14 +133,13 @@ export function useTokenFromNetwork(
 
   return useMemo(() => {
     // If the token is on another chain, we cannot fetch it on-chain, and it is invalid.
-    if (tokenChainId !== undefined && tokenChainId !== chainId) return undefined
     if (typeof tokenAddress !== 'string' || !isSupportedChain(chainId) || !formattedAddress) return undefined
 
     if (isLoading || !chainId) return null
     if (!parsedDecimals) return undefined
 
     return new Token(chainId, formattedAddress, parsedDecimals, parsedSymbol, parsedName)
-  }, [tokenChainId, chainId, tokenAddress, formattedAddress, isLoading, parsedDecimals, parsedSymbol, parsedName])
+  }, [chainId, tokenAddress, formattedAddress, isLoading, parsedDecimals, parsedSymbol, parsedName])
 }
 
 type TokenMap = { [address: string]: Token }

--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -56,9 +56,10 @@ export function useTokenBalancesWithLoadingIndicator(
   address?: string,
   tokens?: (Token | undefined)[]
 ): [{ [tokenAddress: string]: CurrencyAmount<Token> | undefined }, boolean] {
+  const { chainId } = useWeb3React() // we cannot fetch balances cross-chain
   const validatedTokens: Token[] = useMemo(
-    () => tokens?.filter((t?: Token): t is Token => isAddress(t?.address) !== false) ?? [],
-    [tokens]
+    () => tokens?.filter((t?: Token): t is Token => isAddress(t?.address) !== false && t?.chainId === chainId) ?? [],
+    [chainId, tokens]
   )
   const validatedTokenAddresses = useMemo(() => validatedTokens.map((vt) => vt.address), [validatedTokens])
 

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -78,10 +78,11 @@ export default function TokenDetails() {
     currentChainName,
     timePeriod
   )
-  const token = useTokenFromQuery({ ...tokenQueryData, chainId: pageChainId })
+  const queryToken = useTokenFromQuery(isNative ? undefined : { ...tokenQueryData, chainId: pageChainId })
+  const token = isNative ? nativeCurrency : queryToken
 
   const nativeCurrencyBalance = useCurrencyBalance(account, nativeCurrency)
-  const tokenBalance = useTokenBalance(account, isNative ? nativeCurrency.wrapped : token ?? undefined)
+  const tokenBalance = useTokenBalance(account, token?.wrapped)
 
   const tokenWarning = tokenAddress ? checkWarning(tokenAddress) : null
   const isBlockedToken = tokenWarning?.canProceed === false

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -160,7 +160,11 @@ export default function TokenDetails() {
             <AddressSection address={tokenQueryData.address ?? ''} />
           </LeftPanel>
           <RightPanel>
-            <Widget defaultToken={widgetToken} onReviewSwapClick={onReviewSwap} />
+            <Widget
+              // A null token is still loading, and should not be overridden.
+              defaultToken={pageToken === null ? undefined : pageToken ?? nativeCurrency}
+              onReviewSwapClick={onReviewSwap}
+            />
             {tokenWarning && <TokenSafetyMessage tokenAddress={tokenQueryData.address ?? ''} warning={tokenWarning} />}
             <BalanceSummary
               tokenAmount={tokenBalance}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4305,10 +4305,10 @@
     "@uniswap/v3-core" "1.0.0"
     "@uniswap/v3-periphery" "^1.0.1"
 
-"@uniswap/widgets@^2.14.1":
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/@uniswap/widgets/-/widgets-2.14.1.tgz#82fb36d2258dd673e9e4c74df191f37cb4ac794c"
-  integrity sha512-uVf8wWjpkODNW1+GWKYzkDp+uFuctyFz0wj2UlNmhmgmKx4aSXeZKHMhDTgtlj5Xbb2RiKDvKnI0Ko4GCjGJGw==
+"@uniswap/widgets@^2.15.1":
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/widgets/-/widgets-2.15.1.tgz#34632d74048d32e1842765f9a3d1c35aa955847c"
+  integrity sha512-1DCanZVpGoifykZSEjJmXesTQE+Gmm66mo7hZ2CVLSZxRCsQLFSPaZ8FWTRU2p3FW8pyECnEpe79CpkkK22WIg==
   dependencies:
     "@babel/runtime" ">=7.17.0"
     "@fontsource/ibm-plex-mono" "^4.5.1"


### PR DESCRIPTION
- Prevents balance fetching cross-chain. Balances are fetched on-chain, so cross-chain balances would be invalid.
- Adds an onSwitchChain handler to the widget to allow it to control the global chain.
  - This requires upgrade of the widget.
  - In order to make this visually clean, also adds hysteresis to the widget:
    - A loading token does not update the widget's output token.
    - The widget will continue to render as a skeleton until it has a token specified.
- Loads the Token Details token (the initial widget token) using query data.
  - This is faster (fewer on-chain calls), only requiring a call for decimals.
  - Uses the RPC provider for the cross-chain, if applicable, to ensure valid data.
  
---

  REVIEWER: These changes are split across specific commits. You may review this as one PR, but you will probably find it easier to look at each commit individually.