### PR TITLE
chore: disable Sentry in production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -8,4 +8,4 @@ REACT_APP_MOONPAY_LINK="https://us-central1-uniswap-mobile.cloudfunctions.net/si
 REACT_APP_MOONPAY_PUBLISHABLE_KEY="pk_live_uQG4BJC4w3cxnqpcSqAfohdBFDTsY6E"
 REACT_APP_FIREBASE_KEY="AIzaSyBcZWwTcTJHj_R6ipZcrJkXdq05PuX0Rs0"
 THE_GRAPH_SCHEMA_ENDPOINT="https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3"
-REACT_APP_SENTRY_ENABLED=true
+REACT_APP_SENTRY_ENABLED=false


### PR DESCRIPTION
We have already disabled Sentry last year. This flag is just to re-build our project with different error page (without Sentry error ID). 

We will turn this back on in the next 3-4 weeks, once we have improved our tracking with additional context, letting us resolve and most popular bug reports.