### PR TITLE
fix(cypress): patch to add another parallelization and make timeout longer than block time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   projectId: 'yp82ef',
   videoUploadOnPasses: false,
-  defaultCommandTimeout: 10000,
+  defaultCommandTimeout: 24000, // 2x average block time
   chromeWebSecurity: false,
   e2e: {
     setupNodeEvents(on, config) {


### PR DESCRIPTION
running into lots of timeouts with tests that do testnet interactions