### PR TITLE
fix: slideout menu title overlap on firefox

### DIFF
--- a/src/components/WalletDropdown/SlideOutMenu.tsx
+++ b/src/components/WalletDropdown/SlideOutMenu.tsx
@@ -57,7 +57,7 @@ const StyledChevron = styled(ChevronLeft)`
 const BackSection = styled.div`
   position: absolute;
   background-color: ${({ theme }) => theme.backgroundSurface};
-  width: -webkit-fill-available;
+  width: fill-available;
   margin: 0px 2vw 0px 0px;
   padding: 0px 0px 2vh 0px;
   color: ${({ theme }) => theme.textSecondary};


### PR DESCRIPTION
The change to use `webkit` fill available for title of the slideout menu breaks for non-webkit browsers ie firefox. This is a more general solution. Tested on both firefox and chrome.
Before:
<img width="373" alt="Screen Shot 2023-01-19 at 22 23 39 " src="https://user-images.githubusercontent.com/11512321/213634875-88d3c17c-b284-4cac-a3a9-d5246cf034d9.png">
<img width="371" alt="Screen Shot 2023-01-19 at 22 47 47 " src="https://user-images.githubusercontent.com/11512321/213634879-bb4effb2-3204-4a92-b964-e248b14a31e1.png">
After:
<img width="435" alt="Screen Shot 2023-01-19 at 22 46 26 " src="https://user-images.githubusercontent.com/11512321/213634908-65860be3-4440-404e-88b1-32f75f83a6da.png">
<img width="353" alt="Screen Shot 2023-01-19 at 22 48 03 " src="https://user-images.githubusercontent.com/11512321/213634913-33a39664-81e4-4170-b046-fb0eaa8527f6.png">

