### PR TITLE
fix: full width for all TokenRow breakpoints

### DIFF
--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -81,17 +81,14 @@ const StyledTokenRow = styled.div<{
 
   @media only screen and (max-width: ${MAX_WIDTH_MEDIA_BREAKPOINT}) {
     grid-template-columns: 1fr 6.5fr 4.5fr 4.5fr 4.5fr 4.5fr 1.7fr;
-    width: fit-content;
   }
 
   @media only screen and (max-width: ${LARGE_MEDIA_BREAKPOINT}) {
     grid-template-columns: 1fr 7.5fr 4.5fr 4.5fr 4.5fr 1.7fr;
-    width: fit-content;
   }
 
   @media only screen and (max-width: ${MEDIUM_MEDIA_BREAKPOINT}) {
     grid-template-columns: 1fr 10fr 5fr 5fr 1.2fr;
-    width: fit-content;
   }
 
   @media only screen and (max-width: ${SMALL_MEDIA_BREAKPOINT}) {


### PR DESCRIPTION
after:
<img width="1090" alt="Screen Shot 2022-11-30 at 4 49 51 PM" src="https://user-images.githubusercontent.com/4899429/204915740-6ff1ca81-e8f2-4853-8630-73552d5d872d.png">

before:
<img width="1079" alt="Screen Shot 2022-11-30 at 4 50 59 PM" src="https://user-images.githubusercontent.com/4899429/204915743-efead3f2-5004-4167-ae6e-b09d0d631c6b.png">
