### PR TITLE
fix: nav text is wrap

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -40,7 +40,7 @@ const MenuItem = ({ href, dataTestId, id, isActive, children }: MenuItemProps) =
       to={href}
       className={isActive ? styles.activeMenuItem : styles.menuItem}
       id={id}
-      style={{ textDecoration: 'none' }}
+      style={{ textDecoration: 'none', whiteSpace: 'nowrap' }}
       data-testid={dataTestId}
     >
       {children}


### PR DESCRIPTION
Chinese translator, pool navigator can wrap lines
<img width="420" alt="image" src="https://user-images.githubusercontent.com/26568752/215267893-1728128f-b7d1-4449-9c9b-9981560a88d0.png">
