### PR TITLE
feat: add floor change on mobile

### DIFF
--- a/src/nft/components/explore/Cells/Cells.tsx
+++ b/src/nft/components/explore/Cells/Cells.tsx
@@ -108,12 +108,10 @@ export const EthCell = ({
   value,
   denomination,
   usdPrice,
-  className,
 }: {
   value?: number
   denomination: Denomination
   usdPrice?: number
-  className?: string
 }) => {
   const denominatedValue = getDenominatedValue(denomination, true, value, usdPrice)
   const formattedValue = denominatedValue
@@ -127,7 +125,7 @@ export const EthCell = ({
 
   return (
     <EthContainer>
-      <TextComponent className={className}>{value ? formattedValue : '-'}</TextComponent>
+      <TextComponent>{value ? formattedValue : '-'}</TextComponent>
     </EthContainer>
   )
 }
@@ -158,15 +156,7 @@ export const VolumeCell = ({
   )
 }
 
-export const ChangeCell = ({
-  change,
-  children,
-  className,
-}: {
-  children?: ReactNode
-  change?: number
-  className?: string
-}) => {
+export const ChangeCell = ({ change, children }: { children?: ReactNode; change?: number }) => {
   const isMobile = useIsMobile()
   const TextComponent = isMobile ? ThemedText.Caption : ThemedText.BodyPrimary
   return (
@@ -176,9 +166,7 @@ export const ChangeCell = ({
       ) : (
         <SquareArrowDownIcon width="20px" height="20px" />
       )}
-      <TextComponent className={className} color="currentColor">
-        {children || `${change ? Math.abs(Math.round(change)) : 0}%`}
-      </TextComponent>
+      <TextComponent color="currentColor">{children || `${change ? Math.abs(Math.round(change)) : 0}%`}</TextComponent>
     </ChangeCellContainer>
   )
 }

--- a/src/nft/components/explore/Cells/Cells.tsx
+++ b/src/nft/components/explore/Cells/Cells.tsx
@@ -108,10 +108,12 @@ export const EthCell = ({
   value,
   denomination,
   usdPrice,
+  className,
 }: {
   value?: number
   denomination: Denomination
   usdPrice?: number
+  className?: string
 }) => {
   const denominatedValue = getDenominatedValue(denomination, true, value, usdPrice)
   const formattedValue = denominatedValue
@@ -120,9 +122,12 @@ export const EthCell = ({
       : ethNumberStandardFormatter(denominatedValue, true, false, true)
     : '-'
 
+  const isMobile = useIsMobile()
+  const TextComponent = isMobile ? ThemedText.BodySmall : ThemedText.BodyPrimary
+
   return (
     <EthContainer>
-      <ThemedText.BodyPrimary>{value ? formattedValue : '-'}</ThemedText.BodyPrimary>
+      <TextComponent className={className}>{value ? formattedValue : '-'}</TextComponent>
     </EthContainer>
   )
 }
@@ -153,15 +158,27 @@ export const VolumeCell = ({
   )
 }
 
-export const ChangeCell = ({ change, children }: { children?: ReactNode; change?: number }) => (
-  <ChangeCellContainer change={change ?? 0}>
-    {!change || change > 0 ? (
-      <SquareArrowUpIcon width="20px" height="20px" />
-    ) : (
-      <SquareArrowDownIcon width="20px" height="20px" />
-    )}
-    <ThemedText.BodyPrimary color="currentColor">
-      {children || `${change ? Math.abs(Math.round(change)) : 0}%`}
-    </ThemedText.BodyPrimary>
-  </ChangeCellContainer>
-)
+export const ChangeCell = ({
+  change,
+  children,
+  className,
+}: {
+  children?: ReactNode
+  change?: number
+  className?: string
+}) => {
+  const isMobile = useIsMobile()
+  const TextComponent = isMobile ? ThemedText.Caption : ThemedText.BodyPrimary
+  return (
+    <ChangeCellContainer change={change ?? 0}>
+      {!change || change > 0 ? (
+        <SquareArrowUpIcon width="20px" height="20px" />
+      ) : (
+        <SquareArrowDownIcon width="20px" height="20px" />
+      )}
+      <TextComponent className={className} color="currentColor">
+        {children || `${change ? Math.abs(Math.round(change)) : 0}%`}
+      </TextComponent>
+    </ChangeCellContainer>
+  )
+}

--- a/src/nft/components/explore/CollectionTable.tsx
+++ b/src/nft/components/explore/CollectionTable.tsx
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { CollectionTableColumn, TimePeriod } from 'nft/types'
 import { useMemo } from 'react'
 import { CellProps, Column, Row } from 'react-table'
+import { MediumOnly } from 'theme/components'
 
 import { ChangeCell, CollectionTitleCell, DiscreteNumberCell, EthCell, TextCell, VolumeCell } from './Cells/Cells'
 import { Table } from './Table'
@@ -65,11 +66,18 @@ const CollectionTable = ({ data, timePeriod }: { data: CollectionTableColumn[]; 
         sortType: floorSort,
         Cell: function ethCell(cell: CellProps<CollectionTableColumn>) {
           return (
-            <EthCell
-              value={cell.row.original.floor.value}
-              denomination={cell.row.original.denomination}
-              usdPrice={cell.row.original.usdPrice}
-            />
+            <>
+              <EthCell
+                value={cell.row.original.floor.value}
+                denomination={cell.row.original.denomination}
+                usdPrice={cell.row.original.usdPrice}
+              />
+              {timePeriod !== TimePeriod.AllTime && (
+                <MediumOnly>
+                  <ChangeCell change={cell.row.original.floor.change} />
+                </MediumOnly>
+              )}
+            </>
           )
         },
       },

--- a/src/nft/components/explore/Table.tsx
+++ b/src/nft/components/explore/Table.tsx
@@ -125,11 +125,11 @@ export function Table<D extends Record<string, unknown>>({
   useEffect(() => {
     if (!width) return
 
-    if (width < theme.breakpoint.sm) {
+    if (width <= theme.breakpoint.sm) {
       setHiddenColumns(smallHiddenColumns)
-    } else if (width < theme.breakpoint.md) {
+    } else if (width <= theme.breakpoint.md) {
       setHiddenColumns(mediumHiddenColumns)
-    } else if (width < theme.breakpoint.lg) {
+    } else if (width <= theme.breakpoint.lg) {
       setHiddenColumns(largeHiddenColumns)
     } else {
       setHiddenColumns([])

--- a/src/theme/components/index.tsx
+++ b/src/theme/components/index.tsx
@@ -465,6 +465,13 @@ export const SmallOnly = styled.span`
   `};
 `
 
+export const MediumOnly = styled.span`
+  display: none;
+  @media (max-width: ${({ theme }) => theme.breakpoint.md}px) {
+    display: block;
+  }
+`
+
 export const Separator = styled.div`
   width: 100%;
   height: 1px;

--- a/src/theme/components/text.tsx
+++ b/src/theme/components/text.tsx
@@ -14,11 +14,18 @@ type TextProps = Omit<TextPropsOriginal, 'css'>
 // todo: export each component individually
 
 export const ThemedText = {
+  // todo: there should be just one `Body` with default color, no need to make all variations
   BodyPrimary(props: TextProps) {
     return <TextWrapper fontWeight={400} fontSize={16} color="textPrimary" {...props} />
   },
   BodySecondary(props: TextProps) {
     return <TextWrapper fontWeight={400} fontSize={16} color="textSecondary" {...props} />
+  },
+  BodySmall(props: TextProps) {
+    return <TextWrapper fontWeight={400} fontSize={14} color="textPrimary" {...props} />
+  },
+  Caption(props: TextProps) {
+    return <TextWrapper fontWeight={400} fontSize={12} color="textPrimary" {...props} />
   },
   HeadlineSmall(props: TextProps) {
     return <TextWrapper fontWeight={600} fontSize={20} lineHeight="28px" color="textPrimary" {...props} />


### PR DESCRIPTION
Fixes WEB-1978

Other changes:
- Breakpoints in CSS are inclusive, so changed `<` to `<=` so that the Table behavior for hiding columns matches the one from CSS
- Added two Text variants that I've found in Figma (used on this screen), it would be good to increase that usage in the future

I'm not sure whether we should stick to CSS media queries for displaying/hiding elements or use React to do it, but I think we will have to decide on the best path to handle it. For example, while we're currently rendering `BodyPrimary` vs `BodySmall` based on `isMobile`, we could've just made a single `BodyPrimary` component with an appropriate media query for small devices.

I haven't implemented that change in this PR, as it would most likely affect the entire website, but I think it's something to think about going forward.

Either way, I think it's best to stick to existing Medium/Small only components, we may eventually change their implementation to use `isMobile` (or other React features), but this will happen behind the scenes.