### PR TITLE
chore: Migrate List PriceInput from vanilla-extract to styled-components

### DIFF
--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -7,7 +7,7 @@ import { body } from 'nft/css/common.css'
 import { useSellAsset } from 'nft/hooks'
 import { ListingWarning, WalletAsset } from 'nft/types'
 import { formatEth } from 'nft/utils/currency'
-import { Dispatch, FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { Dispatch, FormEvent, useEffect, useRef, useState } from 'react'
 import styled, { useTheme } from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 import { colors } from 'theme/colors'
@@ -121,17 +121,14 @@ export const PriceTextInput = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listPrice])
 
-  const borderColor = useMemo(
-    () =>
-      warningType !== WarningType.NONE && !focused
-        ? colors.red400
-        : isGlobalPrice
-        ? theme.accentAction
-        : listPrice != null
-        ? theme.textSecondary
-        : theme.accentAction,
-    [focused, isGlobalPrice, listPrice, theme.accentAction, theme.textSecondary, warningType]
-  )
+  const borderColor =
+    warningType !== WarningType.NONE && !focused
+      ? colors.red400
+      : isGlobalPrice
+      ? theme.accentAction
+      : listPrice != null
+      ? theme.textSecondary
+      : theme.accentAction
 
   return (
     <PriceTextInputWrapper>

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -9,6 +9,7 @@ import { ListingWarning, WalletAsset } from 'nft/types'
 import { formatEth } from 'nft/utils/currency'
 import { Dispatch, FormEvent, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components/macro'
+import { colors } from 'theme/colors'
 
 const PriceTextInputWrapper = styled(Column)`
   gap: 12px;
@@ -29,11 +30,10 @@ const GlobalPriceIcon = styled.div`
   background-color: ${({ theme }) => theme.backgroundSurface};
 `
 
-const WarningMessage = styled.div<{ warningType: WarningType }>`
+const WarningAction = styled.div<{ warningType: WarningType }>`
   margin-left: 8px;
   cursor: pointer;
-  color: ${({ warningType, theme }) =>
-    warningType === WarningType.BELOW_FLOOR ? theme.accentAction : theme.accentCritical};
+  color: ${({ warningType, theme }) => (warningType === WarningType.BELOW_FLOOR ? theme.accentAction : colors.red400)};
 `
 
 enum WarningType {
@@ -163,7 +163,7 @@ export const PriceTextInput = ({
                   ? formatEth(asset?.floorPrice ?? 0)
                   : formatEth(asset?.floor_sell_order_price ?? 0)}
                 ETH
-                <WarningMessage
+                <WarningAction
                   warningType={warningType}
                   onClick={() => {
                     warningType === WarningType.ALREADY_LISTED && removeSellAsset(asset)
@@ -171,7 +171,7 @@ export const PriceTextInput = ({
                   }}
                 >
                   {warningType === WarningType.BELOW_FLOOR ? <Trans>DISMISS</Trans> : <Trans>REMOVE ITEM</Trans>}
-                </WarningMessage>
+                </WarningAction>
               </>
             )}
       </Row>

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -1,20 +1,31 @@
 import { Trans } from '@lingui/macro'
 import Column from 'components/Column'
-import { Row } from 'nft/components/Flex'
+import Row from 'components/Row'
 import { AttachPriceIcon, EditPriceIcon } from 'nft/components/icons'
 import { NumericInput } from 'nft/components/layout/Input'
 import { body } from 'nft/css/common.css'
 import { useSellAsset } from 'nft/hooks'
 import { ListingWarning, WalletAsset } from 'nft/types'
 import { formatEth } from 'nft/utils/currency'
-import { Dispatch, FormEvent, useEffect, useRef, useState } from 'react'
-import styled from 'styled-components/macro'
+import { Dispatch, FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import styled, { useTheme } from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 import { colors } from 'theme/colors'
 
 const PriceTextInputWrapper = styled(Column)`
   gap: 12px;
   position: relative;
+`
+
+const InputWrapper = styled(Row)<{ borderColor: string }>`
+  height: 44px;
+  color: ${({ theme }) => theme.textTertiary};
+  padding: 4px;
+  border: 2px solid;
+  border-radius: 8px;
+  border-color: ${({ borderColor }) => borderColor};
+  margin-right: auto;
+  box-sizing: border-box;
 `
 
 const CurrencyWrapper = styled.div<{ listPrice: number | undefined }>`
@@ -97,6 +108,7 @@ export const PriceTextInput = ({
   const removeMarketplaceWarning = useSellAsset((state) => state.removeMarketplaceWarning)
   const removeSellAsset = useSellAsset((state) => state.removeSellAsset)
   const inputRef = useRef() as React.MutableRefObject<HTMLInputElement>
+  const theme = useTheme()
 
   useEffect(() => {
     inputRef.current.value = listPrice !== undefined ? `${listPrice}` : ''
@@ -109,27 +121,21 @@ export const PriceTextInput = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listPrice])
 
+  const borderColor = useMemo(
+    () =>
+      warningType !== WarningType.NONE && !focused
+        ? colors.red400
+        : isGlobalPrice
+        ? theme.accentAction
+        : listPrice != null
+        ? theme.textSecondary
+        : theme.accentAction,
+    [focused, isGlobalPrice, listPrice, theme.accentAction, theme.textSecondary, warningType]
+  )
+
   return (
     <PriceTextInputWrapper>
-      <Row
-        color="textTertiary"
-        height="44"
-        width="min"
-        padding="4"
-        borderRadius="8"
-        borderWidth="2px"
-        borderStyle="solid"
-        marginRight="auto"
-        borderColor={
-          warningType !== WarningType.NONE && !focused
-            ? 'orange'
-            : isGlobalPrice
-            ? 'accentAction'
-            : listPrice != null
-            ? 'textSecondary'
-            : 'blue400'
-        }
-      >
+      <InputWrapper borderColor={borderColor}>
         <NumericInput
           as="input"
           pattern="[0-9]"
@@ -160,7 +166,7 @@ export const PriceTextInput = ({
             {globalOverride ? <AttachPriceIcon /> : <EditPriceIcon />}
           </GlobalPriceIcon>
         )}
-      </Row>
+      </InputWrapper>
       <WarningMessage warningType={warningType}>
         {warning
           ? warning.message

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -16,6 +16,11 @@ const PriceTextInputWrapper = styled(Column)`
   position: relative;
 `
 
+const CurrencyWrapper = styled.div<{ listPrice: number | undefined }>`
+  margin-right: 16px;
+  color: ${({ listPrice, theme }) => (listPrice && listPrice >= 0 ? theme.textPrimary : theme.textSecondary)};
+`
+
 enum WarningType {
   BELOW_FLOOR,
   ALREADY_LISTED,
@@ -118,9 +123,7 @@ export const PriceTextInput = ({
             setListPrice(isNaN(val) ? undefined : val)
           }}
         />
-        <Box color={listPrice && listPrice >= 0 ? 'textPrimary' : 'textSecondary'} marginRight="16">
-          &nbsp;ETH
-        </Box>
+        <CurrencyWrapper listPrice={listPrice}>&nbsp;ETH</CurrencyWrapper>
         <Box
           cursor="pointer"
           display={isGlobalPrice || globalOverride ? 'block' : 'none'}

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -1,6 +1,5 @@
 import { Trans } from '@lingui/macro'
 import Column from 'components/Column'
-import { Box } from 'nft/components/Box'
 import { Row } from 'nft/components/Flex'
 import { AttachPriceIcon, EditPriceIcon } from 'nft/components/icons'
 import { NumericInput } from 'nft/components/layout/Input'
@@ -28,6 +27,13 @@ const GlobalPriceIcon = styled.div`
   top: -6px;
   right: -4px;
   background-color: ${({ theme }) => theme.backgroundSurface};
+`
+
+const WarningMessage = styled.div<{ warningType: WarningType }>`
+  margin-left: 8px;
+  cursor: pointer;
+  color: ${({ warningType, theme }) =>
+    warningType === WarningType.BELOW_FLOOR ? theme.accentAction : theme.accentCritical};
 `
 
 enum WarningType {
@@ -157,17 +163,15 @@ export const PriceTextInput = ({
                   ? formatEth(asset?.floorPrice ?? 0)
                   : formatEth(asset?.floor_sell_order_price ?? 0)}
                 ETH
-                <Box
-                  color={warningType === WarningType.BELOW_FLOOR ? 'accentAction' : 'orange'}
-                  marginLeft="8"
-                  cursor="pointer"
+                <WarningMessage
+                  warningType={warningType}
                   onClick={() => {
                     warningType === WarningType.ALREADY_LISTED && removeSellAsset(asset)
                     setWarningType(WarningType.NONE)
                   }}
                 >
                   {warningType === WarningType.BELOW_FLOOR ? <Trans>DISMISS</Trans> : <Trans>REMOVE ITEM</Trans>}
-                </Box>
+                </WarningMessage>
               </>
             )}
       </Row>

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -21,6 +21,15 @@ const CurrencyWrapper = styled.div<{ listPrice: number | undefined }>`
   color: ${({ listPrice, theme }) => (listPrice && listPrice >= 0 ? theme.textPrimary : theme.textSecondary)};
 `
 
+const GlobalPriceIcon = styled.div`
+  display: block;
+  cursor: pointer;
+  position: absolute;
+  top: -6px;
+  right: -4px;
+  background-color: ${({ theme }) => theme.backgroundSurface};
+`
+
 enum WarningType {
   BELOW_FLOOR,
   ALREADY_LISTED,
@@ -124,16 +133,11 @@ export const PriceTextInput = ({
           }}
         />
         <CurrencyWrapper listPrice={listPrice}>&nbsp;ETH</CurrencyWrapper>
-        <Box
-          cursor="pointer"
-          display={isGlobalPrice || globalOverride ? 'block' : 'none'}
-          position="absolute"
-          style={{ marginTop: '-36px', marginLeft: '124px' }}
-          backgroundColor="backgroundSurface"
-          onClick={() => setGlobalOverride(!globalOverride)}
-        >
-          {globalOverride ? <AttachPriceIcon /> : <EditPriceIcon />}
-        </Box>
+        {(isGlobalPrice || globalOverride) && (
+          <GlobalPriceIcon onClick={() => setGlobalOverride(!globalOverride)}>
+            {globalOverride ? <AttachPriceIcon /> : <EditPriceIcon />}
+          </GlobalPriceIcon>
+        )}
       </Row>
       <Row
         top="52"

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro'
+import Column from 'components/Column'
 import { Box } from 'nft/components/Box'
-import { Column, Row } from 'nft/components/Flex'
+import { Row } from 'nft/components/Flex'
 import { AttachPriceIcon, EditPriceIcon } from 'nft/components/icons'
 import { NumericInput } from 'nft/components/layout/Input'
 import { badge, body } from 'nft/css/common.css'
@@ -8,6 +9,12 @@ import { useSellAsset } from 'nft/hooks'
 import { ListingWarning, WalletAsset } from 'nft/types'
 import { formatEth } from 'nft/utils/currency'
 import { Dispatch, FormEvent, useEffect, useRef, useState } from 'react'
+import styled from 'styled-components/macro'
+
+const PriceTextInputWrapper = styled(Column)`
+  gap: 12px;
+  position: relative;
+`
 
 enum WarningType {
   BELOW_FLOOR,
@@ -67,7 +74,7 @@ export const PriceTextInput = ({
   }, [listPrice])
 
   return (
-    <Column gap="12" position="relative">
+    <PriceTextInputWrapper>
       <Row
         color="textTertiary"
         height="44"
@@ -157,6 +164,6 @@ export const PriceTextInput = ({
               </>
             )}
       </Row>
-    </Column>
+    </PriceTextInputWrapper>
   )
 }

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -30,7 +30,7 @@ const InputWrapper = styled(Row)<{ borderColor: string }>`
 
 const CurrencyWrapper = styled.div<{ listPrice: number | undefined }>`
   margin-right: 16px;
-  color: ${({ listPrice, theme }) => (listPrice && listPrice >= 0 ? theme.textPrimary : theme.textSecondary)};
+  color: ${({ listPrice, theme }) => (listPrice ? theme.textPrimary : theme.textSecondary)};
 `
 
 const GlobalPriceIcon = styled.div`

--- a/src/nft/components/profile/list/PriceTextInput.tsx
+++ b/src/nft/components/profile/list/PriceTextInput.tsx
@@ -3,12 +3,13 @@ import Column from 'components/Column'
 import { Row } from 'nft/components/Flex'
 import { AttachPriceIcon, EditPriceIcon } from 'nft/components/icons'
 import { NumericInput } from 'nft/components/layout/Input'
-import { badge, body } from 'nft/css/common.css'
+import { body } from 'nft/css/common.css'
 import { useSellAsset } from 'nft/hooks'
 import { ListingWarning, WalletAsset } from 'nft/types'
 import { formatEth } from 'nft/utils/currency'
 import { Dispatch, FormEvent, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components/macro'
+import { BREAKPOINTS } from 'theme'
 import { colors } from 'theme/colors'
 
 const PriceTextInputWrapper = styled(Column)`
@@ -28,6 +29,21 @@ const GlobalPriceIcon = styled.div`
   top: -6px;
   right: -4px;
   background-color: ${({ theme }) => theme.backgroundSurface};
+`
+
+const WarningMessage = styled(Row)<{ warningType: WarningType }>`
+  top: 52px;
+  width: max-content;
+  position: absolute;
+  right: 0;
+  font-weight: 600;
+  font-size: 10px;
+  line-height: 12px;
+  color: ${({ warningType, theme }) => (warningType === WarningType.BELOW_FLOOR ? colors.red400 : theme.textSecondary)};
+
+  @media screen and (min-width: ${BREAKPOINTS.md}px) {
+    right: unset;
+  }
 `
 
 const WarningAction = styled.div<{ warningType: WarningType }>`
@@ -145,14 +161,7 @@ export const PriceTextInput = ({
           </GlobalPriceIcon>
         )}
       </Row>
-      <Row
-        top="52"
-        width="max"
-        className={badge}
-        color={warningType === WarningType.BELOW_FLOOR && !focused ? 'orange' : 'textSecondary'}
-        position="absolute"
-        right={{ sm: '0', md: 'unset' }}
-      >
+      <WarningMessage warningType={warningType}>
         {warning
           ? warning.message
           : warningType !== WarningType.NONE && (
@@ -174,7 +183,7 @@ export const PriceTextInput = ({
                 </WarningAction>
               </>
             )}
-      </Row>
+      </WarningMessage>
     </PriceTextInputWrapper>
   )
 }


### PR DESCRIPTION
- no functional difference only changes the components to use styled components instead of VE
  - the only exception is the location of the top right icon when setting a global price which is now better aligned