### PR TITLE
fix: only show owner container if we have NftBalance data

### DIFF
--- a/src/graphql/data/nft/NftBalance.ts
+++ b/src/graphql/data/nft/NftBalance.ts
@@ -72,6 +72,7 @@ const nftBalancePaginationQuery = graphql`
                   }
                   createdAt
                   marketplace
+                  endAt
                 }
               }
             }

--- a/src/nft/components/details/AssetPriceDetails.tsx
+++ b/src/nft/components/details/AssetPriceDetails.tsx
@@ -314,9 +314,12 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
 
   const USDPrice = useUsdPrice(asset)
 
-  const assetsFilter = [{ address: asset.address, tokenId: asset.tokenId }]
+  const assetsFilter = [{ address: asset.address, tokenId: asset.tokenId + 'adskhdashk' }]
   const { walletAssets: ownerAssets } = useNftBalanceQuery(account ?? '', [], assetsFilter, 1)
-  const walletAsset: WalletAsset = useMemo(() => ownerAssets[0], [ownerAssets])
+  const walletAsset: WalletAsset | undefined = useMemo(
+    () => (ownerAssets?.length > 0 ? ownerAssets[0] : undefined),
+    [ownerAssets]
+  )
 
   const { assetInBag } = useMemo(() => {
     return {

--- a/src/nft/components/details/AssetPriceDetails.tsx
+++ b/src/nft/components/details/AssetPriceDetails.tsx
@@ -314,7 +314,7 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
 
   const USDPrice = useUsdPrice(asset)
 
-  const assetsFilter = [{ address: asset.address, tokenId: asset.tokenId + 'adskhdashk' }]
+  const assetsFilter = [{ address: asset.address, tokenId: asset.tokenId }]
   const { walletAssets: ownerAssets } = useNftBalanceQuery(account ?? '', [], assetsFilter, 1)
   const walletAsset: WalletAsset | undefined = useMemo(
     () => (ownerAssets?.length > 0 ? ownerAssets[0] : undefined),

--- a/src/nft/components/details/AssetPriceDetails.tsx
+++ b/src/nft/components/details/AssetPriceDetails.tsx
@@ -208,8 +208,7 @@ const OwnerContainer = ({ asset }: { asset: WalletAsset }) => {
   const resetSellAssets = useSellAsset((state) => state.reset)
 
   const listing = asset.sellOrders && asset.sellOrders.length > 0 ? asset.sellOrders[0] : undefined
-  const cheapestOrder = asset.sellOrders && asset.sellOrders.length > 0 ? asset.sellOrders[0] : undefined
-  const expirationDate = cheapestOrder ? new Date(cheapestOrder.endAt) : undefined
+  const expirationDate = listing ? new Date(listing.endAt) : undefined
 
   const USDPrice = useMemo(
     () => (USDValue ? USDValue * asset.floor_sell_order_price : undefined),

--- a/src/nft/components/details/AssetPriceDetails.tsx
+++ b/src/nft/components/details/AssetPriceDetails.tsx
@@ -6,6 +6,7 @@ import { useBag, useProfilePageState, useSellAsset } from 'nft/hooks'
 import { CollectionInfoForAsset, GenieAsset, ProfilePageStateType, WalletAsset } from 'nft/types'
 import {
   ethNumberStandardFormatter,
+  fetchPrice,
   formatEthPrice,
   generateTweetForAsset,
   getMarketplaceIcon,
@@ -15,6 +16,7 @@ import {
 import { shortenAddress } from 'nft/utils/address'
 import { useMemo } from 'react'
 import { Upload } from 'react-feather'
+import { useQuery } from 'react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import styled, { css, useTheme } from 'styled-components/macro'
 import { ExternalLink, ThemedText } from 'theme'
@@ -198,25 +200,26 @@ const DefaultLink = styled(Link)`
   text-decoration: none;
 `
 
-const OwnerContainer = ({ asset }: { asset: GenieAsset }) => {
+const OwnerContainer = ({ asset }: { asset: WalletAsset }) => {
   const navigate = useNavigate()
-  const USDPrice = useUsdPrice(asset)
+  const { data: USDValue } = useQuery(['fetchPrice', {}], () => fetchPrice(), {})
   const setSellPageState = useProfilePageState((state) => state.setProfilePageState)
   const selectSellAsset = useSellAsset((state) => state.selectSellAsset)
   const resetSellAssets = useSellAsset((state) => state.reset)
-  const { account } = useWeb3React()
-  const assetsFilter = [{ address: asset.address, tokenId: asset.tokenId }]
-  const { walletAssets: ownerAssets } = useNftBalanceQuery(account ?? '', [], assetsFilter, 1)
-  const walletAsset: WalletAsset = useMemo(() => ownerAssets[0], [ownerAssets])
 
-  const listing = asset.sellorders && asset.sellorders.length > 0 ? asset.sellorders[0] : undefined
-  const cheapestOrder = asset.sellorders && asset.sellorders.length > 0 ? asset.sellorders[0] : undefined
+  const listing = asset.sellOrders && asset.sellOrders.length > 0 ? asset.sellOrders[0] : undefined
+  const cheapestOrder = asset.sellOrders && asset.sellOrders.length > 0 ? asset.sellOrders[0] : undefined
   const expirationDate = cheapestOrder ? new Date(cheapestOrder.endAt) : undefined
+
+  const USDPrice = useMemo(
+    () => (USDValue ? USDValue * asset.floor_sell_order_price : undefined),
+    [USDValue, asset.floor_sell_order_price]
+  )
 
   const goToListPage = () => {
     resetSellAssets()
     navigate('/nfts/profile')
-    selectSellAsset(walletAsset)
+    selectSellAsset(asset)
     setSellPageState(ProfilePageStateType.LISTING)
   }
 
@@ -312,6 +315,10 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
 
   const USDPrice = useUsdPrice(asset)
 
+  const assetsFilter = [{ address: asset.address, tokenId: asset.tokenId }]
+  const { walletAssets: ownerAssets } = useNftBalanceQuery(account ?? '', [], assetsFilter, 1)
+  const walletAsset: WalletAsset = useMemo(() => ownerAssets[0], [ownerAssets])
+
   const { assetInBag } = useMemo(() => {
     return {
       assetInBag: itemsInBag.some(
@@ -330,7 +337,7 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
     )
   }
 
-  const isOwner = asset.owner ? account?.toLowerCase() === asset.owner?.address?.toLowerCase() : false
+  const isOwner = asset.owner && !!walletAsset ? account?.toLowerCase() === asset.owner?.address?.toLowerCase() : false
   const isForSale = cheapestOrder && asset.priceInfo
 
   return (
@@ -349,7 +356,7 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
         <AssetHeader>{asset.name ?? `${asset.collectionName} #${asset.tokenId}`}</AssetHeader>
       </AssetInfoContainer>
       {isOwner ? (
-        <OwnerContainer asset={asset} />
+        <OwnerContainer asset={walletAsset} />
       ) : isForSale ? (
         <BestPriceContainer>
           <HeaderRow>

--- a/src/nft/components/details/AssetPriceDetails.tsx
+++ b/src/nft/components/details/AssetPriceDetails.tsx
@@ -336,7 +336,7 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
     )
   }
 
-  const isOwner = asset.owner && !!walletAsset ? account?.toLowerCase() === asset.owner?.address?.toLowerCase() : false
+  const isOwner = asset.owner && !!walletAsset && account?.toLowerCase() === asset.owner?.address?.toLowerCase()
   const isForSale = cheapestOrder && asset.priceInfo
 
   return (


### PR DESCRIPTION
Previously there could be a BE discrepancy where an asset could be shown as owned by a user but when calling their NftBalance, the asset would not be present. This would cause a crash if they tried to list said asset. We now hide the owner container in Details unless the NftBalanceQuery for that asset returns data.