### PR TITLE
feat: Adds support for embedded animation_urls

### DIFF
--- a/src/nft/components/details/AssetDetails.css.ts
+++ b/src/nft/components/details/AssetDetails.css.ts
@@ -30,31 +30,18 @@ export const embedContainer = style({
   paddingTop: '100%',
 })
 
-export const embed = style({
-  borderRadius: '20px',
-  alignSelf: 'center',
-  maxHeight: 'calc(90vh - 165px)',
-  minHeight: 400,
-  maxWidth: 780,
-  boxShadow: `0px 20px 50px var(--shadow), 0px 10px 50px rgba(70, 115, 250, 0.2)`,
-  '@media': {
-    '(max-width: 1024px)': {
-      maxHeight: '64vh',
-    },
-    '(max-width: 640px)': {
-      minHeight: 280,
-      maxHeight: '56vh',
-      maxWidth: '100%',
-    },
+export const embed = style([
+  image,
+  {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    width: '100%',
+    height: '100%',
   },
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  bottom: 0,
-  right: 0,
-  width: '100%',
-  height: '100%',
-})
+])
 
 export const container = style([
   center,

--- a/src/nft/components/details/AssetDetails.css.ts
+++ b/src/nft/components/details/AssetDetails.css.ts
@@ -23,41 +23,38 @@ export const image = style([
   },
 ])
 
-export const embedContainer = style([
-  {
-    position: 'relative',
-    overflow: 'hidden',
-    width: '100%',
-    paddingTop: '100%',
-  },
-])
+export const embedContainer = style({
+  position: 'relative',
+  overflow: 'hidden',
+  width: '100%',
+  paddingTop: '100%',
+})
 
-export const embed = style([
-  sprinkles({ borderRadius: '20', height: 'full', alignSelf: 'center' }),
-  {
-    maxHeight: 'calc(90vh - 165px)',
-    minHeight: 400,
-    maxWidth: 780,
-    boxShadow: `0px 20px 50px var(--shadow), 0px 10px 50px rgba(70, 115, 250, 0.2)`,
-    '@media': {
-      '(max-width: 1024px)': {
-        maxHeight: '64vh',
-      },
-      '(max-width: 640px)': {
-        minHeight: 280,
-        maxHeight: '56vh',
-        maxWidth: '100%',
-      },
+export const embed = style({
+  borderRadius: '20px',
+  alignSelf: 'center',
+  maxHeight: 'calc(90vh - 165px)',
+  minHeight: 400,
+  maxWidth: 780,
+  boxShadow: `0px 20px 50px var(--shadow), 0px 10px 50px rgba(70, 115, 250, 0.2)`,
+  '@media': {
+    '(max-width: 1024px)': {
+      maxHeight: '64vh',
     },
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-    width: '100%',
-    height: '100%',
+    '(max-width: 640px)': {
+      minHeight: 280,
+      maxHeight: '56vh',
+      maxWidth: '100%',
+    },
   },
-])
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+  width: '100%',
+  height: '100%',
+})
 
 export const container = style([
   center,

--- a/src/nft/components/details/AssetDetails.css.ts
+++ b/src/nft/components/details/AssetDetails.css.ts
@@ -23,6 +23,42 @@ export const image = style([
   },
 ])
 
+export const embedContainer = style([
+  {
+    position: 'relative',
+    overflow: 'hidden',
+    width: '100%',
+    paddingTop: '100%',
+  },
+])
+
+export const embed = style([
+  sprinkles({ borderRadius: '20', height: 'full', alignSelf: 'center' }),
+  {
+    maxHeight: 'calc(90vh - 165px)',
+    minHeight: 400,
+    maxWidth: 780,
+    boxShadow: `0px 20px 50px var(--shadow), 0px 10px 50px rgba(70, 115, 250, 0.2)`,
+    '@media': {
+      '(max-width: 1024px)': {
+        maxHeight: '64vh',
+      },
+      '(max-width: 640px)': {
+        minHeight: 280,
+        maxHeight: '56vh',
+        maxWidth: '100%',
+      },
+    },
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    width: '100%',
+    height: '100%',
+  },
+])
+
 export const container = style([
   center,
   {

--- a/src/nft/components/details/AssetDetails.tsx
+++ b/src/nft/components/details/AssetDetails.tsx
@@ -191,27 +191,34 @@ const initialFilterState = {
   [ActivityEventType.CancelListing]: false,
 }
 
+enum MediaType {
+  Audio = 'audio',
+  Video = 'video',
+  Image = 'image',
+  Embed = 'embed',
+}
+
 const AssetView = ({
   mediaType,
   asset,
   dominantColor,
 }: {
-  mediaType: 'image' | 'video' | 'audio' | 'embed'
+  mediaType: MediaType
   asset: GenieAsset
   dominantColor: [number, number, number]
 }) => {
   const style = { ['--shadow' as string]: `rgba(${dominantColor.join(', ')}, 0.5)` }
 
   switch (mediaType) {
-    case 'video':
+    case MediaType.Video:
       return <video src={asset.animationUrl} className={styles.image} autoPlay controls muted loop style={style} />
-    case 'image':
+    case MediaType.Image:
       return (
         <img className={styles.image} src={asset.imageUrl} alt={asset.name || asset.collectionName} style={style} />
       )
-    case 'audio':
+    case MediaType.Audio:
       return <AudioPlayer {...asset} dominantColor={dominantColor} />
-    case 'embed':
+    case MediaType.Embed:
       return (
         <div className={styles.embedContainer}>
           <iframe
@@ -229,13 +236,6 @@ const AssetView = ({
         </div>
       )
   }
-}
-
-enum MediaType {
-  Audio = 'audio',
-  Video = 'video',
-  Image = 'image',
-  Embed = 'embed',
 }
 
 interface AssetDetailsProps {

--- a/src/nft/components/details/AssetDetails.tsx
+++ b/src/nft/components/details/AssetDetails.tsx
@@ -196,7 +196,7 @@ const AssetView = ({
   asset,
   dominantColor,
 }: {
-  mediaType: 'image' | 'video' | 'audio'
+  mediaType: 'image' | 'video' | 'audio' | 'embed'
   asset: GenieAsset
   dominantColor: [number, number, number]
 }) => {
@@ -211,6 +211,23 @@ const AssetView = ({
       )
     case 'audio':
       return <AudioPlayer {...asset} dominantColor={dominantColor} />
+    case 'embed':
+      return (
+        <div className={styles.embedContainer}>
+          <iframe
+            title={asset.name ?? `${asset.collectionName} #${asset.tokenId}`}
+            src={asset.animationUrl}
+            className={styles.embed}
+            style={style}
+            frameBorder={0}
+            height="100%"
+            width="100%"
+            sandbox="allow-scripts"
+            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+      )
   }
 }
 
@@ -218,6 +235,7 @@ enum MediaType {
   Audio = 'audio',
   Video = 'video',
   Image = 'image',
+  Embed = 'embed',
 }
 
 interface AssetDetailsProps {
@@ -245,6 +263,8 @@ export const AssetDetails = ({ asset, collection }: AssetDetailsProps) => {
       return MediaType.Audio
     } else if (isVideo(asset.animationUrl ?? '')) {
       return MediaType.Video
+    } else if (asset.animationUrl !== undefined) {
+      return MediaType.Embed
     }
     return MediaType.Image
   }, [asset])


### PR DESCRIPTION
Many NFT collections use embedded HTML pages to represent their artwork. This is achieved by setting the `animation_url` to a URI that hosts a static webpage. Supporting embedded `animation_url`s will allow Uniswap to showcase some of the most innovative NFT projects in their full glory on the Uniswap NFT platform.

This PR adds support for rendering embedded HTML artwork on the Asset Details page of the Uniswap NFT application.

A few collections that make use of embedded `animation_url`s:
- [ArtBlocks](https://opensea.io/assets/ethereum/0x99a9b7c1116f9ceeb1652de04d5969cce509b069/377000022) (currently the top collection on Uniswap NFT)
- [Tickle Beach](https://opensea.io/assets/ethereum/0x6f4388602c5dd6c593bf7c9cf3128aaa2a3e09ce/9440) (fully on-chain 3d rendered characters)
- [Roses](https://opensea.io/assets/ethereum/0x3e743377417cd7ca70dcc9bf08fac55664ed3181/10) (procedurally generated on-chain roses)

Demo video:
![CleanShot 2022-11-30 at 13 59 21](https://user-images.githubusercontent.com/10178895/204917340-1b515106-0fca-4b1f-b088-76650f26d85b.gif)


