### PR TITLE
fix: don't fetch tokens on empty search

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -58,6 +58,7 @@ export const SearchBar = () => {
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
+      enabled: !!searchValue,
     }
   )
 


### PR DESCRIPTION
When the search query is empty we don't need to make a request. This will fail from the backend.