### PR TITLE
fix: enforce uniform asset height

### DIFF
--- a/src/nft/components/collection/Card.tsx
+++ b/src/nft/components/collection/Card.tsx
@@ -256,6 +256,7 @@ const Image = ({ uniformHeight, setUniformHeight }: ImageProps) => {
         width="full"
         style={{
           aspectRatio: uniformHeight === UniformHeights.notUniform ? '1' : 'auto',
+          minHeight: uniformHeight,
           transition: 'transform 0.4s ease 0s',
         }}
         src={asset.imageUrl || asset.smallImageUrl}
@@ -408,6 +409,7 @@ const Audio = ({ uniformHeight, setUniformHeight, shouldPlay, setCurrentTokenPla
           width="full"
           style={{
             aspectRatio: uniformHeight === UniformHeights.notUniform ? '1' : 'auto',
+            minHeight: uniformHeight,
             transition: 'transform 0.4s ease 0s',
           }}
           src={asset.imageUrl || asset.smallImageUrl}

--- a/src/nft/components/collection/Card.tsx
+++ b/src/nft/components/collection/Card.tsx
@@ -256,7 +256,6 @@ const Image = ({ uniformHeight, setUniformHeight }: ImageProps) => {
         width="full"
         style={{
           aspectRatio: uniformHeight === UniformHeights.notUniform ? '1' : 'auto',
-          minHeight: uniformHeight,
           transition: 'transform 0.4s ease 0s',
         }}
         src={asset.imageUrl || asset.smallImageUrl}
@@ -268,7 +267,9 @@ const Image = ({ uniformHeight, setUniformHeight }: ImageProps) => {
             if (uniformHeight === UniformHeights.unset) {
               setUniformHeight(e.currentTarget.clientHeight)
             } else if (uniformHeight !== UniformHeights.notUniform && e.currentTarget.clientHeight !== uniformHeight) {
-              setUniformHeight(UniformHeights.notUniform)
+              if (!uniformHeight || Math.abs(uniformHeight - e.currentTarget.clientHeight) > 1) {
+                setUniformHeight(UniformHeights.notUniform)
+              }
             }
           }
           setLoaded(true)
@@ -409,7 +410,6 @@ const Audio = ({ uniformHeight, setUniformHeight, shouldPlay, setCurrentTokenPla
           width="full"
           style={{
             aspectRatio: uniformHeight === UniformHeights.notUniform ? '1' : 'auto',
-            minHeight: uniformHeight,
             transition: 'transform 0.4s ease 0s',
           }}
           src={asset.imageUrl || asset.smallImageUrl}
@@ -424,7 +424,9 @@ const Audio = ({ uniformHeight, setUniformHeight, shouldPlay, setCurrentTokenPla
                 uniformHeight !== UniformHeights.notUniform &&
                 e.currentTarget.clientHeight !== uniformHeight
               ) {
-                setUniformHeight(UniformHeights.notUniform)
+                if (!uniformHeight || Math.abs(uniformHeight - e.currentTarget.clientHeight) > 1) {
+                  setUniformHeight(UniformHeights.notUniform)
+                }
               }
             }
             setImageLoaded(true)

--- a/src/nft/components/collection/CollectionAssetLoading.tsx
+++ b/src/nft/components/collection/CollectionAssetLoading.tsx
@@ -5,10 +5,10 @@ import { Box } from '../../components/Box'
 import { Row } from '../Flex'
 import * as styles from './CollectionAssetLoading.css'
 
-export const CollectionAssetLoading = () => {
+export const CollectionAssetLoading = ({ height }: { height?: number }) => {
   return (
     <Box as="div" className={styles.collectionAssetLoading}>
-      <Box as="div" position="relative" width="full">
+      <Box as="div" position="relative" width="full" style={{ height }}>
         <Box as="div" className={styles.collectionAssetsImageLoading} />
         <Box as="img" width="full" opacity="0" src={SizingImage} draggable={false} />
       </Box>

--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -165,17 +165,17 @@ export const LoadingButton = styled.div`
   background-size: 400%;
 `
 
-const loadingAssets = (
+const loadingAssets = (height?: number) => (
   <>
     {Array.from(Array(ASSET_PAGE_SIZE), (_, index) => (
-      <CollectionAssetLoading key={index} />
+      <CollectionAssetLoading key={index} height={height} />
     ))}
   </>
 )
 
 export const CollectionNftsLoading = () => (
   <Box width="full" className={styles.assetList}>
-    {loadingAssets}
+    {loadingAssets()}
   </Box>
 )
 
@@ -508,7 +508,7 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
       <InfiniteScroll
         next={() => loadNext(ASSET_PAGE_SIZE)}
         hasMore={hasNext}
-        loader={hasNext && hasNfts ? loadingAssets : null}
+        loader={hasNext && hasNfts ? loadingAssets(uniformHeight) : null}
         dataLength={collectionNfts?.length ?? 0}
         style={{ overflow: 'unset' }}
         className={hasNfts || isLoadingNext ? styles.assetList : undefined}

--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -322,9 +322,9 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
     }
   }, [contractAddress])
 
-  const Nfts =
-    collectionNfts &&
-    collectionNfts.map((asset) =>
+  const assets = useMemo(() => {
+    if (!collectionNfts) return null
+    return collectionNfts.map((asset) =>
       asset ? (
         <CollectionAsset
           key={asset.address + asset.tokenId}
@@ -338,6 +338,7 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
         />
       ) : null
     )
+  }, [collectionNfts, currentTokenPlayingMedia, isMobile, rarityVerified, uniformHeight])
 
   const hasNfts = collectionNfts && collectionNfts.length > 0
   const hasErc1155s = hasNfts && collectionNfts[0] && collectionNfts[0].tokenType === TokenType.ERC1155
@@ -514,7 +515,7 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
         className={hasNfts || isLoadingNext ? styles.assetList : undefined}
       >
         {hasNfts ? (
-          Nfts
+          assets
         ) : collectionNfts?.length === 0 ? (
           <Center width="full" color="textSecondary" textAlign="center" style={{ height: '60vh' }}>
             <EmptyCollectionWrapper>

--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -324,20 +324,18 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
 
   const assets = useMemo(() => {
     if (!collectionNfts) return null
-    return collectionNfts.map((asset) =>
-      asset ? (
-        <CollectionAsset
-          key={asset.address + asset.tokenId}
-          asset={asset}
-          isMobile={isMobile}
-          uniformHeight={uniformHeight}
-          setUniformHeight={setUniformHeight}
-          mediaShouldBePlaying={asset.tokenId === currentTokenPlayingMedia}
-          setCurrentTokenPlayingMedia={setCurrentTokenPlayingMedia}
-          rarityVerified={rarityVerified}
-        />
-      ) : null
-    )
+    return collectionNfts.map((asset) => (
+      <CollectionAsset
+        key={asset.address + asset.tokenId}
+        asset={asset}
+        isMobile={isMobile}
+        uniformHeight={uniformHeight}
+        setUniformHeight={setUniformHeight}
+        mediaShouldBePlaying={asset.tokenId === currentTokenPlayingMedia}
+        setCurrentTokenPlayingMedia={setCurrentTokenPlayingMedia}
+        rarityVerified={rarityVerified}
+      />
+    ))
   }, [collectionNfts, currentTokenPlayingMedia, isMobile, rarityVerified, uniformHeight])
 
   const hasNfts = collectionNfts && collectionNfts.length > 0


### PR DESCRIPTION
Sets the loading assets to the same height as loaded assets.
This also fixes an inconsistent bug where the uniformHeight would be reset due to an inconsistent aspect ratio.