### PR TITLE
fix: fallback to eth_sign for permit approval

### DIFF
--- a/src/hooks/usePermitAllowance.ts
+++ b/src/hooks/usePermitAllowance.ts
@@ -1,3 +1,5 @@
+import 'utils/signTypedData'
+
 import { AllowanceTransfer, MaxAllowanceTransferAmount, PERMIT2_ADDRESS, PermitSingle } from '@uniswap/permit2-sdk'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -2,8 +2,8 @@ import { _TypedDataEncoder } from '@ethersproject/hash'
 import { JsonRpcSigner } from '@ethersproject/providers'
 
 /**
- * Overrides the _signTypedData method to add support for wallets without EIP-712 support (eg Zerion),
- * by adding a fallback to eth_sign.
+ * Overrides the _signTypedData method to add support for wallets without EIP-712 support (eg Zerion) by adding a fallback to eth_sign.
+ * The implementation is copied from ethers (and linted), except for the catch statement, which removes the logger and adds the fallback.
  * @see https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/providers/src.ts/json-rpc-provider.ts#L334
  */
 JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbacks(this, domain, types, value) {

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -1,0 +1,31 @@
+import { _TypedDataEncoder } from '@ethersproject/hash'
+import { JsonRpcSigner } from '@ethersproject/providers'
+
+/**
+ * Overrides the _signTypedData method to add support for wallets without EIP-712 support (eg Zerion).
+ * Adds a fallback to eth_sign.
+ */
+JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbacks(this, domain, types, value) {
+  // Populate any ENS names (in-place)
+  const populated = await _TypedDataEncoder.resolveNames(domain, types, value, (name: string) => {
+    return this.provider.resolveName(name) as Promise<string>
+  })
+
+  const address = (await this.getAddress()).toLowerCase()
+  const payload = JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value))
+
+  return this.provider
+    .send('eth_signTypedData_v4', [address, payload])
+    .catch((e) => {
+      if ('message' in e && e.message.match(/not found/i)) {
+        console.warn('eth_signTypedData_v4 failed, falling back to eth_sign:', e)
+        const hash = _TypedDataEncoder.hash(populated.domain, types, populated.value)
+        return this.provider.send('eth_sign', [address, hash])
+      }
+      throw e
+    })
+    .catch((e) => {
+      console.warn('eth_sign failed:', e)
+      throw e
+    })
+}

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -2,8 +2,9 @@ import { _TypedDataEncoder } from '@ethersproject/hash'
 import { JsonRpcSigner } from '@ethersproject/providers'
 
 /**
- * Overrides the _signTypedData method to add support for wallets without EIP-712 support (eg Zerion).
- * Adds a fallback to eth_sign.
+ * Overrides the _signTypedData method to add support for wallets without EIP-712 support (eg Zerion),
+ * by adding a fallback to eth_sign.
+ * @see https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/providers/src.ts/json-rpc-provider.ts#L334
  */
 JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbacks(this, domain, types, value) {
   // Populate any ENS names (in-place)
@@ -14,18 +15,14 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
   const address = (await this.getAddress()).toLowerCase()
   const payload = JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value))
 
-  return this.provider
-    .send('eth_signTypedData_v4', [address, payload])
-    .catch((e) => {
-      if ('message' in e && e.message.match(/not found/i)) {
-        console.warn('eth_signTypedData_v4 failed, falling back to eth_sign:', e)
-        const hash = _TypedDataEncoder.hash(populated.domain, types, populated.value)
-        return this.provider.send('eth_sign', [address, hash])
-      }
-      throw e
-    })
-    .catch((e) => {
+  return this.provider.send('eth_signTypedData_v4', [address, payload]).catch((e) => {
+    if (!('message' in e && e.message.match(/not found/i))) throw e
+
+    console.warn('eth_signTypedData_v4 failed, falling back to eth_sign:', e)
+    const hash = _TypedDataEncoder.hash(populated.domain, types, populated.value)
+    return this.provider.send('eth_sign', [address, hash]).catch((e) => {
       console.warn('eth_sign failed:', e)
       throw e
     })
+  })
 }


### PR DESCRIPTION
Falls back to eth_sign if eth_signTypedData_v4 (ie EIP-712) is not implemented, eg for zerion.
This has been tested with zerion; other known wallets implement EIP-712.

Implementing this as a polyfill overriding JsonRpcSigner.prototype._signTypedData allows the fix to propagate to widgets as well. This is preferable to a utility method (eg `function signTypedData(...)`), as that would require additional changes/releases to widgets.

This will be ported to conedison, as well as proposed as an upstream change to ethers.

WEB-2792