### PR TITLE
feat: [NFTListV2] convert old bag to modal

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
 import Web3Status from 'components/Web3Status'
+import { NftListV2Variant, useNftListV2Flag } from 'featureFlags/flags/nftListV2'
 import { chainIdToBackendName } from 'graphql/data/util'
 import { useIsNftPage } from 'hooks/useIsNftPage'
 import { Box } from 'nft/components/Box'
@@ -82,6 +83,7 @@ export const PageTabs = () => {
 const Navbar = () => {
   const isNftPage = useIsNftPage()
   const sellPageState = useProfilePageState((state) => state.state)
+  const isNftListV2 = useNftListV2Flag() === NftListV2Variant.Enabled
   const navigate = useNavigate()
 
   return (
@@ -123,7 +125,7 @@ const Navbar = () => {
               <Box display={{ sm: 'none', lg: 'flex' }}>
                 <MenuDropdown />
               </Box>
-              {isNftPage && sellPageState !== ProfilePageStateType.LISTING && <Bag />}
+              {isNftPage && (!isNftListV2 || sellPageState !== ProfilePageStateType.LISTING) && <Bag />}
               {!isNftPage && (
                 <Box display={{ sm: 'none', lg: 'flex' }}>
                   <ChainSelector />

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -6,6 +6,8 @@ import { useIsNftPage } from 'hooks/useIsNftPage'
 import { Box } from 'nft/components/Box'
 import { Row } from 'nft/components/Flex'
 import { UniIcon } from 'nft/components/icons'
+import { useProfilePageState } from 'nft/hooks'
+import { ProfilePageStateType } from 'nft/types'
 import { ReactNode } from 'react'
 import { NavLink, NavLinkProps, useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components/macro'
@@ -79,6 +81,7 @@ export const PageTabs = () => {
 
 const Navbar = () => {
   const isNftPage = useIsNftPage()
+  const sellPageState = useProfilePageState((state) => state.state)
   const navigate = useNavigate()
 
   return (
@@ -120,7 +123,7 @@ const Navbar = () => {
               <Box display={{ sm: 'none', lg: 'flex' }}>
                 <MenuDropdown />
               </Box>
-              {isNftPage && <Bag />}
+              {isNftPage && sellPageState !== ProfilePageStateType.LISTING && <Bag />}
               {!isNftPage && (
                 <Box display={{ sm: 'none', lg: 'flex' }}>
                   <ChainSelector />

--- a/src/nft/components/profile/list/ListModal.tsx
+++ b/src/nft/components/profile/list/ListModal.tsx
@@ -1,5 +1,6 @@
 import ListingModal from 'nft/components/bag/profile/ListingModal'
 import { Portal } from 'nft/components/common/Portal'
+import { Overlay } from 'nft/components/modals/Overlay'
 import styled from 'styled-components/macro'
 import { Z_INDEX } from 'theme/zIndex'
 
@@ -17,12 +18,13 @@ const ListModalWrapper = styled.div`
   padding: 0px 12px 4px;
 `
 
-export const ListModal = () => {
+export const ListModal = ({ overlayClick }: { overlayClick: () => void }) => {
   return (
     <Portal>
       <ListModalWrapper>
         <ListingModal />
       </ListModalWrapper>
+      <Overlay onClick={overlayClick} />
     </Portal>
   )
 }

--- a/src/nft/components/profile/list/ListModal.tsx
+++ b/src/nft/components/profile/list/ListModal.tsx
@@ -1,0 +1,28 @@
+import ListingModal from 'nft/components/bag/profile/ListingModal'
+import { Portal } from 'nft/components/common/Portal'
+import styled from 'styled-components/macro'
+import { Z_INDEX } from 'theme/zIndex'
+
+const ListModalWrapper = styled.div`
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 420px;
+  z-index: ${Z_INDEX.modalOverTooltip};
+  background: ${({ theme }) => theme.backgroundSurface};
+  border-radius: 20px;
+  border: ${({ theme }) => `1px solid ${theme.backgroundOutline}`};
+  box-shadow: ${({ theme }) => theme.deepShadow};
+  padding: 0px 12px 4px;
+`
+
+export const ListModal = () => {
+  return (
+    <Portal>
+      <ListModalWrapper>
+        <ListingModal />
+      </ListModalWrapper>
+    </Portal>
+  )
+}

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -13,7 +13,7 @@ import { ListingStatus, ProfilePageStateType } from 'nft/types'
 import { fetchPrice, formatEth, formatUsdPrice } from 'nft/utils'
 import { ListingMarkets } from 'nft/utils/listNfts'
 import { useEffect, useMemo, useReducer, useState } from 'react'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { Z_INDEX } from 'theme/zIndex'
 
@@ -38,11 +38,20 @@ const ButtonsWrapper = styled(Row)`
   width: min-content;
 `
 
-const MarketWrap = styled.section`
+const MarketWrap = styled.section<{ isNftListV2: boolean }>`
   gap: 48px;
   margin: 0px auto;
   width: 100%;
   max-width: 1200px;
+  ${({ isNftListV2 }) => !isNftListV2 && v1Padding}
+`
+
+const v1Padding = css`
+  padding: 0px 16px;
+
+  @media screen and (min-width: ${SMALL_MEDIA_BREAKPOINT}) {
+    padding: 0px 44px;
+  }
 `
 
 const ListingHeader = styled(Row)`
@@ -157,7 +166,7 @@ export const ListPage = () => {
 
   return (
     <Column>
-      <MarketWrap>
+      <MarketWrap isNftListV2={isNftListV2}>
         <ListingHeader>
           <TitleWrapper>
             <BackArrowIcon

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -12,11 +12,12 @@ import { useBag, useIsMobile, useNFTList, useProfilePageState, useSellAsset } fr
 import { ListingStatus, ProfilePageStateType } from 'nft/types'
 import { fetchPrice, formatEth, formatUsdPrice } from 'nft/utils'
 import { ListingMarkets } from 'nft/utils/listNfts'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useReducer, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { Z_INDEX } from 'theme/zIndex'
 
+import { ListModal } from './ListModal'
 import { NFTListingsGrid } from './NFTListingsGrid'
 import { SelectMarketplacesDropdown } from './SelectMarketplacesDropdown'
 import { SetDurationModal } from './SetDurationModal'
@@ -127,6 +128,7 @@ export const ListPage = () => {
   const totalEthListingValue = useMemo(() => getTotalEthValue(sellAssets), [sellAssets])
   const anyListingsMissingPrice = useMemo(() => !!listings.find((listing) => !listing.price), [listings])
   const [ethPriceInUSD, setEthPriceInUSD] = useState(0)
+  const [showListModal, toggleShowListModal] = useReducer((s) => !s, false)
 
   useEffect(() => {
     fetchPrice().then((price) => {
@@ -198,7 +200,7 @@ export const ListPage = () => {
               </ProceedsWrapper>
               <ListingButtonWrapper>
                 <ListingButton
-                  onClick={toggleBag}
+                  onClick={isNftListV2 ? toggleShowListModal : toggleBag}
                   buttonText={anyListingsMissingPrice ? t`Set prices to continue` : t`Start listing`}
                 />
               </ListingButtonWrapper>
@@ -211,6 +213,11 @@ export const ListPage = () => {
         <MobileListButtonWrapper>
           <ListingButton onClick={toggleBag} buttonText="Continue listing" />
         </MobileListButtonWrapper>
+      )}
+      {isNftListV2 && showListModal && (
+        <>
+          <ListModal />
+        </>
       )}
     </Column>
   )

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -216,7 +216,7 @@ export const ListPage = () => {
       )}
       {isNftListV2 && showListModal && (
         <>
-          <ListModal />
+          <ListModal overlayClick={toggleShowListModal} />
         </>
       )}
     </Column>

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -40,13 +40,8 @@ const ButtonsWrapper = styled(Row)`
 const MarketWrap = styled.section`
   gap: 48px;
   margin: 0px auto;
-  padding: 0px 16px;
-  max-width: 1200px;
   width: 100%;
-
-  @media screen and (min-width: ${SMALL_MEDIA_BREAKPOINT}) {
-    padding: 0px 44px;
-  }
+  max-width: 1200px;
 `
 
 const ListingHeader = styled(Row)`
@@ -87,8 +82,10 @@ const FloatingConfirmationBar = styled(Row)`
   background: ${({ theme }) => theme.backgroundSurface};
   position: fixed;
   bottom: 32px;
-  margin: 0px 156px;
   width: calc(100vw - 312px);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 1200px;
   z-index: ${Z_INDEX.under_dropdown};
 `
 

--- a/src/nft/pages/profile/profile.tsx
+++ b/src/nft/pages/profile/profile.tsx
@@ -61,7 +61,7 @@ const ProfileContent = () => {
                   ? 312
                   : 0
               }px)`,
-              margin: '0px 156px',
+              margin: isNftListV2 ? '0px 156px' : 'unset',
             }}
           >
             {sellPageState === ProfilePageStateType.VIEWING ? <ProfilePage /> : <ListPage />}

--- a/src/nft/pages/profile/profile.tsx
+++ b/src/nft/pages/profile/profile.tsx
@@ -57,8 +57,11 @@ const ProfileContent = () => {
               width: `calc(100% - ${
                 cartExpanded && (!isNftListV2 || sellPageState === ProfilePageStateType.VIEWING)
                   ? SHOPPING_BAG_WIDTH
+                  : isNftListV2
+                  ? 312
                   : 0
               }px)`,
+              margin: '0px 156px',
             }}
           >
             {sellPageState === ProfilePageStateType.VIEWING ? <ProfilePage /> : <ListPage />}

--- a/src/nft/pages/profile/profile.tsx
+++ b/src/nft/pages/profile/profile.tsx
@@ -1,6 +1,7 @@
 import { Trace } from '@uniswap/analytics'
 import { InterfacePageName } from '@uniswap/analytics-events'
 import { useWeb3React } from '@web3-react/core'
+import { NftListV2Variant, useNftListV2Flag } from 'featureFlags/flags/nftListV2'
 import { Box } from 'nft/components/Box'
 import { Center, Column } from 'nft/components/Flex'
 import { ListPage } from 'nft/components/profile/list/ListPage'
@@ -42,6 +43,7 @@ const ProfileContent = () => {
     }
   }, [account, resetSellAssets, setSellPageState, clearCollectionFilters])
   const cartExpanded = useBag((state) => state.bagExpanded)
+  const isNftListV2 = useNftListV2Flag() === NftListV2Variant.Enabled
 
   return (
     <Trace page={InterfacePageName.NFT_PROFILE_PAGE} shouldLogImpression>
@@ -53,7 +55,9 @@ const ProfileContent = () => {
           <Box
             style={{
               width: `calc(100% - ${
-                cartExpanded && sellPageState === ProfilePageStateType.VIEWING ? SHOPPING_BAG_WIDTH : 0
+                cartExpanded && (!isNftListV2 || sellPageState === ProfilePageStateType.VIEWING)
+                  ? SHOPPING_BAG_WIDTH
+                  : 0
               }px)`,
             }}
           >

--- a/src/nft/pages/profile/profile.tsx
+++ b/src/nft/pages/profile/profile.tsx
@@ -50,7 +50,13 @@ const ProfileContent = () => {
           <title>Genie | Sell</title>
         </Head> */}
         {account ? (
-          <Box style={{ width: `calc(100% - ${cartExpanded ? SHOPPING_BAG_WIDTH : 0}px)` }}>
+          <Box
+            style={{
+              width: `calc(100% - ${
+                cartExpanded && sellPageState === ProfilePageStateType.VIEWING ? SHOPPING_BAG_WIDTH : 0
+              }px)`,
+            }}
+          >
             {sellPageState === ProfilePageStateType.VIEWING ? <ProfilePage /> : <ListPage />}
           </Box>
         ) : (


### PR DESCRIPTION
- Converts the old list bag into a floating modal above a scrim
- update grid to new spacing that doesn't factor in an open bag
- hide list tag icon on navbar when listing

<img width="1728" alt="Screen Shot 2023-01-17 at 11 54 07 " src="https://user-images.githubusercontent.com/11512321/213000010-d41783b4-831f-4ba6-b05f-0517a42ead12.png">
<img width="1728" alt="Screen Shot 2023-01-17 at 11 54 16 " src="https://user-images.githubusercontent.com/11512321/213000016-ccf9ebfa-5f5a-4107-b8a8-04cb109aef11.png">
