### PR TITLE
fix: reduce size for remove liquidity button

### DIFF
--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -132,6 +132,7 @@ const ResponsiveButtonPrimary = styled(ButtonPrimary)`
   border-radius: 12px;
   padding: 6px 8px;
   width: fit-content;
+  font-size: 16px;
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
     flex: 1 1 auto;
     width: 49%;


### PR DESCRIPTION
Before vs After
<img width="388" alt="Screen Shot 2022-11-30 at 10 42 51 PM" src="https://user-images.githubusercontent.com/109188881/205098247-96dbaf1e-cb8e-45c7-94ae-b5dcd0ebae2d.png">
<img width="407" alt="Screen Shot 2022-11-30 at 10 54 00 PM" src="https://user-images.githubusercontent.com/109188881/205098251-4fbb6987-f1c5-472f-9d16-07225c570c58.png">
