### PR TITLE
fix: use wallet modal for widget-prompted connection

### DIFF
--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -58,7 +58,12 @@ export default function Widget({ token, onTokenChange, onReviewSwapClick }: Widg
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
 
-  const onConnectWalletClick = useToggleWalletModal()
+  const toggleWalletModal = useToggleWalletModal()
+  const onConnectWalletClick = useCallback(() => {
+    toggleWalletModal
+    return false // prevents the in-widget wallet modal from opening
+  }, [toggleWalletModal])
+
   const onSwitchChain = useCallback(
     // TODO(WEB-1757): Widget should not break if this rejects - upstream the catch to ignore it.
     ({ chainId }: AddEthereumChainParameter) => switchChain(connector, Number(chainId)).catch(() => undefined),

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -26,6 +26,7 @@ import {
   getTokenAddress,
 } from 'lib/utils/analytics'
 import { useCallback, useState } from 'react'
+import { useToggleWalletModal } from 'state/application/hooks'
 import { useIsDarkMode } from 'state/user/hooks'
 import { computeRealizedPriceImpact } from 'utils/prices'
 import { switchChain } from 'utils/switchChain'
@@ -57,6 +58,7 @@ export default function Widget({ token, onTokenChange, onReviewSwapClick }: Widg
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
 
+  const onConnectWalletClick = useToggleWalletModal()
   const onSwitchChain = useCallback(
     // TODO(WEB-1757): Widget should not break if this rejects - upstream the catch to ignore it.
     ({ chainId }: AddEthereumChainParameter) => switchChain(connector, Number(chainId)).catch(() => undefined),
@@ -154,6 +156,7 @@ export default function Widget({ token, onTokenChange, onReviewSwapClick }: Widg
         theme={theme}
         width={WIDGET_WIDTH}
         // defaultChainId is excluded - it is always inferred from the passed provider
+        onConnectWalletClick={onConnectWalletClick}
         provider={provider}
         onSwitchChain={onSwitchChain}
         tokenList={EMPTY_TOKEN_LIST} // prevents loading the default token list, as we use our own token selector UI

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -60,7 +60,7 @@ export default function Widget({ token, onTokenChange, onReviewSwapClick }: Widg
 
   const toggleWalletModal = useToggleWalletModal()
   const onConnectWalletClick = useCallback(() => {
-    toggleWalletModal
+    toggleWalletModal()
     return false // prevents the in-widget wallet modal from opening
   }, [toggleWalletModal])
 


### PR DESCRIPTION
Fixes "Connect Wallet" through the widget, by implementing a callback for onConnectWalletClick. This triggers the interface wallet modal, instead of connecting through the widget (which does not make the connection available to the interface).

WEB-2813