### PR TITLE
feat: force landing page to show based on `landing` query param

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -189,7 +189,7 @@ export default function Landing() {
 
   // This can be simplified significantly once the flag is removed! For now being explicit is clearer.
   useEffect(() => {
-    if (queryParams.landing) {
+    if (queryParams.intro) {
       setShowContent(true)
     } else if (selectedWallet) {
       if (landingRedirectFlag === LandingRedirectVariant.Enabled) {

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -3,8 +3,9 @@ import { BrowserEvent, ElementName, EventName, PageName } from '@uniswap/analyti
 import { BaseButton } from 'components/Button'
 import { LandingRedirectVariant, useLandingRedirectFlag } from 'featureFlags/flags/landingRedirect'
 import Swap from 'pages/Swap'
+import { parse } from 'qs'
 import { useEffect, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { Link as NativeLink } from 'react-router-dom'
 import { useAppSelector } from 'state/hooks'
 import { useIsDarkMode } from 'state/user/hooks'
@@ -182,11 +183,13 @@ export default function Landing() {
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
   const landingRedirectFlag = useLandingRedirectFlag()
   const navigate = useNavigate()
-  const params = useParams()
+  const queryParams = parse(location.search, {
+    ignoreQueryPrefix: true,
+  })
 
   // This can be simplified significantly once the flag is removed! For now being explicit is clearer.
   useEffect(() => {
-    if (params.landing) {
+    if (queryParams.landing) {
       setShowContent(true)
     } else if (selectedWallet) {
       if (landingRedirectFlag === LandingRedirectVariant.Enabled) {

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -4,7 +4,7 @@ import { BaseButton } from 'components/Button'
 import { LandingRedirectVariant, useLandingRedirectFlag } from 'featureFlags/flags/landingRedirect'
 import Swap from 'pages/Swap'
 import { useEffect, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Link as NativeLink } from 'react-router-dom'
 import { useAppSelector } from 'state/hooks'
 import { useIsDarkMode } from 'state/user/hooks'
@@ -182,8 +182,13 @@ export default function Landing() {
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
   const landingRedirectFlag = useLandingRedirectFlag()
   const navigate = useNavigate()
+  const params = useParams()
+
+  // This can be simplified significantly once the flag is removed! For now being explicit is clearer.
   useEffect(() => {
-    if (selectedWallet) {
+    if (params.landing) {
+      setShowContent(true)
+    } else if (selectedWallet) {
       if (landingRedirectFlag === LandingRedirectVariant.Enabled) {
         navigate('/swap')
       } else {

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -200,7 +200,7 @@ export default function Landing() {
     } else {
       setShowContent(true)
     }
-  }, [navigate, selectedWallet, landingRedirectFlag])
+  }, [navigate, selectedWallet, landingRedirectFlag, queryParams.intro])
 
   if (!isOpen) return null
 


### PR DESCRIPTION
This enforces that the landing page will show when the query param is used, even for users with a conncted wallet. This is useful for linking via a Tweet or for usage elsewhere in the app.
