### PR TITLE
fix: err and warn if user modifies tx

### DIFF
--- a/src/lib/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/lib/hooks/swap/useSendSwapTransaction.tsx
@@ -29,7 +29,7 @@ interface FailedCall extends SwapCallEstimate {
   error: Error
 }
 
-class SwapError extends Error {}
+class InvalidSwapError extends Error {}
 
 // returns a function that will execute a swap, if the parameters are all valid
 export default function useSendSwapTransaction(
@@ -117,7 +117,7 @@ export default function useSendSwapTransaction(
           })
           .then((response) => {
             if (calldata !== response.data) {
-              throw new SwapError(
+              throw new InvalidSwapError(
                 t`Your swap was modified through your wallet. If this was a mistake, please cancel immediately or risk losing your funds.`
               )
             }
@@ -131,7 +131,7 @@ export default function useSendSwapTransaction(
               // otherwise, the error was unexpected and we need to convey that
               console.error(`Swap failed`, error, address, calldata, value)
 
-              if (error instanceof SwapError) {
+              if (error instanceof InvalidSwapError) {
                 throw error
               } else {
                 throw new Error(t`Swap failed: ${swapErrorToUserReadableMessage(error)}`)

--- a/src/lib/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/lib/hooks/swap/useSendSwapTransaction.tsx
@@ -118,8 +118,7 @@ export default function useSendSwapTransaction(
           .then((response) => {
             if (calldata !== response.data) {
               throw new SwapError(
-                t`You've modified your swap:
-we recommend canceling it immediately using your wallet, as it may no longer be what you wanted`
+                t`Your swap was modified through your wallet. If this was a mistake, please cancel immediately or risk losing your funds.`
               )
             }
             return response

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -59,7 +59,6 @@ export function swapErrorToUserReadableMessage(error: any): ReactNode {
       )
     default:
       if (reason?.indexOf('undefined is not an object') !== -1) {
-        console.error(error, reason)
         return (
           <Trans>
             An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If


### PR DESCRIPTION
Omit tracking modified transactions, and instead show the user an error modal warning them to immediately cancel their tx.

Some wallets allow users to modify transactions before approving them, but this (a) risks converting the tx to something else, like a `transfer()`; and (b) means that we no longer have accurate data with which to track the tx in our transactions history views.

![image](https://user-images.githubusercontent.com/5403956/201781165-f40df589-51cf-4569-bdd6-2c1ede3af198.png)
