### PR TITLE
feat: show wrapped native asset at top of token selector

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -110,8 +110,8 @@ export function CurrencySearch({
     const s = debouncedQuery.toLowerCase().trim()
 
     const tokens = filteredSortedTokens.filter((t) => !(t.equals(wrapped) || (disableNonToken && t.isNative)))
-    const natives = (native.equals(wrapped) ? [native] : [native, wrapped]).filter(
-      (n) => n.symbol?.toLowerCase()?.indexOf(s) !== -1
+    const natives = (disableNonToken || native.equals(wrapped) ? [wrapped] : [native, wrapped]).filter(
+      (n) => n.symbol?.toLowerCase()?.indexOf(s) !== -1 || n.name?.toLowerCase()?.indexOf(s) !== -1
     )
     return [...natives, ...tokens]
   }, [debouncedQuery, filteredSortedTokens, wrapped, disableNonToken, native])

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -106,21 +106,14 @@ export function CurrencySearch({
   const native = useNativeCurrency()
   const wrapped = native.wrapped
 
-  const displayCurrencies: Currency[] = useMemo(() => {
+  const searchCurrencies: Currency[] = useMemo(() => {
     const s = debouncedQuery.toLowerCase().trim()
-    let tokens: Currency[] = filteredSortedTokens
-    if (wrapped.symbol?.toLowerCase()?.indexOf(s) !== -1) {
-      // Always bump the wrapped token to the top of the list.
-      tokens = [wrapped, ...tokens.filter((t) => !t.equals(wrapped))]
-    }
-    if (
-      (!disableNonToken && native.symbol?.toLowerCase()?.indexOf(s) !== -1) ||
-      native.name?.toLowerCase()?.indexOf(s) !== -1
-    ) {
-      // Always bump the native token to the top of the list.
-      tokens = [native, ...tokens.filter((t) => !t.equals(native))]
-    }
-    return tokens
+
+    const tokens = filteredSortedTokens.filter((t) => !(t.equals(wrapped) || (disableNonToken && t.isNative)))
+    const natives = (native.equals(wrapped) ? [native] : [native, wrapped]).filter(
+      (n) => n.symbol?.toLowerCase()?.indexOf(s) !== -1
+    )
+    return [...natives, ...tokens]
   }, [debouncedQuery, filteredSortedTokens, wrapped, disableNonToken, native])
 
   const handleCurrencySelect = useCallback(
@@ -151,17 +144,17 @@ export function CurrencySearch({
         const s = debouncedQuery.toLowerCase().trim()
         if (s === native?.symbol?.toLowerCase()) {
           handleCurrencySelect(native)
-        } else if (displayCurrencies.length > 0) {
+        } else if (searchCurrencies.length > 0) {
           if (
-            displayCurrencies[0].symbol?.toLowerCase() === debouncedQuery.trim().toLowerCase() ||
-            displayCurrencies.length === 1
+            searchCurrencies[0].symbol?.toLowerCase() === debouncedQuery.trim().toLowerCase() ||
+            searchCurrencies.length === 1
           ) {
-            handleCurrencySelect(displayCurrencies[0])
+            handleCurrencySelect(searchCurrencies[0])
           }
         }
       }
     },
-    [debouncedQuery, native, displayCurrencies, handleCurrencySelect]
+    [debouncedQuery, native, searchCurrencies, handleCurrencySelect]
   )
 
   // menu ui
@@ -233,13 +226,13 @@ export function CurrencySearch({
               )}
             />
           </Column>
-        ) : displayCurrencies?.length > 0 || filteredInactiveTokens?.length > 0 || isLoading ? (
+        ) : searchCurrencies?.length > 0 || filteredInactiveTokens?.length > 0 || isLoading ? (
           <div style={{ flex: '1' }}>
             <AutoSizer disableWidth>
               {({ height }) => (
                 <CurrencyList
                   height={height}
-                  currencies={displayCurrencies}
+                  currencies={searchCurrencies}
                   otherListTokens={filteredInactiveTokens}
                   onCurrencySelect={handleCurrencySelect}
                   otherCurrency={otherSelectedCurrency}

--- a/src/lib/hooks/useTokenList/sorting.ts
+++ b/src/lib/hooks/useTokenList/sorting.ts
@@ -50,9 +50,8 @@ export function useSortTokensByQuery<T extends Token | TokenInfo>(query: string,
     const symbolSubtrings: T[] = []
     const rest: T[] = []
 
-    const trimmedQuery = query.toLowerCase().trim()
-
     // sort tokens by exact match -> subtring on symbol match -> rest
+    const trimmedQuery = query.toLowerCase().trim()
     tokens.map((token) => {
       const symbol = token.symbol?.toLowerCase()
       if (symbol === matches[0]) {

--- a/src/lib/hooks/useTokenList/sorting.ts
+++ b/src/lib/hooks/useTokenList/sorting.ts
@@ -50,11 +50,14 @@ export function useSortTokensByQuery<T extends Token | TokenInfo>(query: string,
     const symbolSubtrings: T[] = []
     const rest: T[] = []
 
+    const trimmedQuery = query.toLowerCase().trim()
+
     // sort tokens by exact match -> subtring on symbol match -> rest
     tokens.map((token) => {
-      if (token.symbol?.toLowerCase() === matches[0]) {
+      const symbol = token.symbol?.toLowerCase()
+      if (symbol === matches[0]) {
         return exactMatches.push(token)
-      } else if (token.symbol?.toLowerCase().startsWith(query.toLowerCase().trim())) {
+      } else if (symbol?.startsWith(trimmedQuery)) {
         return symbolSubtrings.push(token)
       } else {
         return rest.push(token)


### PR DESCRIPTION
Configured token selector to show wrapped native assets at top of token selector list by default

Also fixed bug where ETH wouldn't show up when searching "ether"
+ small performance improvements in sort methods

WEB-1176