### PR TITLE
fix: update analytics package to use default event

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@react-hook/window-scroll": "^1.3.0",
     "@reduxjs/toolkit": "^1.6.1",
     "@types/react-relay": "^13.0.2",
-    "@uniswap/analytics": "1.0.3",
+    "@uniswap/analytics": "1.1.1",
     "@uniswap/analytics-events": "1.1.0",
     "@uniswap/governance": "^1.0.2",
     "@uniswap/liquidity-staker": "^1.0.2",

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -14,6 +14,7 @@ import { useIsDarkMode } from 'state/user/hooks'
 import styled from 'styled-components/macro'
 import { SpinnerSVG } from 'theme/components'
 import { Z_INDEX } from 'theme/zIndex'
+import { isProductionEnv } from 'utils/env'
 import { getCLS, getFCP, getFID, getLCP, Metric } from 'web-vitals'
 
 import { useAnalyticsReporter } from '../components/analytics'
@@ -50,7 +51,13 @@ const Asset = lazy(() => import('nft/pages/asset/Asset'))
 // Placeholder API key. Actual API key used in the proxy server
 const ANALYTICS_DUMMY_KEY = '00000000000000000000000000000000'
 const ANALYTICS_PROXY_URL = process.env.REACT_APP_AMPLITUDE_PROXY_URL
-initializeAnalytics(ANALYTICS_DUMMY_KEY, OriginApplication.INTERFACE, ANALYTICS_PROXY_URL)
+const COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
+initializeAnalytics(ANALYTICS_DUMMY_KEY, OriginApplication.INTERFACE, {
+  proxyUrl: ANALYTICS_PROXY_URL,
+  defaultEventName: EventName.PAGE_VIEWED,
+  commitHash: COMMIT_HASH,
+  isProductionEnv: isProductionEnv(),
+})
 
 const AppWrapper = styled.div`
   display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,10 +4127,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-1.1.0.tgz#459236d86f864039c3931d21ba80f41575d2ce4e"
   integrity sha512-ZJ99dLhJ4q2c0g0PoMxDPbeC010DrdIBLf7jnUsTf/hYm2LfHryr31Sv204xNO7rWVWHi1dk6jdab8DdBnHgPA==
 
-"@uniswap/analytics@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@uniswap/analytics/-/analytics-1.0.3.tgz#bb22cec8f722acd6b0937045f75c6e108e61016f"
-  integrity sha512-1DmKkGh5VlOQM8JXrCvvxkDn7KaDn/9aMrgVb9qOAXgBQ1QhsCkUeadsM2agDeJXQcY2JrOPbS04w/60vqHcXw==
+"@uniswap/analytics@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics/-/analytics-1.1.1.tgz#af9741054f2df61fb595cb3761762bb0a24f8a86"
+  integrity sha512-pRoagKfji+Xwh4YuS1ns0mfBfXwUWJlf7H+D3vzIMspTNdJVPG44G8hGM0JN4f9H9+JerFyC+4dXrmLL6rnh+w==
   dependencies:
     "@amplitude/analytics-browser" "^1.5.8"
     react "^18.2.0"


### PR DESCRIPTION
# Notes

- This PR integrates the codebase with the `1.1.1` version of the analytics package.
- The main driver for the change is that the new package's initialization method accepts a `defaultEventName`, which used to be hardcoded in the *analytics* package.
- The hardcoding (as a string vs an enum) in the *anaytics* package, cause a misanming to occur. The reason it was hardcoded as a string inside the *analytics* package, is because we don't want the *infra* portion to be tied to the *analytics-events* package
- This change ensures that the consuming app defines the `defaultEventName`