### PR TITLE
fix: show error when present (not approval)

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -796,7 +796,7 @@ export default function Swap({ className }: { className?: string }) {
                       </ButtonError>
                     </AutoColumn>
                   </AutoRow>
-                ) : permit.state === PermitState.PERMIT_NEEDED ? (
+                ) : isValid && permit.state === PermitState.PERMIT_NEEDED ? (
                   <ButtonYellow
                     onClick={updatePermit}
                     disabled={isPermitPending || isApprovalPending}


### PR DESCRIPTION
If a `swapInputError` is present, shows that text instead of the approval button.
This codepath can be triggered by trying to swap an unapproved token for which you have insufficient balance to trade:
- _before_: shows approval flow
- _after_: shows "insufficient <TOKEN> balance" error