### PR TITLE
fix:  failing cypress test

### DIFF
--- a/cypress/e2e/redirects.test.ts
+++ b/cypress/e2e/redirects.test.ts
@@ -5,6 +5,6 @@ describe('Redirect', () => {
   })
   it('should redirect to /swap when visiting nonexist url', () => {
     cy.visit('/none-exist-url')
-    cy.url().should('match', /\/swap/)
+    cy.url().should('match', /\/not-found/)
   })
 })

--- a/cypress/e2e/redirects.test.ts
+++ b/cypress/e2e/redirects.test.ts
@@ -3,7 +3,7 @@ describe('Redirect', () => {
     cy.visit('/create-proposal')
     cy.url().should('match', /\/vote\/create-proposal/)
   })
-  it('should redirect to /swap when visiting nonexist url', () => {
+  it('should redirect to /not-found when visiting nonexist url', () => {
     cy.visit('/none-exist-url')
     cy.url().should('match', /\/not-found/)
   })


### PR DESCRIPTION
this test was not updated along with a recent code change.   This will cause a recurring failing cypress test for everyone.  This change fixes that failing test.  Tested and verified locally

<img width="1436" alt="Screen Shot 2022-12-16 at 4 29 07 PM" src="https://user-images.githubusercontent.com/15934595/208192071-aecd5158-1526-40df-9953-596eb7e76238.png">



