### PR TITLE
chore: remove /#/claim

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -44,7 +44,7 @@ import PoolFinder from './PoolFinder'
 import RemoveLiquidity from './RemoveLiquidity'
 import RemoveLiquidityV3 from './RemoveLiquidity/V3'
 import Swap from './Swap'
-import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly } from './Swap/redirects'
+import { RedirectPathToSwapOnly } from './Swap/redirects'
 import Tokens from './Tokens'
 
 const TokenDetails = lazy(() => import('./TokenDetails'))
@@ -218,7 +218,6 @@ export default function App() {
                   }
                 />
                 <Route path="create-proposal" element={<Navigate to="/vote/create-proposal" replace />} />
-                <Route path="claim" element={<OpenClaimAddressModalAndRedirectToSwap />} />
                 <Route path="uni" element={<Earn />} />
                 <Route path="uni/:currencyIdA/:currencyIdB" element={<Manage />} />
 

--- a/src/pages/Swap/redirects.tsx
+++ b/src/pages/Swap/redirects.tsx
@@ -1,19 +1,7 @@
-import { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
-import { useAppDispatch } from 'state/hooks'
-
-import { ApplicationModal, setOpenModal } from '../../state/application/reducer'
 
 // Redirects to swap but only replace the pathname
 export function RedirectPathToSwapOnly() {
   const location = useLocation()
   return <Navigate to={{ ...location, pathname: '/swap' }} replace />
-}
-
-export function OpenClaimAddressModalAndRedirectToSwap() {
-  const dispatch = useAppDispatch()
-  useEffect(() => {
-    dispatch(setOpenModal(ApplicationModal.ADDRESS_CLAIM))
-  }, [dispatch])
-  return <RedirectPathToSwapOnly />
 }


### PR DESCRIPTION
By this point we can assume that there aren't many active links to the /claim url. Instead, users could just claim from the menu.
