### PR TITLE
refactor: change marketplace ordering

### DIFF
--- a/src/nft/components/collection/MarketplaceSelect.tsx
+++ b/src/nft/components/collection/MarketplaceSelect.tsx
@@ -35,13 +35,14 @@ const MarketNameWrapper = styled(Row)`
 `
 
 export const MARKETPLACE_ITEMS = {
-  looksrare: 'LooksRare',
-  nft20: 'NFT20',
-  nftx: 'NFTX',
-  opensea: 'OpenSea',
   x2y2: 'X2Y2',
-  cryptopunks: 'LarvaLabs',
+  opensea: 'OpenSea',
+  looksrare: 'LooksRare',
   sudoswap: 'SudoSwap',
+
+  nftx: 'NFTX',
+  nft20: 'NFT20',
+  cryptopunks: 'LarvaLabs',
 }
 
 function getMarketLogoSrc(market: string) {


### PR DESCRIPTION
Change ordering of markets in filter menu. Requested here: https://uniswapteam.slack.com/archives/C04822DFATE/p1669229291484899?thread_ts=1669227223.337589&cid=C04822DFATE