### PR TITLE
fix: returned sparkline call to memo

### DIFF
--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -128,7 +128,7 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
 
   const environment = useRelayEnvironment()
   const [sparklines, setSparklines] = useState<SparklineMap>({})
-  useEffect(() => {
+  useMemo(() => {
     const subscription = fetchQuery<TopTokensSparklineQuery>(environment, tokenSparklineQuery, { duration, chain })
       .map((data) => ({
         topTokens: data.topTokens?.map((token) => unwrapToken(chainId, token)),


### PR DESCRIPTION
The sparkline query call should be inside a useMemo rather than a useEffect so that it happens pre-render rather than post-render (we want it to run in parallel with the tokens query, rather than after). The useEffect was also triggering repeated calls