### PR TITLE
fix: correct color for selected token in CurrencySearchModal

### DIFF
--- a/src/components/SearchModal/CommonBases.tsx
+++ b/src/components/SearchModal/CommonBases.tsx
@@ -18,7 +18,7 @@ const MobileWrapper = styled(AutoColumn)`
 `
 
 const BaseWrapper = styled.div<{ disable?: boolean }>`
-  border: 1px solid ${({ theme, disable }) => (disable ? theme.accentAction : theme.backgroundOutline)};
+  border: 1px solid ${({ theme, disable }) => (disable ? theme.accentActive : theme.backgroundOutline)};
   border-radius: 16px;
   display: flex;
   padding: 6px;
@@ -30,8 +30,8 @@ const BaseWrapper = styled.div<{ disable?: boolean }>`
     background-color: ${({ theme }) => theme.hoverDefault};
   }
 
-  color: ${({ theme, disable }) => disable && theme.accentAction};
-  background-color: ${({ theme, disable }) => disable && theme.accentActionSoft};
+  color: ${({ theme, disable }) => disable && theme.accentActive};
+  background-color: ${({ theme, disable }) => disable && theme.accentActiveSoft};
 `
 
 const formatAnalyticsEventProperties = (currency: Currency, searchQuery: string, isAddressSearch: string | false) => ({


### PR DESCRIPTION
Changes the CSS color variable used in the "selected" state for the suggested tokens in CurrencySearchModal.

from design:
"what's wrong here is that the selected token chip is pink which means it's probably using our color variable action
it should be using our variable name active
our color variables are pair values that swap back and forth depending on light or dark mode. this is a common mistake here because action is blue in dark mode, pink in light mode, whereas active is blue in both light and dark modes"

tested by verifying that the new color is blue in both light and dark mode