### PR TITLE
refactor: replace sweep query with gql call

### DIFF
--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -534,7 +534,6 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
           </ActionsContainer>
           <Sweep
             contractAddress={contractAddress}
-            collectionStats={collectionStats}
             minPrice={debouncedMinPrice}
             maxPrice={debouncedMaxPrice}
             showSweep={sweepIsOpen && buyNow && !hasErc1155s}

--- a/src/nft/utils/calcPoolPrice.ts
+++ b/src/nft/utils/calcPoolPrice.ts
@@ -21,7 +21,7 @@ export const calcPoolPrice = (asset: GenieAsset, position = 0) => {
       : (asset.sellorders[0] as Deprecated_SellOrder)
 
   const decimals = BigNumber.from(1).mul(10).pow(18)
-  const ammFee = nft.ammFeePercent ? (100 + (nft.ammFeePercent as number)) * 100 : 110 * 100
+  const ammFee = nft?.ammFeePercent ? (100 + (nft.ammFeePercent as number)) * 100 : 110 * 100
 
   if (asset.marketplace === Markets.NFTX) {
     const sixteenmul = BigNumber.from(1).mul(10).pow(16)
@@ -43,7 +43,7 @@ export const calcPoolPrice = (asset: GenieAsset, position = 0) => {
 
   const ethReserves = BigNumber.from(
     (
-      (nft.ethReserves as number) ??
+      (nft?.ethReserves as number) ??
       (
         nft as Record<
           string,
@@ -51,12 +51,12 @@ export const calcPoolPrice = (asset: GenieAsset, position = 0) => {
             ethReserves: number
           }
         >
-      ).poolMetadata.ethReserves
+      )?.poolMetadata?.ethReserves
     )?.toLocaleString('fullwide', { useGrouping: false }) ?? 1
   )
   const tokenReserves = BigNumber.from(
     (
-      (nft.tokenReserves as number) ??
+      (nft?.tokenReserves as number) ??
       (
         nft as Record<
           string,
@@ -64,7 +64,7 @@ export const calcPoolPrice = (asset: GenieAsset, position = 0) => {
             tokenReserves: number
           }
         >
-      ).poolMetadata.tokenReserves
+      )?.poolMetadata?.tokenReserves
     )?.toLocaleString('fullwide', { useGrouping: false }) ?? 1
   )
   const numerator = ethReserves.mul(amountToBuy).mul(1000)


### PR DESCRIPTION
Replace sweep queries with graphql. This is the last query that'll need to be migrated.

Out of Scope:
- Apollo migration
- Adding larvalabs and sudo to Sweep (routing code currently doesn't support)