### PR TITLE
test: reduce parallelization to 4 containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup


### PR DESCRIPTION
1/5 of containers running cypress frequently fail. I'm hopeful that using 4 instead of 5 will be more likely to keep all the machine specs the same.

![image](https://user-images.githubusercontent.com/5403956/206265887-9d199eb3-8c97-400a-a879-f6993202a239.png)
