### PR TITLE
fix: listing ens to x2y2

### DIFF
--- a/src/nft/utils/listNfts.ts
+++ b/src/nft/utils/listNfts.ts
@@ -240,7 +240,12 @@ export async function signListing(
         tokens: [
           {
             token: asset.asset_contract.address,
-            tokenId: BigNumber.from(parseFloat(asset.tokenId)),
+            tokenId: BigNumber.from(
+              parseFloat(asset.tokenId)
+                .toLocaleString('fullwide', { useGrouping: false })
+                .replace(',', '.')
+                .replace(' ', '')
+            ),
           },
         ],
       }


### PR DESCRIPTION
ENS tokenIds were too large and needed to be properly formatted to be cast to a BigNumber