### PR TITLE
fix: token selector contract address search

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -71,7 +71,8 @@ export function CurrencySearch({
   const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 200)
 
-  const allTokens = useActiveTokens(debouncedQuery.length > 0)
+  // Only display 'imported' tokens when the search filter has input
+  const defaultTokens = useActiveTokens(debouncedQuery.length > 0)
 
   // if they input an address, use it
   const isAddressSearch = isAddress(debouncedQuery)
@@ -91,8 +92,8 @@ export function CurrencySearch({
   }, [isAddressSearch])
 
   const filteredTokens: Token[] = useMemo(() => {
-    return Object.values(allTokens).filter(getTokenFilter(debouncedQuery))
-  }, [allTokens, debouncedQuery])
+    return Object.values(defaultTokens).filter(getTokenFilter(debouncedQuery))
+  }, [defaultTokens, debouncedQuery])
 
   const [balances, balancesAreLoading] = useAllTokenBalances()
   const sortedTokens: Token[] = useMemo(

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -19,7 +19,7 @@ import { Text } from 'rebass'
 import { useAllTokenBalances } from 'state/connection/hooks'
 import styled, { useTheme } from 'styled-components/macro'
 
-import { useActiveTokens, useIsUserAddedToken, useSearchInactiveTokenLists, useToken } from '../../hooks/Tokens'
+import { useAllTokens, useIsUserAddedToken, useSearchInactiveTokenLists, useToken } from '../../hooks/Tokens'
 import { CloseIcon, ThemedText } from '../../theme'
 import { isAddress } from '../../utils'
 import Column from '../Column'
@@ -71,7 +71,7 @@ export function CurrencySearch({
   const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 200)
 
-  const allTokens = useActiveTokens()
+  const allTokens = useAllTokens(debouncedQuery.length === 0)
 
   // if they input an address, use it
   const isAddressSearch = isAddress(debouncedQuery)

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -19,7 +19,7 @@ import { Text } from 'rebass'
 import { useAllTokenBalances } from 'state/connection/hooks'
 import styled, { useTheme } from 'styled-components/macro'
 
-import { useAllTokens, useIsUserAddedToken, useSearchInactiveTokenLists, useToken } from '../../hooks/Tokens'
+import { useActiveTokens, useIsUserAddedToken, useSearchInactiveTokenLists, useToken } from '../../hooks/Tokens'
 import { CloseIcon, ThemedText } from '../../theme'
 import { isAddress } from '../../utils'
 import Column from '../Column'
@@ -71,7 +71,7 @@ export function CurrencySearch({
   const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 200)
 
-  const allTokens = useAllTokens(debouncedQuery.length === 0)
+  const allTokens = useActiveTokens(debouncedQuery.length > 0)
 
   // if they input an address, use it
   const isAddressSearch = isAddress(debouncedQuery)

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -14,7 +14,7 @@ import { useUserAddedTokens, useUserAddedTokensOnChain } from '../state/user/hoo
 import { TokenAddressMap, useUnsupportedTokenList } from './../state/lists/hooks'
 
 // reduce token map into standard address <-> Token mapping, optionally include user added tokens
-function useTokensFromMap(tokenMap: TokenAddressMap, excludeUserAdded?: boolean): { [address: string]: Token } {
+function useTokensFromMap(tokenMap: TokenAddressMap, includeUserAdded: boolean): { [address: string]: Token } {
   const { chainId } = useWeb3React()
   const userAddedTokens = useUserAddedTokens()
 
@@ -30,7 +30,7 @@ function useTokensFromMap(tokenMap: TokenAddressMap, excludeUserAdded?: boolean)
       {}
     )
 
-    if (!excludeUserAdded) {
+    if (includeUserAdded) {
       return (
         userAddedTokens
           // reduce into all ALL_TOKENS filtered by the current chain
@@ -47,12 +47,17 @@ function useTokensFromMap(tokenMap: TokenAddressMap, excludeUserAdded?: boolean)
     }
 
     return mapWithoutUrls
-  }, [chainId, userAddedTokens, tokenMap, excludeUserAdded])
+  }, [chainId, userAddedTokens, tokenMap, includeUserAdded])
 }
 
-export function useAllTokens(excludeUserAdded?: boolean): { [address: string]: Token } {
+export function useAllTokens(): { [address: string]: Token } {
   const allTokens = useCombinedActiveList()
-  return useTokensFromMap(allTokens, excludeUserAdded)
+  return useTokensFromMap(allTokens, true)
+}
+
+export function useActiveTokens(includeUserAdded: boolean): { [address: string]: Token } {
+  const allTokens = useCombinedActiveList()
+  return useTokensFromMap(allTokens, includeUserAdded)
 }
 
 type BridgeInfo = Record<

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -14,7 +14,7 @@ import { useUserAddedTokens, useUserAddedTokensOnChain } from '../state/user/hoo
 import { TokenAddressMap, useUnsupportedTokenList } from './../state/lists/hooks'
 
 // reduce token map into standard address <-> Token mapping, optionally include user added tokens
-function useTokensFromMap(tokenMap: TokenAddressMap, includeUserAdded: boolean): { [address: string]: Token } {
+function useTokensFromMap(tokenMap: TokenAddressMap, excludeUserAdded?: boolean): { [address: string]: Token } {
   const { chainId } = useWeb3React()
   const userAddedTokens = useUserAddedTokens()
 
@@ -30,7 +30,7 @@ function useTokensFromMap(tokenMap: TokenAddressMap, includeUserAdded: boolean):
       {}
     )
 
-    if (includeUserAdded) {
+    if (!excludeUserAdded) {
       return (
         userAddedTokens
           // reduce into all ALL_TOKENS filtered by the current chain
@@ -47,17 +47,12 @@ function useTokensFromMap(tokenMap: TokenAddressMap, includeUserAdded: boolean):
     }
 
     return mapWithoutUrls
-  }, [chainId, userAddedTokens, tokenMap, includeUserAdded])
+  }, [chainId, userAddedTokens, tokenMap, excludeUserAdded])
 }
 
-export function useAllTokens(): { [address: string]: Token } {
+export function useAllTokens(excludeUserAdded?: boolean): { [address: string]: Token } {
   const allTokens = useCombinedActiveList()
-  return useTokensFromMap(allTokens, true)
-}
-
-export function useActiveTokens(): { [address: string]: Token } {
-  const allTokens = useCombinedActiveList()
-  return useTokensFromMap(allTokens, false)
+  return useTokensFromMap(allTokens, excludeUserAdded)
 }
 
 type BridgeInfo = Record<


### PR DESCRIPTION
To reproduce the bug this PR fixes in main, search in token selector by contract address i.e. 0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e, acknowledge warning, and then try to search for it again.

Fixed by including user-added tokens when search input exists