### PR TITLE
fix: handle user rejection

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -64,7 +64,7 @@ export function useUniversalRouterSwapCallback(
       return response
     } catch (swapError: unknown) {
       const message = swapErrorToUserReadableMessage(swapError)
-      throw new Error(`Trade failed: ${message}`)
+      throw new Error(message)
     }
   }, [
     account,

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -7,6 +7,14 @@ import { t } from '@lingui/macro'
  */
 export function swapErrorToUserReadableMessage(error: any): string {
   let reason: string | undefined
+
+  if (error.code) {
+    switch (error.code) {
+      case 4001:
+        return t`Transaction rejected`
+    }
+  }
+
   while (Boolean(error)) {
     reason = error.reason ?? error.message ?? reason
     error = error.error ?? error.data?.originalError


### PR DESCRIPTION
Displays a more user-friendly error - "Transaction rejected" - when user rejects a UR swap. This is the same behavior as without UR.