### PR TITLE
fix: link color for learn more in token safety msg

### DIFF
--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -183,6 +183,8 @@ function ExplorerView({ token }: { token: Token }) {
 }
 
 const StyledExternalLink = styled(ExternalLink)`
+  color: ${({ theme }) => theme.textSecondary};
+  stroke: ${({ theme }) => theme.textSecondary};
   font-weight: 600;
 `
 

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -184,7 +184,7 @@ function ExplorerView({ token }: { token: Token }) {
 
 const StyledExternalLink = styled(ExternalLink)`
   color: ${({ theme }) => theme.textSecondary};
-  stroke: ${({ theme }) => theme.textSecondary};
+  stroke: currentColor;
   font-weight: 600;
 `
 


### PR DESCRIPTION
<img width="273" alt="Screen Shot 2022-12-06 at 11 52 20 AM" src="https://user-images.githubusercontent.com/41491154/205973408-89a661f8-95a4-4f94-8a7e-02c7e755e03d.png">


https://uniswaplabs.atlassian.net/browse/WEB-1988