### PR TITLE
fix: rm connect wallet border

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -70,7 +70,6 @@ const HeaderRow = styled.div`
 
 const ContentWrapper = styled.div`
   background-color: ${({ theme }) => theme.backgroundSurface};
-  border: ${({ theme }) => `1px solid ${theme.backgroundOutline}`};
   padding: 0 1rem 1rem 1rem;
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;


### PR DESCRIPTION
Removes the internal border in the connect wallet border, which should not be included.
The only border should be on the entire modal. The existing border is adjacent to WalletConnect with no padding, so it does not look good.

_Before_
![image](https://user-images.githubusercontent.com/5403956/197903201-c9dda027-8bcf-4dad-a630-15146d3ebd9e.png)

_After_
![image](https://user-images.githubusercontent.com/5403956/197903128-34e14a23-72cb-4c91-bfde-1e67b65738bc.png)
