### PR TITLE
chore: fix horizontal overflow 

### DIFF
--- a/src/nft/components/explore/Banner.tsx
+++ b/src/nft/components/explore/Banner.tsx
@@ -32,7 +32,7 @@ const BannerBackground = styled(AbsoluteFill)<{ backgroundImage: string }>`
   background-image: ${(props) => `url(${props.backgroundImage})`};
   filter: blur(62px);
   opacity: ${({ theme }) => (theme.darkMode ? 0.3 : 0.2)};
-  transform: scale(1.1);
+  transform: scaleY(1.1);
 `
 
 const PlainBackground = styled(AbsoluteFill)`


### PR DESCRIPTION
Fixes a regression from #5267, better to apply `scaleY` instead to avoid overflow issues on certain browsers such as Firefox.