### PR TITLE
fix: theme color hex typo

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,5 +26,5 @@
   "iconPath": "./images/256x256_App_Icon_Pink.svg",
   "short_name": "Uniswap",
   "start_url": ".",
-  "theme_color": "#FC72FFs"
+  "theme_color": "#FC72FF"
 }


### PR DESCRIPTION
<img width="609" alt="Screen Shot 2022-11-17 at 6 27 12 PM" src="https://user-images.githubusercontent.com/109188881/202581779-90b6b99e-857d-4f4a-bc0d-4105d647d770.png">

Kept seeing the above warning. We intended it to be `FC72FF`.