### PR TITLE
feat: create Save-for-Later bag

### DIFF
--- a/src/components/NavBar/Bag.tsx
+++ b/src/components/NavBar/Bag.tsx
@@ -2,6 +2,7 @@ import { NavIcon } from 'components/NavBar/NavIcon'
 import { useIsNftProfilePage } from 'hooks/useIsNftPage'
 import { BagIcon, HundredsOverflowIcon, TagIcon } from 'nft/components/icons'
 import { useBag, useSellAsset } from 'nft/hooks'
+import { BagItemStatus } from 'nft/types'
 import { useCallback } from 'react'
 import styled from 'styled-components/macro'
 import shallow from 'zustand/shallow'
@@ -35,7 +36,9 @@ export const Bag = () => {
     setBagExpanded({ bagExpanded: !bagExpanded })
   }, [bagExpanded, setBagExpanded])
 
-  const bagQuantity = isProfilePage ? sellAssets.length : itemsInBag.length
+  const bagQuantity = isProfilePage
+    ? sellAssets.length
+    : itemsInBag.filter((item) => item.status !== BagItemStatus.SAVED_FOR_LATER).length
   const bagHasItems = bagQuantity > 0
 
   return (

--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -386,6 +386,7 @@ export type NftCollectionTraitStats = {
 
 export type NftCollectionsFilterInput = {
   addresses?: InputMaybe<Array<Scalars['String']>>;
+  nameQuery?: InputMaybe<Scalars['String']>;
 };
 
 export type NftContract = IContract & {

--- a/src/nft/components/bag/Bag.tsx
+++ b/src/nft/components/bag/Bag.tsx
@@ -167,7 +167,7 @@ const Bag = () => {
   const { totalEthPrice, totalUsdPrice } = useMemo(() => {
     const totalEthPrice = itemsInBag.reduce(
       (total, item) =>
-        item.status !== BagItemStatus.UNAVAILABLE && BagItemStatus.SAVED_FOR_LATER
+        item.status !== BagItemStatus.UNAVAILABLE && item.status !== BagItemStatus.SAVED_FOR_LATER
           ? total.add(
               BigNumber.from(
                 item.asset.updatedPriceInfo ? item.asset.updatedPriceInfo.ETHPrice : item.asset.priceInfo.ETHPrice

--- a/src/nft/components/bag/Bag.tsx
+++ b/src/nft/components/bag/Bag.tsx
@@ -204,7 +204,8 @@ const Bag = () => {
 
   const handleCloseBag = useCallback(() => {
     setBagExpanded({ bagExpanded: false, manualClose: true })
-  }, [setBagExpanded])
+    setActiveBagView(isProfilePage ? BagView.SELL : BagView.MAIN)
+  }, [setBagExpanded, setActiveBagView, isProfilePage])
 
   const fetchAssets = async () => {
     const itemsToBuy = itemsInBag

--- a/src/nft/components/bag/BagContent.tsx
+++ b/src/nft/components/bag/BagContent.tsx
@@ -11,11 +11,13 @@ import { useQuery } from 'react-query'
 export const BagContent = () => {
   const bagStatus = useBag((s) => s.bagStatus)
   const setBagStatus = useBag((s) => s.setBagStatus)
+  const activeBagView = useBag((s) => s.activeBagView)
   const markAssetAsReviewed = useBag((s) => s.markAssetAsReviewed)
   const didOpenUnavailableAssets = useBag((s) => s.didOpenUnavailableAssets)
   const setDidOpenUnavailableAssets = useBag((s) => s.setDidOpenUnavailableAssets)
   const uncheckedItemsInBag = useBag((s) => s.itemsInBag)
   const setItemsInBag = useBag((s) => s.setItemsInBag)
+  const addAssetsToBag = useBag((s) => s.addAssetsToBag)
   const removeAssetsFromBag = useBag((s) => s.removeAssetsFromBag)
 
   const isMobile = useIsMobile()
@@ -103,8 +105,10 @@ export const BagContent = () => {
           .map((asset) => (
             <BagRow
               key={asset.id}
+              activeBagView={activeBagView}
               asset={asset}
               usdPrice={fetchedPriceData}
+              addAsset={addAssetsToBag}
               removeAsset={removeAssetsFromBag}
               showRemove={true}
               isMobile={isMobile}

--- a/src/nft/components/bag/BagHeader.tsx
+++ b/src/nft/components/bag/BagHeader.tsx
@@ -1,17 +1,39 @@
 import { Trans } from '@lingui/macro'
 import { OpacityHoverState } from 'components/Common'
+import { Column } from 'nft/components/Flex'
 import { BagCloseIcon } from 'nft/components/icons'
+import { BagView } from 'nft/types'
 import { useMemo } from 'react'
 import styled from 'styled-components/macro'
 import { ButtonText, ThemedText } from 'theme'
 
+const BagSelector = styled.div`
+  display: flex;
+  flex-direction: row;
+`
+const BagButton = styled.button`
+  margin-right: 10px;
+  padding: 0px;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+
+  ${OpacityHoverState}
+`
+const BagControls = styled.div`
+  width: 90px;
+  justify-content: space-between;
+  display: flex;
+  flex-direction: row;
+  margin-top: 4px;
+`
 const ClearButton = styled(ButtonText)`
   color: ${({ theme }) => theme.textSecondary};
   cursor: pointer;
   font-weight: 600;
   font-size: 14px;
   line-height: 16px;
-
+  margin: 2px;
   :active {
     text-decoration: none;
   }
@@ -27,7 +49,7 @@ const IconWrapper = styled.button`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  margin-left: auto;
+  margin: 0px 0px auto auto;
   padding: 2px;
   opacity: 1;
 
@@ -53,13 +75,15 @@ const Wrapper = styled.div`
   gap: 8px;
   justify-content: flex-start;
   margin: 16px 28px;
-  text-align: center;
+  text-align: left;
 `
 interface BagHeaderProps {
+  bagViews: BagView[]
+  activeBagView: BagView
+  changeBagView: (newView: BagView) => void
   numberOfAssets: number
   closeBag: () => void
-  resetFlow: () => void
-  isProfilePage: boolean
+  resetFlow: (bagView: BagView) => void
 }
 
 const BASE_SIZING = 14
@@ -73,20 +97,41 @@ const getCircleSizing = (numberOfAssets: number): string => {
   return `${BASE_SIZING + INCREMENTAL_SIZING * numberOfCharacters}px`
 }
 
-export const BagHeader = ({ numberOfAssets, closeBag, resetFlow, isProfilePage }: BagHeaderProps) => {
+export const BagHeader = ({
+  bagViews,
+  activeBagView,
+  changeBagView,
+  numberOfAssets,
+  closeBag,
+  resetFlow,
+}: BagHeaderProps) => {
   const sizing = useMemo(() => getCircleSizing(numberOfAssets), [numberOfAssets])
 
   return (
     <Wrapper>
-      <ThemedText.HeadlineSmall>{isProfilePage ? <Trans>Sell</Trans> : <Trans>Bag</Trans>}</ThemedText.HeadlineSmall>
-      {numberOfAssets > 0 && (
-        <>
-          <CounterDot sizing={sizing}>{numberOfAssets}</CounterDot>
-          <ClearButton onClick={resetFlow}>
-            <Trans>Clear all</Trans>
-          </ClearButton>
-        </>
-      )}
+      <Column>
+        <BagSelector>
+          {bagViews.map((view) => (
+            <BagButton
+              key={view}
+              onClick={() => changeBagView(view)}
+              style={view === activeBagView ? { pointerEvents: 'none' } : {}}
+            >
+              <ThemedText.HeadlineSmall opacity={view === activeBagView ? 1 : 0.5}>
+                <Trans>{view}</Trans>
+              </ThemedText.HeadlineSmall>
+            </BagButton>
+          ))}
+        </BagSelector>
+        {numberOfAssets > 0 && (
+          <BagControls>
+            <CounterDot sizing={sizing}>{numberOfAssets}</CounterDot>
+            <ClearButton onClick={() => resetFlow(activeBagView)}>
+              <Trans>Clear all</Trans>
+            </ClearButton>
+          </BagControls>
+        )}
+      </Column>
       <IconWrapper onClick={closeBag}>
         <BagCloseIcon data-testid="nft-bag-close-icon" />
       </IconWrapper>

--- a/src/nft/components/bag/BagRow.tsx
+++ b/src/nft/components/bag/BagRow.tsx
@@ -136,6 +136,7 @@ export const BagRow = ({
       e.preventDefault()
       e.stopPropagation()
       setOptionsOpened(!optionsOpened)
+      window.addEventListener('click', () => setOptionsOpened(false))
     },
     [optionsOpened]
   )

--- a/src/nft/components/bag/EmptyContent.tsx
+++ b/src/nft/components/bag/EmptyContent.tsx
@@ -1,8 +1,9 @@
-import { useIsNftProfilePage } from 'hooks/useIsNftPage'
 import { Center, Column } from 'nft/components/Flex'
 import { BagIcon, LargeTagIcon } from 'nft/components/icons'
 import { subhead } from 'nft/css/common.css'
 import { themeVars } from 'nft/css/sprinkles.css'
+import { useBag } from 'nft/hooks'
+import { BagView } from 'nft/types'
 import styled from 'styled-components/macro'
 
 const StyledColumn = styled(Column)`
@@ -11,28 +12,28 @@ const StyledColumn = styled(Column)`
 `
 
 const EmptyState = () => {
-  const isProfilePage = useIsNftProfilePage()
+  const activeBagView = useBag((state) => state.activeBagView)
 
   return (
     <StyledColumn>
       <Center>
-        {isProfilePage ? (
+        {activeBagView === BagView.SELL ? (
           <LargeTagIcon color={themeVars.colors.textTertiary} />
         ) : (
           <BagIcon color={themeVars.colors.textTertiary} height="96px" width="96px" strokeWidth="1px" />
         )}
       </Center>
-      {isProfilePage ? (
+      {activeBagView === BagView.SELL ? (
         <Center data-testid="nft-no-nfts-selected" className={subhead}>
           No NFTs selected
         </Center>
       ) : (
         <Column gap="16">
           <Center data-testid="nft-empty-bag" className={subhead} style={{ lineHeight: '24px' }}>
-            Your bag is empty
+            {activeBagView === BagView.MAIN ? 'Your bag is empty' : 'No NFTs saved for later'}
           </Center>
           <Center fontSize="12" fontWeight="normal" color="textSecondary" style={{ lineHeight: '16px' }}>
-            Selected NFTs will appear here
+            {activeBagView === BagView.MAIN ? 'Selected NFTs will appear here' : ''}
           </Center>
         </Column>
       )}

--- a/src/nft/components/bag/MobileHoverBag.tsx
+++ b/src/nft/components/bag/MobileHoverBag.tsx
@@ -2,11 +2,12 @@ import { Box } from 'nft/components/Box'
 import { Column, Row } from 'nft/components/Flex'
 import { body, bodySmall } from 'nft/css/common.css'
 import { useBag } from 'nft/hooks'
+import { BagItemStatus } from 'nft/types'
 import { ethNumberStandardFormatter, formatWeiToDecimal, roundAndPluralize } from 'nft/utils'
 
 import * as styles from './MobileHoverBag.css'
 export const MobileHoverBag = () => {
-  const itemsInBag = useBag((state) => state.itemsInBag)
+  const itemsInBag = useBag((state) => state.itemsInBag.filter((item) => item.status !== BagItemStatus.SAVED_FOR_LATER))
   const toggleBag = useBag((state) => state.toggleBag)
   const totalEthPrice = useBag((state) => state.totalEthPrice)
   const totalUsdPrice = useBag((state) => state.totalUsdPrice)

--- a/src/nft/components/bag/SaveForLaterContent.tsx
+++ b/src/nft/components/bag/SaveForLaterContent.tsx
@@ -1,0 +1,47 @@
+import { Column } from 'nft/components/Flex'
+import { useBag, useIsMobile } from 'nft/hooks'
+import { BagItemStatus } from 'nft/types'
+import { fetchPrice, recalculateBagUsingPooledAssets } from 'nft/utils'
+import { useMemo } from 'react'
+import { useQuery } from 'react-query'
+
+import { BagRow } from './BagRow'
+
+export const SaveForLaterContent = () => {
+  const uncheckedItemsInBag = useBag((state) => state.itemsInBag)
+  const addAssetsToBag = useBag((state) => state.addAssetsToBag)
+  const removeAssetsFromBag = useBag((state) => state.removeAssetsFromBag)
+  const itemsInBag = useMemo(() => {
+    return recalculateBagUsingPooledAssets(uncheckedItemsInBag)
+  }, [uncheckedItemsInBag])
+
+  const { data: fetchedPriceData } = useQuery(['fetchPrice', {}], () => fetchPrice(), {})
+
+  const { saveForLaterAssets } = useMemo(() => {
+    const saveForLaterAssets = itemsInBag
+      .filter((item) => item.status === BagItemStatus.SAVED_FOR_LATER)
+      .map((item) => item.asset)
+    return { saveForLaterAssets }
+  }, [itemsInBag])
+
+  const isMobile = useIsMobile()
+
+  return (
+    <Column>
+      {saveForLaterAssets
+        .slice(0)
+        .reverse()
+        .map((asset) => (
+          <BagRow
+            key={asset.id}
+            asset={asset}
+            usdPrice={fetchedPriceData}
+            addAsset={addAssetsToBag}
+            removeAsset={removeAssetsFromBag}
+            showRemove={true}
+            isMobile={isMobile}
+          />
+        ))}
+    </Column>
+  )
+}

--- a/src/nft/types/checkout/checkout.ts
+++ b/src/nft/types/checkout/checkout.ts
@@ -79,6 +79,7 @@ export enum BagItemStatus {
   REVIEWED = 'Reviewed',
   REVIEWING_PRICE_CHANGE = 'REVIEWING_PRICE_CHANGE',
   UNAVAILABLE = 'UNAVAILABLE',
+  SAVED_FOR_LATER = 'Saved for later',
 }
 
 export type BagItem = {
@@ -96,4 +97,10 @@ export enum BagStatus {
   FETCHING_FINAL_ROUTE = 'Fetching final route',
   CONFIRMING_IN_WALLET = 'Confirming in wallet',
   PROCESSING_TRANSACTION = 'Processing',
+}
+
+export enum BagView {
+  MAIN = 'Bag',
+  SAVE_FOR_LATER = 'Saved',
+  SELL = 'Sell',
 }


### PR DESCRIPTION
This PR adds a Save-for-Later (SFL) tab to the existing Bag feature, allowing customers to keep track of items which they may want to purchase. Previously, the bag interface only had an option for customers to remove items. Now, they may move items between their main and SFL bags.

This feature is implemented in an extensible manner, in order to reuse functionality across the existing bag types (Main, Sell, Save-for-Later) and make it easier to add new bag types in the future (e.g. Wishlist, Category-specific bags, etc). 

Check out a recorded demo here: https://youtu.be/vx7YDi9MHTs