### PR TITLE
fix: Revert "fix: textPrimary for landing page copy"

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -76,7 +76,7 @@ const SubText = styled.h3`
 const CTAButton = styled(BaseButton)`
   padding: 16px;
   border-radius: 24px;
-  color: ${({ theme }) => theme.textPrimary};
+  color: ${({ theme }) => theme.white};
 
   &:hover {
     opacity: 50%;


### PR DESCRIPTION
Reverts Uniswap/interface#5580

Design said it should always be white.