### PR TITLE
fix: display loaded logo on token details

### DIFF
--- a/src/components/CurrencyLogo/index.tsx
+++ b/src/components/CurrencyLogo/index.tsx
@@ -37,7 +37,7 @@ export default function CurrencyLogo({
   src?: string | null
 }) {
   const logoURIs = useCurrencyLogoURIs(currency)
-  const srcs = useMemo(() => (src ? [src] : logoURIs), [src, logoURIs])
+  const srcs = useMemo(() => (src ? [src, ...logoURIs] : logoURIs), [src, logoURIs])
   const props = {
     alt: `${currency?.symbol ?? 'token'} logo`,
     size,

--- a/src/components/Tokens/TokenDetails/ChartSection.tsx
+++ b/src/components/Tokens/TokenDetails/ChartSection.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { NativeCurrency, Token } from '@uniswap/sdk-core'
+import { Currency, NativeCurrency, Token } from '@uniswap/sdk-core'
 import { ParentSize } from '@visx/responsive'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { VerifiedIcon } from 'components/TokenSafety/TokenSafetyIcon'
@@ -70,10 +70,12 @@ export function useTokenLogoURI(
 
 export default function ChartSection({
   token,
+  currency,
   nativeCurrency,
   prices,
 }: {
   token: NonNullable<SingleTokenData>
+  currency?: Currency | null
   nativeCurrency?: Token | NativeCurrency
   prices: PriceDurations
 }) {
@@ -111,7 +113,12 @@ export default function ChartSection({
       <TokenInfoContainer>
         <TokenNameCell>
           <LogoContainer>
-            <CurrencyLogo src={logoSrc} size={'32px'} symbol={nativeCurrency?.symbol ?? token.symbol} />
+            <CurrencyLogo
+              src={logoSrc}
+              size={'32px'}
+              symbol={nativeCurrency?.symbol ?? token.symbol}
+              currency={nativeCurrency ? undefined : currency}
+            />
             <L2NetworkLogo networkUrl={L2Icon} size={'16px'} />
           </LogoContainer>
           {nativeCurrency?.name ?? token.name ?? <Trans>Name not found</Trans>}

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -133,6 +133,7 @@ export default function TokenDetails() {
             </BreadcrumbNavLink>
             <ChartSection
               token={tokenQueryData}
+              currency={token}
               nativeCurrency={isNative ? nativeCurrency : undefined}
               prices={prices}
             />


### PR DESCRIPTION
Passes the loaded WrappedTokenInfo (which includes a logoURI) into the chart header so its logo can be displayed.
Falls back if the queried data's logoURI fails (which was occuring for Optimism USDC).