### PR TITLE
fix: clear or retain amounts on token select

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -84,11 +84,15 @@ export function useSyncWidgetInputs({
 
       setType((type) => {
         // If flipping the tokens, also flip the type/amount.
-        if (isFlip) return invertTradeType(type)
+        if (isFlip) {
+          return invertTradeType(type)
+        }
 
         // Setting a new token should clear its amount, if it is set.
         const activeField = type === TradeType.EXACT_INPUT ? Field.INPUT : Field.OUTPUT
-        if (selectingField === activeField) setAmount(() => EMPTY_AMOUNT)
+        if (selectingField === activeField) {
+          setAmount(() => EMPTY_AMOUNT)
+        }
 
         return type
       })

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -48,7 +48,7 @@ export function useSyncWidgetInputs({
       if (origin === 'max') {
         sendAnalyticsEvent(EventName.SWAP_MAX_TOKEN_AMOUNT_SELECTED, { ...trace })
       }
-      setType(toTradeType(field))
+      setType(field === Field.INPUT ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT)
       setAmount(amount)
     },
     [trace]
@@ -71,20 +71,30 @@ export function useSyncWidgetInputs({
   }, [])
 
   const onTokenSelect = useCallback(
-    (token: Currency) => {
+    (selectingToken: Currency) => {
       if (selectingField === undefined) return
-      setType(toTradeType(selectingField))
 
       const otherField = invertField(selectingField)
-      let otherToken = tokens[otherField]
-      otherToken = otherToken?.equals(token) ? tokens[selectingField] : otherToken
-      const update = {
-        [selectingField]: token,
-        [otherField]: otherToken,
+      const isFlip = tokens[otherField]?.equals(selectingToken)
+      const update: SwapTokens = {
+        [selectingField]: selectingToken,
+        [otherField]: isFlip ? tokens[selectingField] : tokens[otherField],
         default: tokens.default,
       }
+
+      setType((type) => {
+        // If flipping the tokens, also flip the type/amount.
+        if (isFlip) return invertTradeType(type)
+
+        // Setting a new token should clear its amount, if it is set.
+        const activeField = type === TradeType.EXACT_INPUT ? Field.INPUT : Field.OUTPUT
+        if (selectingField === activeField) setAmount(() => EMPTY_AMOUNT)
+
+        return type
+      })
+
       if (!includesDefaultToken(update)) {
-        onTokenChange?.(update[Field.OUTPUT] || update[Field.INPUT] || token)
+        onTokenChange?.(update[Field.OUTPUT] || selectingToken)
       }
       setTokens(update)
     },
@@ -124,16 +134,6 @@ function invertField(field: Field) {
       return Field.OUTPUT
     case Field.OUTPUT:
       return Field.INPUT
-  }
-}
-
-// TODO(zzmp): Move to @uniswap/widgets.
-function toTradeType(modifiedField: Field) {
-  switch (modifiedField) {
-    case Field.INPUT:
-      return TradeType.EXACT_INPUT
-    case Field.OUTPUT:
-      return TradeType.EXACT_OUTPUT
   }
 }
 


### PR DESCRIPTION
Clears the amount when the token with an amount is switched.
Swaps the active token if the token with an amount is moved to the other spot.