### PR TITLE
fix: do not test rpc urls before walletconnecting

### DIFF
--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -52,17 +52,25 @@ export const gnosisSafeConnection: Connection = {
   type: ConnectionType.GNOSIS_SAFE,
 }
 
-const [web3WalletConnect, web3WalletConnectHooks] = initializeConnector<WalletConnect>(
-  (actions) =>
-    new WalletConnect({
-      actions,
-      options: {
-        rpc: RPC_URLS,
-        qrcode: true,
-      },
-      onError,
-    })
-)
+const [web3WalletConnect, web3WalletConnectHooks] = initializeConnector<WalletConnect>((actions) => {
+  // Avoid testing for the best URL by only passing a single URL per chain.
+  // Otherwise, WC will not initialize until all URLs have been tested (see getBestUrl in web3-react).
+  const RPC_URLS_WITHOUT_FALLBACKS = Object.entries(RPC_URLS).reduce(
+    (map, [chainId, urls]) => ({
+      ...map,
+      [chainId]: urls[0],
+    }),
+    {}
+  )
+  return new WalletConnect({
+    actions,
+    options: {
+      rpc: RPC_URLS_WITHOUT_FALLBACKS,
+      qrcode: true,
+    },
+    onError,
+  })
+})
 export const walletConnectConnection: Connection = {
   connector: web3WalletConnect,
   hooks: web3WalletConnectHooks,


### PR DESCRIPTION
Avoids testing RPC_URLS for the best URL before initializing WalletConnect, which is done be web3-react in the case that multiple URLs are passed for a single chain. Because the interface has fallback URLs, this was resulting in _every single fallback JSON-RPC url_ being queried before displaying the WalletConnect QR code.

Fixed by only passing the infura RPC_URL to WalletConnect. This could potentially fail if there is an infura outage, but this is preferable than the current delay. A future iteration might test URLs on pageload.