### PR TITLE
fix: tx screen overflow

### DIFF
--- a/src/nft/components/collection/TransactionCompleteModal.css.ts
+++ b/src/nft/components/collection/TransactionCompleteModal.css.ts
@@ -11,14 +11,18 @@ export const modalContainer = style([
     left: { sm: '0', md: '1/2' },
     top: '0',
     zIndex: 'modal',
+    overflow: 'scroll',
+    paddingY: '72',
   }),
   {
-    alignContent: 'center',
+    justifyContent: 'center',
     '@media': {
       'screen and (min-width: 656px)': {
         marginLeft: '-320px',
       },
     },
+    '::-webkit-scrollbar': { display: 'none' },
+    scrollbarWidth: 'none',
   },
 ])
 

--- a/src/nft/components/collection/TransactionCompleteModal.tsx
+++ b/src/nft/components/collection/TransactionCompleteModal.tsx
@@ -137,7 +137,7 @@ const TxCompleteModal = () => {
                       </Box>
                       <Box>{formatEthPrice(totalPurchaseValue.toString())} ETH</Box>
                     </Row>
-                    <a href={txHashUrl} target="_blank" rel="noreferrer">
+                    <a href={txHashUrl} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
                       <Box color="textPrimary" fontWeight="normal">
                         {shortenTxHash(txHash, 2, 2)}
                       </Box>
@@ -202,7 +202,7 @@ const TxCompleteModal = () => {
                           marginRight={{ sm: '40', md: '24' }}
                           width={{ sm: 'half', md: 'auto' }}
                         >
-                          <a href={txHashUrl} target="_blank" rel="noreferrer">
+                          <a href={txHashUrl} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
                             <Box fontWeight="normal" marginTop="16" className={styles.totalEthCost}>
                               {shortenTxHash(txHash, 2, 2)}
                             </Box>


### PR DESCRIPTION
Allows for overflow of tx complete screens. Also removes underline on tx hash urls. There are designs for full screen tx complete pages to replace these so I purposefully didn't convert them to styled components as it would all be throwaway work.