### PR TITLE
revert: "fix: surface connection error"

### DIFF
--- a/src/components/WalletModal/PendingView.tsx
+++ b/src/components/WalletModal/PendingView.tsx
@@ -65,12 +65,12 @@ const LoadingWrapper = styled.div`
 
 export default function PendingView({
   connector,
-  error,
+  error = false,
   tryActivation,
   openOptions,
 }: {
   connector: Connector
-  error?: string
+  error?: boolean
   tryActivation: (connector: Connector) => void
   openOptions: () => void
 }) {
@@ -82,10 +82,12 @@ export default function PendingView({
             <ErrorGroup>
               <AlertTriangleIcon />
               <ThemedText.MediumHeader marginBottom={12}>
-                <Trans>Connection failed</Trans>
+                <Trans>Error connecting</Trans>
               </ThemedText.MediumHeader>
-              <ThemedText.BodyPrimary marginBottom={36} textAlign="center">
-                {error}
+              <ThemedText.BodyPrimary fontSize={16} marginBottom={36} textAlign="center">
+                <Trans>
+                  The connection attempt failed. Please click try again and follow the steps to connect in your wallet.
+                </Trans>
               </ThemedText.BodyPrimary>
               <ButtonPrimary
                 $borderRadius="12px"
@@ -93,7 +95,7 @@ export default function PendingView({
                   tryActivation(connector)
                 }}
               >
-                <Trans>Try again</Trans>
+                <Trans>Try Again</Trans>
               </ButtonPrimary>
               <ButtonEmpty width="fit-content" padding="0" marginTop={20}>
                 <ThemedText.Link onClick={openOptions}>

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -355,7 +355,7 @@ export default function WalletModal({
               <PendingView
                 openOptions={openOptions}
                 connector={pendingConnector}
-                error={pendingError}
+                error={!!pendingError}
                 tryActivation={tryActivation}
               />
             )}


### PR DESCRIPTION
Reverts Uniswap/interface#5931, as it risks showing an overly technical error message to the user.
It should be designed such that the user opts in to such a message (eg the error screen, where the user toggles open the technical error message).