### PR TITLE
fix: accept client-side SOR error as valid GetQuoteResult

### DIFF
--- a/src/lib/hooks/routing/clientSideSmartOrderRouter.ts
+++ b/src/lib/hooks/routing/clientSideSmartOrderRouter.ts
@@ -4,7 +4,7 @@ import { BigintIsh, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 import { AlphaRouter, AlphaRouterConfig, ChainId } from '@uniswap/smart-order-router'
 import { SupportedChainId } from 'constants/chains'
 import JSBI from 'jsbi'
-import { GetQuoteResult } from 'state/routing/types'
+import { GetQuoteResult, NO_ROUTE } from 'state/routing/types'
 import { transformSwapRouteToGetQuoteResult } from 'utils/transformSwapRouteToGetQuoteResult'
 
 export function toSupportedChainId(chainId: ChainId): SupportedChainId | undefined {
@@ -31,7 +31,7 @@ async function getQuote(
   },
   router: AlphaRouter,
   config: Partial<AlphaRouterConfig>
-): Promise<{ data: GetQuoteResult; error?: unknown }> {
+): Promise<GetQuoteResult> {
   const currencyIn = new Token(tokenIn.chainId, tokenIn.address, tokenIn.decimals, tokenIn.symbol)
   const currencyOut = new Token(tokenOut.chainId, tokenOut.address, tokenOut.decimals, tokenOut.symbol)
 
@@ -47,9 +47,9 @@ async function getQuote(
     config
   )
 
-  if (!swapRoute) throw new Error('Failed to generate client side quote')
+  if (!swapRoute) return NO_ROUTE
 
-  return { data: transformSwapRouteToGetQuoteResult(type, amount, swapRoute) }
+  return transformSwapRouteToGetQuoteResult(type, amount, swapRoute)
 }
 
 interface QuoteArguments {

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -90,8 +90,6 @@ export const routingApi = createApi({
         const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, routerPreference, type } =
           args
 
-        let result
-
         try {
           if (routerPreference === RouterPreference.API) {
             const query = qs.stringify({
@@ -103,19 +101,19 @@ export const routingApi = createApi({
               amount,
               type,
             })
-            result = await fetch(`quote?${query}`)
+            const { data } = await fetch(`quote?${query}`)
+            return { data: data as GetQuoteResult }
           } else {
             const router = getRouter(args.tokenInChainId)
-            result = await getClientSideQuote(
+            const data = await getClientSideQuote(
               args,
               router,
               // TODO(zzmp): Use PRICE_PARAMS for RouterPreference.PRICE.
               // This change is intentionally being deferred to first see what effect router caching has.
               CLIENT_PARAMS
             )
+            return { data }
           }
-
-          return { data: result.data as GetQuoteResult }
         } catch (e) {
           // TODO: fall back to client-side quoter when auto router fails.
           // deprecate 'legacy' v2/v3 routers first.

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -49,7 +49,7 @@ export type V2PoolInRoute = {
   address?: string
 }
 
-export interface GetQuoteResult {
+interface QuoteResult {
   quoteId?: string
   blockNumber: string
   amount: string
@@ -67,6 +67,10 @@ export interface GetQuoteResult {
   route: Array<(V3PoolInRoute | V2PoolInRoute)[]>
   routeString: string
 }
+
+export const NO_ROUTE = 'No Route'
+
+export type GetQuoteResult = QuoteResult | typeof NO_ROUTE
 
 export class InterfaceTrade<
   TInput extends Currency,

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -49,7 +49,7 @@ export type V2PoolInRoute = {
   address?: string
 }
 
-interface QuoteResult {
+export interface QuoteResult {
   quoteId?: string
   blockNumber: string
   amount: string

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -49,7 +49,8 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     pollingInterval: routerPreference === RouterPreference.PRICE ? ms`2m` : AVERAGE_L1_BLOCK_TIME,
   })
 
-  const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(data?.blockNumber) || 0) ? data : undefined
+  const quote = typeof data === 'object' ? data : undefined
+  const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(quote?.blockNumber) || 0) ? quote : undefined
 
   const route = useMemo(
     () => computeRoutes(currencyIn, currencyOut, tradeType, quoteResult),

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -3,7 +3,7 @@ import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 import { Pair, Route as V2Route } from '@uniswap/v2-sdk'
 import { FeeAmount, Pool, Route as V3Route } from '@uniswap/v3-sdk'
 
-import { GetQuoteResult, InterfaceTrade, V2PoolInRoute, V3PoolInRoute } from './types'
+import { InterfaceTrade, QuoteResult, V2PoolInRoute, V3PoolInRoute } from './types'
 
 /**
  * Transforms a Routing API quote into an array of routes that can be used to create
@@ -13,7 +13,7 @@ export function computeRoutes(
   currencyIn: Currency | undefined,
   currencyOut: Currency | undefined,
   tradeType: TradeType,
-  quoteResult: Pick<GetQuoteResult, 'route'> | undefined
+  quoteResult: Pick<QuoteResult, 'route'> | undefined
 ) {
   if (!quoteResult || !quoteResult.route || !currencyIn || !currencyOut) return undefined
 
@@ -93,7 +93,7 @@ export function transformRoutesToTrade<TTradeType extends TradeType>(
   })
 }
 
-const parseToken = ({ address, chainId, decimals, symbol }: GetQuoteResult['route'][0][0]['tokenIn']): Token => {
+const parseToken = ({ address, chainId, decimals, symbol }: QuoteResult['route'][0][0]['tokenIn']): Token => {
   return new Token(chainId, address, parseInt(decimals.toString()), symbol)
 }
 


### PR DESCRIPTION
Prevents errors from being incorrectly serialized, leading to console flooding from redux.