### PR TITLE
build: don't fail local build on lint

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,4 @@ REACT_APP_AWS_API_ACCESS_SECRET="V9PoU0FhBP3cX760rPs9jMG/MIuDNLX6hYvVcaYO"
 REACT_APP_AWS_X_API_KEY="z9dReS5UtHu7iTrUsTuWRozLthi3AxOZlvobrIdr14"
 REACT_APP_AWS_API_ENDPOINT="https://beta.api.uniswap.org/v1/graphql"
 REACT_APP_TEMP_API_URL="https://temp.api.uniswap.org/v1"
+ESLINT_NO_DEV_ERRORS=true


### PR DESCRIPTION
When developing it is really helpful to comment out sections of code (for example, if wanting to test a loading or failure state). However, the no-unused-imports for example will get triggered quickly when that is done.

We can ignore these lint issues on build, and devs can add the requirements to their editor, pre-commit hook, etc. The build will also fail on GitHub anyways, so it will be obvious.
