### PR TITLE
fix: chart price

### DIFF
--- a/src/components/Tokens/TokenDetails/ChartSection.tsx
+++ b/src/components/Tokens/TokenDetails/ChartSection.tsx
@@ -69,11 +69,13 @@ export default function ChartSection({
   token,
   currency,
   nativeCurrency,
+  price,
   prices,
 }: {
   token: NonNullable<TokenQueryData>
   currency?: Currency | null
   nativeCurrency?: Token | NativeCurrency
+  price?: number | null
   prices?: PriceDurations
 }) {
   const chainId = CHAIN_NAME_TO_CHAIN_ID[token.chain]
@@ -104,7 +106,9 @@ export default function ChartSection({
       </TokenInfoContainer>
       <ChartContainer>
         <ParentSize>
-          {({ width }) => <PriceChart prices={prices ? prices?.[timePeriod] : null} width={width} height={436} />}
+          {({ width }) => (
+            <PriceChart price={price} prices={prices ? prices?.[timePeriod] : null} width={width} height={436} />
+          )}
         </ParentSize>
       </ChartContainer>
     </ChartHeader>

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -14,6 +14,7 @@ import { useAtom } from 'jotai'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowDownRight, ArrowUpRight, TrendingUp } from 'react-feather'
 import styled, { useTheme } from 'styled-components/macro'
+import { textFadeIn } from 'theme/animations'
 import {
   dayHourFormatter,
   hourFormatter,
@@ -69,6 +70,7 @@ export function formatDelta(delta: number | null | undefined) {
 
 export const ChartHeader = styled.div`
   position: absolute;
+  ${textFadeIn}
 `
 export const TokenPrice = styled.span`
   font-size: 36px;

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -98,6 +98,7 @@ export default function TokenDetails() {
               token={tokenQueryData}
               currency={token}
               nativeCurrency={isNative ? nativeCurrency : undefined}
+              price={tokenQueryData?.market?.price?.value}
               prices={prices}
             />
             <StatsSection


### PR DESCRIPTION
- Pulls the initial chart price from the token query, to avoid waiting for token price query
- Fades the chart price in, to match other UI elements
- Stores the displayPrice as an index, so that old token's prices will not be incorrectly shown when switching