### PR TITLE
fix: fixing header on light mode

### DIFF
--- a/src/nft/components/collection/CollectionNfts.css.ts
+++ b/src/nft/components/collection/CollectionNfts.css.ts
@@ -8,6 +8,8 @@ export const assetList = style([
     gap: { sm: '8', md: '12', lg: '20' },
   }),
   {
+    paddingLeft: 14,
+    paddingRight: 14,
     gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr) )',
     '@media': {
       'screen and (min-width: 708px)': {

--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -511,7 +511,7 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
         hasMore={hasNext}
         loader={hasNext && hasNfts ? loadingAssets : null}
         dataLength={collectionNfts?.length ?? 0}
-        style={{ overflow: 'unset', paddingLeft: 14, paddingRight: 14 }}
+        style={{ overflow: 'unset' }}
         className={hasNfts || isLoadingNext ? styles.assetList : undefined}
       >
         {hasNfts ? (

--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -120,6 +120,7 @@ const SweepButton = styled.div<{ toggled: boolean; disabled?: boolean }>`
   border: none;
   border-radius: 12px;
   padding: 12px 18px 12px 12px;
+  margin-right: 14px;
   cursor: ${({ disabled }) => (disabled ? 'auto' : 'pointer')};
   color: ${({ toggled, disabled, theme }) => (toggled && !disabled ? theme.accentTextLightPrimary : theme.textPrimary)};
   background: ${({ theme, toggled, disabled }) =>
@@ -512,7 +513,7 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
         hasMore={hasNext}
         loader={hasNext && hasNfts ? loadingAssets : null}
         dataLength={collectionNfts?.length ?? 0}
-        style={{ overflow: 'unset' }}
+        style={{ overflow: 'unset', paddingLeft: 14, paddingRight: 14 }}
         className={hasNfts || isLoadingNext ? styles.assetList : undefined}
       >
         {hasNfts ? (

--- a/src/nft/components/collection/FilterButton.tsx
+++ b/src/nft/components/collection/FilterButton.tsx
@@ -34,6 +34,7 @@ export const FilterButton = ({
       position="relative"
       onClick={onClick}
       padding="12"
+      marginLeft="14"
       width={isMobile ? '44' : 'auto'}
       height="44"
       whiteSpace="nowrap"


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-2064

1. The box shadow from the nfts shows the edges of the navbar
2. Moving everything 14px in (left and right) moves the edges of the navbar away from the box shadow so it doesn't show the edges
3. 14px was the smallest width I could find where this works
4. See Jira for before and after