### PR TITLE
fix: add back floor to search results

### DIFF
--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -134,6 +134,7 @@ export const SearchBarDropdown = ({
               stats: {
                 total_supply: collection.totalSupply,
                 one_day_change: collection.floorChange,
+                floor_price: formatEthPrice(collection.floor?.toString()),
               },
             }))
             .slice(0, isNFTPage ? 3 : 2)

--- a/src/nft/queries/genie/SearchCollectionsFetcher.ts
+++ b/src/nft/queries/genie/SearchCollectionsFetcher.ts
@@ -39,10 +39,21 @@ export const fetchSearchCollections = async (addressOrName: string, recursive = 
     body: JSON.stringify(payload),
   })
   if (isName) {
-    const data = (await r.json()) as { data: GenieCollection[] }
-    return data?.data ? data.data.slice(0, 6) : []
+    const data = await r.json()
+    const formattedData = data?.data
+      ? data.data.map((collection: { stats: Record<string, unknown>; floorPrice: string }) => {
+          return {
+            ...collection,
+            stats: {
+              ...collection.stats,
+              floor_price: collection.floorPrice,
+            },
+          }
+        })
+      : []
+    return formattedData.slice(0, 6)
   }
   const data = await r.json()
 
-  return data.data ? [data.data[0]] : []
+  return data.data ? [{ ...data.data[0], stats: { ...data.data[0], floor_price: data.data[0].floorPrice } }] : []
 }

--- a/src/nft/queries/genie/SearchCollectionsFetcher.ts
+++ b/src/nft/queries/genie/SearchCollectionsFetcher.ts
@@ -2,6 +2,8 @@ import { isAddress } from '@ethersproject/address'
 
 import { GenieCollection } from '../../types'
 
+const MAX_SEARCH_RESULTS = 6
+
 export const fetchSearchCollections = async (addressOrName: string, recursive = false): Promise<GenieCollection[]> => {
   const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/searchCollections`
   const isName = !isAddress(addressOrName.toLowerCase())
@@ -51,7 +53,7 @@ export const fetchSearchCollections = async (addressOrName: string, recursive = 
           }
         })
       : []
-    return formattedData.slice(0, 6)
+    return formattedData.slice(0, MAX_SEARCH_RESULTS)
   }
   const data = await r.json()
 

--- a/src/nft/queries/genie/SearchCollectionsFetcher.ts
+++ b/src/nft/queries/genie/SearchCollectionsFetcher.ts
@@ -55,5 +55,5 @@ export const fetchSearchCollections = async (addressOrName: string, recursive = 
   }
   const data = await r.json()
 
-  return data.data ? [{ ...data.data[0], stats: { ...data.data[0], floor_price: data.data[0].floorPrice } }] : []
+  return data.data ? [{ ...data.data[0], stats: { ...data.data[0].stats, floor_price: data.data[0].floorPrice } }] : []
 }


### PR DESCRIPTION
When restructuring GenieCollection type, floor price stopped showing in universal search results. This fixes that bug.