### PR TITLE
fix: avoid error swap state while loading

### DIFF
--- a/src/utils/prices.test.ts
+++ b/src/utils/prices.test.ts
@@ -119,8 +119,8 @@ describe('prices', () => {
   })
 
   describe('#warningSeverity', () => {
-    it('max for undefined', () => {
-      expect(warningSeverity(undefined)).toEqual(4)
+    it('0 for undefined', () => {
+      expect(warningSeverity(undefined)).toEqual(0)
     })
     it('correct for 0', () => {
       expect(warningSeverity(new Percent(0))).toEqual(0)

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -84,7 +84,7 @@ const IMPACT_TIERS = [
 
 type WarningSeverity = 0 | 1 | 2 | 3 | 4
 export function warningSeverity(priceImpact: Percent | undefined): WarningSeverity {
-  if (!priceImpact) return 4
+  if (!priceImpact) return 0
   let impact: WarningSeverity = IMPACT_TIERS.length as WarningSeverity
   for (const impactLevel of IMPACT_TIERS) {
     if (impactLevel.lessThan(priceImpact)) return impact


### PR DESCRIPTION
Considers a loading trade to have `0` price impact warning, so that the swap button does not use an `error`-colored background.

Fixes the flash of red (error) swap button while the swap is still loading.