### PR TITLE
fix: right arrow in carousel not rotated

### DIFF
--- a/src/nft/components/icons.tsx
+++ b/src/nft/components/icons.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components/macro'
 
 import { themeVars, vars } from '../css/sprinkles.css'
 
@@ -173,8 +174,6 @@ export const EllipsisIcon = (props: SVGProps) => (
     />
   </svg>
 )
-
-export const ChevronRightIcon = (props: SVGProps) => <ChevronLeftIcon {...props} transform="rotate(180)" />
 
 export const LightningBoltIcon = (props: SVGProps) => (
   <svg {...props} width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -602,6 +601,10 @@ export const ChevronLeftIcon = (props: SVGProps) => (
     <path d="M7 1L1 7L7 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 )
+
+export const ChevronRightIcon = styled(ChevronLeftIcon)`
+  transform: rotate(180deg);
+`
 
 export const TrendingArrow = (props: SVGProps) => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>


### PR DESCRIPTION
Unfortunately, Safari doesn't support `transform` of SVG2 spec. More cross-browser approach is to use CSS + styled components.