### PR TITLE
fix: sync network connector to wallet

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -225,7 +225,6 @@ export default function WalletModal({
         setWalletView(WALLET_VIEWS.PENDING)
         dispatch(updateConnectionError({ connectionType, error: undefined }))
 
-        // TODO(zzmp)
         await connector.activate()
 
         dispatch(updateSelectedWallet({ wallet: connectionType }))

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -6,6 +6,7 @@ import { CUSTOM_USER_PROPERTIES, EventName, WALLET_CONNECTION_RESULT } from 'ana
 import { sendEvent } from 'components/analytics'
 import { AutoColumn } from 'components/Column'
 import { AutoRow } from 'components/Row'
+import { networkConnection } from 'connection'
 import { getConnection, getConnectionName, getIsCoinbaseWallet, getIsInjected, getIsMetaMask } from 'connection/utils'
 import { NftVariant, useNftFlag } from 'featureFlags/flags/nft'
 import usePrevious from 'hooks/usePrevious'
@@ -189,6 +190,13 @@ export default function WalletModal({
     }
   }, [pendingConnector, walletView])
 
+  // Keep the network connector in sync with any active user connector to prevent chain-switching on wallet disconnection.
+  useEffect(() => {
+    if (chainId && connector !== networkConnection.connector) {
+      networkConnection.connector.activate(chainId)
+    }
+  }, [chainId, connector])
+
   // When new wallet is successfully set by the user, trigger logging of Amplitude analytics event.
   useEffect(() => {
     if (account && account !== lastActiveWalletAddress) {
@@ -217,6 +225,7 @@ export default function WalletModal({
         setWalletView(WALLET_VIEWS.PENDING)
         dispatch(updateConnectionError({ connectionType, error: undefined }))
 
+        // TODO(zzmp)
         await connector.activate()
 
         dispatch(updateSelectedWallet({ wallet: connectionType }))


### PR DESCRIPTION
Syncs the network connector to any active user connector (eg wallet) while the network connector is not the priority connector. Effectively, this maintains the network connector chain when a wallet is disconnected.