### PR TITLE
fix: max depth error

### DIFF
--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -204,10 +204,10 @@ export const SearchBarDropdown = ({
     (isNFTPage && (hasVerifiedCollection || !hasVerifiedToken)) ||
     (!isNFTPage && !hasVerifiedToken && hasVerifiedCollection)
 
-  const trace = useTrace({ section: SectionName.NAVBAR_SEARCH })
+  const trace = JSON.stringify(useTrace({ section: SectionName.NAVBAR_SEARCH }))
 
   useEffect(() => {
-    const eventProperties = { total_suggestions: totalSuggestions, query_text: queryText, ...trace }
+    const eventProperties = { total_suggestions: totalSuggestions, query_text: queryText, ...JSON.parse(trace) }
     if (!isLoading) {
       const tokenSearchResults =
         tokens.length > 0 ? (


### PR DESCRIPTION
issue

Clicking on search causes maximum depth error.  It's because an object is being passed to the dependency array

![Screen Shot 2022-11-16 at 3 56 17 PM](https://user-images.githubusercontent.com/15934595/202292514-8098311f-e719-4a41-80d1-f81e89752dec.png)

after

![Screen Shot 2022-11-16 at 3 57 28 PM](https://user-images.githubusercontent.com/15934595/202292750-2a2bd4aa-0468-4f3c-873f-0680d23af210.png)

