### PR TITLE
fix: crash when invalid ENS avatar

### DIFF
--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -77,8 +77,8 @@ function useAvatarFromNFT(nftUri = '', enforceOwnership: boolean): { avatar?: st
   const [contractAddress, id] = parts[2]?.split('/') ?? []
   const isERC721 = protocol === 'eip155' && erc === 'erc721'
   const isERC1155 = protocol === 'eip155' && erc === 'erc1155'
-  const erc721 = useERC721Uri(isERC721 ? contractAddress : undefined, id, enforceOwnership)
-  const erc1155 = useERC1155Uri(isERC1155 ? contractAddress : undefined, id, enforceOwnership)
+  const erc721 = useERC721Uri(isERC721 ? contractAddress : undefined, isERC721 ? id : undefined, enforceOwnership)
+  const erc1155 = useERC1155Uri(isERC1155 ? contractAddress : undefined, isERC1155 ? id : undefined, false)
   const uri = erc721.uri || erc1155.uri
   const http = uri && uriToHttp(uri)[0]
 
@@ -136,14 +136,18 @@ function useERC1155Uri(
   const contract = useERC1155Contract(contractAddress)
   const balance = useSingleCallResult(contract, 'balanceOf', accountArgument)
   const uri = useSingleCallResult(contract, 'uri', idArgument)
-  // ERC-1155 allows a generic {id} in the URL, so prepare to replace if relevant,
-  //   in lowercase hexadecimal (with no 0x prefix) and leading zero padded to 64 hex characters.
-  const idHex = id ? hexZeroPad(BigNumber.from(id).toHexString(), 32).substring(2) : id
-  return useMemo(
-    () => ({
-      uri: !enforceOwnership || balance.result?.[0] > 0 ? uri.result?.[0]?.replaceAll('{id}', idHex) : undefined,
-      loading: balance.loading || uri.loading,
-    }),
-    [balance.loading, balance.result, enforceOwnership, uri.loading, uri.result, idHex]
-  )
+  return useMemo(() => {
+    try {
+      // ERC-1155 allows a generic {id} in the URL, so prepare to replace if relevant,
+      // in lowercase hexadecimal (with no 0x prefix) and leading zero padded to 64 hex characters.
+      const idHex = id ? hexZeroPad(BigNumber.from(id).toHexString(), 32).substring(2) : id
+      return {
+        uri: !enforceOwnership || balance.result?.[0] > 0 ? uri.result?.[0]?.replaceAll('{id}', idHex) : undefined,
+        loading: balance.loading || uri.loading,
+      }
+    } catch (error) {
+      console.error('Invalid token id', error)
+      return { loading: false }
+    }
+  }, [balance.loading, balance.result, enforceOwnership, uri.loading, uri.result, id])
 }

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -78,7 +78,7 @@ function useAvatarFromNFT(nftUri = '', enforceOwnership: boolean): { avatar?: st
   const isERC721 = protocol === 'eip155' && erc === 'erc721'
   const isERC1155 = protocol === 'eip155' && erc === 'erc1155'
   const erc721 = useERC721Uri(isERC721 ? contractAddress : undefined, isERC721 ? id : undefined, enforceOwnership)
-  const erc1155 = useERC1155Uri(isERC1155 ? contractAddress : undefined, isERC1155 ? id : undefined, false)
+  const erc1155 = useERC1155Uri(isERC1155 ? contractAddress : undefined, isERC1155 ? id : undefined, enforceOwnership)
   const uri = erc721.uri || erc1155.uri
   const http = uri && uriToHttp(uri)[0]
 


### PR DESCRIPTION
Fixes WEB-2602

When ENS avatar is invalid, e.g. `eip155:1/erc721: 0xabEFBc9fD2F806065b4f3C237d4b59D9A97Bcac7 / 6058`, the application would crash when parsing.

In case of WEB-2602, this is caused by a token id containing whitespaces (we split by `/`). Looking at example provided above, the value of ID would be ` 6058`, causing the application to crash.

This PR guards ID parsing with a try/catch, similar to what we already do within `useContract` hook.

Note: I also tweaked the code to not pass an `id` to either `useERC721Uri` or `useERC1155Uri` since I believe no parameters should be passed when the address wasn't written in one of these protocols.  This code doesn't look beautiful, but this is caused by the throughout use of hooks in those functions, making it impossible to use conditionals at any level. 

Going forward, we should schedule some time to rewrite the logic of some of the lowest building blocks (such as `getContract`) to be arbitrary functions instead of hooks. That could allow cleaning this code to a bit more reasonable state, without use of hooks. 

Right now, the reason `getContract` is `useContract` is because it uses `useWeb3React`:
```ts
// returns null on errors
export function useContract<T extends Contract = Contract>(
  addressOrAddressMap: string | { [chainId: number]: string } | undefined,
  ABI: any,
  withSignerIfPossible = true
): T | null {
  const { provider, account, chainId } = useWeb3React()

 
}
```
If contents of `web3React` were passed to this function as arguments, it would let us drop hooks in those parts.
