### PR TITLE
fix: disable swap while permit loading

### DIFF
--- a/src/hooks/usePermit2.ts
+++ b/src/hooks/usePermit2.ts
@@ -11,7 +11,7 @@ import { PermitSignature, usePermitAllowance, useUpdatePermitAllowance } from '.
 import { useTokenAllowance, useUpdateTokenAllowance } from './useTokenAllowance'
 
 export enum PermitState {
-  UNKNOWN,
+  INVALID,
   LOADING,
   PERMIT_NEEDED,
   PERMITTED,
@@ -87,7 +87,7 @@ export default function usePermit(amount?: CurrencyAmount<Token>, spender?: stri
 
   return useMemo(() => {
     if (!amount) {
-      return { state: PermitState.UNKNOWN }
+      return { state: PermitState.INVALID }
     } else if (!tokenAllowance || !permitAllowance) {
       return { state: PermitState.LOADING }
     } else if (isAllowed) {

--- a/src/hooks/usePermit2.ts
+++ b/src/hooks/usePermit2.ts
@@ -12,6 +12,7 @@ import { useTokenAllowance, useUpdateTokenAllowance } from './useTokenAllowance'
 
 export enum PermitState {
   UNKNOWN,
+  LOADING,
   PERMIT_NEEDED,
   PERMITTED,
 }
@@ -85,8 +86,10 @@ export default function usePermit(amount?: CurrencyAmount<Token>, spender?: stri
   )
 
   return useMemo(() => {
-    if (!amount || !tokenAllowance) {
+    if (!amount) {
       return { state: PermitState.UNKNOWN }
+    } else if (!tokenAllowance || !permitAllowance) {
+      return { state: PermitState.LOADING }
     } else if (isAllowed) {
       if (isPermitted) {
         return { state: PermitState.PERMITTED }
@@ -95,5 +98,5 @@ export default function usePermit(amount?: CurrencyAmount<Token>, spender?: stri
       }
     }
     return { state: PermitState.PERMIT_NEEDED, callback }
-  }, [amount, callback, isAllowed, isPermitted, isSigned, signature, tokenAllowance])
+  }, [amount, callback, isAllowed, isPermitted, isSigned, permitAllowance, signature, tokenAllowance])
 }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -873,7 +873,7 @@ export default function Swap() {
                       routeIsSyncing ||
                       routeIsLoading ||
                       priceImpactTooHigh ||
-                      Boolean(!permit2Enabled && swapCallbackError)
+                      (permit2Enabled ? permit.state === PermitState.LOADING : Boolean(swapCallbackError))
                     }
                     error={isValid && priceImpactSeverity > 2 && (permit2Enabled || !swapCallbackError)}
                   >


### PR DESCRIPTION
Adds a PermitState.LOADING to avoid initiating a swap before PermitState is known.
This prevents swaps from failing because they have not yet been permitted.