### PR TITLE
fix: Remove CMC token list

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -3,7 +3,6 @@ export const UNI_EXTENDED_LIST = 'https://extendedtokens.uniswap.org/'
 const UNI_UNSUPPORTED_LISTS = 'https://unsupportedtokens.uniswap.org/'
 const AAVE_LIST = 'tokenlist.aave.eth'
 const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
-const CMC_ALL_LIST = 'https://api.coinmarketcap.com/data-api/v3/uniswap/all.json'
 const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
 const COMPOUND_LIST = 'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json'
 const GEMINI_LIST = 'https://www.gemini.com/uniswap/manifest.json'
@@ -25,7 +24,6 @@ const DEFAULT_LIST_OF_LISTS_TO_DISPLAY: string[] = [
   UNI_EXTENDED_LIST,
   COMPOUND_LIST,
   AAVE_LIST,
-  CMC_ALL_LIST,
   COINGECKO_LIST,
   KLEROS_LIST,
   GEMINI_LIST,


### PR DESCRIPTION
This token list has been unreliable, and always seems to have bad decimal places

