### PR TITLE
fix: throw on missing env var url

### DIFF
--- a/src/graphql/data/fetchGraphQL.ts
+++ b/src/graphql/data/fetchGraphQL.ts
@@ -2,17 +2,13 @@ import { Variables } from 'react-relay'
 import { GraphQLResponse, RequestParameters } from 'relay-runtime'
 
 const TOKEN_URL = process.env.REACT_APP_AWS_API_ENDPOINT
-const NFT_URL = process.env.REACT_APP_NFT_AWS_API_ENDPOINT ?? ''
+const NFT_URL = process.env.REACT_APP_NFT_AWS_API_ENDPOINT
+if (!TOKEN_URL) throw new Error('Token URL missing from environment')
 
-if (!TOKEN_URL) {
-  throw new Error('AWS URL MISSING FROM ENVIRONMENT')
-}
-
-const baseHeaders = {
-  'Content-Type': 'application/json',
-}
+const baseHeaders = { 'Content-Type': 'application/json' }
+const tokenHeaders = { ...baseHeaders }
 const nftHeaders = {
-  'Content-Type': 'application/json',
+  ...baseHeaders,
   'from-x-api-key': process.env.REACT_APP_NFT_FROM_AWS_X_API_KEY ?? '',
   'x-api-key': process.env.REACT_APP_NFT_AWS_X_API_KEY ?? '',
 }
@@ -29,16 +25,25 @@ const NFT_QUERIES = [
   'NftBalancePaginationQuery',
 ]
 
+const fetchToken = (body: string): Promise<Response> => {
+  return fetch(TOKEN_URL, { method: 'POST', body, headers: tokenHeaders })
+}
+
+const fetchNFT = (body: string): Promise<Response> => {
+  if (!NFT_URL) {
+    throw new Error('NFT URL missing from environment')
+  }
+  return fetch(NFT_URL, { method: 'POST', body, headers: nftHeaders })
+}
+
 const fetchQuery = (params: RequestParameters, variables: Variables): Promise<GraphQLResponse> => {
-  const isNFT = NFT_QUERIES.includes(params.name)
   const body = JSON.stringify({
     query: params.text, // GraphQL text from input
     variables,
   })
-  const url = isNFT ? NFT_URL : TOKEN_URL
-  const headers = isNFT ? nftHeaders : baseHeaders
-
-  return fetch(url, { method: 'POST', body, headers })
+  const isNFT = NFT_QUERIES.includes(params.name)
+  const response = isNFT ? fetchNFT(body) : fetchToken(body)
+  return response
     .then((res) => res.json())
     .catch((e) => {
       console.error(e)

--- a/src/nft/queries/genie/ActivityFetcher.ts
+++ b/src/nft/queries/genie/ActivityFetcher.ts
@@ -1,4 +1,5 @@
 import { ActivityEventResponse, ActivityFilter } from '../../types'
+import { getNftUrl } from '../url'
 
 export const ActivityFetcher = async (
   contractAddress: string,
@@ -13,9 +14,9 @@ export const ActivityFetcher = async (
 
   const tokenId = filters?.token_id ? `&token_id=${filters?.token_id}` : ''
 
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/collections/${contractAddress}/activity?limit=${
-    limit ? limit : '25'
-  }${filterParam}${cursor ? `&cursor=${cursor}` : ''}${tokenId}`
+  const url = `${getNftUrl()}}/collections/${contractAddress}/activity?limit=${limit ? limit : '25'}${filterParam}${
+    cursor ? `&cursor=${cursor}` : ''
+  }${tokenId}`
 
   const r = await fetch(url, {
     method: 'GET',

--- a/src/nft/queries/genie/CollectionPreviewFetcher.ts
+++ b/src/nft/queries/genie/CollectionPreviewFetcher.ts
@@ -1,3 +1,5 @@
+import { getNftUrl } from '../url'
+
 export const CollectionPreviewFetcher = async (
   address: string
 ): Promise<
@@ -8,7 +10,7 @@ export const CollectionPreviewFetcher = async (
     }
   ]
 > => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/collectionPreview?address=${address}`
+  const url = `${getNftUrl()}/collectionPreview?address=${address}`
 
   const controller = new AbortController()
 

--- a/src/nft/queries/genie/RouteFetcher.ts
+++ b/src/nft/queries/genie/RouteFetcher.ts
@@ -1,4 +1,5 @@
 import { GenieAsset, RouteResponse, TokenType } from '../../types'
+import { getNftUrl } from '../url'
 
 export const fetchRoute = async ({
   toSell,
@@ -9,7 +10,7 @@ export const fetchRoute = async ({
   toBuy: any
   senderAddress: string
 }): Promise<RouteResponse> => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/route`
+  const url = `${getNftUrl()}/route`
   const payload = {
     sell: [...toSell].map((x) => buildRouteItem(x)),
     buy: [...toBuy].filter((x) => x.tokenType !== 'Dust').map((x) => buildRouteItem(x)),

--- a/src/nft/queries/genie/SearchCollectionsFetcher.ts
+++ b/src/nft/queries/genie/SearchCollectionsFetcher.ts
@@ -1,11 +1,12 @@
 import { isAddress } from '@ethersproject/address'
 
 import { GenieCollection } from '../../types'
+import { getNftUrl } from '../url'
 
 const MAX_SEARCH_RESULTS = 6
 
 export const fetchSearchCollections = async (addressOrName: string, recursive = false): Promise<GenieCollection[]> => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/searchCollections`
+  const url = `${getNftUrl()}/searchCollections`
   const isName = !isAddress(addressOrName.toLowerCase())
 
   if (!isName && !recursive) {

--- a/src/nft/queries/genie/SearchTokensFetcher.ts
+++ b/src/nft/queries/genie/SearchTokensFetcher.ts
@@ -1,7 +1,9 @@
 import { FungibleToken } from '../../types'
+import { getTokenUrl } from '../url'
 
 export const fetchSearchTokens = async (tokenQuery: string): Promise<FungibleToken[]> => {
-  const url = `${process.env.REACT_APP_TEMP_API_URL}/tokens/search?tokenQuery=${tokenQuery}`
+  // TODO
+  const url = `${getTokenUrl()}/tokens/search?tokenQuery=${tokenQuery}`
 
   const r = await fetch(url, {
     method: 'GET',

--- a/src/nft/queries/genie/TrendingCollectionsFetcher.ts
+++ b/src/nft/queries/genie/TrendingCollectionsFetcher.ts
@@ -1,11 +1,12 @@
 import { TimePeriod, TrendingCollection } from '../../types'
+import { getNftUrl } from '../url'
 
 export const fetchTrendingCollections = async (payload: {
   volumeType: 'eth' | 'nft'
   timePeriod: TimePeriod
   size: number
 }): Promise<TrendingCollection[]> => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/collections/trending`
+  const url = `${getNftUrl()}/collections/trending`
   const r = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/nft/queries/genie/TrendingTokensFetcher.ts
+++ b/src/nft/queries/genie/TrendingTokensFetcher.ts
@@ -1,9 +1,11 @@
 import { unwrapToken } from 'graphql/data/util'
 
 import { FungibleToken } from '../../types'
+import { getTokenUrl } from '../url'
 
 export const fetchTrendingTokens = async (numTokens?: number): Promise<FungibleToken[]> => {
-  const url = `${process.env.REACT_APP_TEMP_API_URL}/tokens/trending${numTokens ? `?numTokens=${numTokens}` : ''}`
+  // TODO
+  const url = `${getTokenUrl()}/tokens/trending${numTokens ? `?numTokens=${numTokens}` : ''}`
 
   const r = await fetch(url, {
     method: 'GET',

--- a/src/nft/queries/genie/logListing.ts
+++ b/src/nft/queries/genie/logListing.ts
@@ -1,11 +1,13 @@
 import { ListingMarket, ListingRow } from 'nft/types'
 
+import { getNftUrl } from '../url'
+
 interface Listing extends ListingRow {
   marketplaces: ListingMarket[]
 }
 
 export const logListing = async (listings: ListingRow[], userAddress: string): Promise<boolean> => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/logGenieList`
+  const url = `${getNftUrl()}/logGenieList`
   const listingsConsolidated: Listing[] = listings.map((el) => ({ ...el, marketplaces: [] }))
   const marketplacesById: Record<string, ListingMarket[]> = {}
   const listingsWithMarketsConsolidated = listingsConsolidated.reduce((uniqueListings, curr) => {

--- a/src/nft/queries/looksRare/createLooksRareOrder.ts
+++ b/src/nft/queries/looksRare/createLooksRareOrder.ts
@@ -1,5 +1,7 @@
+import { getNftUrl } from '../url'
+
 export const createLooksRareOrder = async (payload: any): Promise<boolean> => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/createLooksRareOrder`
+  const url = `${getNftUrl()}/createLooksRareOrder`
   const res = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/nft/queries/openSea/PostOpenSeaSellOrder.ts
+++ b/src/nft/queries/openSea/PostOpenSeaSellOrder.ts
@@ -1,8 +1,10 @@
 import ms from 'ms.macro'
 
+import { getNftUrl } from '../url'
+
 export async function PostOpenSeaSellOrder(payload?: Record<string, unknown>): Promise<boolean> {
   const body = payload ? JSON.stringify(payload) : undefined
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/postOpenSeaSellOrderWithApiKey`
+  const url = `${getNftUrl()}/postOpenSeaSellOrderWithApiKey`
   const ac = new AbortController()
   const req = new Request(url, {
     method: 'POST',

--- a/src/nft/queries/url.ts
+++ b/src/nft/queries/url.ts
@@ -1,0 +1,11 @@
+export function getTokenUrl() {
+  const url = process.env.REACT_APP_TEMP_API_URL
+  if (!url) throw new Error('Token API URL missing from environment')
+  return url
+}
+
+export function getNftUrl() {
+  const url = process.env.REACT_APP_GENIE_V3_API_URL
+  if (!url) throw new Error('Genie V3 API URL missing from environment')
+  return url
+}

--- a/src/nft/queries/x2y2/index.ts
+++ b/src/nft/queries/x2y2/index.ts
@@ -1,10 +1,11 @@
 import { OrderPayload } from '../../utils/x2y2'
+import { getNftUrl } from '../url'
 
 export const X2Y2_TRANSFER_CONTRACT = '0xf849de01b080adc3a814fabe1e2087475cf2e354'
 
 export const newX2Y2Order = async (payload: OrderPayload): Promise<boolean> => {
   const body = JSON.stringify(payload)
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/postX2Y2SellOrderWithApiKey`
+  const url = `${getNftUrl()}/postX2Y2SellOrderWithApiKey`
   const ac = new AbortController()
   const req = new Request(url, {
     method: 'POST',
@@ -27,7 +28,7 @@ export const newX2Y2Order = async (payload: OrderPayload): Promise<boolean> => {
 }
 
 export const getOrderId = async (collectionAddress: string, tokenId: string): Promise<number | undefined> => {
-  const url = `${process.env.REACT_APP_GENIE_V3_API_URL}/getX2Y2OrderId?collectionAddress=${collectionAddress}&tokenId=${tokenId}`
+  const url = `${getNftUrl()}/getX2Y2OrderId?collectionAddress=${collectionAddress}&tokenId=${tokenId}`
   const r = await fetch(url, {
     method: 'GET',
     headers: {


### PR DESCRIPTION
Throws on missing env var URLs. This prevents red herrings / false alarms from network fetches that are not actually intended.