### PR TITLE
fix: center empty wallet text on Profile Page Mobile

### DIFF
--- a/src/nft/components/profile/view/EmptyWalletContent.tsx
+++ b/src/nft/components/profile/view/EmptyWalletContent.tsx
@@ -10,14 +10,15 @@ const EmptyWalletContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 190px;
-  flex: none;
+  justify-content: center;
+  margin: 190px 0px;
+  flex-wrap: wrap;
 `
 
 const EmptyWalletText = styled.div`
-  width: min-content;
-  white-space: nowrap;
+  white-space: normal;
   margin-top: 12px;
+  text-align: center;
 `
 
 const ExploreNFTsButton = styled.button`
@@ -37,16 +38,16 @@ const ExploreNFTsButton = styled.button`
 `
 
 export const EmptyWalletContent = () => {
-  const { account } = useWeb3React()
+  const { account, ENSName } = useWeb3React()
   const navigate = useNavigate()
   return (
     <EmptyWalletContainer>
       <EmptyNFTWalletIcon />
       <EmptyWalletText className={headlineMedium}>
-        <Trans>No NFTs in</Trans>&nbsp;{shortenAddress(account ?? '')}
+        <Trans>No NFTs in</Trans>&nbsp;{ENSName || shortenAddress(account ?? '')}
       </EmptyWalletText>
       <ExploreNFTsButton data-testid="nft-explore-nfts-button" onClick={() => navigate('/nfts')}>
-        Explore NFTs
+        <Trans>Explore NFTs</Trans>
       </ExploreNFTsButton>
     </EmptyWalletContainer>
   )


### PR DESCRIPTION
Center Empty Wallet text on mobile. Also show ENS if present but this should be a very rare edge case which only happens if ens has registered the NFT to the wallet before our BE has indexed it.

New:
<img width="394" alt="Screen Shot 2022-12-27 at 07 56 39 " src="https://user-images.githubusercontent.com/11512321/209670747-84e15a19-2ab9-4596-8912-2225f4127850.png">

