### PR TITLE
style: prevent content of remove liquidity page from displaying itself outside of the main page

### DIFF
--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -37,8 +37,7 @@ import { WRAPPED_NATIVE_CURRENCY } from '../../constants/tokens'
 import { TransactionType } from '../../state/transactions/types'
 import { calculateGasMargin } from '../../utils/calculateGasMargin'
 import { currencyId } from '../../utils/currencyId'
-import AppBody from '../AppBody'
-import { ResponsiveHeaderText, SmallMaxButton, Wrapper } from './styled'
+import { Body, ResponsiveHeaderText, SmallMaxButton, Wrapper } from './styled'
 
 const DEFAULT_REMOVE_V3_LIQUIDITY_SLIPPAGE_TOLERANCE = new Percent(5, 100)
 
@@ -290,7 +289,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
         )}
         pendingText={pendingText}
       />
-      <AppBody>
+      <Body>
         <AddRemoveTabs
           creating={false}
           adding={false}
@@ -425,7 +424,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
             <Loader />
           )}
         </Wrapper>
-      </AppBody>
+      </Body>
     </AutoColumn>
   )
 }

--- a/src/pages/RemoveLiquidity/styled.ts
+++ b/src/pages/RemoveLiquidity/styled.ts
@@ -1,3 +1,4 @@
+import AppBody from 'pages/AppBody'
 import { MaxButton } from 'pages/Pool/styleds'
 import { Text } from 'rebass'
 import styled from 'styled-components/macro'
@@ -10,6 +11,10 @@ export const Wrapper = styled.div`
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToExtraSmall`
     min-width: 340px;
   `};
+`
+
+export const Body = styled(AppBody)`
+  max-width: 500px;
 `
 
 export const SmallMaxButton = styled(MaxButton)`


### PR DESCRIPTION
A Smol UI Fix 
- fix: prevent page content from displaying itself outside of RemoveLiquidity page wrapper  

## Screenshots:
### Before:
<img width="375" alt="Screenshot 2022-12-05 at 14 04 48" src="https://user-images.githubusercontent.com/10917606/205561126-21d85aec-4385-444e-8c6b-7073ce467579.png">


### After:
<img width="375" alt="Screenshot 2022-12-05 at 14 05 48" src="https://user-images.githubusercontent.com/10917606/205561258-f4c0a9d4-41d7-4594-9a16-0097a2952e80.png">
