### PR TITLE
fix: update <AppBody /> to allow its intended prop passthrough

### DIFF
--- a/src/pages/AppBody.tsx
+++ b/src/pages/AppBody.tsx
@@ -1,11 +1,16 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import styled from 'styled-components/macro'
 import { Z_INDEX } from 'theme/zIndex'
 
-export const BodyWrapper = styled.main<{ margin?: string; maxWidth?: string }>`
+interface BodyWrapperProps {
+  $margin?: string
+  $maxWidth?: string
+}
+
+export const BodyWrapper = styled.main<BodyWrapperProps>`
   position: relative;
-  margin-top: ${({ margin }) => margin ?? '0px'};
-  max-width: ${({ maxWidth }) => maxWidth ?? '420px'};
+  margin-top: ${({ $margin }) => $margin ?? '0px'};
+  max-width: ${({ $maxWidth }) => $maxWidth ?? '420px'};
   width: 100%;
   background: ${({ theme }) => theme.backgroundSurface};
   border-radius: 16px;
@@ -20,6 +25,6 @@ export const BodyWrapper = styled.main<{ margin?: string; maxWidth?: string }>`
 /**
  * The styled container element that wraps the content of most pages and the tabs.
  */
-export default function AppBody({ children, ...rest }: { children: React.ReactNode }) {
-  return <BodyWrapper {...rest}>{children}</BodyWrapper>
+export default function AppBody(props: PropsWithChildren<BodyWrapperProps>) {
+  return <BodyWrapper {...props} />
 }

--- a/src/pages/CreateProposal/index.tsx
+++ b/src/pages/CreateProposal/index.tsx
@@ -241,7 +241,7 @@ ${bodyValue}
   return (
     <Trace page={PageName.VOTE_PAGE} shouldLogImpression>
       <PageWrapper>
-        <AppBody {...{ maxWidth: '800px' }}>
+        <AppBody $maxWidth="800px">
           <CreateProposalTabs />
           <CreateProposalWrapper>
             <BlueCard>

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -290,7 +290,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
         )}
         pendingText={pendingText}
       />
-      <AppBody>
+      <AppBody $maxWidth="unset">
         <AddRemoveTabs
           creating={false}
           adding={false}


### PR DESCRIPTION
also fixes a visual bug that was occurring on v3 liquidity removal

## After
![image](https://user-images.githubusercontent.com/5773490/205679642-f8cf7a5c-78af-4e3c-9d51-1ae885c13fed.png)


## Current
![image](https://user-images.githubusercontent.com/5773490/205679674-ac73449f-4d6f-42be-860a-17ac97b4928e.png)
