### PR TITLE
fix: making colors correct on approval screen

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -677,15 +677,17 @@ export default function Swap() {
                         }
                       >
                         <AutoRow justify="space-between" style={{ flexWrap: 'nowrap' }} height="20px">
-                          <ThemedText.SubHeader width="100%" textAlign="center" color="white">
-                            {/* we need to shorten this string on mobile */}
-                            {approvalState === ApprovalState.APPROVED ||
-                            signatureState === UseERC20PermitState.SIGNED ? (
+                          {/* we need to shorten this string on mobile */}
+                          {approvalState === ApprovalState.APPROVED || signatureState === UseERC20PermitState.SIGNED ? (
+                            <ThemedText.SubHeader width="100%" textAlign="center" color="textSecondary">
                               <Trans>You can now trade {currencies[Field.INPUT]?.symbol}</Trans>
-                            ) : (
+                            </ThemedText.SubHeader>
+                          ) : (
+                            <ThemedText.SubHeader width="100%" textAlign="center" color="white">
                               <Trans>Allow the Uniswap Protocol to use your {currencies[Field.INPUT]?.symbol}</Trans>
-                            )}
-                          </ThemedText.SubHeader>
+                            </ThemedText.SubHeader>
+                          )}
+
                           {approvalPending || approvalState === ApprovalState.PENDING ? (
                             <Loader stroke={theme.white} />
                           ) : (approvalSubmitted && approvalState === ApprovalState.APPROVED) ||


### PR DESCRIPTION
Before
<img width="541" alt="Screen Shot 2022-11-29 at 3 13 37 PM" src="https://user-images.githubusercontent.com/15934595/204643374-b9a4056c-ca0c-45c6-b863-e54a87e6b81f.png">



After
<img width="466" alt="Screen Shot 2022-11-29 at 3 35 43 PM" src="https://user-images.githubusercontent.com/15934595/204643331-be7c9d64-e7ab-4a48-9583-409ef549fc00.png">
<img width="472" alt="Screen Shot 2022-11-29 at 3 35 27 PM" src="https://user-images.githubusercontent.com/15934595/204643332-8b78eca9-e9ec-416e-a69c-0fa43dba2695.png">
