### PR TITLE
fix: center playback switch on video asset cards

### DIFF
--- a/src/nft/components/collection/Card.css.ts
+++ b/src/nft/components/collection/Card.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { calc } from '@vanilla-extract/css-utils'
 import { sprinkles, themeVars, vars } from 'nft/css/sprinkles.css'
 
 export const card = style([
@@ -108,7 +107,9 @@ export const playbackSwitch = style([
     zIndex: '1',
   }),
   {
-    marginLeft: calc.subtract('100%', '50px'),
-    transform: 'translateY(-56px)',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
   },
 ])


### PR DESCRIPTION
On collection pages, hovering over an asset with video content is supposed to display a playback switch button on the center of the card. However, the switch is currently appearing in the bottom right corner. This PR applies new styling to properly position the switch. Attaching screenshots for reference.
<img width="349" alt="before" src="https://user-images.githubusercontent.com/18626088/215539236-9965c1e1-6505-40eb-a5b4-7a4d400e7415.png">
<img width="346" alt="after" src="https://user-images.githubusercontent.com/18626088/215539238-b8c3141d-3ef8-4833-9269-c850e8947f77.png">