### PR TITLE
fix: Issue where decimal appears as 0 on listings page.

### DIFF
--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -184,6 +184,9 @@ const PriceTextInput = ({
           ref={inputRef}
           onChange={(v: FormEvent<HTMLInputElement>) => {
             const val = parseFloat(v.currentTarget.value)
+            if (!listPrice && val === 0) {
+              return
+            }
             setListPrice(isNaN(val) ? undefined : val)
           }}
         />

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -183,10 +183,10 @@ const PriceTextInput = ({
           }}
           ref={inputRef}
           onChange={(v: FormEvent<HTMLInputElement>) => {
-            const val = parseFloat(v.currentTarget.value)
-            if (!listPrice && val === 0) {
+            if (!listPrice && v.currentTarget.value === '0.') {
               return
             }
+            const val = parseFloat(v.currentTarget.value)
             setListPrice(isNaN(val) ? undefined : val)
           }}
         />


### PR DESCRIPTION
Fixes WEB-2362: Bug: Period (.) ignored by price input field on the listing page.

Fixed it by leaving all string equivalents of `0` (like '0.") as is if price is undefined. Feels a tiny bit hacky, but couldn't think of a better solution that leaves a small footprint.
