### PR TITLE
fix: allow empty states on days in listing

### DIFF
--- a/src/nft/components/profile/list/SetDurationModal.tsx
+++ b/src/nft/components/profile/list/SetDurationModal.tsx
@@ -66,11 +66,11 @@ enum ErrorState {
 export const SetDurationModal = () => {
   const [duration, setDuration] = useState(Duration.day)
   const [displayDuration, setDisplayDuration] = useState(Duration.day)
-  const [amount, setAmount] = useState(7)
+  const [amount, setAmount] = useState('7')
   const [errorState, setErrorState] = useState(ErrorState.valid)
   const setGlobalExpiration = useSellAsset((state) => state.setGlobalExpiration)
   const setCustomExpiration = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setAmount(!!event.target.value.length ? parseFloat(event.target.value) : 0)
+    setAmount(!!event.target.value.length ? event.target.value : '')
     setDuration(displayDuration)
   }
   const selectDuration = (duration: Duration) => {
@@ -99,8 +99,9 @@ export const SetDurationModal = () => {
     []
   )
   useEffect(() => {
-    const expiration = convertDurationToExpiration(amount, duration)
-    if (expiration * 1000 - Date.now() < ms`60 seconds`) setErrorState(ErrorState.empty)
+    const expiration = convertDurationToExpiration(parseFloat(amount), duration)
+
+    if (expiration * 1000 - Date.now() < ms`60 seconds` || isNaN(expiration)) setErrorState(ErrorState.empty)
     else if (expiration * 1000 - Date.now() > ms`180 days`) setErrorState(ErrorState.overMax)
     else setErrorState(ErrorState.valid)
     setGlobalExpiration(expiration)
@@ -127,7 +128,7 @@ export const SetDurationModal = () => {
           <SortDropdown
             dropDownOptions={durationOptions}
             mini
-            miniPrompt={displayDuration + (displayDuration === duration ? pluralize(amount) : 's')}
+            miniPrompt={displayDuration + (displayDuration === duration ? pluralize(parseFloat(amount)) : 's')}
             left={38}
             top={38}
           />


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-2508

Task requested ability to set days to empty when typing delete

Show error state with 0 or no amount set
<img width="1092" alt="Screen Shot 2022-12-13 at 12 56 33 PM" src="https://user-images.githubusercontent.com/15934595/207409115-e44b2bec-fe99-46d3-82a4-12f4241ab9c4.png">

<img width="1130" alt="Screen Shot 2022-12-13 at 12 56 37 PM" src="https://user-images.githubusercontent.com/15934595/207409060-1d5d5c11-83b0-4f49-8f97-cab567573248.png">

No error state when value is set
<img width="1125" alt="Screen Shot 2022-12-13 at 12 56 40 PM" src="https://user-images.githubusercontent.com/15934595/207409057-4dfad15e-6e6c-4baf-ad6d-f2714c93470b.png">

