### PR TITLE
fix: show ens in wallet dropdown too if available

### DIFF
--- a/src/components/WalletDropdown/AuthenticatedHeader.tsx
+++ b/src/components/WalletDropdown/AuthenticatedHeader.tsx
@@ -184,7 +184,7 @@ const AuthenticatedHeader = () => {
                 <AccountContainer>{account && shortenAddress(account, 2, 4)}</AccountContainer>
               </AccountNamesWrapper>
             ) : (
-              <ThemedText.BodySmall marginTop="2.5px">{account && shortenAddress(account, 2, 4)}</ThemedText.BodySmall>
+              <ThemedText.SubHeader marginTop="2.5px">{account && shortenAddress(account, 2, 4)}</ThemedText.SubHeader>
             )}
           </FlexContainer>
         </StatusWrapper>

--- a/src/components/WalletDropdown/AuthenticatedHeader.tsx
+++ b/src/components/WalletDropdown/AuthenticatedHeader.tsx
@@ -17,7 +17,8 @@ import { Text } from 'rebass'
 import { useCurrencyBalanceString } from 'state/connection/hooks'
 import { useAppDispatch } from 'state/hooks'
 import { updateSelectedWallet } from 'state/user/reducer'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
+import { ThemedText } from 'theme'
 
 import { shortenAddress } from '../../nft/utils/address'
 import { useCloseModal, useToggleModal } from '../../state/application/hooks'
@@ -82,6 +83,30 @@ const FlexContainer = styled.div`
 const StatusWrapper = styled.div`
   display: inline-block;
   margin-top: 4px;
+  width: 70%;
+`
+
+const TruncatedTextStyle = css`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`
+
+const AccountNamesWrapper = styled.div`
+  ${TruncatedTextStyle}
+  margin-right: 8px;
+`
+
+const ENSNameContainer = styled(ThemedText.SubHeader)`
+  ${TruncatedTextStyle}
+  color: ${({ theme }) => theme.textPrimary};
+  margin-top: 2.5px;
+`
+
+const AccountContainer = styled(ThemedText.BodySmall)`
+  ${TruncatedTextStyle}
+  color: ${({ theme }) => theme.textSecondary};
+  margin-top: 2.5px;
 `
 
 const BalanceWrapper = styled.div`
@@ -99,7 +124,7 @@ const AuthenticatedHeaderWrapper = styled.div`
 `
 
 const AuthenticatedHeader = () => {
-  const { account, chainId, connector } = useWeb3React()
+  const { account, chainId, connector, ENSName } = useWeb3React()
   const [isCopied, setCopied] = useCopyClipboard()
   const copy = useCallback(() => {
     setCopied(account || '')
@@ -153,9 +178,14 @@ const AuthenticatedHeader = () => {
         <StatusWrapper>
           <FlexContainer>
             <StatusIcon connectionType={connectionType} size={24} />
-            <Text fontSize={16} fontWeight={600} marginTop="2.5px">
-              {account && shortenAddress(account, 2, 4)}
-            </Text>
+            {ENSName ? (
+              <AccountNamesWrapper>
+                <ENSNameContainer>{ENSName}</ENSNameContainer>
+                <AccountContainer>{account && shortenAddress(account, 2, 4)}</AccountContainer>
+              </AccountNamesWrapper>
+            ) : (
+              <ThemedText.BodySmall marginTop="2.5px">{account && shortenAddress(account, 2, 4)}</ThemedText.BodySmall>
+            )}
           </FlexContainer>
         </StatusWrapper>
         <IconContainer>


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-1572?atlOrigin=eyJpIjoiNzFmODRmNDU5YmIzNGFjOTk4ODYzNmQ4YjRmNTE1MDEiLCJwIjoiaiJ9

note: it also truncates the account name stuff with ellipsis (...) when too long

has ENS: 
<img width="276" alt="Screen Shot 2022-12-07 at 1 43 31 PM" src="https://user-images.githubusercontent.com/41491154/206268723-b159351b-46f6-4b1a-82d0-b55f80bf07ac.png">

no ENS: 
<img width="277" alt="Screen Shot 2022-12-07 at 1 45 23 PM" src="https://user-images.githubusercontent.com/41491154/206268969-a5f8fc71-1a7c-4642-8e9b-c0670524d7a9.png">
