### PR TITLE
fix: nft add to bag test

### DIFF
--- a/cypress/e2e/nfts.test.ts
+++ b/cypress/e2e/nfts.test.ts
@@ -41,7 +41,7 @@ describe('Testing nfts', () => {
   })
 
   it('should toggle buy now on details page', () => {
-    cy.visit(`#/nfts/asset/${COLLECTION_ADDRESS}/8565`)
+    cy.visit(`#/nfts/asset/${COLLECTION_ADDRESS}/2043`)
     cy.get(getTestSelector('nft-details-description-text')).should('exist')
     cy.get(getTestSelector('nft-details-description')).click()
     cy.get(getTestSelector('nft-details-description-text')).should('not.exist')


### PR DESCRIPTION
* the testing suite is failing because the pudgy penguin that was being tested is no longer for sale