### PR TITLE
build: upgrade widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@uniswap/v3-core": "1.0.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-sdk": "^3.9.0",
-    "@uniswap/widgets": "^2.15.1",
+    "@uniswap/widgets": "^2.16.1",
     "@vanilla-extract/css": "^1.7.2",
     "@vanilla-extract/css-utils": "^0.1.2",
     "@vanilla-extract/dynamic": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4305,10 +4305,10 @@
     "@uniswap/v3-core" "1.0.0"
     "@uniswap/v3-periphery" "^1.0.1"
 
-"@uniswap/widgets@^2.15.1":
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/@uniswap/widgets/-/widgets-2.15.1.tgz#34632d74048d32e1842765f9a3d1c35aa955847c"
-  integrity sha512-1DCanZVpGoifykZSEjJmXesTQE+Gmm66mo7hZ2CVLSZxRCsQLFSPaZ8FWTRU2p3FW8pyECnEpe79CpkkK22WIg==
+"@uniswap/widgets@^2.16.1":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/widgets/-/widgets-2.16.1.tgz#f372f253c18fedcaab4727b2f6f663044a4e2b01"
+  integrity sha512-2vHUnt00ZfwiMCdKaXJNRBFEV8HLmSPj5A+D+b3EcnRNL5x91MnmKaI5O52lzfMb3juPABPfxzpZUcKLmaJgRw==
   dependencies:
     "@babel/runtime" ">=7.17.0"
     "@fontsource/ibm-plex-mono" "^4.5.1"
@@ -4330,7 +4330,8 @@
     "@web3-react/types" "8.0.20-beta.0"
     "@web3-react/url" "8.0.25-beta.0"
     "@web3-react/walletconnect" "8.0.35-beta.0"
-    ajv "^6.12.3"
+    ajv "^8.11.0"
+    ajv-formats "^2.1.1"
     cids "^1.0.0"
     ethers "^5.6.1"
     immer "^9.0.6"
@@ -5197,6 +5198,13 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -5222,7 +5230,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
+ajv@^8.0.0, ajv@^8.0.1, ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==


### PR DESCRIPTION
Upgrades widget to 16.1, which includes fixes for ajv (used in #4909) and fixes to use passed logoURI's in currencies.