### PR TITLE
fix: Stop traits from url re-appearing

### DIFF
--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -455,7 +455,8 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
         }
       })
     }
-  }, [collectionStats, location])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location])
 
   useEffect(() => {
     if (collectionStats && collectionStats.stats?.floor_price) {


### PR DESCRIPTION
Previously we had a bug where when you loaded a page with a url that included filters, when you tried to remove a filter it would re-appear. This was caused by the useeffect that applied filters to the url and vice versa firing when it shouldn't have. This removes the unneeded triggering condition. You should still be able to apply and remove filters as usual and when you land on a page from a url with filters and remove it, the url should be updated and the filter should not re-appear.