### PR TITLE
chore: Change font weights for headlines from normal -> medium.

### DIFF
--- a/src/nft/css/common.css.ts
+++ b/src/nft/css/common.css.ts
@@ -21,9 +21,9 @@ export const column = sprinkles({
 })
 
 // TYPOGRAPHY
-export const headlineLarge = sprinkles({ fontWeight: 'normal', fontSize: '36', lineHeight: '44' })
-export const headlineMedium = sprinkles({ fontWeight: 'normal', fontSize: '28', lineHeight: '36' })
-export const headlineSmall = sprinkles({ fontWeight: 'normal', fontSize: '20', lineHeight: '28' })
+export const headlineLarge = sprinkles({ fontWeight: 'medium', fontSize: '36', lineHeight: '44' })
+export const headlineMedium = sprinkles({ fontWeight: 'medium', fontSize: '28', lineHeight: '36' })
+export const headlineSmall = sprinkles({ fontWeight: 'medium', fontSize: '20', lineHeight: '28' })
 
 export const subhead = sprinkles({ fontWeight: 'medium', fontSize: '16', lineHeight: '24' })
 export const subheadSmall = sprinkles({ fontWeight: 'medium', fontSize: '14', lineHeight: '14' })


### PR DESCRIPTION
Updated `headlineLarge`, `headlineMedium`, and `headlineSmall` to adhere to latest design system by changing the font weight from `normal` to `medium`. 

This also fixes [this issue](https://uniswaplabs.atlassian.net/browse/WEB-2037), which asks for a thicker font on NFT collection pages.

I tested by manually viewing pages affected by these updates and making sure the font weights looked alright.