### PR TITLE
fix: end -> flex-end

### DIFF
--- a/src/nft/components/explore/Cells/Cells.tsx
+++ b/src/nft/components/explore/Cells/Cells.tsx
@@ -51,14 +51,14 @@ const RoundedImage = styled.div<{ src?: string }>`
 const ChangeCellContainer = styled.div<{ change: number }>`
   display: flex;
   color: ${({ theme, change }) => (change >= 0 ? theme.accentSuccess : theme.accentFailure)};
-  justify-content: end;
+  justify-content: flex-end;
   align-items: center;
   gap: 2px;
 `
 
 const EthContainer = styled.div`
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
 `
 
 interface CellProps {

--- a/src/nft/components/explore/Table.tsx
+++ b/src/nft/components/explore/Table.tsx
@@ -61,7 +61,7 @@ const StyledHeader = styled.th<{ disabled?: boolean }>`
 const StyledLoadingHolder = styled.div`
   display: flex;
   width: 100%;
-  justify-content: end;
+  justify-content: flex-end;
   align-items: center;
 `
 

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -88,7 +88,7 @@ const ContentContainer = styled.div<{ isDarkMode: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   width: 100%;
   padding: 0 0 40px;
   max-width: min(720px, 90%);


### PR DESCRIPTION
`justify-content: end` doesn't work on safari. 

@zzmp @grabbou should own adding a lint rule to prevent using `end` in flex properties.