### PR TITLE
fix: reverting some changes to wallet dropdown

### DIFF
--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -1,7 +1,7 @@
 import { getTestSelector } from '../utils'
 
-describe.skip('Wallet Dropdown', () => {
-  beforeEach(() => {
+describe('Wallet Dropdown', () => {
+  before(() => {
     cy.visit('/pool')
   })
 
@@ -12,7 +12,6 @@ describe.skip('Wallet Dropdown', () => {
   })
 
   it('should select a language', () => {
-    cy.get(getTestSelector('web3-status-connected')).click()
     cy.get(getTestSelector('wallet-select-language')).click()
     cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
     cy.get(getTestSelector('wallet-header')).should('contain', 'Taal')
@@ -22,24 +21,20 @@ describe.skip('Wallet Dropdown', () => {
   })
 
   it('should be able to view transactions', () => {
-    cy.get(getTestSelector('web3-status-connected')).click()
     cy.get(getTestSelector('wallet-transactions')).click()
     cy.get(getTestSelector('wallet-empty-transaction-text')).should('exist')
     cy.get(getTestSelector('wallet-back')).click()
   })
 
   it('should change the theme when not connected', () => {
-    cy.get(getTestSelector('web3-status-connected')).click()
     cy.get(getTestSelector('wallet-disconnect')).click()
     cy.get(getTestSelector('wallet-select-theme')).click()
-    cy.get(getTestSelector('wallet-select-theme')).contains('Light theme').should('exist')
-    cy.get(getTestSelector('wallet-select-theme')).click()
     cy.get(getTestSelector('wallet-select-theme')).contains('Dark theme').should('exist')
+    cy.get(getTestSelector('wallet-select-theme')).click()
+    cy.get(getTestSelector('wallet-select-theme')).contains('Light theme').should('exist')
   })
 
   it('should select a language when not connected', () => {
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.get(getTestSelector('wallet-disconnect')).click()
     cy.get(getTestSelector('wallet-select-language')).click()
     cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
     cy.get(getTestSelector('wallet-header')).should('contain', 'Taal')
@@ -49,8 +44,6 @@ describe.skip('Wallet Dropdown', () => {
   })
 
   it('should open the wallet connect modal from the drop down when not connected', () => {
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.get(getTestSelector('wallet-disconnect')).click()
     cy.get(getTestSelector('wallet-connect-wallet')).click()
     cy.get(getTestSelector('wallet-modal')).should('exist')
     cy.get(getTestSelector('wallet-modal-close')).click()


### PR DESCRIPTION
reverting changes to walletdrop down test to run all tests in a single flow.  This is how the test have been for a while and were not flaky.  