### PR TITLE
fix: allow signing from safepal

### DIFF
--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -23,7 +23,7 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
       ])
     } catch (error) {
       // MetaMask complains that the unversioned eth_signTypedData is formatted incorrectly (32602) - it prefers _v4.
-      if (typeof error.code === 'number' && error.code === -32602) {
+      if (error.code === -32602) {
         console.warn('eth_signTypedData failed, falling back to eth_signTypedData_v4:', error)
         return await this.provider.send('eth_signTypedData_v4', [
           address.toLowerCase(),

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -24,6 +24,7 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
     } catch (error) {
       // MetaMask complains that the unversioned eth_signTypedData is formatted incorrectly (32602) - it prefers _v4.
       if (typeof error.code === 'number' && error.code === -32602) {
+        console.warn('eth_signTypedData failed, falling back to eth_signTypedData_v4:', error)
         return await this.provider.send('eth_signTypedData_v4', [
           address.toLowerCase(),
           JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value)),
@@ -34,7 +35,7 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
   } catch (error) {
     // If neither other method are available (eg Zerion), fallback to eth_sign.
     if (typeof error.message === 'string' && error.message.match(/not found/i)) {
-      console.warn('eth_signTypedData_v4 failed, falling back to eth_sign:', error)
+      console.warn('eth_signTypedData_* failed, falling back to eth_sign:', error)
       const hash = _TypedDataEncoder.hash(populated.domain, types, populated.value)
       return await this.provider.send('eth_sign', [address, hash])
     }

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -15,7 +15,7 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
   const address = await this.getAddress()
 
   try {
-    return await this.provider.send('eth_signTypedData_v4', [
+    return await this.provider.send('eth_signTypedData', [
       address.toLowerCase(),
       JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value)),
     ])

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -33,7 +33,7 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
       throw error
     }
   } catch (error) {
-    // If neither other method are available (eg Zerion), fallback to eth_sign.
+    // If neither other method is available (eg Zerion), fallback to eth_sign.
     if (typeof error.message === 'string' && error.message.match(/not found/i)) {
       console.warn('eth_signTypedData_* failed, falling back to eth_sign:', error)
       const hash = _TypedDataEncoder.hash(populated.domain, types, populated.value)

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -27,6 +27,7 @@ JsonRpcSigner.prototype._signTypedData = async function signTypedDataWithFallbac
           JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value)),
         ])
       }
+      throw error
     }
   } catch (error) {
     console.log(error)


### PR DESCRIPTION
Uses an unversioned call for signTypedData so that it is accepted by all wallets. SafePal hangs on _v4.
Practically, this uses eth_signTypedData for all wallets _except_ for MetaMask, which rejects it and falls back to eth_signTypedData_v4.

Tested with:
- [x] SafePal
- [x] Coinbase Wallet
- [x] Trust
- [x] MetaMask
- [x] Zerion
- [x] Rainbow
- [x] Other