### PR TITLE
fix: only poll every 12s

### DIFF
--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -3,9 +3,12 @@ import { deepCopy } from '@ethersproject/properties'
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { isPlain } from '@reduxjs/toolkit'
+import ms from 'ms.macro'
 
-import { SupportedChainId } from './chains'
+import { CHAIN_IDS_TO_NAMES, SupportedChainId } from './chains'
 import { RPC_URLS } from './networks'
+
+export const POLLING_INTERVAL = ms`12s`
 
 class AppJsonRpcProvider extends StaticJsonRpcProvider {
   private _blockCache = new Map<string, Promise<any>>()
@@ -18,8 +21,9 @@ class AppJsonRpcProvider extends StaticJsonRpcProvider {
     return this._blockCache
   }
 
-  constructor(urls: string[]) {
-    super(urls[0])
+  constructor(chainId: SupportedChainId) {
+    super(RPC_URLS[chainId][0], { chainId, name: CHAIN_IDS_TO_NAMES[chainId] })
+    this.pollingInterval = POLLING_INTERVAL
   }
 
   send(method: string, params: Array<any>): Promise<any> {
@@ -50,17 +54,17 @@ class AppJsonRpcProvider extends StaticJsonRpcProvider {
  * These are the only JsonRpcProviders used directly by the interface.
  */
 export const RPC_PROVIDERS: { [key in SupportedChainId]: StaticJsonRpcProvider } = {
-  [SupportedChainId.MAINNET]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET]),
-  [SupportedChainId.RINKEBY]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.RINKEBY]),
-  [SupportedChainId.ROPSTEN]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.ROPSTEN]),
-  [SupportedChainId.GOERLI]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.GOERLI]),
-  [SupportedChainId.KOVAN]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.KOVAN]),
-  [SupportedChainId.OPTIMISM]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM]),
-  [SupportedChainId.OPTIMISM_GOERLI]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.OPTIMISM_GOERLI]),
-  [SupportedChainId.ARBITRUM_ONE]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_ONE]),
-  [SupportedChainId.ARBITRUM_RINKEBY]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.ARBITRUM_RINKEBY]),
-  [SupportedChainId.POLYGON]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON]),
-  [SupportedChainId.POLYGON_MUMBAI]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.POLYGON_MUMBAI]),
-  [SupportedChainId.CELO]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.CELO]),
-  [SupportedChainId.CELO_ALFAJORES]: new AppJsonRpcProvider(RPC_URLS[SupportedChainId.CELO_ALFAJORES]),
+  [SupportedChainId.MAINNET]: new AppJsonRpcProvider(SupportedChainId.MAINNET),
+  [SupportedChainId.RINKEBY]: new AppJsonRpcProvider(SupportedChainId.RINKEBY),
+  [SupportedChainId.ROPSTEN]: new AppJsonRpcProvider(SupportedChainId.ROPSTEN),
+  [SupportedChainId.GOERLI]: new AppJsonRpcProvider(SupportedChainId.GOERLI),
+  [SupportedChainId.KOVAN]: new AppJsonRpcProvider(SupportedChainId.KOVAN),
+  [SupportedChainId.OPTIMISM]: new AppJsonRpcProvider(SupportedChainId.OPTIMISM),
+  [SupportedChainId.OPTIMISM_GOERLI]: new AppJsonRpcProvider(SupportedChainId.OPTIMISM_GOERLI),
+  [SupportedChainId.ARBITRUM_ONE]: new AppJsonRpcProvider(SupportedChainId.ARBITRUM_ONE),
+  [SupportedChainId.ARBITRUM_RINKEBY]: new AppJsonRpcProvider(SupportedChainId.ARBITRUM_RINKEBY),
+  [SupportedChainId.POLYGON]: new AppJsonRpcProvider(SupportedChainId.POLYGON),
+  [SupportedChainId.POLYGON_MUMBAI]: new AppJsonRpcProvider(SupportedChainId.POLYGON_MUMBAI),
+  [SupportedChainId.CELO]: new AppJsonRpcProvider(SupportedChainId.CELO),
+  [SupportedChainId.CELO_ALFAJORES]: new AppJsonRpcProvider(SupportedChainId.CELO_ALFAJORES),
 }

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -11,7 +11,7 @@ import { RPC_URLS } from './networks'
 // NB: Third-party providers (eg MetaMask) will have their own polling intervals,
 // which should be left as-is to allow operations (eg transaction confirmation) to resolve faster.
 // Network providers (eg AppJsonRpcProvider) need to update less frequently to be considered responsive.
-export const POLLING_INTERVAL = ms`12s` // mainnet block frequency
+export const POLLING_INTERVAL = ms`12s` // mainnet block frequency - ok for other chains as it is a sane refresh rate
 
 class AppJsonRpcProvider extends StaticJsonRpcProvider {
   private _blockCache = new Map<string, Promise<any>>()
@@ -25,7 +25,9 @@ class AppJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   constructor(chainId: SupportedChainId) {
-    super(RPC_URLS[chainId][0], { chainId, name: CHAIN_IDS_TO_NAMES[chainId] })
+    // Including networkish allows ethers to skip the initial detectNetwork call.
+    const networkish = { chainId, name: CHAIN_IDS_TO_NAMES[chainId] }
+    super(RPC_URLS[chainId][0], networkish)
     this.pollingInterval = POLLING_INTERVAL
   }
 

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -8,7 +8,10 @@ import ms from 'ms.macro'
 import { CHAIN_IDS_TO_NAMES, SupportedChainId } from './chains'
 import { RPC_URLS } from './networks'
 
-export const POLLING_INTERVAL = ms`12s`
+// NB: Third-party providers (eg MetaMask) will have their own polling intervals,
+// which should be left as-is to allow operations (eg transaction confirmation) to resolve faster.
+// Network providers (eg AppJsonRpcProvider) need to update less frequently to be considered responsive.
+export const POLLING_INTERVAL = ms`12s` // mainnet block frequency
 
 class AppJsonRpcProvider extends StaticJsonRpcProvider {
   private _blockCache = new Map<string, Promise<any>>()

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -26,8 +26,7 @@ class AppJsonRpcProvider extends StaticJsonRpcProvider {
 
   constructor(chainId: SupportedChainId) {
     // Including networkish allows ethers to skip the initial detectNetwork call.
-    const networkish = { chainId, name: CHAIN_IDS_TO_NAMES[chainId] }
-    super(RPC_URLS[chainId][0], networkish)
+    super(RPC_URLS[chainId][0], /* networkish= */ { chainId, name: CHAIN_IDS_TO_NAMES[chainId] })
     this.pollingInterval = POLLING_INTERVAL
   }
 

--- a/src/lib/hooks/useBlockNumber.tsx
+++ b/src/lib/hooks/useBlockNumber.tsx
@@ -58,6 +58,9 @@ export function BlockNumberProvider({ children }: { children: ReactNode }) {
           console.error(`Failed to get block number for chainId ${activeChainId}`, error)
         })
 
+      // Avoid extra calls by only polling every 12s.
+      provider.pollingInterval = 12
+
       provider.on('block', onBlock)
       return () => {
         stale = true

--- a/src/lib/hooks/useBlockNumber.tsx
+++ b/src/lib/hooks/useBlockNumber.tsx
@@ -58,9 +58,6 @@ export function BlockNumberProvider({ children }: { children: ReactNode }) {
           console.error(`Failed to get block number for chainId ${activeChainId}`, error)
         })
 
-      // Avoid extra calls by only polling every 12s.
-      provider.pollingInterval = 12
-
       provider.on('block', onBlock)
       return () => {
         stale = true

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -2,6 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react'
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { IMetric, MetricLoggerUnit, setGlobalMetric } from '@uniswap/smart-order-router'
 import { sendTiming } from 'components/analytics'
+import { POLLING_INTERVAL } from 'constants/providers'
 import { useStablecoinAmountFromFiatValue } from 'hooks/useStablecoinPrice'
 import { useRoutingAPIArguments } from 'lib/hooks/routing/useRoutingAPIArguments'
 import useIsValidBlock from 'lib/hooks/useIsValidBlock'
@@ -45,7 +46,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
 
   const { isLoading, isError, data, currentData } = useGetQuoteQuery(queryArgs ?? skipToken, {
     // Price-fetching is informational and costly, so it's done less frequently.
-    pollingInterval: routerPreference === RouterPreference.PRICE ? ms`2m` : ms`15s`,
+    pollingInterval: routerPreference === RouterPreference.PRICE ? ms`2m` : POLLING_INTERVAL,
   })
 
   const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(data?.blockNumber) || 0) ? data : undefined


### PR DESCRIPTION
- Updates network providers to only poll for a new block every 12s, to match mainnet's block frequency.
- Exports this polling interval, and reuses it for routing staleness.