### PR TITLE
chore: remove /swap/:outputCurrency redirect

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -39,7 +39,7 @@ import PoolFinder from './PoolFinder'
 import RemoveLiquidity from './RemoveLiquidity'
 import RemoveLiquidityV3 from './RemoveLiquidity/V3'
 import Swap from './Swap'
-import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly, RedirectToSwap } from './Swap/redirects'
+import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly } from './Swap/redirects'
 import Tokens from './Tokens'
 
 const TokenDetails = lazy(() => import('./TokenDetails'))

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -216,7 +216,6 @@ export default function App() {
                   <Route path="uni/:currencyIdA/:currencyIdB" element={<Manage />} />
 
                   <Route path="send" element={<RedirectPathToSwapOnly />} />
-                  <Route path="swap/:outputCurrency" element={<RedirectToSwap />} />
                   <Route path="swap" element={<Swap />} />
 
                   <Route path="pool/v2/find" element={<PoolFinder />} />

--- a/src/pages/Swap/redirects.tsx
+++ b/src/pages/Swap/redirects.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Navigate, useLocation, useParams } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAppDispatch } from 'state/hooks'
 
 import { ApplicationModal, setOpenModal } from '../../state/application/reducer'
@@ -8,27 +8,6 @@ import { ApplicationModal, setOpenModal } from '../../state/application/reducer'
 export function RedirectPathToSwapOnly() {
   const location = useLocation()
   return <Navigate to={{ ...location, pathname: '/swap' }} replace />
-}
-
-// Redirects from the /swap/:outputCurrency path to the /swap?outputCurrency=:outputCurrency format
-export function RedirectToSwap() {
-  const location = useLocation()
-  const { search } = location
-  const { outputCurrency } = useParams<{ outputCurrency: string }>()
-
-  return (
-    <Navigate
-      to={{
-        ...location,
-        pathname: '/swap',
-        search:
-          search && search.length > 1
-            ? `${search}&outputCurrency=${outputCurrency}`
-            : `?outputCurrency=${outputCurrency}`,
-      }}
-      replace
-    />
-  )
 }
 
 export function OpenClaimAddressModalAndRedirectToSwap() {


### PR DESCRIPTION
I'd like to start simplifying the swap/home redirect logic as we start working on a landing page, and this is the first step. I think this is reasonable enough to remove.
