### PR TITLE
fix: change readMore val on address change

### DIFF
--- a/src/nft/components/collection/CollectionStats.tsx
+++ b/src/nft/components/collection/CollectionStats.tsx
@@ -219,7 +219,8 @@ const CollectionDescription = ({ description }: { description: string }) => {
         descriptionRef.current.getBoundingClientRect().width >= 590)
     )
       setShowReadMore(true)
-  }, [descriptionRef, baseRef, isCollectionStatsLoading])
+    else setShowReadMore(false)
+  }, [descriptionRef, baseRef, isCollectionStatsLoading, description])
 
   return isCollectionStatsLoading ? (
     <CollectionDescriptionLoading />


### PR DESCRIPTION
Previously the boolean that determines if the description should truncate and have a `read more` prompt didn't change when the collection changed. This fixes that bug. To test here and on main go to a collection with a truncated description such as cryptopunks and then switch to a collection with a short description like `0x01371a682ff3a9d0c9fa7d073c2983081ca938c8`.

Working gif:
![workingReadMore](https://user-images.githubusercontent.com/11512321/206257104-791a0763-7b60-44da-8392-727ef46bb7a3.gif)
