### PR TITLE
build: pause scheduled releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,5 @@
 name: Release
 on:
-  schedule:
-    - cron: '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
   # manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
Pauses scheduled releases to coincide with the holidays.
This will be reverted after the holidays.