### PR TITLE
Add pinning to Arweave on 4everland

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,16 @@ jobs:
         uses: uniswap/convert-cidv0-cidv1@v1.0.0
         with:
           cidv0: ${{ steps.pinata.outputs.hash }}
+          
+      - name: Pin to Arweave on 4everland
+        uses: 4everland/pin-action@v1.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          EVER_TOKEN: ${{ secrets.EVER_TOKEN }}
+          EVER_PROJECT_NAME: 'uniswap-interface'
+          EVER_PROJECT_PLAT: 'AR'
+          BUILD_LOCATION: './build'
 
       - uses: actions/cache@v3
         id: cypress-cache


### PR DESCRIPTION
**Introduce**
[4EVERLAND](https://www.4everland.org/) can provide you with pin service and global acceleration.

**Step**
1. Open [Dashboard](https://dashboard.4everland.org/) and connect with wallet
2. Create token in [Auth Tokens](https://dashboard.4everland.org/hosting/auth-tokens), and add it as EVER_TOKEN in Settings->Secrets->Actions

3. Add script below to workflows
```
    - name: Pin to Arweave on 4everland
       uses: 4everland/pin-action@v1.2
       continue-on-error: true
       timeout-minutes: 2
       with:
         EVER_TOKEN: ${{ secrets.EVER_TOKEN }}
         EVER_PROJECT_NAME: 'uniswap-interface'
         EVER_PROJECT_PLAT: 'AR'
         BUILD_LOCATION: './build'
```