### PR TITLE
fix: connect button word break

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -176,6 +176,7 @@ const StyledConnectButton = styled.button`
   font-weight: 600;
   font-size: 16px;
   padding: 10px 8px 10px 12px;
+  word-break: keep-all;
 
   transition: ${({
     theme: {


### PR DESCRIPTION
Resolves #5480 

Add `word-break: keep-all;` to Connect button styles. This is the only 
East asian languages has specific rules that are followed when breaking text ([e.g. "kinsoku shori" standard for Japanese](https://en.wikipedia.org/wiki/Line_breaking_rules_in_East_Asian_languages)). In opposition to English, words are not separated with with white spaces. 

This PR provide simplest and most efficient way to fix it. Another ways are:
- recognise special characters using JavaScript,
- wrap Japanese words to special CSS classes,
- depend used styles on the currently selected language.