### PR TITLE
fix: display impact before severity

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -873,10 +873,10 @@ export default function Swap({ className }: { className?: string }) {
                         swapInputError
                       ) : routeIsSyncing || routeIsLoading ? (
                         <Trans>Swap</Trans>
-                      ) : priceImpactSeverity > 2 ? (
-                        <Trans>Swap Anyway</Trans>
                       ) : priceImpactTooHigh ? (
                         <Trans>Price Impact Too High</Trans>
+                      ) : priceImpactSeverity > 2 ? (
+                        <Trans>Swap Anyway</Trans>
                       ) : (
                         <Trans>Swap</Trans>
                       )}


### PR DESCRIPTION
If the price impact is too high, swapping is disabled (unless in expert mode). Currently, however, the button still displays "Swap Anyway".

This fixes that, so that if price impact is too high the disabled button will show "Price Impact Too High" and not suggest that swapping is still possible.

To test: try to swap ETH for 1 Adventure Gold (LOOT)