### PR TITLE
style: Fix Trending Table filter borders on Safari (mobile & desktop)

### DIFF
--- a/src/nft/components/explore/TrendingCollections.tsx
+++ b/src/nft/components/explore/TrendingCollections.tsx
@@ -49,7 +49,7 @@ const FiltersRow = styled.div`
 
 const Filter = styled.div`
   display: flex;
-  outline: 1px solid ${({ theme }) => theme.backgroundOutline};
+  border: 1px solid ${({ theme }) => theme.backgroundOutline};
   border-radius: 16px;
   padding: 4px;
 `


### PR DESCRIPTION
Use border instead of outline