### PR TITLE
fix: overflow and empty popup

### DIFF
--- a/src/components/Popups/PopupItem.tsx
+++ b/src/components/Popups/PopupItem.tsx
@@ -81,11 +81,11 @@ export default function PopupItem({
     popupContent = <FailedNetworkSwitchPopup chainId={content.failedSwitchNetwork} />
   }
 
-  return (
+  return popupContent ? (
     <Popup>
       <StyledClose color={theme.deprecated_text2} onClick={removeThisPopup} />
       {popupContent}
       {removeAfterMs !== null ? <AnimatedFader style={faderStyle} /> : null}
     </Popup>
-  )
+  ) : null
 }

--- a/src/components/WalletDropdown/SlideOutMenu.tsx
+++ b/src/components/WalletDropdown/SlideOutMenu.tsx
@@ -6,6 +6,7 @@ const Menu = styled.div`
   height: 100%;
   font-size: 16px;
   overflow: auto;
+  max-height: 600px;
 
   // Firefox scrollbar styling
   scrollbar-width: thin;

--- a/src/components/WalletDropdown/SlideOutMenu.tsx
+++ b/src/components/WalletDropdown/SlideOutMenu.tsx
@@ -6,7 +6,7 @@ const Menu = styled.div`
   height: 100%;
   font-size: 16px;
   overflow: auto;
-  max-height: 600px;
+  max-height: 450px;
 
   // Firefox scrollbar styling
   scrollbar-width: thin;


### PR DESCRIPTION
Scroll no longer works on language and transactions overflow, this a quick fix for that.  I picked a height slightly larger than the wallet that should fit for pretty much any screen size to allow users to select all languages

Bugs:

<img width="363" alt="Screen Shot 2022-10-20 at 10 07 45 AM" src="https://user-images.githubusercontent.com/15934595/196987236-ef619823-fbd2-4465-ba8d-bf2ea69ecf94.png">


<img width="463" alt="Screen Shot 2022-10-20 at 9 48 03 AM" src="https://user-images.githubusercontent.com/15934595/196997320-c93ca07d-2877-4c44-a904-3d7c6b28a921.png">



fix
<img width="388" alt="Screen Shot 2022-10-20 at 10 51 29 AM" src="https://user-images.githubusercontent.com/15934595/196997501-215878e6-79eb-4d80-ac3a-31dca43346dc.png">


