### PR TITLE
fix: don't fetch collections without flag

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -48,6 +48,7 @@ export const SearchBar = () => {
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
+      enabled: phase1Flag === NftVariant.Enabled,
     }
   )
 

--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -48,7 +48,7 @@ export const SearchBar = () => {
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
-      enabled: phase1Flag === NftVariant.Enabled,
+      enabled: !!debouncedSearchValue && phase1Flag === NftVariant.Enabled,
     }
   )
 


### PR DESCRIPTION
This will avoid failing requests in productions, since we can't avoid the rule of hooks (useQuery can't be conditionally called).