### PR TITLE
fix: textPrimary for landing page copy

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -75,7 +75,7 @@ const SubText = styled.h3`
 const CTAButton = styled(BaseButton)`
   padding: 16px;
   border-radius: 24px;
-  color: ${({ theme }) => theme.white};
+  color: ${({ theme }) => theme.textPrimary};
 
   &:hover {
     opacity: 50%;


### PR DESCRIPTION
This is necessary so light mode works properly