### PR TITLE
chore: change About learn more to link to uniswap.org/about

### DIFF
--- a/src/pages/About/index.tsx
+++ b/src/pages/About/index.tsx
@@ -148,7 +148,7 @@ export default function About() {
               tokens, list a token, or provide liquidity in a pool to earn fees.
             </IntroCopy>
             <ActionsContainer>
-              <InfoButton as="a" rel="noopener noreferrer" href="https://uniswap.org" target="_blank">
+              <InfoButton as="a" rel="noopener noreferrer" href="https://uniswap.org/about" target="_blank">
                 Learn more
               </InfoButton>
               <InfoButton as="a" rel="noopener noreferrer" href="https://docs.uniswap.org" target="_blank">


### PR DESCRIPTION
Unclear when this change will happen, but right now it links to uniswap.org. We'll switch the content of that page to /about, so need to change this link.
