### PR TITLE
build: release to cloudflare pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
 
             ${{ needs.tag.outputs.changelog }}
 
-      - name: Install node@16 (for Cloudflare Pages compat)
+      - name: Setup node@16 (required by Cloudflare Pages)
         uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
         uses: cloudflare/pages-action@364c7ca09a4b57837c5967871d64a2c31adb8c0d
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId:
-          projectName:
-          directory:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          directory: build
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,29 +71,6 @@ jobs:
         with:
           cidv0: ${{ steps.pinata.outputs.hash }}
 
-      - uses: actions/cache@v3
-        id: cypress-cache
-        with:
-          path: /home/runner/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('node_modules/cypress') }}
-      - if: steps.cypress-cache.outputs.cache-hit != 'true'
-        run: yarn cypress install
-      - uses: cypress-io/github-action@v4
-        with:
-          install: false
-          browser: chrome
-          config-file: cypress.release.config.ts
-          config: baseUrl=https://cloudflare-ipfs.com/ipfs/${{ steps.pinata.outputs.hash }}
-
-      - name: Update DNS with new IPFS hash
-        env:
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_GATEWAY_ID }}
-        uses: Uniswap/cloudflare-update-web3-gateway@b3205288b1c6d0acb63fa3bd8fb686c72a9e3f3e
-        with:
-          cid: ${{ steps.pinata.outputs.hash }}
-
       - name: Release
         uses: actions/create-release@v1.1.0
         env:
@@ -119,3 +96,12 @@ jobs:
             - [ipfs://${{ steps.upload.outputs.hash }}/](ipfs://${{ steps.pinata.outputs.hash }}/)
 
             ${{ needs.tag.outputs.changelog }}
+
+      - name: Update Cloudflare Pages deployment
+        uses: cloudflare/pages-action@364c7ca09a4b57837c5967871d64a2c31adb8c0d
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId:
+          projectName:
+          directory:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,11 @@ jobs:
 
             ${{ needs.tag.outputs.changelog }}
 
+      - name: Install node@16 (for Cloudflare Pages compat)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Update Cloudflare Pages deployment
         uses: cloudflare/pages-action@364c7ca09a4b57837c5967871d64a2c31adb8c0d
         with:


### PR DESCRIPTION
Releases to Cloudflare Pages.

Retools the release.yaml file so that a release is created after pinning, and is not dependent on deployment.