### PR TITLE
feat: close landing page when wallet connected

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -11,6 +11,7 @@ import { getConnection, getConnectionName, getIsCoinbaseWallet, getIsInjected, g
 import usePrevious from 'hooks/usePrevious'
 import { useCallback, useEffect, useState } from 'react'
 import { ArrowLeft } from 'react-feather'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { updateConnectionError } from 'state/connection/reducer'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { updateSelectedWallet } from 'state/user/reducer'
@@ -151,6 +152,9 @@ export default function WalletModal({
   const { connector, account, chainId } = useWeb3React()
   const previousAccount = usePrevious(account)
 
+  const location = useLocation()
+  const navigate = useNavigate()
+
   const [connectedWallets, addWalletToConnectedWallets] = useConnectedWallets()
 
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
@@ -177,8 +181,11 @@ export default function WalletModal({
   useEffect(() => {
     if (account && account !== previousAccount && walletModalOpen) {
       toggleWalletModal()
+      if (location.pathname === '/') {
+        navigate('/swap')
+      }
     }
-  }, [account, previousAccount, toggleWalletModal, walletModalOpen])
+  }, [account, previousAccount, toggleWalletModal, walletModalOpen, location.pathname, navigate])
 
   useEffect(() => {
     if (pendingConnector && walletView !== WALLET_VIEWS.PENDING) {


### PR DESCRIPTION
I would rather do this in some async fashion, but we don't have that set up in the app right now. I also think it can be confusing if there are random listeners all over, so maybe this is actually good to be explicit?