### PR TITLE
feat: permit 2 feature flag

### DIFF
--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -1,5 +1,6 @@
 import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'featureFlags'
 import { LandingPageVariant, useLandingPageFlag } from 'featureFlags/flags/landingPage'
+import { Permit2Variant, usePermit2Flag } from 'featureFlags/flags/permit2'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { Children, PropsWithChildren, ReactElement, ReactNode, useCallback, useState } from 'react'
@@ -202,20 +203,24 @@ export default function FeatureFlagModal() {
           <X size={24} />
         </CloseButton>
       </Header>
+      <FeatureFlagOption
+        variant={LandingPageVariant}
+        value={useLandingPageFlag()}
+        featureFlag={FeatureFlag.landingPage}
+        label="Landing page"
+      />
+      <FeatureFlagOption
+        variant={Permit2Variant}
+        value={usePermit2Flag()}
+        featureFlag={FeatureFlag.permit2}
+        label="Permit 2 / Universal Router"
+      />
       <FeatureFlagGroup name="Debug">
         <FeatureFlagOption
           variant={TraceJsonRpcVariant}
           value={useTraceJsonRpcFlag()}
           featureFlag={FeatureFlag.traceJsonRpc}
           label="Enables JSON-RPC tracing"
-        />
-      </FeatureFlagGroup>
-      <FeatureFlagGroup name="Tokens">
-        <FeatureFlagOption
-          variant={LandingPageVariant}
-          value={useLandingPageFlag()}
-          featureFlag={FeatureFlag.landingPage}
-          label="Landing Page"
         />
       </FeatureFlagGroup>
       <SaveButton onClick={() => window.location.reload()}>Reload</SaveButton>

--- a/src/featureFlags/flags/featureFlags.ts
+++ b/src/featureFlags/flags/featureFlags.ts
@@ -1,6 +1,5 @@
 export enum FeatureFlag {
-  favoriteTokens = 'favoriteTokens',
   traceJsonRpc = 'traceJsonRpc',
-  multiNetworkBalances = 'multiNetworkBalances',
   landingPage = 'landingPage',
+  permit2 = 'permit2',
 }

--- a/src/featureFlags/flags/permit2.ts
+++ b/src/featureFlags/flags/permit2.ts
@@ -1,0 +1,7 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+export function usePermit2Flag(): BaseVariant {
+  return useBaseFlag(FeatureFlag.permit2)
+}
+
+export { BaseVariant as Permit2Variant }


### PR DESCRIPTION
Adds a Permit 2 / Universal Router feature flag.
Cleans up old feature flags, and the feature flags modal.