### PR TITLE
fix: add max-width to landing page subtext

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -65,6 +65,7 @@ const SubText = styled.h3`
   line-height: 24px;
   font-weight: 400;
   text-align: center;
+  max-width: 600px;
 
   @media screen and (min-width: ${DESKTOP_BREAKPOINT}px) {
     font-size: 28px;


### PR DESCRIPTION
<img width="1400" alt="Screen Shot 2022-12-08 at 12 51 06 PM" src="https://user-images.githubusercontent.com/4899429/206526779-67702f6a-c7ca-4f48-80c0-4b88c245ddb4.png">
