### PR TITLE
feat: multiline ellipsis when text is too large

### DIFF
--- a/src/nft/components/explore/CarouselCard.tsx
+++ b/src/nft/components/explore/CarouselCard.tsx
@@ -81,16 +81,15 @@ const CardHeaderColumn = styled.div`
   align-items: center;
   flex-direction: column;
   gap: 8px;
-  padding: 40px;
+  height: 202px;
+  justify-content: center;
+  padding: 0 40px;
   z-index: 1;
 `
 
 const CardNameRow = styled.div`
   display: flex;
   gap: 2px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 `
 const IconContainer = styled.div`
   display: flex;
@@ -99,10 +98,13 @@ const IconContainer = styled.div`
 `
 
 const CollectionNameContainer = styled.div`
-  display: flex;
+  display: -webkit-box;
   overflow: hidden;
-  white-space: nowrap;
   text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  text-align: center;
+  max-height: 56px;
 `
 
 const LoadingCollectionNameContainer = styled(LoadingBubble)`
@@ -291,8 +293,13 @@ const CarouselCardHeader = ({ collection }: { collection: TrendingCollection }) 
         <CollectionImage src={collection.imageUrl} />
         <CardNameRow>
           <CollectionNameContainer>
-            <ThemedText.MediumHeader color={theme.accentTextLightPrimary} fontWeight="500" lineHeight="28px">
-              {collection.name}
+            <ThemedText.MediumHeader
+              color={theme.accentTextLightPrimary}
+              fontWeight="500"
+              lineHeight="28px"
+              display="inline"
+            >
+              {collection.name.repeat(2)}
             </ThemedText.MediumHeader>
           </CollectionNameContainer>
           {collection.isVerified && (

--- a/src/nft/components/explore/CarouselCard.tsx
+++ b/src/nft/components/explore/CarouselCard.tsx
@@ -299,7 +299,7 @@ const CarouselCardHeader = ({ collection }: { collection: TrendingCollection }) 
               lineHeight="28px"
               display="inline"
             >
-              {collection.name.repeat(2)}
+              {collection.name}
             </ThemedText.MediumHeader>
           </CollectionNameContainer>
           {collection.isVerified && (


### PR DESCRIPTION
Fixes WEB-2376

When collection name is too large, we want to split it into two lines and eventually, truncate when the name is too long. We also want to center things vertically while keeping the overall header height. 

This is done with a `line-ellipsis` CSS feature that has relatively good support across the landscape, despite being under a prefix (Edge & Firefox support it under this prefix too). In case this is not supported, I added a maximum height for the title component that corresponds to two lines and added an `overflow: hidden`. This will hide overflowing text without putting an ellipsis, but I think it's a fair trade-off give how easy this is to support with pure CSS.

Since this is hard to reproduce without manually repeating the collection name programatically, I left some comments on Slack showing the behaviour: https://uniswapteam.slack.com/archives/C04AYQQLVQU/p1669054341919679?thread_ts=1668816740.434209&cid=C04AYQQLVQU