### PR TITLE
fix: defer useInterval until callback resolves

### DIFF
--- a/src/hooks/useMachineTime.ts
+++ b/src/hooks/useMachineTime.ts
@@ -1,12 +1,15 @@
 import useInterval from 'lib/hooks/useInterval'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 const useMachineTimeMs = (updateInterval: number): number => {
   const [now, setNow] = useState(Date.now())
 
-  useInterval(() => {
-    setNow(Date.now())
-  }, updateInterval)
+  useInterval(
+    useCallback(() => {
+      setNow(Date.now())
+    }, []),
+    updateInterval
+  )
   return now
 }
 

--- a/src/lib/hooks/useInterval.test.tsx
+++ b/src/lib/hooks/useInterval.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react'
+
+import useInterval from './useInterval'
+
+describe('useInterval', () => {
+  const spy = jest.fn()
+
+  it('with no interval it does not run', () => {
+    renderHook(() => useInterval(spy, null))
+    expect(spy).toHaveBeenCalledTimes(0)
+  })
+
+  describe('with a synchronous function', () => {
+    it('it runs on an interval', () => {
+      jest.useFakeTimers()
+
+      renderHook(() => useInterval(spy, 100))
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      jest.runTimersToTime(100)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('with an async funtion', () => {
+    it('it runs on an interval exclusive of fn resolving', async () => {
+      jest.useFakeTimers()
+      spy.mockImplementation(() => Promise.resolve(undefined))
+
+      renderHook(() => useInterval(spy, 100))
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      jest.runTimersToTime(100)
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      await spy.mock.results[0].value
+      jest.runTimersToTime(100)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+  })
+})


### PR DESCRIPTION
Updates `useInterval` to defer the next interval until the callback has completed.

For synchronous callbacks, this has no effect. For callbacks returning a `Promise`, this prevents stacking invocations, should the invocation take longer than the interval.