### PR TITLE
chore: various responsive tweaks to carousel

### DIFF
--- a/src/nft/components/explore/Carousel.tsx
+++ b/src/nft/components/explore/Carousel.tsx
@@ -84,7 +84,7 @@ export const Carousel = ({ children, activeIndex, toggleNextSlide }: CarouselPro
         return {
           x: (-y % (MAX_CARD_WIDTH * children.length)) + MAX_CARD_WIDTH * rank,
           immediate: vy < 0 ? prevPosition > position : prevPosition < position,
-          config: { tension: 250, friction: 35 },
+          config: { tension: 250, friction: 30 },
         }
       })
       prev.current = [firstVis, firstVisIdx]

--- a/src/nft/components/explore/Carousel.tsx
+++ b/src/nft/components/explore/Carousel.tsx
@@ -38,7 +38,7 @@ const CarouselItemCard = styled(a.div)`
 
 const CarouselItemIcon = styled.div`
   align-items: center;
-  color: ${({ theme }) => theme.accentAction};
+  color: ${({ theme }) => theme.textPrimary};
   cursor: pointer;
   display: none;
   user-select: none;

--- a/src/nft/components/explore/CarouselCard.tsx
+++ b/src/nft/components/explore/CarouselCard.tsx
@@ -76,17 +76,11 @@ const CardHeaderColumn = styled.div`
   padding: 0 40px;
   z-index: 1;
 `
-
-const CardNameRow = styled.div`
-  display: flex;
-  gap: 2px;
-`
 const IconContainer = styled.div`
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
+  display: inline;
+  vertical-align: text-bottom;
+  margin-left: 2px;
 `
-
 const CollectionNameContainer = styled.div`
   display: -webkit-box;
   overflow: hidden;
@@ -183,6 +177,9 @@ const CarouselCardContainer = styled.div`
     }
     ${TableElement} {
       justify-self: left !important;
+    }
+    ${CardHeaderColumn} {
+      padding: 0 20px;
     }
   }
 `
@@ -292,29 +289,28 @@ export const LoadingTable = () => {
   )
 }
 
+const CollectionName = styled(ThemedText.MediumHeader)`
+  display: inline;
+  vertical-align: text-bottom;
+  line-height: 28px;
+`
+
 const CarouselCardHeader = ({ collection }: { collection: TrendingCollection }) => {
   const theme = useTheme()
   return (
     <CardHeaderContainer src={collection.bannerImageUrl}>
       <CardHeaderColumn>
         <CollectionImage src={collection.imageUrl} />
-        <CardNameRow>
-          <CollectionNameContainer>
-            <ThemedText.MediumHeader
-              color={theme.accentTextLightPrimary}
-              fontWeight="500"
-              lineHeight="28px"
-              display="inline"
-            >
-              {collection.name}
-            </ThemedText.MediumHeader>
-          </CollectionNameContainer>
+        <CollectionNameContainer>
+          <CollectionName color={theme.accentTextLightPrimary} fontWeight="500">
+            {collection.name}
+          </CollectionName>
           {collection.isVerified && (
             <IconContainer>
               <VerifiedIcon width="24px" height="24px" />
             </IconContainer>
           )}
-        </CardNameRow>
+        </CollectionNameContainer>
       </CardHeaderColumn>
       <HeaderOverlay />
     </CardHeaderContainer>

--- a/src/nft/components/explore/CarouselCard.tsx
+++ b/src/nft/components/explore/CarouselCard.tsx
@@ -8,16 +8,6 @@ import { formatWeiToDecimal } from 'nft/utils'
 import styled, { useTheme } from 'styled-components/macro'
 import { ThemedText } from 'theme/components/text'
 
-const CarouselCardContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  background-color: ${({ theme }) => theme.backgroundSurface};
-  border: 1px solid ${({ theme }) => theme.backgroundOutline};
-  border-radius: 20px;
-  overflow: hidden;
-  height: 100%;
-`
-
 const CarouselCardBorder = styled.div`
   width: 100%;
   position: relative;
@@ -155,12 +145,7 @@ const TableElement = styled.div`
   gap: 6px;
 `
 
-const FirstColumnTextWrapper = styled.div`
-  @media (min-width: ${({ theme }) => theme.breakpoint.sm}px) and (max-width: ${({ theme }) => theme.breakpoint.lg}px) {
-    display: none;
-  }
-}
-`
+const FirstColumnTextWrapper = styled.div``
 
 const CardBottomContainer = styled.div`
   display: grid;
@@ -168,6 +153,21 @@ const CardBottomContainer = styled.div`
   gap: 8px;
   grid-template-columns: auto auto auto;
   padding: 16px 16px 20px;
+`
+
+const MarketplaceIcon = styled.img`
+  width: 20px;
+  height: 20px;
+`
+
+const CarouselCardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.backgroundSurface};
+  border: 1px solid ${({ theme }) => theme.backgroundOutline};
+  border-radius: 20px;
+  overflow: hidden;
+  height: 100%;
 
   ${TableElement}:nth-child(3n-1), ${LoadingTableElement}:nth-child(3n-1) {
     justify-self: center;
@@ -176,11 +176,15 @@ const CardBottomContainer = styled.div`
   ${TableElement}:nth-child(3n), ${LoadingTableElement}:nth-child(3n) {
     justify-self: right;
   }
-`
 
-const MarketplaceIcon = styled.img`
-  width: 20px;
-  height: 20px;
+  @media (max-width: 396px) or ((min-width: ${({ theme }) => theme.breakpoint.sm}px) and (max-width: 880px)) {
+    ${FirstColumnTextWrapper} {
+      display: none;
+    }
+    ${TableElement} {
+      justify-self: left !important;
+    }
+  }
 `
 
 interface MarketplaceRowProps {


### PR DESCRIPTION
Fixes WEB-2399

Fixes:
- display badge next to collection title when collection name is broken down into two lines
- text-align columns to the left (as well as hide marketplace name) when the banner width is more or less under 400px*
- slightly faster animation on carousel (follow-up from previous PR)
- smaller paddings on mobile for banner to fit more text (follow-up from previous PR)
- updated arrow colours to black/white on light/dark mode

The reason I said `more or less`:

Initially, our intention was to use CSS container queries to write a rule in a similar fashion to media queries, but relative to container width. This would let us automatically hide/show certain UI elements based on the parent dimensions.

Here's an example:

```
@supports (container-type: inline-size) {
  @container (max-width: 396px) {
    .tableElement { flex-align: left; }
  }
}

@supports not (container-type: inline-size) {
 /* backwards compatible workaround - currently implemented in this PR */
}
```

Unfortunately, it turns out this is not supported in Styled Components. The parser doesn't support `@container` queries as of 5.x version. This was just added to the parser and is being shipped with Styled Components `6.0.0-beta.4`. It might be possible to use it in the future, as soon as the final release is out and we do the upgrade!

For now, I decided to workaround it with media queries. While the upper breakpoint of 880px is what I came up with during testing to be most good looking, I am not particularly fixed on that number.

 I am pasting a reference video / pictures for this and other tweaks mentioned in this PR in a Slack thread. Feel free to check them out!