### PR TITLE
build: deploy on friday AMs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 on:
   schedule:
-    - cron: '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
+    - cron: '0 12 * * 1-5' # every day 12:00 UTC Monday-Friday
   # manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
Right now if someone merges a PR on Thursday afternoon it won't deploy until Monday. I don't think that's preferable since we will have someone available during working hours on Friday incase any issues arise.

I can't tell how to test a github action, but I don't think there's a good way.
