### PR TITLE
fix: approve button font size

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -677,7 +677,15 @@ export default function Swap() {
                         }
                       >
                         <AutoRow justify="space-between" style={{ flexWrap: 'nowrap' }} height="20px">
-                          <span style={{ display: 'flex', alignItems: 'center' }}>
+                          <span
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              fontSize: '16px',
+                              width: '100%',
+                              justifyContent: 'center',
+                            }}
+                          >
                             {/* we need to shorten this string on mobile */}
                             {approvalState === ApprovalState.APPROVED ||
                             signatureState === UseERC20PermitState.SIGNED ? (


### PR DESCRIPTION
### Changes
Styled the home screen "`Allow the uniswap Protocol to user your `TOKEN``" CTA. Was looking super odd with 20px

### Before
![before-fix](https://iili.io/yGFTEQ.png)
### Now 🦄
![before-fix](https://iili.io/yG3krB.png)
