### PR TITLE
fix: Display blank row if no listing price.

### DIFF
--- a/src/nft/components/collection/Card.tsx
+++ b/src/nft/components/collection/Card.tsx
@@ -490,7 +490,7 @@ const InfoContainer = ({ children }: { children: ReactNode }) => {
 
 const TruncatedTextRow = styled(Row)`
   padding: 2px;
-  white-space: nowrap;
+  white-space: pre;
   text-overflow: ellipsis;
   display: block;
   overflow: hidden;
@@ -532,11 +532,9 @@ const ProfileNftDetails = ({ asset, hideDetails }: ProfileNftDetailsProps) => {
         </TruncatedTextRow>
         {asset.susFlag && <Suspicious />}
       </Row>
-      {shouldShowUserListedPrice && (
-        <TruncatedTextRow className={buttonTextMedium} style={{ color: themeVars.colors.textPrimary }}>
-          {`${floorFormatter(asset.floor_sell_order_price)} ETH`}
-        </TruncatedTextRow>
-      )}
+      <TruncatedTextRow className={buttonTextMedium} style={{ color: themeVars.colors.textPrimary }}>
+        {shouldShowUserListedPrice ? `${floorFormatter(asset.floor_sell_order_price)} ETH` : ' '}
+      </TruncatedTextRow>
     </Box>
   )
 }


### PR DESCRIPTION
fixes https://uniswaplabs.atlassian.net/browse/WEB-2384?filter=10136

Solution looks a bit hacky, but if we want the space consistently there we'll have to explicitly add a space.

I considered another option where I set card height to 100% (full), which makes the card heights equal across a row, but could result in different sized rows depending on whether there's >= 1 listed NFT present on the row.