### PR TITLE
fix: useStablecoinPrice switching between WETH and ETH

### DIFF
--- a/src/hooks/useStablecoinPrice.ts
+++ b/src/hooks/useStablecoinPrice.ts
@@ -48,7 +48,12 @@ export default function useStablecoinPrice(currency?: Currency): Price<Currency,
   }, [currency, stablecoin, trade])
 
   const lastPrice = useRef(price)
-  if (!price || !lastPrice.current || !price.equalTo(lastPrice.current)) {
+  if (
+    !price ||
+    !lastPrice.current ||
+    !price.equalTo(lastPrice.current) ||
+    !price.baseCurrency.equals(lastPrice.current.baseCurrency)
+  ) {
     lastPrice.current = price
   }
   return lastPrice.current


### PR DESCRIPTION
* This adds a check between the last price and the new price if the currency itself changes. This is necessary because when used with `useStablecoinValue` when switching from a currency with the same numerator and denominator (which is what `equalTo` checks) will throw an invariant error because the `quote` function checks if the `CurrencyAmount`'s currency is the same as the base currency. This will result in never rendering the new price.

* this can be tested on main when you put in a value for WETH then switch to ETH it will load forever