### PR TITLE
feat: add glow to landing page

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -38,7 +38,6 @@ const Nav = styled.nav`
   width: 100%;
   height: ${({ theme }) => theme.navHeight}px;
   z-index: 2;
-  background: ${({ theme }) => theme.backgroundFloating};
 `
 
 interface MenuItemProps {

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -24,13 +24,21 @@ const MobileBottomBar = styled.div`
   left: 0;
   justify-content: space-between;
   padding: 4px 8px;
-  height: 56px;
+  height: ${({ theme }) => theme.mobileBottomBarHeight}px;
   background: ${({ theme }) => theme.backgroundSurface};
   border-top: 1px solid ${({ theme }) => theme.backgroundOutline};
 
   @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
     display: none;
   }
+`
+
+const Nav = styled.nav`
+  padding: 20px 12px;
+  width: 100%;
+  height: ${({ theme }) => theme.navHeight}px;
+  z-index: 2;
+  background: ${({ theme }) => theme.backgroundFloating};
 `
 
 interface MenuItemProps {
@@ -91,7 +99,7 @@ const Navbar = () => {
 
   return (
     <>
-      <nav className={styles.nav}>
+      <Nav>
         <Box display="flex" height="full" flexWrap="nowrap" alignItems="stretch">
           <Box className={styles.leftSideContainer}>
             <Box className={styles.logoContainer}>
@@ -135,7 +143,7 @@ const Navbar = () => {
             </Row>
           </Box>
         </Box>
-      </nav>
+      </Nav>
       <MobileBottomBar>
         <PageTabs />
         <Box marginY="4">

--- a/src/components/NavBar/style.css.ts
+++ b/src/components/NavBar/style.css.ts
@@ -12,9 +12,6 @@ export const nav = style([
     zIndex: '2',
     background: 'backgroundFloating',
   }),
-  {
-    backdropFilter: 'blur(24px)',
-  },
 ])
 
 export const logoContainer = style([

--- a/src/components/NavBar/style.css.ts
+++ b/src/components/NavBar/style.css.ts
@@ -3,17 +3,6 @@ import { style } from '@vanilla-extract/css'
 import { subhead } from '../../nft/css/common.css'
 import { sprinkles, vars } from '../../nft/css/sprinkles.css'
 
-export const nav = style([
-  sprinkles({
-    paddingX: '20',
-    paddingY: '12',
-    width: 'full',
-    height: '72',
-    zIndex: '2',
-    background: 'backgroundFloating',
-  }),
-])
-
 export const logoContainer = style([
   sprinkles({
     display: 'flex',

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -18,9 +18,9 @@ const PageWrapper = styled.div`
   flex-direction: column;
   align-items: center;
 
-  height: calc(100vh - 72px - 56px);
-  @media screen and (min-width: ${BREAKPOINTS.md}px) {
-    height: calc(100vh - 72px);
+  height: ${({ theme }) => `calc(100vh - ${theme.navHeight + theme.mobileBottomBarHeight}px)`};
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
+    height: ${({ theme }) => `calc(100vh - ${theme.navHeight}px)`};
   }
 `
 

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -11,30 +11,54 @@ import styled from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 import { Z_INDEX } from 'theme/zIndex'
 
-const PageWrapper = styled.div<{ isDarkMode: boolean }>`
-  height: 100%;
+const PageWrapper = styled.div`
   width: 100%;
+  height: calc(100vh - 72px);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const Shadow = styled.div<{ isDarkMode: boolean }>`
   position: absolute;
+  top: 0;
   bottom: 0;
+  width: 100%;
   background: ${({ isDarkMode }) =>
     isDarkMode
       ? 'linear-gradient(rgba(8, 10, 24, 0) 9.84%, rgb(8 10 24 / 86%) 35.35%)'
       : 'linear-gradient(rgba(8, 10, 24, 0) 9.84%, rgb(255 255 255 / 86%) 35.35%)'};
   z-index: ${Z_INDEX.dropdown};
-  display: flex;
-  flex-direction: column;
-  justify-content: end;
-  align-items: center;
-  padding: 32px;
-  transition: 250ms ease opacity;
   pointer-events: none;
+`
+
+const Glow = styled.div`
+  position: absolute;
+  top: 68px;
+  bottom: 0;
+  background: radial-gradient(72.04% 72.04% at 50% 3.99%, #ff37eb 0%, rgba(166, 151, 255, 0) 100%);
+  filter: blur(72px);
+  border-radius: 24px;
+  max-width: 480px;
+  width: 100%;
+`
+
+const ContentWrapper = styled.div<{ isDarkMode: boolean }>`
+  width: 100%;
+  max-width: 720px;
+  position: absolute;
+  bottom: 0;
+  z-index: ${Z_INDEX.dropdown};
+  padding: 32px 0;
+  transition: 250ms ease opacity;
 
   * {
     pointer-events: auto;
   }
 
   @media screen and (min-width: ${BREAKPOINTS.sm}px) {
-    padding: 64px;
+    padding: 64px 0;
   }
 `
 
@@ -124,10 +148,6 @@ const ButtonCTAText = styled.p`
   }
 `
 
-const TitleWrapper = styled.span`
-  max-width: 720px;
-`
-
 const ActionsWrapper = styled.span`
   display: flex;
   justify-content: center;
@@ -168,23 +188,25 @@ export default function Landing() {
 
   return (
     <Trace page={PageName.LANDING_PAGE} shouldLogImpression>
-      <PageWrapper isDarkMode={isDarkMode}>
-        <TitleWrapper>
+      <PageWrapper>
+        <Swap />
+        <Glow />
+        <Shadow isDarkMode={isDarkMode} />
+        <ContentWrapper isDarkMode={isDarkMode}>
           <TitleText isDarkMode={isDarkMode}>Trade crypto & NFTs with confidence.</TitleText>
           <SubTextContainer>
             <SubText>Buy, sell, and explore tokens and NFTs </SubText>
           </SubTextContainer>
-        </TitleWrapper>
-        <ActionsWrapper>
-          <ButtonCTA as={Link} to="/swap">
-            <ButtonCTAText>Continue</ButtonCTAText>
-          </ButtonCTA>
-          <ButtonCTASecondary as={Link} to="/about">
-            <ButtonCTAText>Learn more</ButtonCTAText>
-          </ButtonCTASecondary>
-        </ActionsWrapper>
+          <ActionsWrapper>
+            <ButtonCTA as={Link} to="/swap">
+              <ButtonCTAText>Continue</ButtonCTAText>
+            </ButtonCTA>
+            <ButtonCTASecondary as={Link} to="/about">
+              <ButtonCTAText>Learn more</ButtonCTAText>
+            </ButtonCTASecondary>
+          </ActionsWrapper>
+        </ContentWrapper>
       </PageWrapper>
-      <Swap />
     </Trace>
   )
 }

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -13,11 +13,15 @@ import { Z_INDEX } from 'theme/zIndex'
 
 const PageWrapper = styled.div`
   width: 100%;
-  height: calc(100vh - 72px);
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  height: calc(100vh - 72px - 56px);
+  @media screen and (min-width: ${BREAKPOINTS.md}px) {
+    height: calc(100vh - 72px);
+  }
 `
 
 const Shadow = styled.div<{ isDarkMode: boolean }>`
@@ -46,7 +50,7 @@ const Glow = styled.div`
 
 const ContentWrapper = styled.div<{ isDarkMode: boolean }>`
   width: 100%;
-  max-width: 720px;
+  max-width: min(720px, 90%);
   position: absolute;
   bottom: 0;
   z-index: ${Z_INDEX.dropdown};

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -24,7 +24,7 @@ const PageWrapper = styled.div`
   }
 `
 
-const Shadow = styled.div<{ isDarkMode: boolean }>`
+const Gradient = styled.div<{ isDarkMode: boolean }>`
   position: absolute;
   top: 0;
   bottom: 0;
@@ -55,7 +55,7 @@ const ContentWrapper = styled.div<{ isDarkMode: boolean }>`
   bottom: 0;
   z-index: ${Z_INDEX.dropdown};
   padding: 32px 0;
-  transition: 250ms ease opacity;
+  transition: ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.ease} opacity`};
 
   * {
     pointer-events: auto;
@@ -195,7 +195,7 @@ export default function Landing() {
       <PageWrapper>
         <Swap />
         <Glow />
-        <Shadow isDarkMode={isDarkMode} />
+        <Gradient isDarkMode={isDarkMode} />
         <ContentWrapper isDarkMode={isDarkMode}>
           <TitleText isDarkMode={isDarkMode}>Trade crypto & NFTs with confidence.</TitleText>
           <SubTextContainer>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -20,7 +20,7 @@ const PageWrapper = styled.div<{ isDarkMode: boolean }>`
     isDarkMode
       ? 'linear-gradient(rgba(8, 10, 24, 0) 9.84%, rgb(8 10 24 / 86%) 35.35%)'
       : 'linear-gradient(rgba(8, 10, 24, 0) 9.84%, rgb(255 255 255 / 86%) 35.35%)'};
-  z-index: ${Z_INDEX.sticky};
+  z-index: ${Z_INDEX.dropdown};
   display: flex;
   flex-direction: column;
   justify-content: end;

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -80,6 +80,9 @@ function getSettings(darkMode: boolean) {
     // media queries
     deprecated_mediaWidth: deprecated_mediaWidthTemplates,
 
+    navHeight: 72,
+    mobileBottomBarHeight: 52,
+
     // deprecated - please use hardcoded exported values instead of
     // adding to the theme object
     breakpoint: BREAKPOINTS,


### PR DESCRIPTION
Adding a glow to the Swap component on a landing page + fixing a z-index issue

<img width="779" alt="Screenshot 2022-12-11 at 16 45 09" src="https://user-images.githubusercontent.com/2464966/206931716-4999df60-cc60-489b-9199-c7893fe45eb6.png">
<img width="774" alt="Screenshot 2022-12-11 at 16 45 26" src="https://user-images.githubusercontent.com/2464966/206931719-5fc473c6-d4ab-44e7-971b-3af254c6589e.png">
<img width="803" alt="Screenshot 2022-12-11 at 16 45 21" src="https://user-images.githubusercontent.com/2464966/206931720-b05727b9-f7c3-4942-9ceb-8f33ef26cac8.png">
<img width="854" alt="Screenshot 2022-12-11 at 16 45 12" src="https://user-images.githubusercontent.com/2464966/206931721-4cc4bef9-1c13-4823-9996-72063fd0768b.png">
