### PR TITLE
feat: enable permit2

### DIFF
--- a/src/featureFlags/flags/permit2.ts
+++ b/src/featureFlags/flags/permit2.ts
@@ -4,7 +4,7 @@ import { useWeb3React } from '@web3-react/core'
 import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
 
 export function usePermit2Flag(): BaseVariant {
-  return useBaseFlag(FeatureFlag.permit2)
+  return useBaseFlag(FeatureFlag.permit2, BaseVariant.Enabled)
 }
 
 export function usePermit2Enabled(): boolean {


### PR DESCRIPTION
Launches Permit2/Universal Router on supported chains.
Falls back to the older swap router on unsupported chains.