### PR TITLE
feat: navigate to widget-selected token

### DIFF
--- a/src/components/Tokens/TokenDetails/LoadingTokenDetails.tsx
+++ b/src/components/Tokens/TokenDetails/LoadingTokenDetails.tsx
@@ -1,4 +1,4 @@
-import { WidgetSkeleton } from 'components/Widget'
+import Widget from 'components/Widget'
 import { LeftPanel, RightPanel, TokenDetailsLayout } from 'pages/TokenDetails'
 import styled, { useTheme } from 'styled-components/macro'
 
@@ -156,7 +156,7 @@ export function LoadingTokenDetails() {
     <TokenDetailsLayout>
       <LoadingTokenDetail />
       <RightPanel>
-        <WidgetSkeleton />
+        <Widget />
       </RightPanel>
     </TokenDetailsLayout>
   )

--- a/src/components/Tokens/TokenDetails/LoadingTokenDetails.tsx
+++ b/src/components/Tokens/TokenDetails/LoadingTokenDetails.tsx
@@ -1,4 +1,4 @@
-import Widget from 'components/Widget'
+import { WidgetSkeleton } from 'components/Widget'
 import { LeftPanel, RightPanel, TokenDetailsLayout } from 'pages/TokenDetails'
 import styled, { useTheme } from 'styled-components/macro'
 
@@ -156,7 +156,7 @@ export function LoadingTokenDetails() {
     <TokenDetailsLayout>
       <LoadingTokenDetail />
       <RightPanel>
-        <Widget />
+        <WidgetSkeleton />
       </RightPanel>
     </TokenDetailsLayout>
   )

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -34,6 +34,10 @@ export const WIDGET_WIDTH = 360
 
 const WIDGET_ROUTER_URL = 'https://api.uniswap.org/v1/'
 
+function useWidgetTheme() {
+  return useIsDarkMode() ? DARK_THEME : LIGHT_THEME
+}
+
 export interface WidgetProps {
   defaultToken?: Currency
   onTokensChange?: (input: Currency | undefined, output: Currency | undefined) => void
@@ -41,10 +45,9 @@ export interface WidgetProps {
 }
 
 export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick }: WidgetProps) {
-  const locale = useActiveLocale()
-  const theme = useIsDarkMode() ? DARK_THEME : LIGHT_THEME
   const { connector, provider } = useWeb3React()
-
+  const locale = useActiveLocale()
+  const theme = useWidgetTheme()
   const { inputs, tokenSelector } = useSyncWidgetInputs(defaultToken)
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
@@ -132,7 +135,7 @@ export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick
   )
 
   if (!inputs.value.INPUT && !inputs.value.OUTPUT) {
-    return <SwapWidgetSkeleton theme={theme} width={WIDGET_WIDTH} />
+    return <WidgetSkeleton />
   }
 
   return (
@@ -161,4 +164,9 @@ export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick
       {tokenSelector}
     </>
   )
+}
+
+export function WidgetSkeleton() {
+  const theme = useWidgetTheme()
+  return <SwapWidgetSkeleton theme={theme} width={WIDGET_WIDTH} />
 }

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -52,7 +52,7 @@ export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
   const onSwitchChain = useCallback(
-    // TODO: Widget should not break if this rejects - upstream the catch to ignore it.
+    // TODO(WEB-1757): Widget should not break if this rejects - upstream the catch to ignore it.
     ({ chainId }: AddEthereumChainParameter) => switchChain(connector, Number(chainId)).catch(() => undefined),
     [connector]
   )

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -132,7 +132,7 @@ export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick
   )
 
   if (!inputs.value.INPUT && !inputs.value.OUTPUT) {
-    return <WidgetSkeleton />
+    return <SwapWidgetSkeleton theme={theme} width={WIDGET_WIDTH} />
   }
 
   return (
@@ -141,9 +141,9 @@ export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick
         disableBranding
         hideConnectionUI
         routerUrl={WIDGET_ROUTER_URL}
-        width={WIDGET_WIDTH}
         locale={locale}
         theme={theme}
+        width={WIDGET_WIDTH}
         // defaultChainId is excluded - it is always inferred from the passed provider
         provider={provider}
         onSwitchChain={onSwitchChain}
@@ -161,8 +161,4 @@ export default function Widget({ defaultToken, onTokensChange, onReviewSwapClick
       {tokenSelector}
     </>
   )
-}
-
-export function WidgetSkeleton() {
-  return <SwapWidgetSkeleton theme={useIsDarkMode() ? DARK_THEME : LIGHT_THEME} width={WIDGET_WIDTH} />
 }

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -34,10 +34,10 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
   useEffect(() => {
     // Avoid overwriting tokens if none are specified, so that a loading token does not cause layout flashing.
     if (!defaultToken) return
-    setTokens((tokens) => {
-      if (Object.values(tokens).some((token) => token?.equals(defaultToken))) return tokens
-      return { [Field.OUTPUT]: defaultToken }
-    })
+    setTokens((tokens) =>
+      // Avoid overwriting tokens if the default is already included, so that the widget does not spuriously reset.
+      Object.values(tokens).some((token) => token?.equals(defaultToken)) ? tokens : { [Field.OUTPUT]: defaultToken }
+    )
     setAmount(EMPTY_AMOUNT)
   }, [defaultToken])
 

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -34,8 +34,9 @@ export function useSyncWidgetInputs(defaultToken?: Currency) {
   useEffect(() => {
     // Avoid overwriting tokens if none are specified, so that a loading token does not cause layout flashing.
     if (!defaultToken) return
-    setTokens({
-      [Field.OUTPUT]: defaultToken,
+    setTokens((tokens) => {
+      if (Object.values(tokens).some((token) => token?.equals(defaultToken))) return tokens
+      return { [Field.OUTPUT]: defaultToken }
     })
     setAmount(EMPTY_AMOUNT)
   }, [defaultToken])

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -1,3 +1,4 @@
+import { Currency } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { PageName } from 'analytics/constants'
 import { Trace } from 'analytics/Trace'
@@ -70,14 +71,14 @@ export const RightPanel = styled.div`
 export default function TokenDetails() {
   const { tokenAddress, chainName } = useParams<{ tokenAddress?: string; chainName?: string }>()
   const { account } = useWeb3React()
-  const currentChainName = validateUrlChainParam(chainName)
-  const pageChainId = CHAIN_NAME_TO_CHAIN_ID[currentChainName]
+  const chain = validateUrlChainParam(chainName)
+  const pageChainId = CHAIN_NAME_TO_CHAIN_ID[chain]
   const nativeCurrency = nativeOnChain(pageChainId)
   const timePeriod = useAtomValue(filterTimeAtom)
   const isNative = tokenAddress === NATIVE_CHAIN_ID
   const [tokenQueryData, prices] = useTokenQuery(
     isNative ? nativeCurrency.wrapped.address : tokenAddress ?? '',
-    currentChainName,
+    chain,
     timePeriod
   )
   const queryToken = useTokenFromQuery(isNative ? undefined : { ...tokenQueryData, chainId: pageChainId })
@@ -91,28 +92,34 @@ export default function TokenDetails() {
   const isBlockedToken = tokenWarning?.canProceed === false
 
   const navigate = useNavigate()
-  const switchChains = useCallback(
-    (newChain: Chain) => {
-      const chainSegment = newChain.toLowerCase()
+  const navigateToTokenForChain = useCallback(
+    (chain: Chain) => {
+      const chainName = chain.toLowerCase()
+      const token = tokenQueryData?.project?.tokens.find((token) => token.chain === chain && token.address)
       if (isNative) {
-        navigate(`/tokens/${chainSegment}/NATIVE`)
-      } else {
-        tokenQueryData?.project?.tokens?.forEach((token) => {
-          if (token.chain === newChain && token.address) {
-            navigate(`/tokens/${chainSegment}/${token.address}`)
-          }
-        })
+        navigate(`/tokens/${chainName}/${NATIVE_CHAIN_ID}`)
+      } else if (token) {
+        navigate(`/tokens/${chainName}/${token.address}`)
       }
     },
     [isNative, navigate, tokenQueryData?.project?.tokens]
   )
-  useOnGlobalChainSwitch(switchChains)
+  useOnGlobalChainSwitch(navigateToTokenForChain)
+  const navigateToWidgetSelectedToken = useCallback(
+    (input: Currency | undefined, output: Currency | undefined) => {
+      const update = output || input
+      if (!token || input?.equals(token) || output?.equals(token) || !update) return
+      const address = update.isNative ? NATIVE_CHAIN_ID : update.address
+      navigate(`/tokens/${chainName}/${address}`)
+    },
+    [chainName, navigate, token]
+  )
 
   const [continueSwap, setContinueSwap] = useState<{ resolve: (value: boolean | PromiseLike<boolean>) => void }>()
 
-  const shouldShowSpeedbump = !useIsUserAddedTokenOnChain(tokenAddress, pageChainId) && tokenWarning !== null
   // Show token safety modal if Swap-reviewing a warning token, at all times if the current token is blocked
-  const onReviewSwap = useCallback(
+  const shouldShowSpeedbump = !useIsUserAddedTokenOnChain(tokenAddress, pageChainId) && tokenWarning !== null
+  const onReviewSwapClick = useCallback(
     () => new Promise<boolean>((resolve) => (shouldShowSpeedbump ? setContinueSwap({ resolve }) : resolve(true))),
     [shouldShowSpeedbump]
   )
@@ -157,9 +164,9 @@ export default function TokenDetails() {
             </LeftPanel>
             <RightPanel>
               <Widget
-                // A null token is still loading, and should not be overridden.
-                defaultToken={token === null ? undefined : token ?? nativeCurrency}
-                onReviewSwapClick={onReviewSwap}
+                defaultToken={token === null ? undefined : token ?? nativeCurrency} // a null token is still loading, and should not be overridden.
+                onTokensChange={navigateToWidgetSelectedToken}
+                onReviewSwapClick={onReviewSwapClick}
               />
               {tokenWarning && (
                 <TokenSafetyMessage tokenAddress={tokenQueryData.address ?? ''} warning={tokenWarning} />

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -108,7 +108,7 @@ export default function TokenDetails() {
   const navigateToWidgetSelectedToken = useCallback(
     (input: Currency | undefined, output: Currency | undefined) => {
       const update = output || input
-      if (!token || input?.equals(token) || output?.equals(token) || !update) return
+      if (!token || !update || input?.equals(token) || output?.equals(token)) return
       const address = update.isNative ? NATIVE_CHAIN_ID : update.address
       navigate(`/tokens/${chainName}/${address}`)
     },


### PR DESCRIPTION
Updates the Token Details page to match the token selected in the widget, if the current page's token is no longer displayed.

NB: This has a visual bug where navigating to the new token goes back to a LoadingTokenDetails state. <s>I'm working on fixing this, but it will likely be a follow-up (unless it is a very small change).</s> This is fixed in a follow-up: #4981.

See WEB-1467