### PR TITLE
build: skip Monday releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 on:
   schedule:
-    - cron: '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
+    - cron: '0 12 * * 2-4' # every day 12:00 UTC Monday-Thursday
   # manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
Skips Monday releases. This can be reverted _after_ next Monday, which should be skipped due to holiday.