### PR TITLE
feat: navigate to /swap if user has a wallet cached

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -1,6 +1,7 @@
 import { Trace, TraceEvent } from '@uniswap/analytics'
 import { BrowserEvent, ElementName, EventName, PageName } from '@uniswap/analytics-events'
 import { BaseButton } from 'components/Button'
+import { LandingRedirectVariant, useLandingRedirectFlag } from 'featureFlags/flags/landingRedirect'
 import Swap from 'pages/Swap'
 import { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -178,12 +179,13 @@ export default function Landing() {
   }, [])
 
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
+  const landingRedirectFlag = useLandingRedirectFlag()
   const navigate = useNavigate()
   useEffect(() => {
-    if (selectedWallet) {
+    if (selectedWallet && landingRedirectFlag === LandingRedirectVariant.Enabled) {
       navigate('/swap')
     }
-  })
+  }, [navigate, selectedWallet, landingRedirectFlag])
 
   if (!isOpen) return null
 

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -3,8 +3,9 @@ import { BrowserEvent, ElementName, EventName, PageName } from '@uniswap/analyti
 import { BaseButton } from 'components/Button'
 import Swap from 'pages/Swap'
 import { useEffect } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { Link as NativeLink } from 'react-router-dom'
+import { useAppSelector } from 'state/hooks'
 import { useIsDarkMode } from 'state/user/hooks'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
@@ -175,6 +176,14 @@ export default function Landing() {
       document.body.style.overflow = 'auto'
     }
   }, [])
+
+  const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
+  const navigate = useNavigate()
+  useEffect(() => {
+    if (selectedWallet) {
+      navigate('/swap')
+    }
+  })
 
   if (!isOpen) return null
 


### PR DESCRIPTION
Wallet cached -> stay on landing page
Wallet not cached -> redirect to swap

This does not yet handle the case where the user clicks on the header or is linked specifically to the landing page yet.