### PR TITLE
fix: Can't scroll behind bag

### DIFF
--- a/src/nft/components/profile/view/FilterSidebar.tsx
+++ b/src/nft/components/profile/view/FilterSidebar.tsx
@@ -11,6 +11,7 @@ import { WalletCollection } from 'nft/types'
 import { Dispatch, FormEvent, SetStateAction, useCallback, useEffect, useReducer, useState } from 'react'
 import { easings, useSpring } from 'react-spring'
 import styled from 'styled-components/macro'
+import { TRANSITION_DURATIONS } from 'theme/styles'
 
 import * as styles from './ProfilePage.css'
 
@@ -31,7 +32,7 @@ export const FilterSidebar = () => {
   const { sidebarX } = useSpring({
     sidebarX: isFiltersExpanded ? 0 : -360,
     config: {
-      duration: 250,
+      duration: TRANSITION_DURATIONS.medium,
       easing: easings.easeOutSine,
     },
   })

--- a/src/nft/components/profile/view/FilterSidebar.tsx
+++ b/src/nft/components/profile/view/FilterSidebar.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from 'nft/components/layout/Checkbox'
 import { Input } from 'nft/components/layout/Input'
 import { subhead } from 'nft/css/common.css'
 import { themeVars } from 'nft/css/sprinkles.css'
-import { useFiltersExpanded, useIsMobile, useWalletCollections } from 'nft/hooks'
+import { useBag, useFiltersExpanded, useIsMobile, useWalletCollections } from 'nft/hooks'
 import { WalletCollection } from 'nft/types'
 import { Dispatch, FormEvent, SetStateAction, useCallback, useEffect, useReducer, useState } from 'react'
 import { easings, useSpring } from 'react-spring'
@@ -22,7 +22,7 @@ const ItemsContainer = styled.div`
 export const FilterSidebar = () => {
   const collectionFilters = useWalletCollections((state) => state.collectionFilters)
   const setCollectionFilters = useWalletCollections((state) => state.setCollectionFilters)
-
+  const isBagExpanded = useBag((state) => state.bagExpanded)
   const walletCollections = useWalletCollections((state) => state.walletCollections)
 
   const [isFiltersExpanded, setFiltersExpanded] = useFiltersExpanded()
@@ -44,7 +44,7 @@ export const FilterSidebar = () => {
       width={{ sm: 'full', md: '332', lg: '332' }}
       height={{ sm: 'full', md: 'auto' }}
       zIndex={{ sm: '3', md: 'auto' }}
-      display={isFiltersExpanded ? 'flex' : 'none'}
+      display={isFiltersExpanded || isBagExpanded ? 'flex' : 'none'}
       style={{ transform: sidebarX.to((x) => `translateX(${x}px)`) }}
     >
       <Box

--- a/src/nft/components/profile/view/FilterSidebar.tsx
+++ b/src/nft/components/profile/view/FilterSidebar.tsx
@@ -9,7 +9,7 @@ import { themeVars } from 'nft/css/sprinkles.css'
 import { useFiltersExpanded, useIsMobile, useWalletCollections } from 'nft/hooks'
 import { WalletCollection } from 'nft/types'
 import { Dispatch, FormEvent, SetStateAction, useCallback, useEffect, useReducer, useState } from 'react'
-import { useSpring } from 'react-spring'
+import { easings, useSpring } from 'react-spring'
 import styled from 'styled-components/macro'
 
 import * as styles from './ProfilePage.css'
@@ -30,6 +30,10 @@ export const FilterSidebar = () => {
 
   const { sidebarX } = useSpring({
     sidebarX: isFiltersExpanded ? 0 : -360,
+    config: {
+      duration: 250,
+      easing: easings.easeOutSine,
+    },
   })
   return (
     // @ts-ignore

--- a/src/nft/components/profile/view/FilterSidebar.tsx
+++ b/src/nft/components/profile/view/FilterSidebar.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from 'nft/components/layout/Checkbox'
 import { Input } from 'nft/components/layout/Input'
 import { subhead } from 'nft/css/common.css'
 import { themeVars } from 'nft/css/sprinkles.css'
-import { useBag, useFiltersExpanded, useIsMobile, useWalletCollections } from 'nft/hooks'
+import { useFiltersExpanded, useIsMobile, useWalletCollections } from 'nft/hooks'
 import { WalletCollection } from 'nft/types'
 import { Dispatch, FormEvent, SetStateAction, useCallback, useEffect, useReducer, useState } from 'react'
 import { easings, useSpring } from 'react-spring'
@@ -23,7 +23,6 @@ const ItemsContainer = styled.div`
 export const FilterSidebar = () => {
   const collectionFilters = useWalletCollections((state) => state.collectionFilters)
   const setCollectionFilters = useWalletCollections((state) => state.setCollectionFilters)
-  const isBagExpanded = useBag((state) => state.bagExpanded)
   const walletCollections = useWalletCollections((state) => state.walletCollections)
 
   const [isFiltersExpanded, setFiltersExpanded] = useFiltersExpanded()
@@ -45,7 +44,7 @@ export const FilterSidebar = () => {
       width={{ sm: 'full', md: '332', lg: '332' }}
       height={{ sm: 'full', md: 'auto' }}
       zIndex={{ sm: '3', md: 'auto' }}
-      display={isFiltersExpanded || isBagExpanded ? 'flex' : 'none'}
+      display={isFiltersExpanded ? 'flex' : 'none'}
       style={{ transform: sidebarX.to((x) => `translateX(${x}px)`) }}
     >
       <Box

--- a/src/nft/components/profile/view/ProfilePage.tsx
+++ b/src/nft/components/profile/view/ProfilePage.tsx
@@ -21,7 +21,7 @@ import { WalletCollection } from 'nft/types'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import { useQuery } from 'react-query'
-import { useSpring } from 'react-spring'
+import { easings, useSpring } from 'react-spring'
 import styled from 'styled-components/macro'
 import shallow from 'zustand/shallow'
 
@@ -91,6 +91,10 @@ export const ProfilePage = () => {
 
   const { gridX } = useSpring({
     gridX: isFiltersExpanded ? FILTER_SIDEBAR_WIDTH : -PADDING,
+    config: {
+      duration: 250,
+      easing: easings.easeOutSine,
+    },
   })
 
   return (

--- a/src/nft/components/profile/view/ProfilePage.tsx
+++ b/src/nft/components/profile/view/ProfilePage.tsx
@@ -66,6 +66,7 @@ export const ProfilePage = () => {
     shallow
   )
   const sellAssets = useSellAsset((state) => state.sellAssets)
+  const isBagExpanded = useBag((state) => state.bagExpanded)
   const toggleBag = useBag((state) => state.toggleBag)
   const [isFiltersExpanded, setFiltersExpanded] = useFiltersExpanded()
   const isMobile = useIsMobile()
@@ -111,6 +112,7 @@ export const ProfilePage = () => {
               <Column width="full">
                 <AnimatedBox
                   flexShrink="0"
+                  position={isMobile && (isFiltersExpanded || isBagExpanded) ? 'fixed' : 'static'}
                   style={{
                     transform: gridX.to(
                       (x) =>

--- a/src/nft/components/profile/view/ProfilePage.tsx
+++ b/src/nft/components/profile/view/ProfilePage.tsx
@@ -112,7 +112,7 @@ export const ProfilePage = () => {
               <Column width="full">
                 <AnimatedBox
                   flexShrink="0"
-                  position={isMobile && (isFiltersExpanded || isBagExpanded) ? 'fixed' : 'static'}
+                  position={isMobile && isBagExpanded ? 'fixed' : 'static'}
                   style={{
                     transform: gridX.to(
                       (x) =>

--- a/src/nft/pages/collection/index.tsx
+++ b/src/nft/pages/collection/index.tsx
@@ -24,6 +24,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { easings, useSpring } from 'react-spring'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
+import { TRANSITION_DURATIONS } from 'theme/styles'
 
 const FILTER_WIDTH = 332
 const BAG_WIDTH = 324
@@ -94,7 +95,7 @@ const Collection = () => {
   const collectionStats = useCollectionQuery(contractAddress as string)
 
   const { gridX, gridWidthOffset } = useSpring({
-    gridX: (isFiltersExpanded || isBagExpanded) && !isMobile ? FILTER_WIDTH : 0,
+    gridX: isFiltersExpanded && !isMobile ? FILTER_WIDTH : 0,
     gridWidthOffset:
       isFiltersExpanded && !isMobile
         ? isBagExpanded
@@ -104,7 +105,7 @@ const Collection = () => {
         ? BAG_WIDTH
         : 0,
     config: {
-      duration: 250,
+      duration: TRANSITION_DURATIONS.medium,
       easing: easings.easeOutSine,
     },
   })

--- a/src/nft/pages/collection/index.tsx
+++ b/src/nft/pages/collection/index.tsx
@@ -94,13 +94,13 @@ const Collection = () => {
   const collectionStats = useCollectionQuery(contractAddress as string)
 
   const { gridX, gridWidthOffset } = useSpring({
-    gridX: isFiltersExpanded && !isMobile ? FILTER_WIDTH : 0,
+    gridX: (isFiltersExpanded || isBagExpanded) && !isMobile ? FILTER_WIDTH : 0,
     gridWidthOffset:
       isFiltersExpanded && !isMobile
         ? isBagExpanded
           ? BAG_WIDTH + FILTER_WIDTH
           : FILTER_WIDTH
-        : isBagExpanded
+        : isBagExpanded && !isMobile
         ? BAG_WIDTH
         : 0,
     config: {
@@ -188,7 +188,7 @@ const Collection = () => {
 
                 {/* @ts-ignore: https://github.com/microsoft/TypeScript/issues/34933 */}
                 <AnimatedBox
-                  position={isMobile && isFiltersExpanded ? 'fixed' : 'static'}
+                  position={isMobile && (isFiltersExpanded || isBagExpanded) ? 'fixed' : 'static'}
                   style={{
                     transform: gridX.to((x) => `translate(${x as number}px)`),
                     width: gridWidthOffset.to((x) => `calc(100% - ${x as number}px)`),

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -10,11 +10,17 @@ export const flexRowNoWrap = css`
   flex-flow: row nowrap;
 `
 
+export enum TRANSITION_DURATIONS {
+  slow = 500,
+  medium = 250,
+  fast = 125,
+}
+
 const transitions = {
   duration: {
-    slow: '500ms',
-    medium: '250ms',
-    fast: '125ms',
+    slow: `${TRANSITION_DURATIONS.slow}ms`,
+    medium: `${TRANSITION_DURATIONS.medium}ms`,
+    fast: `${TRANSITION_DURATIONS.fast}ms`,
   },
   timing: {
     ease: 'ease',


### PR DESCRIPTION
- Fixes the bug on collection and profile page where you could scroll assets underneath
- Stops the cards from moving around underneath the bag causing them to snap in place when the bag was closed
- Fixes the laggy animation when filters were opened/closed on profile