### PR TITLE
fix: always show listed %

### DIFF
--- a/src/nft/components/collection/CollectionStats.tsx
+++ b/src/nft/components/collection/CollectionStats.tsx
@@ -321,7 +321,7 @@ const StatsRow = ({ stats, isMobile, ...props }: { stats: GenieCollection; isMob
             </StatsItem>
           ) : null}
 
-          {stats.stats?.total_listings && stats.standard !== TokenType.ERC1155 && listedPercentageStr > 0 ? (
+          {stats.stats?.total_listings && stats.standard !== TokenType.ERC1155 ? (
             <StatsItem label="Listed" shouldHide={isMobile ?? false}>
               {listedPercentageStr}%
             </StatsItem>


### PR DESCRIPTION
Before:
<img width="769" alt="Screen Shot 2022-12-01 at 08 09 25 " src="https://user-images.githubusercontent.com/11512321/205061063-47221d54-cf60-4a5c-8373-b5dc99ba1f2a.png">

After:
<img width="811" alt="Screen Shot 2022-12-01 at 08 09 21 " src="https://user-images.githubusercontent.com/11512321/205061085-263d52dc-e881-435e-8324-e16001e9d9b3.png">
