### PR TITLE
fix: Remove top level Suspense

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -200,111 +200,109 @@ export default function App() {
           <Popups />
           <Polling />
           <TopLevelModals />
-          <Suspense fallback={<Loader />}>
-            {isLoaded ? (
-              <Routes>
-                <Route path="/" element={<Landing />} />
+          {isLoaded ? (
+            <Routes>
+              <Route path="/" element={<Landing />} />
 
-                <Route path="tokens" element={<Tokens />}>
-                  <Route path=":chainName" />
-                </Route>
-                <Route path="tokens/:chainName/:tokenAddress" element={<TokenDetails />} />
-                <Route
-                  path="vote/*"
-                  element={
-                    <Suspense fallback={<LazyLoadSpinner />}>
-                      <Vote />
-                    </Suspense>
-                  }
-                />
-                <Route path="create-proposal" element={<Navigate to="/vote/create-proposal" replace />} />
-                <Route path="claim" element={<OpenClaimAddressModalAndRedirectToSwap />} />
-                <Route path="uni" element={<Earn />} />
-                <Route path="uni/:currencyIdA/:currencyIdB" element={<Manage />} />
+              <Route path="tokens" element={<Tokens />}>
+                <Route path=":chainName" />
+              </Route>
+              <Route path="tokens/:chainName/:tokenAddress" element={<TokenDetails />} />
+              <Route
+                path="vote/*"
+                element={
+                  <Suspense fallback={<LazyLoadSpinner />}>
+                    <Vote />
+                  </Suspense>
+                }
+              />
+              <Route path="create-proposal" element={<Navigate to="/vote/create-proposal" replace />} />
+              <Route path="claim" element={<OpenClaimAddressModalAndRedirectToSwap />} />
+              <Route path="uni" element={<Earn />} />
+              <Route path="uni/:currencyIdA/:currencyIdB" element={<Manage />} />
 
-                <Route path="send" element={<RedirectPathToSwapOnly />} />
-                <Route path="swap" element={<Swap />} />
+              <Route path="send" element={<RedirectPathToSwapOnly />} />
+              <Route path="swap" element={<Swap />} />
 
-                <Route path="pool/v2/find" element={<PoolFinder />} />
-                <Route path="pool/v2" element={<PoolV2 />} />
-                <Route path="pool" element={<Pool />} />
-                <Route path="pool/:tokenId" element={<PositionPage />} />
+              <Route path="pool/v2/find" element={<PoolFinder />} />
+              <Route path="pool/v2" element={<PoolV2 />} />
+              <Route path="pool" element={<Pool />} />
+              <Route path="pool/:tokenId" element={<PositionPage />} />
 
-                <Route path="add/v2" element={<RedirectDuplicateTokenIdsV2 />}>
-                  <Route path=":currencyIdA" />
-                  <Route path=":currencyIdA/:currencyIdB" />
-                </Route>
-                <Route path="add" element={<RedirectDuplicateTokenIds />}>
-                  {/* this is workaround since react-router-dom v6 doesn't support optional parameters any more */}
-                  <Route path=":currencyIdA" />
-                  <Route path=":currencyIdA/:currencyIdB" />
-                  <Route path=":currencyIdA/:currencyIdB/:feeAmount" />
-                </Route>
+              <Route path="add/v2" element={<RedirectDuplicateTokenIdsV2 />}>
+                <Route path=":currencyIdA" />
+                <Route path=":currencyIdA/:currencyIdB" />
+              </Route>
+              <Route path="add" element={<RedirectDuplicateTokenIds />}>
+                {/* this is workaround since react-router-dom v6 doesn't support optional parameters any more */}
+                <Route path=":currencyIdA" />
+                <Route path=":currencyIdA/:currencyIdB" />
+                <Route path=":currencyIdA/:currencyIdB/:feeAmount" />
+              </Route>
 
-                <Route path="increase" element={<AddLiquidity />}>
-                  <Route path=":currencyIdA" />
-                  <Route path=":currencyIdA/:currencyIdB" />
-                  <Route path=":currencyIdA/:currencyIdB/:feeAmount" />
-                  <Route path=":currencyIdA/:currencyIdB/:feeAmount/:tokenId" />
-                </Route>
+              <Route path="increase" element={<AddLiquidity />}>
+                <Route path=":currencyIdA" />
+                <Route path=":currencyIdA/:currencyIdB" />
+                <Route path=":currencyIdA/:currencyIdB/:feeAmount" />
+                <Route path=":currencyIdA/:currencyIdB/:feeAmount/:tokenId" />
+              </Route>
 
-                <Route path="remove/v2/:currencyIdA/:currencyIdB" element={<RemoveLiquidity />} />
-                <Route path="remove/:tokenId" element={<RemoveLiquidityV3 />} />
+              <Route path="remove/v2/:currencyIdA/:currencyIdB" element={<RemoveLiquidity />} />
+              <Route path="remove/:tokenId" element={<RemoveLiquidityV3 />} />
 
-                <Route path="migrate/v2" element={<MigrateV2 />} />
-                <Route path="migrate/v2/:address" element={<MigrateV2Pair />} />
+              <Route path="migrate/v2" element={<MigrateV2 />} />
+              <Route path="migrate/v2/:address" element={<MigrateV2Pair />} />
 
-                <Route path="about" element={<About />} />
+              <Route path="about" element={<About />} />
 
-                <Route
-                  path="/nfts"
-                  element={
-                    // TODO: replace loading state during Apollo migration
-                    <Suspense fallback={null}>
-                      <NftExplore />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="/nfts/asset/:contractAddress/:tokenId"
-                  element={
-                    <Suspense fallback={<AssetDetailsLoading />}>
-                      <Asset />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="/nfts/profile"
-                  element={
-                    <Suspense fallback={<ProfilePageLoadingSkeleton />}>
-                      <Profile />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="/nfts/collection/:contractAddress"
-                  element={
-                    <Suspense fallback={<CollectionPageSkeleton />}>
-                      <Collection />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="/nfts/collection/:contractAddress/activity"
-                  element={
-                    <Suspense fallback={<CollectionPageSkeleton />}>
-                      <Collection />
-                    </Suspense>
-                  }
-                />
+              <Route
+                path="/nfts"
+                element={
+                  // TODO: replace loading state during Apollo migration
+                  <Suspense fallback={null}>
+                    <NftExplore />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/nfts/asset/:contractAddress/:tokenId"
+                element={
+                  <Suspense fallback={<AssetDetailsLoading />}>
+                    <Asset />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/nfts/profile"
+                element={
+                  <Suspense fallback={<ProfilePageLoadingSkeleton />}>
+                    <Profile />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/nfts/collection/:contractAddress"
+                element={
+                  <Suspense fallback={<CollectionPageSkeleton />}>
+                    <Collection />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/nfts/collection/:contractAddress/activity"
+                element={
+                  <Suspense fallback={<CollectionPageSkeleton />}>
+                    <Collection />
+                  </Suspense>
+                }
+              />
 
-                <Route path="*" element={<Navigate to="/not-found" replace />} />
-                <Route path="/not-found" element={<NotFound />} />
-              </Routes>
-            ) : (
-              <Loader />
-            )}
-          </Suspense>
+              <Route path="*" element={<Navigate to="/not-found" replace />} />
+              <Route path="/not-found" element={<NotFound />} />
+            </Routes>
+          ) : (
+            <Loader />
+          )}
         </BodyWrapper>
         <MobileBottomBar>
           <PageTabs />


### PR DESCRIPTION
Before v0's style update we had 1 top level Suspense state with a blue loading circle. This is outdated as every page has their own loading skeleton and there is no case where we'd want to show a blank page with just the spinner. The need for this is apparent during the apollo migration where page level suspense states can be removed but this circle would still flash on initial pageload. Tested loading every page and all skeletons show as expected.

Tip: hide whitespace changes when reviewing