### PR TITLE
fix: refetch trade on focus

### DIFF
--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -47,6 +47,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
   const { isLoading, isError, data, currentData } = useGetQuoteQuery(queryArgs ?? skipToken, {
     // Price-fetching is informational and costly, so it's done less frequently.
     pollingInterval: routerPreference === RouterPreference.PRICE ? ms`2m` : AVERAGE_L1_BLOCK_TIME,
+    refetchOnFocus: true,
   })
 
   const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(data?.blockNumber) || 0) ? data : undefined


### PR DESCRIPTION
Refetches the trade (eg prices) when the window is refocused.
Fixes an issue where leaving the window for 1m causes prices to be stale and not be re-fetched for another minute.