### PR TITLE
fix: allow 0 after decimal

### DIFF
--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -184,7 +184,7 @@ const PriceTextInput = ({
           }}
           ref={inputRef}
           onChange={(v: FormEvent<HTMLInputElement>) => {
-            if (!listPrice && v.currentTarget.value === '0.') {
+            if (!listPrice && v.currentTarget.value.includes('.') && parseFloat(v.currentTarget.value) === 0) {
               return
             }
             const val = parseFloat(v.currentTarget.value)


### PR DESCRIPTION
When a user typed `.` followed by `0` into the listing price input, the decimal would be cleared, this fixes that bug