### PR TITLE
fix: theme-aware root element color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,7 +77,6 @@
       }
 
       #background-radial-gradient {
-        background: linear-gradient(180deg, #202738 0%, #070816 100%);
         position: fixed;
         top: 0;
         left: 0;
@@ -97,13 +96,13 @@
 
       @media (prefers-color-scheme: dark) {
         html {
-          background-color: #212429;
+          background: linear-gradient(180deg, #202738 0%, #070816 100%);
         }
       }
 
       @media (prefers-color-scheme: light) {
         html {
-          background-color: #f7f8fa;
+          background: radial-gradient(100% 100% at 50% 0%, rgba(255, 184, 226, 0.51) 0%, rgba(255, 255, 255, 0) 100%), #FFFFFF
         }
       }
     </style>

--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,7 @@
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
       }
 
+      /* Use this to apply network-specific gradient backgrounds, in RadialGradientByChainUpdater.ts */
       #background-radial-gradient {
         position: fixed;
         top: 0;


### PR DESCRIPTION
changes the default background colors for our root elements in the site.

the bug here is that we were always showing the dark linear-gradient when the page loaded. the theme-aware defaults in the CSS below were never visible. now, when the page loads, we use these theme-aware backgrounds. later, when the app runs, we still set the background of `#background-radial-gradient` as usual. ([see here](https://github.com/Uniswap/interface/blob/1802f50163bf8092dac6916d64b9e08ac2ae0a74/src/theme/components/RadialGradientByChainUpdater.ts#L30)).

now, when the page loads or reloads we will show the background corresponding to the user's preference in their OS/browser. note that this may not correspond to their most recent theme in our app, which we rely on javascript to store and propagate throughout the app at runtime.