### PR TITLE
fix: marketplace icons on details page

### DIFF
--- a/src/nft/utils/asset.ts
+++ b/src/nft/utils/asset.ts
@@ -26,5 +26,5 @@ export const getAssetHref = (asset: GenieAsset | WalletAsset, origin?: DetailsOr
 }
 
 export const getMarketplaceIcon = (marketplace: string) => {
-  return `/nft/svgs/marketplaces/${marketplace}.svg`
+  return `/nft/svgs/marketplaces/${marketplace.toLowerCase()}.svg`
 }


### PR DESCRIPTION
Marketplaces returned from gql are in all caps, this has them match the format of the public icons.