### PR TITLE
fix: Add ETH to the floor price in trending collections banner.

### DIFF
--- a/src/nft/components/explore/CarouselCard.tsx
+++ b/src/nft/components/explore/CarouselCard.tsx
@@ -164,15 +164,15 @@ const TableElement = styled.div`
 
 interface MarketplaceRowProps {
   marketplace: string
-  floor?: string
+  floorInEth?: string
   listings?: string
 }
 
-export const MarketplaceRow = ({ marketplace, floor, listings }: MarketplaceRowProps) => {
+export const MarketplaceRow = ({ marketplace, floorInEth, listings }: MarketplaceRowProps) => {
   return (
     <>
       <TableElement>{marketplace}</TableElement>
-      <TableElement>{floor ?? '-'}</TableElement>
+      <TableElement>{floorInEth ?? '-'} ETH</TableElement>
       <TableElement>{listings ?? '-'}</TableElement>
     </>
   )
@@ -235,7 +235,7 @@ export const CarouselCard = ({ collection, onClick }: CarouselCardProps) => {
                   key={`CarouselCard-key-${collection.address}-${marketplace.marketplace}`}
                   marketplace={MARKETS_ENUM_TO_NAME[market]}
                   listings={marketplace.count.toString()}
-                  floor={marketplace.floorPrice.toString()}
+                  floorInEth={marketplace.floorPrice.toString()}
                 />
               )
             })}


### PR DESCRIPTION
Adds "ETH" at the end of floor prices for trending collections in the explore banner. 
Hardcoded ETH for now and included a small variable name change to make the logic more explicit and as a quick reminder that we'll need to change that logic if we want to be more flexible with floor price displays in the future.

Fixes https://uniswaplabs.atlassian.net/browse/WEB-2141