### PR TITLE
fix: no pointer-events on Swap children on landing page

### DIFF
--- a/src/components/swap/styleds.tsx
+++ b/src/components/swap/styleds.tsx
@@ -33,6 +33,10 @@ export const SwapWrapper = styled.main<{ margin?: string; maxWidth?: string; ope
   cursor: ${({ open }) => open && 'pointer'};
   transition: transform 250ms ease;
 
+  * {
+    pointer-events: ${({ open }) => open && 'none'};
+  }
+
   &:hover {
     border: 1px solid ${({ theme, open }) => (open ? theme.accentAction : theme.backgroundOutline)};
     transform: ${({ open }) => (open ? `translateY(-4px)` : `none`)};


### PR DESCRIPTION
This makes sure that cursor pointer is always active while on the landing page, and doesn't allow hover states on any elements. In practice, the landing page's Swap is really just a button so this show's that change.