### PR TITLE
fix: default to null when query address is undefined

### DIFF
--- a/src/graphql/data/Token.ts
+++ b/src/graphql/data/Token.ts
@@ -14,7 +14,7 @@ The difference between Token and TokenProject:
     TokenProjectMarket is aggregated market data (aggregated over multiple dexes and centralized exchanges) that we get from coingecko.
 */
 gql`
-  query Token($chain: Chain!, $address: String) {
+  query Token($chain: Chain!, $address: String = null) {
     token(chain: $chain, address: $address) {
       id
       decimals

--- a/src/graphql/data/TokenPrice.ts
+++ b/src/graphql/data/TokenPrice.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 gql`
-  query TokenPrice($chain: Chain!, $address: String, $duration: HistoryDuration!) {
+  query TokenPrice($chain: Chain!, $address: String = null, $duration: HistoryDuration!) {
     token(chain: $chain, address: $address) {
       id
       address

--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -1008,7 +1008,7 @@ export type NftBalanceQuery = { __typename?: 'Query', nftBalances?: { __typename
 
 
 export const TokenDocument = gql`
-    query Token($chain: Chain!, $address: String) {
+    query Token($chain: Chain!, $address: String = null) {
   token(chain: $chain, address: $address) {
     id
     decimals
@@ -1087,7 +1087,7 @@ export type TokenQueryHookResult = ReturnType<typeof useTokenQuery>;
 export type TokenLazyQueryHookResult = ReturnType<typeof useTokenLazyQuery>;
 export type TokenQueryResult = Apollo.QueryResult<TokenQuery, TokenQueryVariables>;
 export const TokenPriceDocument = gql`
-    query TokenPrice($chain: Chain!, $address: String, $duration: HistoryDuration!) {
+    query TokenPrice($chain: Chain!, $address: String = null, $duration: HistoryDuration!) {
   token(chain: $chain, address: $address) {
     id
     address

--- a/src/utils/nativeTokens.ts
+++ b/src/utils/nativeTokens.ts
@@ -2,7 +2,7 @@ import { nativeOnChain } from 'constants/tokens'
 import { Chain } from 'graphql/data/__generated__/types-and-hooks'
 import { CHAIN_NAME_TO_CHAIN_ID } from 'graphql/data/util'
 
-export function getNativeTokenDBAddress(chain: Chain): string {
+export function getNativeTokenDBAddress(chain: Chain): string | undefined {
   const pageChainId = CHAIN_NAME_TO_CHAIN_ID[chain]
   switch (chain) {
     case Chain.Celo:
@@ -12,6 +12,6 @@ export function getNativeTokenDBAddress(chain: Chain): string {
     case Chain.Arbitrum:
     case Chain.EthereumGoerli:
     case Chain.Optimism:
-      return 'ETH'
+      return undefined
   }
 }


### PR DESCRIPTION
fixes issue where non-addressed native tokens would not normalize in cache correctly.

moves interface away from using `"ETH"` convention for natives, matches mobile's usage of `null`