### PR TITLE
fix: disable polling after scroll

### DIFF
--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -224,10 +224,10 @@ export function useLazyLoadAssetsQuery(params: AssetFetcherParams) {
   const POLLING_INTERVAL = ms`5s`
   const environment = useRelayEnvironment()
   const poll = useCallback(async () => {
-    const length = data.nftAssets?.edges?.length
+    if (data.nftAssets?.edges?.length > ASSET_PAGE_SIZE) return
     // Initiate a network request. When it resolves, refresh the UI from store (to avoid re-triggering Suspense);
     // see: https://relay.dev/docs/guided-tour/refetching/refreshing-queries/#if-you-need-to-avoid-suspense-1.
-    await fetchQuery<AssetQuery>(environment, assetQuery, { ...vars, first: length }).toPromise()
+    await fetchQuery<AssetQuery>(environment, assetQuery, { ...vars }).toPromise()
     setFetchKey((fetchKey) => fetchKey + 1)
   }, [data.nftAssets?.edges?.length, environment, vars])
   useInterval(poll, isLoadingNext ? null : POLLING_INTERVAL, /* leading= */ false)


### PR DESCRIPTION
Disables polling after scroll event loads more assets. Stops bug where loading more than 100 assets causes the page to refresh. TODO is to figure out how to continuously poll the first 25 assets after scroll. Optional to setup pullDownToRefresh on infinite scroll component.