### PR TITLE
fix: add origin to every event

### DIFF
--- a/src/analytics/Trace.tsx
+++ b/src/analytics/Trace.tsx
@@ -58,12 +58,10 @@ export const Trace = memo(
 
     useEffect(() => {
       if (shouldLogImpression) {
-        const origin = window.location.origin
         const commitHash = process.env.REACT_APP_GIT_COMMIT_HASH
         sendAnalyticsEvent(name ?? EventName.PAGE_VIEWED, {
           ...combinedProps,
           ...properties,
-          origin,
           git_commit_hash: commitHash,
         })
       }

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -35,12 +35,14 @@ export function initializeAnalytics() {
 
 /** Sends an event to Amplitude. */
 export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<string, unknown>) {
+  const origin = window.location.origin
   if (!API_KEY) {
     console.log(`[analytics(${eventName})]: ${JSON.stringify(eventProperties)}`)
     return
   }
 
-  track(eventName, eventProperties)
+  console.log(`[analytics(${eventName})]: ${JSON.stringify({ ...eventProperties, origin })}`)
+  track(eventName, { ...eventProperties, origin })
 }
 
 type Value = string | number | boolean | string[] | number[]

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -41,7 +41,6 @@ export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<s
     return
   }
 
-  console.log(`[analytics(${eventName})]: ${JSON.stringify({ ...eventProperties, origin })}`)
   track(eventName, { ...eventProperties, origin })
 }
 


### PR DESCRIPTION
add origin property to every analytics event, not just trace events. request from @blairmason 