### PR TITLE
fix: collection names truncating early

### DIFF
--- a/src/nft/components/collection/Card.tsx
+++ b/src/nft/components/collection/Card.tsx
@@ -493,7 +493,7 @@ const TruncatedTextRow = styled(Row)`
   text-overflow: ellipsis;
   display: block;
   overflow: hidden;
-  flex: 0.98;
+  flex: 1;
 `
 
 interface ProfileNftDetailsProps {


### PR DESCRIPTION
Collection names on profile cards were truncating early