### PR TITLE
fix: remove set height from unavailable assets

### DIFF
--- a/src/nft/components/collection/TransactionCompleteModal.css.ts
+++ b/src/nft/components/collection/TransactionCompleteModal.css.ts
@@ -392,7 +392,7 @@ export const bodySmall = style([
 
 export const allUnavailableAssets = style([
   sprinkles({
-    height: 'full',
+    // height: 'full',
     width: 'full',
   }),
   {


### PR DESCRIPTION
Removes set height from the unavailable assets toggle. Fixes issue where buttons were pushed off the bottom.