### PR TITLE
fix: successfully list ENS to x2y2

### DIFF
--- a/src/nft/utils/listNfts.ts
+++ b/src/nft/utils/listNfts.ts
@@ -240,12 +240,7 @@ export async function signListing(
         tokens: [
           {
             token: asset.asset_contract.address,
-            tokenId: BigNumber.from(
-              parseFloat(asset.tokenId)
-                .toLocaleString('fullwide', { useGrouping: false })
-                .replace(',', '.')
-                .replace(' ', '')
-            ),
+            tokenId: BigNumber.from(asset.tokenId),
           },
         ],
       }


### PR DESCRIPTION
My previous fix did not actually allow you to list the ENS just allow you to be prompted. The fix was actually very simple in that the tokenId needed to be passed into BigNumber.from as a string to avoid the scientific notation error