### PR TITLE
fix: infinite render loop on connection error

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -22,7 +22,7 @@ import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import {
   useCloseModal,
   useModalIsOpen,
-  useToggleMetamaskConnectionErrorModal,
+  useOpenMetamaskConnectionErrorModal,
   useToggleWalletDropdown,
   useToggleWalletModal,
 } from '../../state/application/hooks'
@@ -213,16 +213,16 @@ function Web3StatusInner() {
     toggleWalletDropdown()
   }, [toggleWalletDropdown])
   const toggleWalletModal = useToggleWalletModal()
-  const toggleMetamaskConnectionErrorModal = useToggleMetamaskConnectionErrorModal()
+  const openMetamaskConnectionErrorModal = useOpenMetamaskConnectionErrorModal()
   const walletIsOpen = useModalIsOpen(ApplicationModal.WALLET_DROPDOWN)
   const isClaimAvailable = useIsNftClaimAvailable((state) => state.isClaimAvailable)
 
   const error = useAppSelector((state) => state.connection.errorByConnectionType[getConnection(connector).type])
   useEffect(() => {
     if (getIsMetaMask() && error) {
-      toggleMetamaskConnectionErrorModal()
+      openMetamaskConnectionErrorModal()
     }
-  }, [error, toggleMetamaskConnectionErrorModal])
+  }, [error, openMetamaskConnectionErrorModal])
 
   const allTransactions = useAllTransactions()
 

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -97,6 +97,10 @@ export function useToggleMetamaskConnectionErrorModal(): () => void {
   return useToggleModal(ApplicationModal.METAMASK_CONNECTION_ERROR)
 }
 
+export function useOpenMetamaskConnectionErrorModal(): () => void {
+  return useOpenModal(ApplicationModal.METAMASK_CONNECTION_ERROR)
+}
+
 export function useOpenModal(modal: ApplicationModal): () => void {
   const dispatch = useAppDispatch()
   return useCallback(() => dispatch(setOpenModal(modal)), [dispatch, modal])


### PR DESCRIPTION
Fixes WEB-2736

When trying to connect to a network with a Metamask wallet, our application enters infinite render loop and crashes. The reason for that can be traced down to a recent commit https://github.com/Uniswap/interface/commit/802714377ce1e8a9d3ac7c57642bacbad7f86d57 where we added a modal to show on a connection error.

> TL;DR: Do not use any `toggle` functions with `useEffect`, as putting them as a dependency will cause `useEffect` to run infinitely.

This error is caused by a `useEffect` hook that listens to connection errors and in case a connection error happened (and we're using Metamask), it would toggle a special modal. 

Due to the architecture of our modal logic, each `toggle` hook is wrapped with a `useCallback` that depends on the state:
```ts
export function useToggleModal(modal: ApplicationModal): () => void {
  const isOpen = useModalIsOpen(modal)
  const dispatch = useAppDispatch()
  return useCallback(() => dispatch(setOpenModal(isOpen ? null : modal)), [dispatch, modal, isOpen])
}
```

Once modal is toggled, `isOpen` is changed and `useToggleModal` returns a new reference. 

When a `useEffect` hook starts depending on such function, it will cause it to re-run, essentially trying to `toggle` the modal infinitely.

```ts
useEffect(() => {
    if (getIsMetaMask() && error) {
      toggleModal()
    }
  }, [error, toggleModal])
``` 

The reason this did not happen before is that we use `toggle` function either inside `useCallback` or as a simple event handler. 