### PR TITLE
feat: nft input price field to use numeric keypad on mobile

### DIFF
--- a/src/nft/components/layout/Input.tsx
+++ b/src/nft/components/layout/Input.tsx
@@ -26,6 +26,7 @@ export const NumericInput = forwardRef<HTMLInputElement, BoxProps>((props, ref) 
     <Box
       ref={ref}
       as="input"
+      inputMode="decimal"
       autoComplete="off"
       type="text"
       borderColor={{ default: 'backgroundOutline', focus: 'textSecondary' }}


### PR DESCRIPTION
Changes the nft shared numeric input to use the numeric keypad on mobile. This affects the following components:
- Listing price
- Date input when listing
- Price range filter on collection page

![321003951_842835863669387_7303515943766977146_n](https://user-images.githubusercontent.com/11512321/210104145-72a0a67a-5f03-493c-8a39-2480470a626e.jpg)
![321307608_1409779263117271_3890026757414809135_n](https://user-images.githubusercontent.com/11512321/210104147-0e805c80-291e-4186-8633-0c7f89be981d.jpg)
![321584436_2789985551133767_3280774265493638387_n](https://user-images.githubusercontent.com/11512321/210104149-a1d2b145-9fb7-48d0-b0ef-f33d4bbad9e6.jpg)
![319373619_694510402397210_932047828362969867_n](https://user-images.githubusercontent.com/11512321/210104141-7d95ffbb-deb3-46c5-a7bf-d84f042bb993.jpg)
