### PR TITLE
chore: remove deprecated colors

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,4 +1,3 @@
-import { RedesignVariant, useRedesignFlag } from 'featureFlags/flags/redesign'
 import React, { useMemo } from 'react'
 import { Text, TextProps as TextPropsOriginal } from 'rebass'
 import styled, {
@@ -140,67 +139,6 @@ function oldColors(darkMode: boolean): Colors {
     deprecated_black,
 
     // text
-    deprecated_text1: darkMode ? '#FFFFFF' : '#000000',
-    deprecated_text2: darkMode ? '#C3C5CB' : '#565A69',
-    deprecated_text3: darkMode ? '#8F96AC' : '#6E727D',
-    deprecated_text4: darkMode ? '#B2B9D2' : '#C3C5CB',
-    deprecated_text5: darkMode ? '#2C2F36' : '#EDEEF2',
-
-    // backgrounds / greys
-    deprecated_bg0: darkMode ? '#191B1F' : '#FFF',
-    deprecated_bg1: darkMode ? '#212429' : '#F7F8FA',
-    deprecated_bg2: darkMode ? '#2C2F36' : '#EDEEF2',
-    deprecated_bg3: darkMode ? '#40444F' : '#CED0D9',
-    deprecated_bg4: darkMode ? '#565A69' : '#888D9B',
-    deprecated_bg5: darkMode ? '#6C7284' : '#888D9B',
-    deprecated_bg6: darkMode ? '#1A2028' : '#6C7284',
-
-    //specialty colors
-    deprecated_modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
-    deprecated_advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',
-
-    //primary colors
-    deprecated_primary1: darkMode ? '#2172E5' : '#E8006F',
-    deprecated_primary2: darkMode ? '#3680E7' : '#FF8CC3',
-    deprecated_primary3: darkMode ? '#4D8FEA' : '#FF99C9',
-    deprecated_primary4: darkMode ? '#376bad70' : '#F6DDE8',
-    deprecated_primary5: darkMode ? '#153d6f70' : '#FDEAF1',
-
-    // color text
-    deprecated_primaryText1: darkMode ? '#5090ea' : '#D50066',
-
-    // secondary colors
-    deprecated_secondary1: darkMode ? '#2172E5' : '#E8006F',
-    deprecated_secondary2: darkMode ? '#17000b26' : '#F6DDE8',
-    deprecated_secondary3: darkMode ? '#17000b26' : '#FDEAF1',
-
-    // other
-    deprecated_red1: darkMode ? '#FF4343' : '#DA2D2B',
-    deprecated_red2: darkMode ? '#F82D3A' : '#DF1F38',
-    deprecated_red3: '#D60000',
-    deprecated_green1: darkMode ? '#27AE60' : '#007D35',
-    deprecated_yellow1: '#E3A507',
-    deprecated_yellow2: '#FF8F00',
-    deprecated_yellow3: '#F3B71E',
-    deprecated_blue1: darkMode ? '#2172E5' : '#0068FC',
-    deprecated_blue2: darkMode ? '#5199FF' : '#0068FC',
-    deprecated_error: darkMode ? '#FD4040' : '#DF1F38',
-    deprecated_success: darkMode ? '#27AE60' : '#007D35',
-    deprecated_warning: '#FF8F00',
-
-    // dont wanna forget these blue yet
-    deprecated_blue4: darkMode ? '#153d6f70' : '#C4D9F8',
-  }
-}
-
-function oldColorsUpdated(darkMode: boolean): Colors {
-  return {
-    darkMode,
-    // base
-    deprecated_white,
-    deprecated_black,
-
-    // text
     deprecated_text1: darkMode ? colorsDark.textPrimary : colorsLight.textPrimary,
     deprecated_text2: darkMode ? colorsDark.textSecondary : colorsLight.textSecondary,
     deprecated_text3: darkMode ? colorsDark.textTertiary : colorsLight.textTertiary,
@@ -256,11 +194,10 @@ function oldColorsUpdated(darkMode: boolean): Colors {
   }
 }
 
-function getTheme(darkMode: boolean, isNewColorsEnabled: boolean): DefaultTheme {
-  const useColors = isNewColorsEnabled ? oldColorsUpdated(darkMode) : oldColors(darkMode)
+function getTheme(darkMode: boolean): DefaultTheme {
   return {
     ...uniswapThemeColors(darkMode),
-    ...useColors,
+    ...oldColors(darkMode),
 
     grids: {
       sm: 8,
@@ -293,12 +230,8 @@ function getTheme(darkMode: boolean, isNewColorsEnabled: boolean): DefaultTheme 
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const redesignFlag = useRedesignFlag()
   const darkMode = useIsDarkMode()
-  const themeObject = useMemo(
-    () => getTheme(darkMode, redesignFlag === RedesignVariant.Enabled),
-    [darkMode, redesignFlag]
-  )
+  const themeObject = useMemo(() => getTheme(darkMode), [darkMode])
   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 }
 


### PR DESCRIPTION
Now that we have ungated phase0, we can continue to have `deprecated_colorX` to use the current hex values in the new theme. However, over time we should move away from using the colors directly towards using the theme variables. This can be done incrementally and separately.
