### PR TITLE
feat: show 1155s in collection filter

### DIFF
--- a/src/nft/queries/openSea/OSCollectionsFetcher.ts
+++ b/src/nft/queries/openSea/OSCollectionsFetcher.ts
@@ -13,12 +13,14 @@ export const OSCollectionsFetcher = async ({ params }: any): Promise<WalletColle
   const r = await fetch(`https://api.opensea.io/api/v1/collections?${new URLSearchParams(params).toString()}`)
   const walletCollections = await r.json()
   if (walletCollections) {
-    return walletCollections.map((collection: any) => ({
-      address: collection.primary_asset_contracts[0].address,
-      name: collection.name,
-      image: collection.image_url,
-      count: collection.owned_asset_count,
-    }))
+    return walletCollections
+      .filter((collection: any) => collection.primary_asset_contracts.length)
+      .map((collection: any) => ({
+        address: collection.primary_asset_contracts[0].address,
+        name: collection.name,
+        image: collection.image_url,
+        count: collection.owned_asset_count,
+      }))
   } else {
     return []
   }

--- a/src/nft/queries/openSea/OSCollectionsFetcher.ts
+++ b/src/nft/queries/openSea/OSCollectionsFetcher.ts
@@ -13,17 +13,12 @@ export const OSCollectionsFetcher = async ({ params }: any): Promise<WalletColle
   const r = await fetch(`https://api.opensea.io/api/v1/collections?${new URLSearchParams(params).toString()}`)
   const walletCollections = await r.json()
   if (walletCollections) {
-    return walletCollections
-      .filter(
-        (collection: any) =>
-          collection.primary_asset_contracts.length && collection.primary_asset_contracts[0].schema_name === 'ERC721'
-      )
-      .map((collection: any) => ({
-        address: collection.primary_asset_contracts[0].address,
-        name: collection.name,
-        image: collection.image_url,
-        count: collection.owned_asset_count,
-      }))
+    return walletCollections.map((collection: any) => ({
+      address: collection.primary_asset_contracts[0].address,
+      name: collection.name,
+      image: collection.image_url,
+      count: collection.owned_asset_count,
+    }))
   } else {
     return []
   }


### PR DESCRIPTION
Removes the filter for 1155 collections in the filter menu on profile. Allows them to be searchable as well. Can test by impersonating my wallet.

Before:
<img width="1684" alt="Screen Shot 2022-12-01 at 09 31 53 " src="https://user-images.githubusercontent.com/11512321/205079953-cccb0059-fd1b-442d-93f7-60fdcdd10dca.png">

After:
<img width="1675" alt="Screen Shot 2022-12-01 at 09 31 46 " src="https://user-images.githubusercontent.com/11512321/205079978-a8e28732-a868-45fe-82fd-9d1942a0deef.png">
<img width="1709" alt="Screen Shot 2022-12-01 at 09 32 04 " src="https://user-images.githubusercontent.com/11512321/205079981-3af46888-6157-4674-9a59-a5eeda238916.png">
