### PR TITLE
fix: show transparent box on empty banner

### DIFF
--- a/src/nft/pages/collection/index.tsx
+++ b/src/nft/pages/collection/index.tsx
@@ -104,7 +104,7 @@ const Collection = () => {
                     <CollectionBannerLoading />
                   ) : (
                     <Box
-                      as={collectionStats?.bannerImageUrl ? 'img' : undefined}
+                      as={collectionStats?.bannerImageUrl ? 'img' : 'div'}
                       height="full"
                       width="full"
                       src={

--- a/src/nft/pages/collection/index.tsx
+++ b/src/nft/pages/collection/index.tsx
@@ -104,10 +104,14 @@ const Collection = () => {
                     <CollectionBannerLoading />
                   ) : (
                     <Box
-                      as="img"
+                      as={collectionStats?.bannerImageUrl ? 'img' : undefined}
                       height="full"
                       width="full"
-                      src={`${collectionStats?.bannerImageUrl}?w=${window.innerWidth}`}
+                      src={
+                        collectionStats?.bannerImageUrl
+                          ? `${collectionStats.bannerImageUrl}?w=${window.innerWidth}`
+                          : undefined
+                      }
                       className={isLoading ? styles.loadingBanner : styles.bannerImage}
                       background="none"
                     />


### PR DESCRIPTION
Nouns for example have no banner image, so if that's the case we should just make the bg empty.
