### PR TITLE
fix: disallow duplicate currencies in widget

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -65,7 +65,7 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
       setType(TradeType.EXACT_INPUT)
       setTokens(() => {
         return {
-          [otherField]: token === otherToken ? selectingToken : otherToken,
+          [otherField]: otherToken?.equals(token) ? selectingToken : otherToken,
           [selectingField]: token,
         }
       })


### PR DESCRIPTION
Use Currency.equals for Currency comparison in the widget wrapper.
This prevents the same currency from appearing in both input and output in the widget.