### PR TITLE
fix: cache sparkline queries

### DIFF
--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -129,7 +129,12 @@ export function useTopTokens(chain: Chain): UseTopTokensReturnValue {
   const environment = useRelayEnvironment()
   const [sparklines, setSparklines] = useState<SparklineMap>({})
   useEffect(() => {
-    const subscription = fetchQuery<TopTokensSparklineQuery>(environment, tokenSparklineQuery, { duration, chain })
+    const subscription = fetchQuery<TopTokensSparklineQuery>(
+      environment,
+      tokenSparklineQuery,
+      { duration, chain },
+      { networkCacheConfig: { force: false }, fetchPolicy: 'store-or-network' }
+    )
       .map((data) => ({
         topTokens: data.topTokens?.map((token) => unwrapToken(chainId, token)),
       }))


### PR DESCRIPTION
Sparkline queries were not hitting cache due to the default settings of fetchQuery()