### PR TITLE
chore: Migrate NFTListingGrid from vanilla-extract to styled-components

### DIFF
--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -1020,7 +1020,7 @@ export type TokenPriceLazyQueryHookResult = ReturnType<typeof useTokenPriceLazyQ
 export type TokenPriceQueryResult = Apollo.QueryResult<TokenPriceQuery, TokenPriceQueryVariables>;
 export const TopTokens100Document = gql`
     query TopTokens100($duration: HistoryDuration!, $chain: Chain!) {
-  topTokens(pageSize: 100, page: 1, chain: $chain) {
+  topTokens(pageSize: 100, page: 1, chain: $chain, orderBy: VOLUME) {
     id
     name
     chain

--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -1020,7 +1020,7 @@ export type TokenPriceLazyQueryHookResult = ReturnType<typeof useTokenPriceLazyQ
 export type TokenPriceQueryResult = Apollo.QueryResult<TokenPriceQuery, TokenPriceQueryVariables>;
 export const TopTokens100Document = gql`
     query TopTokens100($duration: HistoryDuration!, $chain: Chain!) {
-  topTokens(pageSize: 100, page: 1) {
+  topTokens(pageSize: 100, page: 1, chain: $chain) {
     id
     name
     chain

--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -1020,7 +1020,7 @@ export type TokenPriceLazyQueryHookResult = ReturnType<typeof useTokenPriceLazyQ
 export type TokenPriceQueryResult = Apollo.QueryResult<TokenPriceQuery, TokenPriceQueryVariables>;
 export const TopTokens100Document = gql`
     query TopTokens100($duration: HistoryDuration!, $chain: Chain!) {
-  topTokens(pageSize: 100, page: 1, chain: $chain, orderBy: VOLUME) {
+  topTokens(pageSize: 100, page: 1) {
     id
     name
     chain

--- a/src/nft/components/profile/list/ListPage.css.ts
+++ b/src/nft/components/profile/list/ListPage.css.ts
@@ -1,16 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { sprinkles, themeVars } from 'nft/css/sprinkles.css'
-
-export const nftDivider = style([
-  sprinkles({
-    height: '0',
-    width: 'full',
-    borderRadius: '20',
-    borderWidth: '0.5px',
-    borderStyle: 'solid',
-    borderColor: 'backgroundOutline',
-  }),
-])
+import { themeVars } from 'nft/css/sprinkles.css'
 
 export const chevronDown = style({
   transform: 'rotate(180deg)',

--- a/src/nft/components/profile/list/ListPage.css.ts
+++ b/src/nft/components/profile/list/ListPage.css.ts
@@ -1,19 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { themeVars } from 'nft/css/sprinkles.css'
-
-export const chevronDown = style({
-  transform: 'rotate(180deg)',
-})
-
-export const dropdown = style({
-  boxShadow: `0px 4px 16px ${themeVars.colors.backgroundSurface}`,
-  marginLeft: '-12px',
-})
-
-export const removeAsset = style({
-  top: '31px',
-  left: '8px',
-})
 
 export const removeMarketplace = style({
   top: '11px',

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -1,8 +1,9 @@
 import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
+import { Box } from 'nft/components/Box'
 import { SortDropdown } from 'nft/components/common/SortDropdown'
-import { Column, Row } from 'nft/components/Flex'
+import { Row } from 'nft/components/Flex'
 import { useSellAsset } from 'nft/hooks'
 import { DropDownOption, ListingMarket } from 'nft/types'
 import { useMemo, useState } from 'react'
@@ -63,26 +64,26 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
   return (
     <GridWrapper>
       <TableHeader>
-        <Column flex={{ sm: '2', md: '1.5' }}>
+        <Box flex={{ sm: '2', md: '1.5' }}>
           <Trans>NFT</Trans>
-        </Column>
+        </Box>
         <Row flex={{ sm: '1', md: '3' }}>
-          <Column flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
+          <Box flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
             <Trans>Floor</Trans>
-          </Column>
-          <Column flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
+          </Box>
+          <Box flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
             <Trans>Last</Trans>
-          </Column>
-          <Column flex="2">
+          </Box>
+          <Box flex="2">
             <SortDropdown dropDownOptions={priceDropdownOptions} mini miniPrompt={t`Set price by`} />
-          </Column>
+          </Box>
 
-          <Column flex="1" display={{ sm: 'none', lg: 'flex' }} textAlign="right">
+          <Box flex="1" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
             <Trans>Fees</Trans>
-          </Column>
-          <Column display={{ sm: 'none', lg: 'flex' }} flex="1.5" textAlign="right">
+          </Box>
+          <Box display={{ sm: 'none', lg: 'flex' }} flex="1.5" justifyContent="flex-end">
             <Trans>You receive</Trans>
-          </Column>
+          </Box>
         </Row>
       </TableHeader>
       {sellAssets.map((asset) => {

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -8,7 +8,6 @@ import { useMemo, useState } from 'react'
 import styled, { css } from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 
-import * as styles from './ListPage.css'
 import { NFTListRow } from './NFTListRow'
 
 const GridWrapper = styled.div`

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -79,6 +79,15 @@ const UserReceivesHeader = styled.div`
   ${FeeUserReceivesSharedStyles}
 `
 
+const RowDivider = styled.hr`
+  height: 0px;
+  width: 100%;
+  border-radius: 20px;
+  border-width: 0.5px;
+  border-style: solid;
+  border-color: ${({ theme }) => theme.backgroundInteractive};
+`
+
 export enum SetPriceMethod {
   SAME_PRICE,
   FLOOR_PRICE,
@@ -144,7 +153,7 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
               setGlobalPrice={setGlobalPrice}
               selectedMarkets={selectedMarkets}
             />
-            {sellAssets.indexOf(asset) < sellAssets.length - 1 && <hr className={styles.nftDivider} />}
+            {sellAssets.indexOf(asset) < sellAssets.length - 1 && <RowDivider />}
           </>
         )
       })}

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -3,7 +3,6 @@ import { Trans } from '@lingui/macro'
 import { t } from '@lingui/macro'
 import { SortDropdown } from 'nft/components/common/SortDropdown'
 import { Column, Row } from 'nft/components/Flex'
-import { bodySmall, subheadSmall } from 'nft/css/common.css'
 import { useSellAsset } from 'nft/hooks'
 import { DropDownOption, ListingMarket } from 'nft/types'
 import { useMemo, useState } from 'react'
@@ -11,6 +10,11 @@ import styled from 'styled-components/macro'
 
 import * as styles from './ListPage.css'
 import { NFTListRow } from './NFTListRow'
+
+const GridWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
 
 const TableHeader = styled.div`
   display: flex;
@@ -21,6 +25,10 @@ const TableHeader = styled.div`
   padding-bottom: 24px;
   z-index: 1;
   background-color: ${({ theme }) => theme.backgroundBackdrop};
+  color: ${({ theme }) => theme.textSecondary};
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 20px;
 `
 
 export enum SetPriceMethod {
@@ -53,56 +61,26 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
   )
 
   return (
-    <Column>
+    <GridWrapper>
       <TableHeader>
-        <Column
-          marginLeft="0"
-          transition="500"
-          className={bodySmall}
-          color="textSecondary"
-          flex={{ sm: '2', md: '1.5' }}
-        >
+        <Column flex={{ sm: '2', md: '1.5' }}>
           <Trans>NFT</Trans>
         </Column>
         <Row flex={{ sm: '1', md: '3' }}>
-          <Column
-            className={bodySmall}
-            color="textSecondary"
-            flex="1"
-            display={{ sm: 'none', xxl: 'flex' }}
-            textAlign="left"
-          >
+          <Column flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
             <Trans>Floor</Trans>
           </Column>
-          <Column
-            className={bodySmall}
-            color="textSecondary"
-            flex="1"
-            display={{ sm: 'none', xxl: 'flex' }}
-            textAlign="left"
-          >
+          <Column flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
             <Trans>Last</Trans>
           </Column>
-          <Column className={subheadSmall} flex="2">
+          <Column flex="2">
             <SortDropdown dropDownOptions={priceDropdownOptions} mini miniPrompt={t`Set price by`} />
           </Column>
 
-          <Column
-            className={bodySmall}
-            color="textSecondary"
-            flex="1"
-            display={{ sm: 'none', lg: 'flex' }}
-            textAlign="right"
-          >
+          <Column flex="1" display={{ sm: 'none', lg: 'flex' }} textAlign="right">
             <Trans>Fees</Trans>
           </Column>
-          <Column
-            className={bodySmall}
-            display={{ sm: 'none', lg: 'flex' }}
-            color="textSecondary"
-            flex="1.5"
-            textAlign="right"
-          >
+          <Column display={{ sm: 'none', lg: 'flex' }} flex="1.5" textAlign="right">
             <Trans>You receive</Trans>
           </Column>
         </Row>
@@ -121,6 +99,6 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
           </>
         )
       })}
-    </Column>
+    </GridWrapper>
   )
 }

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -1,12 +1,11 @@
 import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
-import { Box } from 'nft/components/Box'
 import { SortDropdown } from 'nft/components/common/SortDropdown'
 import { useSellAsset } from 'nft/hooks'
 import { DropDownOption, ListingMarket } from 'nft/types'
 import { useMemo, useState } from 'react'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 
 import * as styles from './ListPage.css'
@@ -63,6 +62,24 @@ const DropdownWrapper = styled.div`
   flex: 2;
 `
 
+const FeeUserReceivesSharedStyles = css`
+  display: none;
+  justify-content: flex-end;
+  @media screen and (min-width: ${BREAKPOINTS.lg}px) {
+    display: flex;
+  }
+`
+
+const FeeHeader = styled.div`
+  flex: 1;
+  ${FeeUserReceivesSharedStyles}
+`
+
+const UserReceivesHeader = styled.div`
+  flex: 1.5;
+  ${FeeUserReceivesSharedStyles}
+`
+
 export enum SetPriceMethod {
   SAME_PRICE,
   FLOOR_PRICE,
@@ -105,16 +122,17 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
           <PriceInfoHeader>
             <Trans>Last</Trans>
           </PriceInfoHeader>
+
           <DropdownWrapper>
             <SortDropdown dropDownOptions={priceDropdownOptions} mini miniPrompt={t`Set price by`} />
           </DropdownWrapper>
 
-          <Box flex="1" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
+          <FeeHeader>
             <Trans>Fees</Trans>
-          </Box>
-          <Box flex="1.5" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
+          </FeeHeader>
+          <UserReceivesHeader>
             <Trans>You receive</Trans>
-          </Box>
+          </UserReceivesHeader>
         </PriceHeaders>
       </TableHeader>
       {sellAssets.map((asset) => {

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -8,6 +8,7 @@ import { useSellAsset } from 'nft/hooks'
 import { DropDownOption, ListingMarket } from 'nft/types'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components/macro'
+import { BREAKPOINTS } from 'theme'
 
 import * as styles from './ListPage.css'
 import { NFTListRow } from './NFTListRow'
@@ -30,6 +31,23 @@ const TableHeader = styled.div`
   font-size: 14px;
   font-weight: normal;
   line-height: 20px;
+`
+
+const NFTHeader = styled.div`
+  flex: 2;
+
+  @media screen and (min-width: ${BREAKPOINTS.md}px) {
+    flex: 1.5;
+  }
+`
+
+const PriceInfoHeader = styled.div`
+  display: none;
+  flex: 1;
+
+  @media screen and (min-width: ${BREAKPOINTS.xl}px) {
+    display: flex;
+  }
 `
 
 export enum SetPriceMethod {
@@ -64,16 +82,16 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
   return (
     <GridWrapper>
       <TableHeader>
-        <Box flex={{ sm: '2', md: '1.5' }}>
+        <NFTHeader>
           <Trans>NFT</Trans>
-        </Box>
+        </NFTHeader>
         <Row flex={{ sm: '1', md: '3' }}>
-          <Box flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
+          <PriceInfoHeader>
             <Trans>Floor</Trans>
-          </Box>
-          <Box flex="1" display={{ sm: 'none', xxl: 'flex' }} textAlign="left">
+          </PriceInfoHeader>
+          <PriceInfoHeader>
             <Trans>Last</Trans>
-          </Box>
+          </PriceInfoHeader>
           <Box flex="2">
             <SortDropdown dropDownOptions={priceDropdownOptions} mini miniPrompt={t`Set price by`} />
           </Box>
@@ -81,7 +99,7 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
           <Box flex="1" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
             <Trans>Fees</Trans>
           </Box>
-          <Box display={{ sm: 'none', lg: 'flex' }} flex="1.5" justifyContent="flex-end">
+          <Box flex="1.5" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
             <Trans>You receive</Trans>
           </Box>
         </Row>

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -1,6 +1,8 @@
 import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
+import Column from 'components/Column'
+import Row from 'components/Row'
 import { SortDropdown } from 'nft/components/common/SortDropdown'
 import { useSellAsset } from 'nft/hooks'
 import { DropDownOption, ListingMarket } from 'nft/types'
@@ -9,11 +11,6 @@ import styled, { css } from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 
 import { NFTListRow } from './NFTListRow'
-
-const GridWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-`
 
 const TableHeader = styled.div`
   display: flex;
@@ -38,10 +35,8 @@ const NFTHeader = styled.div`
   }
 `
 
-const PriceHeaders = styled.div`
-  display: flex;
+const PriceHeaders = styled(Row)`
   flex: 1;
-  flex-direction: row;
 
   @media screen and (min-width: ${BREAKPOINTS.md}px) {
     flex: 3;
@@ -118,7 +113,7 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
   )
 
   return (
-    <GridWrapper>
+    <Column>
       <TableHeader>
         <NFTHeader>
           <Trans>NFT</Trans>
@@ -157,6 +152,6 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
           </>
         )
       })}
-    </GridWrapper>
+    </Column>
   )
 }

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -3,7 +3,6 @@ import { Trans } from '@lingui/macro'
 import { t } from '@lingui/macro'
 import { Box } from 'nft/components/Box'
 import { SortDropdown } from 'nft/components/common/SortDropdown'
-import { Row } from 'nft/components/Flex'
 import { useSellAsset } from 'nft/hooks'
 import { DropDownOption, ListingMarket } from 'nft/types'
 import { useMemo, useState } from 'react'
@@ -41,6 +40,16 @@ const NFTHeader = styled.div`
   }
 `
 
+const PriceHeaders = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+
+  @media screen and (min-width: ${BREAKPOINTS.md}px) {
+    flex: 3;
+  }
+`
+
 const PriceInfoHeader = styled.div`
   display: none;
   flex: 1;
@@ -48,6 +57,10 @@ const PriceInfoHeader = styled.div`
   @media screen and (min-width: ${BREAKPOINTS.xl}px) {
     display: flex;
   }
+`
+
+const DropdownWrapper = styled.div`
+  flex: 2;
 `
 
 export enum SetPriceMethod {
@@ -85,16 +98,16 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
         <NFTHeader>
           <Trans>NFT</Trans>
         </NFTHeader>
-        <Row flex={{ sm: '1', md: '3' }}>
+        <PriceHeaders>
           <PriceInfoHeader>
             <Trans>Floor</Trans>
           </PriceInfoHeader>
           <PriceInfoHeader>
             <Trans>Last</Trans>
           </PriceInfoHeader>
-          <Box flex="2">
+          <DropdownWrapper>
             <SortDropdown dropDownOptions={priceDropdownOptions} mini miniPrompt={t`Set price by`} />
-          </Box>
+          </DropdownWrapper>
 
           <Box flex="1" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
             <Trans>Fees</Trans>
@@ -102,7 +115,7 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
           <Box flex="1.5" display={{ sm: 'none', lg: 'flex' }} justifyContent="flex-end">
             <Trans>You receive</Trans>
           </Box>
-        </Row>
+        </PriceHeaders>
       </TableHeader>
       {sellAssets.map((asset) => {
         return (


### PR DESCRIPTION
No functional difference, should only deprecate use of VE in this file and delete unused style. 