### PR TITLE
fix: surface connection error

### DIFF
--- a/src/components/WalletModal/PendingView.tsx
+++ b/src/components/WalletModal/PendingView.tsx
@@ -65,12 +65,12 @@ const LoadingWrapper = styled.div`
 
 export default function PendingView({
   connector,
-  error = false,
+  error,
   tryActivation,
   openOptions,
 }: {
   connector: Connector
-  error?: boolean
+  error?: string
   tryActivation: (connector: Connector) => void
   openOptions: () => void
 }) {
@@ -81,14 +81,13 @@ export default function PendingView({
           {error ? (
             <ErrorGroup>
               <AlertTriangleIcon />
-              <ThemedText.MediumHeader marginBottom={12}>
+              <ThemedText.MediumHeader marginBottom={18}>
                 <Trans>Error connecting</Trans>
               </ThemedText.MediumHeader>
-              <ThemedText.BodyPrimary fontSize={16} marginBottom={36} textAlign="center">
-                <Trans>
-                  The connection attempt failed. Please click try again and follow the steps to connect in your wallet.
-                </Trans>
+              <ThemedText.BodyPrimary marginBottom={12} textAlign="center">
+                <Trans>The connection attempt failed.</Trans>
               </ThemedText.BodyPrimary>
+              <ThemedText.BodySecondary marginBottom={36}>{error}</ThemedText.BodySecondary>
               <ButtonPrimary
                 $borderRadius="12px"
                 onClick={() => {

--- a/src/components/WalletModal/PendingView.tsx
+++ b/src/components/WalletModal/PendingView.tsx
@@ -93,7 +93,7 @@ export default function PendingView({
                   tryActivation(connector)
                 }}
               >
-                <Trans>Try Again</Trans>
+                <Trans>Try again</Trans>
               </ButtonPrimary>
               <ButtonEmpty width="fit-content" padding="0" marginTop={20}>
                 <ThemedText.Link onClick={openOptions}>

--- a/src/components/WalletModal/PendingView.tsx
+++ b/src/components/WalletModal/PendingView.tsx
@@ -81,13 +81,12 @@ export default function PendingView({
           {error ? (
             <ErrorGroup>
               <AlertTriangleIcon />
-              <ThemedText.MediumHeader marginBottom={18}>
-                <Trans>Error connecting</Trans>
+              <ThemedText.MediumHeader marginBottom={12}>
+                <Trans>Connection failed</Trans>
               </ThemedText.MediumHeader>
-              <ThemedText.BodyPrimary marginBottom={12} textAlign="center">
-                <Trans>The connection attempt failed.</Trans>
+              <ThemedText.BodyPrimary marginBottom={36} textAlign="center">
+                {error}
               </ThemedText.BodyPrimary>
-              <ThemedText.BodySecondary marginBottom={36}>{error}</ThemedText.BodySecondary>
               <ButtonPrimary
                 $borderRadius="12px"
                 onClick={() => {

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -355,7 +355,7 @@ export default function WalletModal({
               <PendingView
                 openOptions={openOptions}
                 connector={pendingConnector}
-                error={!!pendingError}
+                error={pendingError}
                 tryActivation={tryActivation}
               />
             )}


### PR DESCRIPTION
Updates the connection error screen to show the actual error string, so that the user can take corrective action.

This is necessary for eg Frame, where on initial install no wallet is selected. In this case, the error is something like "No account selected".

![image](https://user-images.githubusercontent.com/5403956/217060057-809b3f14-8b68-4218-b83a-05de691c5cfe.png)


Before:

![image](https://user-images.githubusercontent.com/5403956/217054697-30acc622-d5de-48d5-a6ef-5260c9ff3955.png)

WEB-2865