### PR TITLE
fix: stop showing the token logos from different chains as a fallback

### DIFF
--- a/src/constants/TokenLogoLookupTable.ts
+++ b/src/constants/TokenLogoLookupTable.ts
@@ -13,11 +13,11 @@ class TokenLogoLookupTable {
       store.getState().lists.byUrl[list].current?.tokens.forEach((token) => {
         if (token.logoURI) {
           const lowercaseAddress = token.address.toLowerCase()
-          const currentEntry = dict[lowercaseAddress]
+          const currentEntry = dict[lowercaseAddress + ':' + token.chainId]
           if (currentEntry) {
             currentEntry.push(token.logoURI)
           } else {
-            dict[lowercaseAddress] = [token.logoURI]
+            dict[lowercaseAddress + ':' + token.chainId] = [token.logoURI]
           }
         }
       })
@@ -25,13 +25,14 @@ class TokenLogoLookupTable {
     this.dict = dict
     this.initialized = true
   }
-  getIcons(address?: string | null) {
+  getIcons(address?: string | null, chainId: number | null = 1) {
     if (!address) return undefined
 
     if (!this.initialized) {
       this.initialize()
     }
-    return this.dict[address.toLowerCase()]
+
+    return this.dict[address.toLowerCase() + ':' + chainId]
   }
 }
 

--- a/src/hooks/useAssetLogoSource.ts
+++ b/src/hooks/useAssetLogoSource.ts
@@ -66,7 +66,7 @@ export default function useAssetLogoSource(
     }
     // Parses and stores logo sources from tokenlists if assets repo url fails
     if (!fallbackSrcs) {
-      const uris = TokenLogoLookupTable.getIcons(address) ?? []
+      const uris = TokenLogoLookupTable.getIcons(address, chainId) ?? []
       if (backupImg) uris.push(backupImg)
       const tokenListIcons = prioritizeLogoSources(parseLogoSources(uris))
 
@@ -75,7 +75,7 @@ export default function useAssetLogoSource(
     } else {
       setCurrent(fallbackSrcs.find((src) => !BAD_SRCS[src]))
     }
-  }, [current, fallbackSrcs, address, backupImg])
+  }, [current, fallbackSrcs, address, chainId, backupImg])
 
   return [current, nextSrc]
 }


### PR DESCRIPTION
Use chainId to select network-specific token logos in the Token Search modal results.

https://uniswaplabs.atlassian.net/browse/WEB-2350?atlOrigin=eyJpIjoiNTk4NDNlZGFmYTY4NDkxNjg0YTc4YjAzZjM5ZjIzYWIiLCJwIjoiaiJ9

the bug report says we should show "No results" in the case of pasting an address of a token from a different network. But I confirmed with product that we actually want to show an unknown token if the user pastes a token address into the search directly.

this change just ensures we don't incorrectly show a token logo from a different chain.

