### PR TITLE
fix: fixing loader

### DIFF
--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -14,7 +14,7 @@ const StyledSVG = styled.svg<{ size: string; stroke?: string }>`
   height: ${({ size }) => size};
   width: ${({ size }) => size};
   path {
-    stroke: ${({ stroke, theme }) => theme.accentActive};
+    stroke: ${({ stroke, theme }) => stroke ?? theme.accentActive};
   }
 `
 


### PR DESCRIPTION
the loader does not currently show up when doing a swap transaction.  This is because the stroke color defaults to accentAction instead of prioritizing the stroke first

Before

<img width="387" alt="Screen Shot 2022-11-09 at 10 35 14 AM" src="https://user-images.githubusercontent.com/15934595/200876526-e861df22-001e-4466-a1d0-82235faa3f51.png">


After

<img width="397" alt="Screen Shot 2022-11-09 at 10 50 06 AM" src="https://user-images.githubusercontent.com/15934595/200876699-b92e1dc8-1f92-4869-867b-29ea729a2c76.png">


