### PR TITLE
build: change cypress timeout to 24s

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   projectId: 'yp82ef',
   videoUploadOnPasses: false,
-  defaultCommandTimeout: 4000, // 2x average block time
+  defaultCommandTimeout: 24000, // 2x average block time
   chromeWebSecurity: false,
   e2e: {
     setupNodeEvents(on, config) {


### PR DESCRIPTION
This was reverted by accident in this PR: https://github.com/Uniswap/interface/pull/5596

It's causing some tests to fail on main right now. In the future, we should be mocking network calls so we're not reliant on the chain state being synced.
