### PR TITLE
test: disable fiat announcement on cypress tests

### DIFF
--- a/cypress/e2e/nfts.test.ts
+++ b/cypress/e2e/nfts.test.ts
@@ -22,7 +22,7 @@ describe('Testing nfts', () => {
     cy.get(getTestSelector('nft-collection-filter-buy-now')).should('exist')
   })
 
-  xit('should be able to open bag and open sweep', () => {
+  it('should be able to open bag and open sweep', () => {
     cy.get(getTestSelector('nft-sweep-button')).first().click()
     cy.get(getTestSelector('nft-empty-bag')).should('exist')
     cy.get(getTestSelector('nft-sweep-slider')).should('exist')
@@ -52,7 +52,7 @@ describe('Testing nfts', () => {
     cy.get(getTestSelector('nft-bag')).should('exist')
   })
 
-  xit('should go view my nfts', () => {
+  it('should go view my nfts', () => {
     cy.get(getTestSelector('web3-status-connected')).click()
     cy.get(getTestSelector('nft-view-self-nfts')).click()
     cy.get(getTestSelector('nft-explore-nfts-button')).should('exist')

--- a/cypress/e2e/pool.test.ts
+++ b/cypress/e2e/pool.test.ts
@@ -1,7 +1,7 @@
 describe('Pool', () => {
   beforeEach(() => cy.visit('/pool'))
 
-  xit('add liquidity links to /add/ETH', () => {
+  it('add liquidity links to /add/ETH', () => {
     cy.get('#join-pool-button').click()
     cy.url().should('contain', '/add/ETH')
   })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -39,6 +39,7 @@ Cypress.Commands.overwrite(
           options?.onBeforeLoad?.(win)
           win.localStorage.clear()
           win.localStorage.setItem('redux_localstorage_simple_user', '{"selectedWallet":"INJECTED"}')
+          win.localStorage.setItem('FiatOnrampAnnouncement-dismissed', 'true')
 
           if (options?.featureFlags) {
             const featureFlags = options.featureFlags.reduce(

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -38,8 +38,10 @@ Cypress.Commands.overwrite(
         onBeforeLoad(win) {
           options?.onBeforeLoad?.(win)
           win.localStorage.clear()
-          win.localStorage.setItem('redux_localstorage_simple_user', '{"selectedWallet":"INJECTED"}')
-          win.localStorage.setItem('FiatOnrampAnnouncement-dismissed', 'true')
+          win.localStorage.setItem(
+            'redux_localstorage_simple_user',
+            '{"selectedWallet":"INJECTED", "fiatOnrampDismissed": "true"}'
+          )
 
           if (options?.featureFlags) {
             const featureFlags = options.featureFlags.reduce(


### PR DESCRIPTION
These skipped tests don't need to test the behavior of the announcement.
