### PR TITLE
fix: adds support for Celo tokens and Celo token verification

### DIFF
--- a/src/constants/TokenSafetyLookupTable.ts
+++ b/src/constants/TokenSafetyLookupTable.ts
@@ -1,12 +1,13 @@
 import { TokenInfo } from '@uniswap/token-lists'
 
 import store from '../state'
-import { UNI_EXTENDED_LIST, UNI_LIST, UNSUPPORTED_LIST_URLS } from './lists'
+import { CELO_LIST, UNI_EXTENDED_LIST, UNI_LIST, UNSUPPORTED_LIST_URLS } from './lists'
 import brokenTokenList from './tokenLists/broken.tokenlist.json'
 import { NATIVE_CHAIN_ID } from './tokens'
 
 export enum TOKEN_LIST_TYPES {
   UNI_DEFAULT = 1,
+  CELO,
   UNI_EXTENDED,
   UNKNOWN,
   BLOCKED,
@@ -27,6 +28,11 @@ class TokenSafetyLookupTable {
     // Initialize default tokens second, so that any tokens on both default and extended will display as default (no warning)
     store.getState().lists.byUrl[UNI_LIST].current?.tokens.forEach((token) => {
       dict[token.address.toLowerCase()] = TOKEN_LIST_TYPES.UNI_DEFAULT
+    })
+
+    // Initialize Celo tokens which are hosted statically on celo-org.github.io and not included in the Uniswap default-token-list
+    store.getState().lists.byUrl[CELO_LIST].current?.tokens.forEach((token) => {
+      dict[token.address.toLowerCase()] = TOKEN_LIST_TYPES.CELO
     })
 
     // TODO: Figure out if this list is still relevant

--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -19,7 +19,8 @@ export const CELO_LIST = 'https://celo-org.github.io/celo-token-list/celo.tokenl
 export const UNSUPPORTED_LIST_URLS: string[] = [BA_LIST, UNI_UNSUPPORTED_LIST]
 
 // default lists to be 'active' aka searched across
-export const DEFAULT_ACTIVE_LIST_URLS: string[] = [UNI_LIST]
+// Tokens on Celo are not included in the UNI_LIST
+export const DEFAULT_ACTIVE_LIST_URLS: string[] = [UNI_LIST, CELO_LIST]
 export const DEFAULT_INACTIVE_LIST_URLS: string[] = [
   UNI_EXTENDED_LIST,
   COMPOUND_LIST,
@@ -33,7 +34,6 @@ export const DEFAULT_INACTIVE_LIST_URLS: string[] = [
   ROLL_LIST,
   ARBITRUM_LIST,
   OPTIMISM_LIST,
-  CELO_LIST,
 ]
 
 // this is the default list of lists that are exposed to users

--- a/src/constants/tokenSafety.tsx
+++ b/src/constants/tokenSafety.tsx
@@ -83,6 +83,7 @@ export function checkWarning(tokenAddress: string) {
   }
   switch (WarningCache.checkToken(tokenAddress.toLowerCase())) {
     case TOKEN_LIST_TYPES.UNI_DEFAULT:
+    case TOKEN_LIST_TYPES.CELO:
       return null
     case TOKEN_LIST_TYPES.UNI_EXTENDED:
       return MediumWarning


### PR DESCRIPTION
**Problem** 
At the moment, the interface has no default list enabled by default for Celo. 
[A recent change](https://github.com/Uniswap/interface/commit/d9434a1a9cb746c1d92bb8692ada4ba886c72d3d) involving the use of lists and token verification [removed the default list per-chain](https://github.com/Uniswap/interface/commit/d9434a1a9cb746c1d92bb8692ada4ba886c72d3d#diff-e7a2c43cfeca1f2de534d960ab283aa48f7b98507cfb06778f565aba7a4515c9L36-L45) feature which Optimism, Arbitrum, and Celo used in replacement for the [Uniswap's default-token-list](https://github.com/Uniswap/default-token-list). Although, among the three, only Optimism and Arbitrum tokens are listed here while Celo tokens are not. 

**Solution**
Earlier this year, it was decided that Celo and future chains deploying Uniswap must host/add their own token lists to the interface. Presuming we'd like to continue with this approach; the following PR proposes the Celo token list is enabled by default and corresponding tokens have a verified status.