### PR TITLE
fix: light mode cards for /about

### DIFF
--- a/src/pages/About/Card.tsx
+++ b/src/pages/About/Card.tsx
@@ -1,9 +1,11 @@
 import { Link } from 'react-router-dom'
+import { useIsDarkMode } from 'state/user/hooks'
 import styled from 'styled-components/macro'
 
-const StyledCard = styled.div`
+const StyledCard = styled.div<{ isDarkMode: boolean }>`
   display: flex;
-  background: linear-gradient(180deg, rgba(19, 22, 27, 0.54) 0%, #13161b 100%);
+  background: ${({ isDarkMode }) =>
+    isDarkMode ? 'linear-gradient(180deg, rgba(19, 22, 27, 0.54) 0%, #13161b 100%)' : 'transparent'};
   flex-direction: column;
   justify-content: space-between;
   text-decoration: none;
@@ -12,6 +14,7 @@ const StyledCard = styled.div`
   height: 400px;
   border-radius: 24px;
   transition: ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.ease}  background-color`};
+  border: 1px solid ${({ theme }) => theme.backgroundOutline};
 
   &:hover {
     background-color: ${({ theme }) => theme.backgroundModule};
@@ -41,6 +44,7 @@ const Card = ({
   to: string
   external?: boolean
 }) => {
+  const isDarkMode = useIsDarkMode()
   return (
     <StyledCard
       as={external ? 'a' : Link}
@@ -48,6 +52,7 @@ const Card = ({
       href={external ? to : undefined}
       target={external ? '_blank' : undefined}
       rel={external ? 'noopenener noreferrer' : undefined}
+      isDarkMode={isDarkMode}
     >
       <CardTitle>{title}</CardTitle>
       <CardDescription>{description}</CardDescription>

--- a/src/pages/About/Card.tsx
+++ b/src/pages/About/Card.tsx
@@ -14,7 +14,7 @@ const StyledCard = styled.div<{ isDarkMode: boolean }>`
   height: 400px;
   border-radius: 24px;
   transition: ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.ease}  background-color`};
-  border: 1px solid ${({ theme }) => theme.backgroundOutline};
+  border: 1px solid ${({ theme, isDarkMode }) => (isDarkMode ? 'transparent' : theme.backgroundOutline)};
 
   &:hover {
     background-color: ${({ theme }) => theme.backgroundModule};


### PR DESCRIPTION
<img width="1201" alt="Screen Shot 2022-12-08 at 9 51 50 PM" src="https://user-images.githubusercontent.com/4899429/206613451-dc348083-a801-4eac-805f-b02a895fb0fd.png">
<img width="1203" alt="Screen Shot 2022-12-08 at 9 51 57 PM" src="https://user-images.githubusercontent.com/4899429/206613453-be57e99f-0ef7-4f94-be53-6afb31782c7b.png">
