### PR TITLE
fix: amend gas estimate error message

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -57,7 +57,7 @@ export function useUniversalRouterSwapCallback(
         gasEstimate = await provider.estimateGas(tx)
       } catch (gasError) {
         console.warn(gasError)
-        throw new InvalidSwapError('Gas estimation failed. Wait a few minutes and try again.')
+        throw new Error('Your swap is expected to fail')
       }
       const gasLimit = calculateGasMargin(gasEstimate)
       const response = await provider

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -47,6 +47,6 @@ export function swapErrorToUserReadableMessage(error: any): string {
         return t`An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If that does not work, there may be an incompatibility with the token you are trading. Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
       }
       return t`${reason ? reason : 'Unknown error'}. Try increasing your slippage tolerance.
-Note: certain tokens are incompatible with Uniswap V3.`
+Note: fee-on-transfer and rebase are incompatible with Uniswap V3.`
   }
 }

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -47,6 +47,6 @@ export function swapErrorToUserReadableMessage(error: any): string {
         return t`An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If that does not work, there may be an incompatibility with the token you are trading. Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
       }
       return t`${reason ? reason : 'Unknown error'}. Try increasing your slippage tolerance.
-Note: fee-on-transfer and rebase are incompatible with Uniswap V3.`
+Note: fee-on-transfer and rebase tokens are incompatible with Uniswap V3.`
   }
 }

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -46,7 +46,7 @@ export function swapErrorToUserReadableMessage(error: any): string {
       if (reason?.indexOf('undefined is not an object') !== -1) {
         return t`An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If that does not work, there may be an incompatibility with the token you are trading. Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
       }
-      return t`Unknown error${reason ? `: "${reason}"` : ''}. Try increasing your slippage tolerance.
-Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
+      return t`${reason ? reason : 'Unknown error'}. Try increasing your slippage tolerance.
+Note: certain tokens are incompatible with Uniswap V3.`
   }
 }


### PR DESCRIPTION
Update the messaging on gas estimate errors.

New text will be: Your swap is expected to fail. Try increasing your slippage tolerance. Note: certain tokens are incompatible with Uniswap V3.