### PR TITLE
fix: rendering of glow effect on mobile safari

### DIFF
--- a/src/nft/components/explore/Banner.tsx
+++ b/src/nft/components/explore/Banner.tsx
@@ -6,7 +6,7 @@ import { calculateCardIndex } from 'nft/utils'
 import { Suspense, useCallback, useMemo, useState } from 'react'
 import { useQuery } from 'react-query'
 import { useNavigate } from 'react-router-dom'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import { opacify } from 'theme/utils'
 
 import { Carousel, LoadingCarousel } from './Carousel'
@@ -20,6 +20,12 @@ const BannerContainer = styled.div`
   position: relative;
 `
 
+// Safari has issues with blur / overflow
+// https://stackoverflow.com/a/71353198
+const fixBlurOnSafari = css`
+  transform: translate3d(0, 0, 0);
+`
+
 const AbsoluteFill = styled.div`
   position: absolute;
   top: -72px;
@@ -29,6 +35,8 @@ const AbsoluteFill = styled.div`
 `
 
 const BannerBackground = styled(AbsoluteFill)<{ backgroundImage: string }>`
+  ${fixBlurOnSafari}
+
   background-image: ${(props) => `url(${props.backgroundImage})`};
   filter: blur(62px);
   opacity: ${({ theme }) => (theme.darkMode ? 0.4 : 0.2)};


### PR DESCRIPTION
Sometimes Safari would render the Banner as if it had overflow set to hidden. This is odd because that does not happen on Chrome. The issue happens when there's a filter (blur) applied to an element and there's a hover state triggered either on that element or any of the elements on top of it. 

Applying `translate3d` seems to do the trick. Decided to link to the StackOverflow issue because this is a strong workaround and there's not many resources on it, beyond that answer. 

While reviewing, check the details on Slack: https://uniswapteam.slack.com/archives/C04822DFATE/p1668686941493839?thread_ts=1668668097.346379&cid=C04822DFATE

My guess is that the glitch doesn't happen when GPU acceleration kicks in for that element, which we achieve by applying `translate3d`.