### PR TITLE
feat: [List V2] Initial Floating Bar

### DIFF
--- a/src/nft/components/bag/Bag.tsx
+++ b/src/nft/components/bag/Bag.tsx
@@ -3,6 +3,7 @@ import { formatEther } from '@ethersproject/units'
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { NFTEventName } from '@uniswap/analytics-events'
 import { useWeb3React } from '@web3-react/core'
+import { NftListV2Variant, useNftListV2Flag } from 'featureFlags/flags/nftListV2'
 import { useIsNftDetailsPage, useIsNftPage, useIsNftProfilePage } from 'hooks/useIsNftPage'
 import { BagFooter } from 'nft/components/bag/BagFooter'
 import ListingModal from 'nft/components/bag/profile/ListingModal'
@@ -135,6 +136,7 @@ const Bag = () => {
   const isDetailsPage = useIsNftDetailsPage()
   const isNFTPage = useIsNftPage()
   const isMobile = useIsMobile()
+  const isNftListV2 = useNftListV2Flag() === NftListV2Variant.Enabled
 
   const sendTransaction = useSendTransaction((state) => state.sendTransaction)
   const transactionState = useSendTransaction((state) => state.state)
@@ -349,7 +351,7 @@ const Bag = () => {
                 color="white"
                 textAlign="center"
                 onClick={() => {
-                  isMobile && toggleBag()
+                  ;(isMobile || isNftListV2) && toggleBag()
                   setProfilePageState(ProfilePageStateType.LISTING)
                   sendAnalyticsEvent(NFTEventName.NFT_PROFILE_PAGE_START_SELL, {
                     list_quantity: sellAssets.length,

--- a/src/nft/components/bag/profile/utils.ts
+++ b/src/nft/components/bag/profile/utils.ts
@@ -133,7 +133,7 @@ export const getTotalEthValue = (sellAssets: WalletAsset[]) => {
     }
     return total
   }, 0)
-  return total ? Math.round(total * 100 + Number.EPSILON) / 100 : 0
+  return total ? Math.round(total * 10000 + Number.EPSILON) / 10000 : 0
 }
 
 export const getListings = (sellAssets: WalletAsset[]): [CollectionRow[], ListingRow[]] => {

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -87,7 +87,7 @@ const FloatingConfirmationBar = styled(Row)`
   bottom: 32px;
   margin: 0px 60px;
   width: calc(100vw - 120px);
-  z-index: ${Z_INDEX.modal};
+  z-index: ${Z_INDEX.under_dropdown};
 `
 
 const Overlay = styled.div`
@@ -98,9 +98,14 @@ const Overlay = styled.div`
   background: ${({ theme }) => `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, ${theme.backgroundBackdrop} 100%)`};
 `
 
-const ProceedsWrapper = styled(Row)`
+const ProceedsAndButtonWrapper = styled(Row)`
   width: min-content;
   gap: 40px;
+`
+
+const ProceedsWrapper = styled(Row)`
+  width: min-content;
+  gap: 16px;
 `
 
 const ListingButtonWrapper = styled.div`
@@ -178,8 +183,8 @@ export const ListPage = () => {
             <ThemedText.HeadlineSmall lineHeight="28px">
               <Trans>Proceeds if sold</Trans>
             </ThemedText.HeadlineSmall>
-            <ProceedsWrapper>
-              <Row>
+            <ProceedsAndButtonWrapper>
+              <ProceedsWrapper>
                 <ThemedText.HeadlineSmall
                   lineHeight="28px"
                   color={totalEthListingValue ? 'textPrimary' : 'textTertiary'}
@@ -187,18 +192,18 @@ export const ListPage = () => {
                   {totalEthListingValue > 0 ? formatEth(totalEthListingValue) : '-'} ETH
                 </ThemedText.HeadlineSmall>
                 {!!totalEthListingValue && !!ethPriceInUSD && (
-                  <ThemedText.HeadlineSmall lineHeight="28px" color="textSecondary" marginLeft="16px">
+                  <ThemedText.HeadlineSmall lineHeight="28px" color="textSecondary">
                     {formatUsdPrice(totalEthListingValue * ethPriceInUSD)}
                   </ThemedText.HeadlineSmall>
                 )}
-              </Row>
+              </ProceedsWrapper>
               <ListingButtonWrapper>
                 <ListingButton
                   onClick={toggleBag}
                   buttonText={anyListingsMissingPrice ? t`Set prices to continue` : t`Start listing`}
                 />
               </ListingButtonWrapper>
-            </ProceedsWrapper>
+            </ProceedsAndButtonWrapper>
           </FloatingConfirmationBar>
           <Overlay />
         </>

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -79,6 +79,8 @@ const MobileListButtonWrapper = styled.div`
 
 const FloatingConfirmationBar = styled(Row)`
   padding: 20px 32px;
+  border: 1px solid;
+  border-color: ${({ theme }) => theme.backgroundOutline};
   border-radius: 20px;
   white-space: nowrap;
   justify-content: space-between;

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -82,7 +82,7 @@ const FloatingConfirmationBar = styled(Row)`
   white-space: nowrap;
   justify-content: space-between;
   background: ${({ theme }) => theme.backgroundSurface};
-  position: absolute;
+  position: fixed;
   bottom: 32px;
   margin: 0px 60px;
   width: calc(100vw - 120px);

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -85,8 +85,8 @@ const FloatingConfirmationBar = styled(Row)`
   background: ${({ theme }) => theme.backgroundSurface};
   position: fixed;
   bottom: 32px;
-  margin: 0px 60px;
-  width: calc(100vw - 120px);
+  margin: 0px 156px;
+  width: calc(100vw - 312px);
   z-index: ${Z_INDEX.under_dropdown};
 `
 

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -15,6 +15,7 @@ import { ListingMarkets } from 'nft/utils/listNfts'
 import { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
+import { Z_INDEX } from 'theme/zIndex'
 
 import { NFTListingsGrid } from './NFTListingsGrid'
 import { SelectMarketplacesDropdown } from './SelectMarketplacesDropdown'
@@ -86,6 +87,15 @@ const FloatingConfirmationBar = styled(Row)`
   bottom: 32px;
   margin: 0px 60px;
   width: calc(100vw - 120px);
+  z-index: ${Z_INDEX.modal};
+`
+
+const Overlay = styled.div`
+  position: fixed;
+  bottom: 0px;
+  height: 158px;
+  width: 100vw;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
 `
 
 const ProceedsWrapper = styled(Row)`
@@ -163,29 +173,35 @@ export const ListPage = () => {
         </GridWrapper>
       </MarketWrap>
       {isNftListV2 && (
-        <FloatingConfirmationBar>
-          <ThemedText.HeadlineSmall lineHeight="28px">
-            <Trans>Proceeds if sold</Trans>
-          </ThemedText.HeadlineSmall>
-          <ProceedsWrapper>
-            <Row>
-              <ThemedText.HeadlineSmall lineHeight="28px" color={totalEthListingValue ? 'textPrimary' : 'textTertiary'}>
-                {totalEthListingValue > 0 ? formatEth(totalEthListingValue) : '-'} ETH
-              </ThemedText.HeadlineSmall>
-              {!!totalEthListingValue && !!ethPriceInUSD && (
-                <ThemedText.HeadlineSmall lineHeight="28px" color="textSecondary" marginLeft="16px">
-                  {formatUsdPrice(totalEthListingValue * ethPriceInUSD)}
+        <>
+          <FloatingConfirmationBar>
+            <ThemedText.HeadlineSmall lineHeight="28px">
+              <Trans>Proceeds if sold</Trans>
+            </ThemedText.HeadlineSmall>
+            <ProceedsWrapper>
+              <Row>
+                <ThemedText.HeadlineSmall
+                  lineHeight="28px"
+                  color={totalEthListingValue ? 'textPrimary' : 'textTertiary'}
+                >
+                  {totalEthListingValue > 0 ? formatEth(totalEthListingValue) : '-'} ETH
                 </ThemedText.HeadlineSmall>
-              )}
-            </Row>
-            <ListingButtonWrapper>
-              <ListingButton
-                onClick={toggleBag}
-                buttonText={anyListingsMissingPrice ? t`Set prices to continue` : t`Start listing`}
-              />
-            </ListingButtonWrapper>
-          </ProceedsWrapper>
-        </FloatingConfirmationBar>
+                {!!totalEthListingValue && !!ethPriceInUSD && (
+                  <ThemedText.HeadlineSmall lineHeight="28px" color="textSecondary" marginLeft="16px">
+                    {formatUsdPrice(totalEthListingValue * ethPriceInUSD)}
+                  </ThemedText.HeadlineSmall>
+                )}
+              </Row>
+              <ListingButtonWrapper>
+                <ListingButton
+                  onClick={toggleBag}
+                  buttonText={anyListingsMissingPrice ? t`Set prices to continue` : t`Start listing`}
+                />
+              </ListingButtonWrapper>
+            </ProceedsWrapper>
+          </FloatingConfirmationBar>
+          <Overlay />
+        </>
       )}
       {!isNftListV2 && (
         <MobileListButtonWrapper>

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -126,13 +126,12 @@ export const ListPage = () => {
   const isNftListV2 = useNftListV2Flag() === NftListV2Variant.Enabled
 
   const totalEthListingValue = useMemo(() => getTotalEthValue(sellAssets), [sellAssets])
-  console.log(totalEthListingValue)
   const anyListingsMissingPrice = useMemo(() => !!listings.find((listing) => !listing.price), [listings])
   const [ethPriceInUSD, setEthPriceInUSD] = useState(0)
 
   useEffect(() => {
     fetchPrice().then((price) => {
-      setEthPriceInUSD(price || 0)
+      setEthPriceInUSD(price ?? 0)
     })
   }, [])
 

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -1,7 +1,10 @@
+import { Trans } from '@lingui/macro'
+import Column from 'components/Column'
+import Row from 'components/Row'
 import { SMALL_MEDIA_BREAKPOINT } from 'components/Tokens/constants'
+import { NftListV2Variant, useNftListV2Flag } from 'featureFlags/flags/nftListV2'
 import { ListingButton } from 'nft/components/bag/profile/ListingButton'
 import { getListingState } from 'nft/components/bag/profile/utils'
-import { Column, Row } from 'nft/components/Flex'
 import { BackArrowIcon } from 'nft/components/icons'
 import { headlineLarge, headlineSmall } from 'nft/css/common.css'
 import { themeVars } from 'nft/css/sprinkles.css'
@@ -10,10 +13,27 @@ import { ListingStatus, ProfilePageStateType } from 'nft/types'
 import { ListingMarkets } from 'nft/utils/listNfts'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components/macro'
+import { ThemedText } from 'theme'
 
 import { NFTListingsGrid } from './NFTListingsGrid'
 import { SelectMarketplacesDropdown } from './SelectMarketplacesDropdown'
 import { SetDurationModal } from './SetDurationModal'
+
+const TitleWrapper = styled(Row)`
+  gap: 4px;
+  margin-bottom: 18px;
+  white-space: nowrap;
+  width: min-content;
+
+  @media screen and (min-width: ${SMALL_MEDIA_BREAKPOINT}) {
+    margin-bottom: 0px;
+  }
+`
+
+const ButtonsWrapper = styled(Row)`
+  gap: 12px;
+  width: min-content;
+`
 
 const MarketWrap = styled.section`
   gap: 48px;
@@ -55,6 +75,23 @@ const MobileListButtonWrapper = styled.div`
   }
 `
 
+const FloatingConfirmationBar = styled(Row)`
+  padding: 20px 32px;
+  border-radius: 20px;
+  white-space: nowrap;
+  justify-content: space-between;
+  background: ${({ theme }) => theme.backgroundSurface};
+`
+
+const ProceedsWrapper = styled(Row)`
+  width: min-content;
+  gap: 40px;
+`
+
+const ListingButtonWrapper = styled.div`
+  width: 170px;
+`
+
 export const ListPage = () => {
   const { setProfilePageState: setSellPageState } = useProfilePageState()
   const setGlobalMarketplaces = useSellAsset((state) => state.setGlobalMarketplaces)
@@ -65,6 +102,7 @@ export const ListPage = () => {
   const listingStatus = useNFTList((state) => state.listingStatus)
   const setListingStatus = useNFTList((state) => state.setListingStatus)
   const isMobile = useIsMobile()
+  const isNftListV2 = useNftListV2Flag() === NftListV2Variant.Enabled
 
   useEffect(() => {
     const state = getListingState(collectionsRequiringApproval, listings)
@@ -89,7 +127,7 @@ export const ListPage = () => {
     <Column>
       <MarketWrap>
         <ListingHeader>
-          <Row gap="4" marginBottom={{ sm: '18', md: '0' }}>
+          <TitleWrapper>
             <BackArrowIcon
               height={isMobile ? 20 : 32}
               width={isMobile ? 20 : 32}
@@ -98,19 +136,36 @@ export const ListPage = () => {
               cursor="pointer"
             />
             <div className={isMobile ? headlineSmall : headlineLarge}>Sell NFTs</div>
-          </Row>
-          <Row gap="12">
+          </TitleWrapper>
+          <ButtonsWrapper>
             <SelectMarketplacesDropdown setSelectedMarkets={setSelectedMarkets} selectedMarkets={selectedMarkets} />
             <SetDurationModal />
-          </Row>
+          </ButtonsWrapper>
         </ListingHeader>
         <GridWrapper>
           <NFTListingsGrid selectedMarkets={selectedMarkets} />
+          {isNftListV2 && (
+            <FloatingConfirmationBar>
+              <ThemedText.HeadlineSmall lineHeight="28px">
+                <Trans>Proceeds if sold</Trans>
+              </ThemedText.HeadlineSmall>
+              <ProceedsWrapper>
+                <ThemedText.HeadlineSmall lineHeight="28px" color="textTertiary">
+                  - ETH
+                </ThemedText.HeadlineSmall>
+                <ListingButtonWrapper>
+                  <ListingButton onClick={toggleBag} buttonText="Set prices to continue" />
+                </ListingButtonWrapper>
+              </ProceedsWrapper>
+            </FloatingConfirmationBar>
+          )}
         </GridWrapper>
       </MarketWrap>
-      <MobileListButtonWrapper>
-        <ListingButton onClick={toggleBag} buttonText="Continue listing" />
-      </MobileListButtonWrapper>
+      {!isNftListV2 && (
+        <MobileListButtonWrapper>
+          <ListingButton onClick={toggleBag} buttonText="Continue listing" />
+        </MobileListButtonWrapper>
+      )}
     </Column>
   )
 }

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -95,7 +95,7 @@ const Overlay = styled.div`
   bottom: 0px;
   height: 158px;
   width: 100vw;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+  background: ${({ theme }) => `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, ${theme.backgroundBackdrop} 100%)`};
 `
 
 const ProceedsWrapper = styled(Row)`

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -126,6 +126,7 @@ export const ListPage = () => {
   const isNftListV2 = useNftListV2Flag() === NftListV2Variant.Enabled
 
   const totalEthListingValue = useMemo(() => getTotalEthValue(sellAssets), [sellAssets])
+  console.log(totalEthListingValue)
   const anyListingsMissingPrice = useMemo(() => !!listings.find((listing) => !listing.price), [listings])
   const [ethPriceInUSD, setEthPriceInUSD] = useState(0)
 

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -82,6 +82,10 @@ const FloatingConfirmationBar = styled(Row)`
   white-space: nowrap;
   justify-content: space-between;
   background: ${({ theme }) => theme.backgroundSurface};
+  position: absolute;
+  bottom: 32px;
+  margin: 0px 60px;
+  width: calc(100vw - 120px);
 `
 
 const ProceedsWrapper = styled(Row)`
@@ -156,36 +160,33 @@ export const ListPage = () => {
         </ListingHeader>
         <GridWrapper>
           <NFTListingsGrid selectedMarkets={selectedMarkets} />
-          {isNftListV2 && (
-            <FloatingConfirmationBar>
-              <ThemedText.HeadlineSmall lineHeight="28px">
-                <Trans>Proceeds if sold</Trans>
-              </ThemedText.HeadlineSmall>
-              <ProceedsWrapper>
-                <Row>
-                  <ThemedText.HeadlineSmall
-                    lineHeight="28px"
-                    color={totalEthListingValue ? 'textPrimary' : 'textTertiary'}
-                  >
-                    {totalEthListingValue > 0 ? formatEth(totalEthListingValue) : '-'} ETH
-                  </ThemedText.HeadlineSmall>
-                  {!!totalEthListingValue && !!ethPriceInUSD && (
-                    <ThemedText.HeadlineSmall lineHeight="28px" color="textSecondary" marginLeft="16px">
-                      {formatUsdPrice(totalEthListingValue * ethPriceInUSD)}
-                    </ThemedText.HeadlineSmall>
-                  )}
-                </Row>
-                <ListingButtonWrapper>
-                  <ListingButton
-                    onClick={toggleBag}
-                    buttonText={anyListingsMissingPrice ? t`Set prices to continue` : t`Start listing`}
-                  />
-                </ListingButtonWrapper>
-              </ProceedsWrapper>
-            </FloatingConfirmationBar>
-          )}
         </GridWrapper>
       </MarketWrap>
+      {isNftListV2 && (
+        <FloatingConfirmationBar>
+          <ThemedText.HeadlineSmall lineHeight="28px">
+            <Trans>Proceeds if sold</Trans>
+          </ThemedText.HeadlineSmall>
+          <ProceedsWrapper>
+            <Row>
+              <ThemedText.HeadlineSmall lineHeight="28px" color={totalEthListingValue ? 'textPrimary' : 'textTertiary'}>
+                {totalEthListingValue > 0 ? formatEth(totalEthListingValue) : '-'} ETH
+              </ThemedText.HeadlineSmall>
+              {!!totalEthListingValue && !!ethPriceInUSD && (
+                <ThemedText.HeadlineSmall lineHeight="28px" color="textSecondary" marginLeft="16px">
+                  {formatUsdPrice(totalEthListingValue * ethPriceInUSD)}
+                </ThemedText.HeadlineSmall>
+              )}
+            </Row>
+            <ListingButtonWrapper>
+              <ListingButton
+                onClick={toggleBag}
+                buttonText={anyListingsMissingPrice ? t`Set prices to continue` : t`Start listing`}
+              />
+            </ListingButtonWrapper>
+          </ProceedsWrapper>
+        </FloatingConfirmationBar>
+      )}
       {!isNftListV2 && (
         <MobileListButtonWrapper>
           <ListingButton onClick={toggleBag} buttonText="Continue listing" />

--- a/src/nft/utils/currency.ts
+++ b/src/nft/utils/currency.ts
@@ -18,7 +18,7 @@ export const formatEth = (price: number) => {
   } else if (price < 0.001) {
     return '<0.001'
   } else {
-    return `${Math.round(price * 100 + Number.EPSILON) / 100}`
+    return `${Math.round(price * 1000 + Number.EPSILON) / 1000}`
   }
 }
 


### PR DESCRIPTION
First PR for the floating bottom bar for the new list page, hidden behind Listing V2 Feature Flag. Dynamically adjusts price and button status depending on user entered price. Overlay below the bar when items scroll underneath. Hides listing panel if flag is enabled until listing is started. Also deprecated some VE components.

Known issues to be resolved in follow up PRs:
- Bar width doesn't match grid width. This will be resolved when the grid layout is updated when we change over the Listing Bag to a centered modal.
- Bar overlaps into current Listing Bag. Will also be resolved when bag is moved to a centered modal
- Mobile. Currently unsupported and will get its own PR.
- Error states. Error states like listing below floor or above current list price will show a misaligned warning tooltip. This logic is being completely updated in its own PR.

<img width="865" alt="Screen Shot 2023-01-11 at 11 41 43 " src="https://user-images.githubusercontent.com/11512321/211902268-5db9a5a0-3f59-44eb-a4d3-7dc2429f1d7a.png">

Update:
- better handle very small numbers
![Screen Shot 2023-01-11 at 12 36 25 ](https://user-images.githubusercontent.com/11512321/211912570-48b46fd0-2fa4-4a82-9d21-826db9d39da0.png)
