### PR TITLE
feat: approve collections 1x1

### DIFF
--- a/src/nft/components/bag/profile/ListingModal.tsx
+++ b/src/nft/components/bag/profile/ListingModal.tsx
@@ -102,14 +102,14 @@ const ListingModal = () => {
     // for all unqiue collection, marketplace combos -> approve collections
     for (const collectionRow of collectionsRequiringApproval) {
       verifyStatus(collectionRow.status) &&
-        approveCollectionRow(
+        (await approveCollectionRow(
           collectionRow,
           collectionsRequiringApproval,
           setCollectionsRequiringApproval,
           signer,
           looksRareAddress,
           pauseAllRows
-        )
+        ))
     }
   }
 


### PR DESCRIPTION
Previously we let you approve all collections all at once, this work on desktop but isn't possible on mobile as you can't queue up the requests. Now all collections must be approved one by one (unless already approved)