### PR TITLE
fix: prevent marking x-chain wrapped as native

### DIFF
--- a/src/graphql/data/util.ts
+++ b/src/graphql/data/util.ts
@@ -97,5 +97,10 @@ export function unwrapToken<T extends { address: string | null } | null>(chainId
   if (address !== nativeAddress) return token
 
   const nativeToken = nativeOnChain(chainId)
-  return { ...token, ...nativeToken, address: NATIVE_CHAIN_ID }
+  return {
+    ...token,
+    ...nativeToken,
+    address: NATIVE_CHAIN_ID,
+    extensions: undefined, // prevents marking cross-chain wrapped tokens as native
+  }
 }


### PR DESCRIPTION
Clears extensions from unwrapped tokens so that the wrapped token is not considered native for other chains, which would result in bad links (using the wrapped address instead of NATIVE).