### PR TITLE
test: skip wallet dropdown tests

### DIFF
--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -1,6 +1,6 @@
 import { getTestSelector } from '../utils'
 
-describe('Wallet Dropdown', () => {
+describe.skip('Wallet Dropdown', () => {
   beforeEach(() => {
     cy.visit('/pool')
   })


### PR DESCRIPTION
These are consistently flaking so better to remove until we resolve the issue.
