### PR TITLE
fix: lowercase markets for gql profile cards

### DIFF
--- a/src/nft/components/profile/view/WalletAssetDisplay.tsx
+++ b/src/nft/components/profile/view/WalletAssetDisplay.tsx
@@ -100,7 +100,7 @@ export const WalletAssetDisplay = ({ asset, isSellMode }: { asset: WalletAsset; 
                           borderRadius="4"
                           marginLeft="4"
                           objectFit="cover"
-                          src={`/nft/svgs/marketplaces/${market}.svg`}
+                          src={`/nft/svgs/marketplaces/${market.toLowerCase()}.svg`}
                         />
                       )
                     })}


### PR DESCRIPTION
markets returned from gql are in all caps, convert to lowercase to show correct icon