### PR TITLE
fix: body, #root, AppWrapper and BodyWrapper height: 100%

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -89,7 +89,9 @@
         z-index: -1;
       }
 
-      html {
+      html,
+      body,
+      #root {
         min-height: 100%;
       }
 

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -67,12 +67,14 @@ const AppWrapper = styled.div`
   display: flex;
   flex-flow: column;
   align-items: flex-start;
+  height: 100%;
 `
 
 const BodyWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   padding: 72px 0px 0px 0px;
   align-items: center;
   flex: 1;


### PR DESCRIPTION
These should be at 100% so inner Page components are able to take up the full page size.