### PR TITLE
chore: fix invalid css color prop on text components

### DIFF
--- a/src/components/SearchModal/CurrencyList/__snapshots__/index.test.tsx.snap
+++ b/src/components/SearchModal/CurrencyList/__snapshots__/index.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`renders currency rows correctly when currencies list is non-empty 1`] =
             </div>
           </div>
           <div
-            class="c10 css-1j6a53a"
+            class="c10 css-yfjwjl"
           >
             DAI
           </div>
@@ -246,7 +246,7 @@ exports[`renders currency rows correctly when currencies list is non-empty 1`] =
             </div>
           </div>
           <div
-            class="c10 css-1j6a53a"
+            class="c10 css-yfjwjl"
           >
             USDC
           </div>
@@ -321,7 +321,7 @@ exports[`renders currency rows correctly when currencies list is non-empty 1`] =
             </div>
           </div>
           <div
-            class="c10 css-1j6a53a"
+            class="c10 css-yfjwjl"
           >
             WBTC
           </div>

--- a/src/theme/components/text.tsx
+++ b/src/theme/components/text.tsx
@@ -5,7 +5,9 @@
 import { Text, TextProps as TextPropsOriginal } from 'rebass'
 import styled from 'styled-components/macro'
 
-const TextWrapper = styled(Text)<{ color: keyof string }>`
+const TextWrapper = styled(Text).withConfig({
+  shouldForwardProp: (prop) => prop !== 'color',
+})<{ color: keyof string }>`
   color: ${({ color, theme }) => (theme as any)[color]};
 `
 


### PR DESCRIPTION
Before:
<img width="263" alt="Screenshot 2022-11-23 at 16 32 22" src="https://user-images.githubusercontent.com/2464966/203586289-cee85f04-2bc3-41d6-984e-82bbdda6c615.png">

After:
<img width="239" alt="Screenshot 2022-11-23 at 16 32 32" src="https://user-images.githubusercontent.com/2464966/203586323-9ceea083-e2d2-45f7-9b4b-324fbaaae9eb.png">

Eventually, I think we're going to migrate away from this Rebass Text component, so I consider this a temporary solution. Ideally, we shouldn't be passing any of the props down the tree, or even configure it this way.

For example, this:
```js
export const ThemedText = {
  HeadlineSmall(props: TextProps) {
    return <TextWrapper fontWeight={600} fontSize={20} lineHeight="28px" color="textPrimary" {...props} />
  },
};
```
could be as simple as
```js
export const HeadlineSmall = styled(BaseText)`
   fontWeight: 600;
   fontSize: 20px;
   lineHeight: 28px;
   color: ${({theme}) => theme.textPrimary}
`
```

Like I said, something to keep in mind for the future