### PR TITLE
test: enable skipped fetchTokenList test

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "cypress": "^10.3.1",
     "env-cmd": "^10.1.0",
     "eslint": "^7.11.0",
+    "jest-fetch-mock": "^3.0.3",
     "jest-styled-components": "^7.0.8",
     "ms.macro": "^2.0.0",
     "patch-package": "^6.4.7",

--- a/src/lib/hooks/useTokenList/fetchTokenList.test.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.test.ts
@@ -1,11 +1,25 @@
+import defaultTokenList from '@uniswap/default-token-list'
+import fetch from 'jest-fetch-mock'
+
 import fetchTokenList, { DEFAULT_TOKEN_LIST } from './fetchTokenList'
 
-describe.skip('fetchTokenList', () => {
+fetch.enableMocks()
+
+describe('fetchTokenList', () => {
   const resolver = jest.fn()
 
+  beforeEach(() => {
+    jest.spyOn(console, 'debug').mockReturnValue(undefined)
+    resolver.mockReset()
+  })
+
   it('throws on an invalid list url', async () => {
-    const url = 'https://example.com'
+    const url = 'https://example.com/invalid-tokenlist.json'
+    fetch.mockOnceIf(url, () => {
+      throw new Error()
+    })
     await expect(fetchTokenList(url, resolver)).rejects.toThrow(`failed to fetch list: ${url}`)
+    expect(console.debug).toHaveBeenCalled()
     expect(resolver).not.toHaveBeenCalled()
   })
 
@@ -13,13 +27,15 @@ describe.skip('fetchTokenList', () => {
     const url = 'example.eth'
     const contenthash = '0xD3ADB33F'
     resolver.mockResolvedValue(contenthash)
-    await expect(fetchTokenList(url, resolver)).rejects.toThrow()
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(
+      `failed to translate contenthash to URI: ${contenthash}`
+    )
     expect(resolver).toHaveBeenCalledWith(url)
   })
 
   it('fetches and validates the default token list', async () => {
-    const list = await (await fetch(DEFAULT_TOKEN_LIST)).json()
-    await expect(fetchTokenList(DEFAULT_TOKEN_LIST, resolver)).resolves.toStrictEqual(list)
+    fetch.mockOnceIf(DEFAULT_TOKEN_LIST, () => Promise.resolve(JSON.stringify(defaultTokenList)))
+    await expect(fetchTokenList(DEFAULT_TOKEN_LIST, resolver)).resolves.toStrictEqual(defaultTokenList)
     expect(resolver).not.toHaveBeenCalled()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8292,7 +8292,7 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.0.6, cross-fetch@^3.1.4, cross-fetch@^3.1.5:
+cross-fetch@^3.0.4, cross-fetch@^3.0.6, cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -12679,6 +12679,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz"
@@ -15949,6 +15957,11 @@ promise-polyfill@8.1.3:
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
   integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
+
+promise-polyfill@^8.1.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
+  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 promise@^7.1.1:
   version "7.3.1"


### PR DESCRIPTION
Updates fetchTokenList.test.ts using jest-fetch-mock to match the tests in widget.
This removes the GitHub Action lint warning for the skipped test.