### PR TITLE
fix: constrain width on token details back button

### DIFF
--- a/src/components/Tokens/TokenDetails/BreadcrumbNavLink.tsx
+++ b/src/components/Tokens/TokenDetails/BreadcrumbNavLink.tsx
@@ -11,6 +11,7 @@ export const BreadcrumbNavLink = styled(Link)`
   text-decoration: none;
   margin-bottom: 16px;
   transition-duration: ${({ theme }) => theme.transition.duration.fast};
+  width: fit-content;
 
   &:hover {
     color: ${({ theme }) => theme.textTertiary};


### PR DESCRIPTION
Adds some CSS to the Token Details Page to constrain the width of the "< back" Link component. Previously it was flex-growing to fill the parent width, but that was causing the cursor-pointer effect to happen all the way to the right, over empty space.