### PR TITLE
fix: Sentry source maps URL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,4 +121,4 @@ jobs:
         with:
           environment: production
           sourcemaps: './build/static/js'
-          url_prefix: '/static/js'
+          url_prefix: '~/static/js'


### PR DESCRIPTION
Updates the source maps settings as per Sentry documentation (see below):

----

That is, if your file is similar to:

JavaScript

```
// -- end script.min.js
//# sourceMappingURL=script.min.js.map
```

and is hosted at http://example.com/js/script.min.js, then Sentry will look for that source map file at http://example.com/js/script.min.js.map. 

Your uploaded artifact must therefore be named http://example.com/js/script.min.js.map (or ~/js/script.min.js.map).