### PR TITLE
fix: show blocked tokens warning

### DIFF
--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -179,16 +179,17 @@ export default function TokenDetails() {
                 isNative={isNative}
               />
             )}
-
-            <TokenSafetyModal
-              isOpen={isBlockedToken || !!continueSwap}
-              tokenAddress={tokenQueryData.address}
-              onContinue={() => onResolveSwap(true)}
-              onBlocked={() => navigate(-1)}
-              onCancel={() => onResolveSwap(false)}
-              showCancel={true}
-            />
           </>
+        )}
+        {tokenAddress && (
+          <TokenSafetyModal
+            isOpen={isBlockedToken || !!continueSwap}
+            tokenAddress={tokenAddress}
+            onContinue={() => onResolveSwap(true)}
+            onBlocked={() => navigate(-1)}
+            onCancel={() => onResolveSwap(false)}
+            showCancel={true}
+          />
         )}
       </TokenDetailsLayout>
     </Trace>

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -25,9 +25,11 @@ export default function Updater(): null {
   const fetchList = useFetchListCallback()
   const fetchAllListsCallback = useCallback(() => {
     if (!isWindowVisible) return
-    Object.keys(lists).forEach((url) =>
-      fetchList(url).catch((error) => console.debug('interval list fetching error', error))
-    )
+    Object.keys(lists).forEach((url) => {
+      // Skip validation on unsupported lists
+      const isUnsupportedList = UNSUPPORTED_LIST_URLS.includes(url)
+      fetchList(url, false, isUnsupportedList).catch((error) => console.debug('interval list fetching error', error))
+    })
   }, [fetchList, isWindowVisible, lists])
 
   useEffect(() => {


### PR DESCRIPTION
Moved token warning to allow it to appear even when backend returns no data for a token

i.e. Grump Cat at http://localhost:3000/#/tokens/ethereum/0x93B2FfF814FCaEFFB01406e80B4Ecd89Ca6A021b
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/39385577/196466152-d6b3e637-4ce2-4976-b130-4529768a2f44.png">

the unsupported tokenlist also appeared to be failing to skip validation locally so I also modified the list updater code. (These lists need to skip validation because many blocked tokens have long names that don't fit validation criteria)