### PR TITLE
feat: nft polling

### DIFF
--- a/src/graphql/data/RelayEnvironment.ts
+++ b/src/graphql/data/RelayEnvironment.ts
@@ -1,38 +1,16 @@
 import ms from 'ms.macro'
-import { Variables } from 'react-relay'
-import { Environment, Network, RecordSource, RequestParameters, Store } from 'relay-runtime'
-import RelayQueryResponseCache from 'relay-runtime/lib/network/RelayQueryResponseCache'
+import { Environment, Network, RecordSource, Store } from 'relay-runtime'
 
 import fetchGraphQL from './fetchGraphQL'
-// max number of request in cache, least-recently updated entries purged first
-const size = 250
-// number in milliseconds, how long records stay valid in cache
-const ttl = ms`5m`
-export const cache = new RelayQueryResponseCache({ size, ttl })
 
-const fetchQuery = async function wrappedFetchQuery(params: RequestParameters, variables: Variables) {
-  const queryID = params.name
-  const cachedData = cache.get(queryID, variables)
+// This makes it possible (and more likely) to be able to reuse data when navigating back to a page,
+// tab or piece of content that has been visited before. These settings together configure the cache
+// to serve the last 250 records, so long as they are less than 5 minutes old:
+const gcReleaseBufferSize = 250
+const queryCacheExpirationTime = ms`5m`
 
-  if (cachedData !== null) return cachedData
-
-  return fetchGraphQL(params, variables).then((data) => {
-    if (params.operationKind !== 'mutation') {
-      cache.set(queryID, variables, data)
-    }
-    return data
-  })
-}
-// This property tells Relay to not immediately clear its cache when the user
-// navigates around the app. Relay will hold onto the specified number of
-// query results, allowing the user to return to recently visited pages
-// and reusing cached data if its available/fresh.
-const gcReleaseBufferSize = 10
-const queryCacheExpirationTime = ms`1m`
-const store = new Store(new RecordSource(), { gcReleaseBufferSize, queryCacheExpirationTime })
-const network = Network.create(fetchQuery)
-// Export a singleton instance of Relay Environment configured with our network function:
-export default new Environment({
-  network,
-  store,
+export const CachingEnvironment = new Environment({
+  network: Network.create(fetchGraphQL),
+  store: new Store(new RecordSource(), { gcReleaseBufferSize, queryCacheExpirationTime }),
 })
+export default CachingEnvironment

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -1,7 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import { parseEther } from 'ethers/lib/utils'
+import useInterval from 'lib/hooks/useInterval'
+import ms from 'ms.macro'
+import { DEFAULT_ASSET_QUERY_AMOUNT } from 'nft/components/collection/CollectionNfts'
 import { GenieAsset, Rarity, SellOrder } from 'nft/types'
-import { useLazyLoadQuery, usePaginationFragment } from 'react-relay'
+import { useCallback, useMemo, useState } from 'react'
+import { fetchQuery, useLazyLoadQuery, usePaginationFragment, useRelayEnvironment } from 'react-relay'
 
 import { AssetPaginationQuery } from './__generated__/AssetPaginationQuery.graphql'
 import { AssetQuery, NftAssetsFilterInput, NftAssetSortableField } from './__generated__/AssetQuery.graphql'
@@ -117,74 +121,91 @@ export function useAssetsQuery(
   last?: number,
   before?: string
 ) {
-  const queryData = useLazyLoadQuery<AssetQuery>(assetQuery, {
-    address,
-    orderBy,
-    asc,
-    filter,
-    first,
-    after,
-    last,
-    before,
-  })
+  const vars = useMemo(
+    () => ({ address, orderBy, asc, filter, first, after, last, before }),
+    [address, after, asc, before, filter, first, last, orderBy]
+  )
+  const [queryOptions, setQueryOptions] = useState({ fetchKey: 0 })
+  const queryData = useLazyLoadQuery<AssetQuery>(assetQuery, vars, queryOptions)
+
   const { data, hasNext, loadNext, isLoadingNext } = usePaginationFragment<AssetPaginationQuery, any>(
     assetPaginationQuery,
     queryData
   )
 
-  const assets: GenieAsset[] = data.nftAssets?.edges?.map((queryAsset: { node: any }) => {
-    const asset = queryAsset.node
-    const ethPrice = parseEther(
-      asset.listings?.edges[0]?.node.price.value?.toLocaleString('fullwide', { useGrouping: false }) ?? '0'
-    ).toString()
-    return {
-      id: asset.id,
-      address: asset.collection.nftContracts[0]?.address,
-      notForSale: asset.listings?.edges.length === 0,
-      collectionName: asset.collection?.name,
-      collectionSymbol: asset.collection?.image?.url,
-      imageUrl: asset.image?.url,
-      animationUrl: asset.animationUrl,
-      marketplace: asset.listings?.edges[0]?.node.marketplace.toLowerCase(),
-      name: asset.name,
-      priceInfo: asset.listings
-        ? {
-            ETHPrice: ethPrice,
-            baseAsset: 'ETH',
-            baseDecimals: '18',
-            basePrice: ethPrice,
-          }
-        : undefined,
-      susFlag: asset.suspiciousFlag,
-      sellorders: asset.listings?.edges.map((listingNode: { node: SellOrder }) => {
+  const environment = useRelayEnvironment()
+  const refresh = useCallback(async () => {
+    const length = data.nftAssets?.edges?.length
+    // Only poll if the user has not started scrolling.
+    // Polling while scrolling requires reloading *all* pages, which is untenable.
+    if (length > DEFAULT_ASSET_QUERY_AMOUNT) return
+
+    await fetchQuery<AssetQuery>(environment, assetQuery, { ...vars, first: length }).toPromise()
+    setQueryOptions(({ fetchKey }) => ({
+      fetchKey: fetchKey + 1,
+      fetchPolicy: 'store-only',
+    }))
+  }, [data.nftAssets?.edges?.length, environment, vars])
+  useInterval(refresh, ms`999ms`)
+
+  const assets: GenieAsset[] = useMemo(
+    () =>
+      data.nftAssets?.edges?.map((queryAsset: { node: any }) => {
+        const asset = queryAsset.node
+        const ethPrice = parseEther(
+          asset.listings?.edges[0]?.node.price.value?.toLocaleString('fullwide', { useGrouping: false }) ?? '0'
+        ).toString()
         return {
-          ...listingNode.node,
-          protocolParameters: listingNode.node.protocolParameters
-            ? JSON.parse(listingNode.node.protocolParameters.toString())
+          id: asset.id,
+          address: asset.collection.nftContracts[0]?.address,
+          notForSale: asset.listings?.edges.length === 0,
+          collectionName: asset.collection?.name,
+          collectionSymbol: asset.collection?.image?.url,
+          imageUrl: asset.image?.url,
+          animationUrl: asset.animationUrl,
+          marketplace: asset.listings?.edges[0]?.node.marketplace.toLowerCase(),
+          name: asset.name,
+          priceInfo: asset.listings
+            ? {
+                ETHPrice: ethPrice,
+                baseAsset: 'ETH',
+                baseDecimals: '18',
+                basePrice: ethPrice,
+              }
             : undefined,
+          susFlag: asset.suspiciousFlag,
+          sellorders: asset.listings?.edges.map((listingNode: { node: SellOrder }) => {
+            return {
+              ...listingNode.node,
+              protocolParameters: listingNode.node.protocolParameters
+                ? JSON.parse(listingNode.node.protocolParameters.toString())
+                : undefined,
+            }
+          }),
+          smallImageUrl: asset.smallImage?.url,
+          tokenId: asset.tokenId,
+          tokenType: asset.collection.nftContracts[0]?.standard,
+          // totalCount?: number, // TODO waiting for BE changes
+          collectionIsVerified: asset.collection?.isVerified,
+          rarity: {
+            primaryProvider: 'Rarity Sniper', // TODO update when backend adds more providers
+            providers: asset.rarities.map((rarity: Rarity) => {
+              return {
+                ...rarity,
+                provider: 'Rarity Sniper',
+              }
+            }),
+          },
+          owner: asset.ownerAddress,
+          creator: {
+            profile_img_url: asset.collection?.creator?.profileImage?.url,
+            address: asset.collection?.creator?.address,
+          },
+          metadataUrl: asset.metadataUrl,
         }
       }),
-      smallImageUrl: asset.smallImage?.url,
-      tokenId: asset.tokenId,
-      tokenType: asset.collection.nftContracts[0]?.standard,
-      // totalCount?: number, // TODO waiting for BE changes
-      collectionIsVerified: asset.collection?.isVerified,
-      rarity: {
-        primaryProvider: 'Rarity Sniper', // TODO update when backend adds more providers
-        providers: asset.rarities.map((rarity: Rarity) => {
-          return {
-            ...rarity,
-            provider: 'Rarity Sniper',
-          }
-        }),
-      },
-      owner: asset.ownerAddress,
-      creator: {
-        profile_img_url: asset.collection?.creator?.profileImage?.url,
-        address: asset.collection?.creator?.address,
-      },
-      metadataUrl: asset.metadataUrl,
-    }
-  })
+    [data.nftAssets?.edges]
+  )
+
   return { assets, hasNext, isLoadingNext, loadNext }
 }

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -133,7 +133,7 @@ export function useAssetsQuery(
   )
 
   // Poll for updates.
-  const POLLING_INTERVAL = ms`999ms`
+  const POLLING_INTERVAL = ms`5s`
   const environment = useRelayEnvironment()
   const refresh = useCallback(async () => {
     const length = data.nftAssets?.edges?.length

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -2,7 +2,6 @@ import graphql from 'babel-plugin-relay/macro'
 import { parseEther } from 'ethers/lib/utils'
 import useInterval from 'lib/hooks/useInterval'
 import ms from 'ms.macro'
-import { DEFAULT_ASSET_QUERY_AMOUNT } from 'nft/components/collection/CollectionNfts'
 import { GenieAsset, Rarity, SellOrder } from 'nft/types'
 import { useCallback, useMemo, useState } from 'react'
 import { fetchQuery, useLazyLoadQuery, usePaginationFragment, useRelayEnvironment } from 'react-relay'
@@ -138,12 +137,6 @@ export function useAssetsQuery(
   const environment = useRelayEnvironment()
   const refresh = useCallback(async () => {
     const length = data.nftAssets?.edges?.length
-    // Only poll if the user has not started paging.
-    // Polling after paging requires reloading *all* pages, which is untenable.
-    // TODO(cbachmeier): Refactor CollectionNfts to pass the first visible cursor to useAssetsQuery,
-    // to allow for polling of the visible page only. This would make polling tenable after the user has paged.
-    if (length > DEFAULT_ASSET_QUERY_AMOUNT) return
-
     // Initiate a network request. When it resolves, refresh the UI from store (to avoid re-triggering Suspense);
     // see: https://relay.dev/docs/guided-tour/refetching/refreshing-queries/#if-you-need-to-avoid-suspense-1.
     await fetchQuery<AssetQuery>(environment, assetQuery, { ...vars, first: length }).toPromise()

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -138,8 +138,10 @@ export function useAssetsQuery(
   const environment = useRelayEnvironment()
   const refresh = useCallback(async () => {
     const length = data.nftAssets?.edges?.length
-    // Only poll if the user has not started scrolling.
-    // Polling while scrolling requires reloading *all* pages, which is untenable.
+    // Only poll if the user has not started paging.
+    // Polling after paging requires reloading *all* pages, which is untenable.
+    // TODO(cbachmeier): Refactor CollectionNfts to pass the first visible cursor to useAssetsQuery,
+    // to allow for polling of the visible page only. This would make polling tenable after the user has paged.
     if (length > DEFAULT_ASSET_QUERY_AMOUNT) return
 
     // Initiate a network request. When it resolves, refresh the UI from store (to avoid re-triggering Suspense);


### PR DESCRIPTION
Implements NFT polling on a 999ms interval if the user has not yet loaded any additional pages.

- Fixes the RelayEnvironment to allow bypassing the cache (using `fetchQuery`), by removing the redundant cache around `fetchGraphQL` and relying solely on the store.
- Fixes Asset.ts to memoize returned assets, preventing redundant work in render cycles when they have not changed.
- Implements polling using the technique described in the relay docs: https://relay.dev/docs/guided-tour/refetching/refetching-queries-with-different-data/#if-you-need-to-avoid-suspense-1
  - The InfiniteScroll does not mark which asset the user has on-screen, and does not use window virtualization, so polling only occurs if the user has not yet loaded any additional pages. This is necessary to avoid loading arbitrarily large requests from the graphql endpoint.
  
  The entire page could be polled, but it would eventually take >1s to fetch. This is accomplishable by setting `first` to `data.nftAssets?.edges?.length`.
  
  Ideally, (a) the scroll would be virtualized, and (b) a cursor to the first visible asset would be passed to `useAssetsQuery`. This would allow the relevant page (after the asset's cursor) to be re-polled, without having to re-poll an arbitrarily large number of assets.

In general, polling every second seems like an anti-pattern: it uses a lot of user bandwidth, and can be achieved in other ways (eg pull down to refresh, which is supported by the InfiniteScroll component).