### PR TITLE
fix: [ListV2] Better Collection and Listing Retry and Removal Logic

### DIFF
--- a/src/nft/components/bag/profile/ListingButton.tsx
+++ b/src/nft/components/bag/profile/ListingButton.tsx
@@ -211,7 +211,7 @@ export const ListingButton = ({ onClick, buttonText, showWarningOverride = false
 
   const warningWrappedClick = () => {
     if ((!disableListButton && canContinue) || showWarningOverride) {
-      if (issues && isNftListV2 && !showResolveIssues) toggleShowResolveIssues()
+      if (issues && isNftListV2) !showResolveIssues && toggleShowResolveIssues()
       else if (listingsBelowFloor.length) setShowWarning(true)
       else onClick()
     } else addWarningMessages()

--- a/src/nft/components/bag/profile/ListingModal.tsx
+++ b/src/nft/components/bag/profile/ListingModal.tsx
@@ -26,6 +26,7 @@ const ListingModal = () => {
   const setListings = useNFTList((state) => state.setListings)
   const collectionsRequiringApproval = useNFTList((state) => state.collectionsRequiringApproval)
   const setCollectionsRequiringApproval = useNFTList((state) => state.setCollectionsRequiringApproval)
+  const setListingStatusAndCallback = useNFTList((state) => state.setListingStatusAndCallback)
   const [openIndex, setOpenIndex] = useState(0)
   const listingStatus = useNFTList((state) => state.listingStatus)
   const setListingStatus = useNFTList((state) => state.setListingStatus)
@@ -146,12 +147,11 @@ const ListingModal = () => {
       verifyStatus(listing.status) &&
         (await signListingRow(
           listing,
-          listings,
-          setListings,
           signer,
           provider,
           getLooksRareNonce,
           setLooksRareNonce,
+          setListingStatusAndCallback,
           pauseAllRows
         ))
     }

--- a/src/nft/components/bag/profile/ListingModal.tsx
+++ b/src/nft/components/bag/profile/ListingModal.tsx
@@ -12,6 +12,7 @@ import { AssetRow, CollectionRow, ListingRow, ListingStatus } from 'nft/types'
 import { fetchPrice } from 'nft/utils/fetchPrice'
 import { pluralize } from 'nft/utils/roundAndPluralize'
 import { Dispatch, useEffect, useMemo, useRef, useState } from 'react'
+import shallow from 'zustand/shallow'
 
 import { ListingButton } from './ListingButton'
 import * as styles from './ListingModal.css'
@@ -21,20 +22,49 @@ import { approveCollectionRow, getTotalEthValue, pauseRow, resetRow, signListing
 const ListingModal = () => {
   const { provider } = useWeb3React()
   const sellAssets = useSellAsset((state) => state.sellAssets)
+  const {
+    listingStatus,
+    setListingStatus,
+    setListings,
+    setCollectionsRequiringApproval,
+    setListingStatusAndCallback,
+    setCollectionStatusAndCallback,
+    looksRareNonce,
+    setLooksRareNonce,
+    getLooksRareNonce,
+    collectionsRequiringApproval,
+    listings,
+  } = useNFTList(
+    ({
+      listingStatus,
+      setListingStatus,
+      setListings,
+      setCollectionsRequiringApproval,
+      setListingStatusAndCallback,
+      setCollectionStatusAndCallback,
+      looksRareNonce,
+      setLooksRareNonce,
+      getLooksRareNonce,
+      collectionsRequiringApproval,
+      listings,
+    }) => ({
+      listingStatus,
+      setListingStatus,
+      setListings,
+      setCollectionsRequiringApproval,
+      setListingStatusAndCallback,
+      setCollectionStatusAndCallback,
+      looksRareNonce,
+      setLooksRareNonce,
+      getLooksRareNonce,
+      collectionsRequiringApproval,
+      listings,
+    }),
+    shallow
+  )
   const signer = provider?.getSigner()
-  const listings = useNFTList((state) => state.listings)
-  const setListings = useNFTList((state) => state.setListings)
-  const collectionsRequiringApproval = useNFTList((state) => state.collectionsRequiringApproval)
-  const setCollectionsRequiringApproval = useNFTList((state) => state.setCollectionsRequiringApproval)
-  const setListingStatusAndCallback = useNFTList((state) => state.setListingStatusAndCallback)
-  const setCollectionStatusAndCallback = useNFTList((state) => state.setCollectionStatusAndCallback)
   const [openIndex, setOpenIndex] = useState(0)
-  const listingStatus = useNFTList((state) => state.listingStatus)
-  const setListingStatus = useNFTList((state) => state.setListingStatus)
   const [allCollectionsApproved, setAllCollectionsApproved] = useState(false)
-  const looksRareNonce = useNFTList((state) => state.looksRareNonce)
-  const setLooksRareNonce = useNFTList((state) => state.setLooksRareNonce)
-  const getLooksRareNonce = useNFTList((state) => state.getLooksRareNonce)
   const toggleCart = useBag((state) => state.toggleBag)
   const looksRareNonceRef = useRef(looksRareNonce)
   const isMobile = useIsMobile()

--- a/src/nft/components/bag/profile/ListingModal.tsx
+++ b/src/nft/components/bag/profile/ListingModal.tsx
@@ -27,6 +27,7 @@ const ListingModal = () => {
   const collectionsRequiringApproval = useNFTList((state) => state.collectionsRequiringApproval)
   const setCollectionsRequiringApproval = useNFTList((state) => state.setCollectionsRequiringApproval)
   const setListingStatusAndCallback = useNFTList((state) => state.setListingStatusAndCallback)
+  const setCollectionStatusAndCallback = useNFTList((state) => state.setCollectionStatusAndCallback)
   const [openIndex, setOpenIndex] = useState(0)
   const listingStatus = useNFTList((state) => state.listingStatus)
   const setListingStatus = useNFTList((state) => state.setListingStatus)
@@ -121,20 +122,8 @@ const ListingModal = () => {
     for (const collectionRow of collectionsRequiringApproval) {
       verifyStatus(collectionRow.status) &&
         (isMobile
-          ? await approveCollectionRow(
-              collectionRow,
-              collectionsRequiringApproval,
-              setCollectionsRequiringApproval,
-              signer,
-              pauseAllRows
-            )
-          : approveCollectionRow(
-              collectionRow,
-              collectionsRequiringApproval,
-              setCollectionsRequiringApproval,
-              signer,
-              pauseAllRows
-            ))
+          ? await approveCollectionRow(collectionRow, signer, setCollectionStatusAndCallback, pauseAllRows)
+          : approveCollectionRow(collectionRow, signer, setCollectionStatusAndCallback, pauseAllRows))
     }
   }
 

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -174,7 +174,7 @@ export const ListPage = () => {
     listingStatus,
     setListingStatus,
     setLooksRareNonce,
-    setCollectionsRequiringApproval,
+    setCollectionStatusAndCallback,
   } = useNFTList(
     ({
       listings,
@@ -182,14 +182,14 @@ export const ListPage = () => {
       listingStatus,
       setListingStatus,
       setLooksRareNonce,
-      setCollectionsRequiringApproval,
+      setCollectionStatusAndCallback,
     }) => ({
       listings,
       collectionsRequiringApproval,
       listingStatus,
       setListingStatus,
       setLooksRareNonce,
-      setCollectionsRequiringApproval,
+      setCollectionStatusAndCallback,
     }),
     shallow
   )
@@ -247,13 +247,8 @@ export const ListPage = () => {
     for (const collectionRow of collectionsRequiringApproval) {
       verifyStatus(collectionRow.status) &&
         (isMobile
-          ? await approveCollectionRow(
-              collectionRow,
-              collectionsRequiringApproval,
-              setCollectionsRequiringApproval,
-              signer
-            )
-          : approveCollectionRow(collectionRow, collectionsRequiringApproval, setCollectionsRequiringApproval, signer))
+          ? await approveCollectionRow(collectionRow, signer, setCollectionStatusAndCallback)
+          : approveCollectionRow(collectionRow, signer, setCollectionStatusAndCallback))
     }
   }
 

--- a/src/nft/components/profile/list/Modal/ListModal.tsx
+++ b/src/nft/components/profile/list/Modal/ListModal.tsx
@@ -13,6 +13,7 @@ import { X } from 'react-feather'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 import { Z_INDEX } from 'theme/zIndex'
+import shallow from 'zustand/shallow'
 
 import { TitleRow } from '../shared'
 import { ListModalSection, Section } from './ListModalSection'
@@ -45,12 +46,31 @@ export const ListModal = ({ overlayClick }: { overlayClick: () => void }) => {
   const signer = provider?.getSigner()
   const trace = useTrace({ modal: InterfaceModalName.NFT_LISTING })
   const sellAssets = useSellAsset((state) => state.sellAssets)
-  const listings = useNFTList((state) => state.listings)
-  const collectionsRequiringApproval = useNFTList((state) => state.collectionsRequiringApproval)
-  const listingStatus = useNFTList((state) => state.listingStatus)
-  const setLooksRareNonce = useNFTList((state) => state.setLooksRareNonce)
-  const getLooksRareNonce = useNFTList((state) => state.getLooksRareNonce)
-  const setListingStatusAndCallback = useNFTList((state) => state.setListingStatusAndCallback)
+  const {
+    listingStatus,
+    setListingStatusAndCallback,
+    setLooksRareNonce,
+    getLooksRareNonce,
+    collectionsRequiringApproval,
+    listings,
+  } = useNFTList(
+    ({
+      listingStatus,
+      setListingStatusAndCallback,
+      setLooksRareNonce,
+      getLooksRareNonce,
+      collectionsRequiringApproval,
+      listings,
+    }) => ({
+      listingStatus,
+      setListingStatusAndCallback,
+      setLooksRareNonce,
+      getLooksRareNonce,
+      collectionsRequiringApproval,
+      listings,
+    }),
+    shallow
+  )
 
   const totalEthListingValue = useMemo(() => getTotalEthValue(sellAssets), [sellAssets])
   const [openSection, toggleOpenSection] = useReducer(

--- a/src/nft/components/profile/list/Modal/ListModal.tsx
+++ b/src/nft/components/profile/list/Modal/ListModal.tsx
@@ -48,9 +48,9 @@ export const ListModal = ({ overlayClick }: { overlayClick: () => void }) => {
   const listings = useNFTList((state) => state.listings)
   const collectionsRequiringApproval = useNFTList((state) => state.collectionsRequiringApproval)
   const listingStatus = useNFTList((state) => state.listingStatus)
-  const setListings = useNFTList((state) => state.setListings)
   const setLooksRareNonce = useNFTList((state) => state.setLooksRareNonce)
   const getLooksRareNonce = useNFTList((state) => state.getLooksRareNonce)
+  const setListingStatusAndCallback = useNFTList((state) => state.setListingStatusAndCallback)
 
   const totalEthListingValue = useMemo(() => getTotalEthValue(sellAssets), [sellAssets])
   const [openSection, toggleOpenSection] = useReducer(
@@ -74,7 +74,7 @@ export const ListModal = ({ overlayClick }: { overlayClick: () => void }) => {
     if (!signer || !provider) return
     // sign listings
     for (const listing of listings) {
-      await signListingRow(listing, listings, setListings, signer, provider, getLooksRareNonce, setLooksRareNonce)
+      await signListingRow(listing, signer, provider, getLooksRareNonce, setLooksRareNonce, setListingStatusAndCallback)
     }
     sendAnalyticsEvent(NFTEventName.NFT_LISTING_COMPLETED, {
       signatures_approved: listings.filter((asset) => asset.status === ListingStatus.APPROVED),

--- a/src/nft/components/profile/list/Modal/ListModalSection.tsx
+++ b/src/nft/components/profile/list/Modal/ListModalSection.tsx
@@ -135,7 +135,7 @@ export const ListModalSection = ({ sectionType, active, content, toggleSection }
             {content.map((row: AssetRow) => (
               <ContentRow
                 row={row}
-                key={row.name}
+                key={(row?.name ?? '') + row?.images[1]}
                 removeRow={removeRow}
                 isCollectionApprovalSection={isCollectionApprovalSection}
               />

--- a/src/nft/hooks/useNFTList.ts
+++ b/src/nft/hooks/useNFTList.ts
@@ -64,7 +64,32 @@ export const useNFTList = create<NFTListState>()(
       }),
     setCollectionsRequiringApproval: (collections) =>
       set(() => {
-        return { collectionsRequiringApproval: collections }
+        const updatedCollections = collections.map((collection) => {
+          const oldStatus = get().collectionsRequiringApproval.find(
+            (oldCollection) =>
+              oldCollection.collectionAddress === collection.collectionAddress &&
+              oldCollection.marketplace.name === collection.marketplace.name
+          )?.status
+          const status = () => {
+            switch (oldStatus) {
+              case ListingStatus.APPROVED:
+                return ListingStatus.APPROVED
+              case ListingStatus.FAILED:
+                return collection.status === ListingStatus.SIGNING ? ListingStatus.SIGNING : ListingStatus.FAILED
+              case ListingStatus.REJECTED:
+                return collection.status === ListingStatus.SIGNING ? ListingStatus.SIGNING : ListingStatus.REJECTED
+              default:
+                return collection.status
+            }
+          }
+          return {
+            ...collection,
+            status: status(),
+          }
+        })
+        return {
+          collectionsRequiringApproval: updatedCollections,
+        }
       }),
   }))
 )

--- a/src/nft/hooks/useNFTList.ts
+++ b/src/nft/hooks/useNFTList.ts
@@ -13,6 +13,11 @@ interface NFTListState {
   setListings: (listings: ListingRow[]) => void
   setCollectionsRequiringApproval: (collections: CollectionRow[]) => void
   setListingStatusAndCallback: (listing: ListingRow, status: ListingStatus, callback?: () => Promise<void>) => void
+  setCollectionStatusAndCallback: (
+    collection: CollectionRow,
+    status: ListingStatus,
+    callback?: () => Promise<void>
+  ) => void
 }
 
 export const useNFTList = create<NFTListState>()(
@@ -99,10 +104,9 @@ export const useNFTList = create<NFTListState>()(
         }
       }),
     setListingStatusAndCallback: (listing, status, callback) =>
-      set(() => {
-        const listings = get().listings
+      set(({ listings }) => {
         const listingsCopy = [...listings]
-        const oldListingIndex = listings.findIndex(
+        const oldListingIndex = listingsCopy.findIndex(
           (oldListing) =>
             oldListing.name === listing.name &&
             oldListing.price === listing.price &&
@@ -118,6 +122,25 @@ export const useNFTList = create<NFTListState>()(
         }
         return {
           listings: listingsCopy,
+        }
+      }),
+    setCollectionStatusAndCallback: (collection, status, callback) =>
+      set(({ collectionsRequiringApproval }) => {
+        const collectionsCopy = [...collectionsRequiringApproval]
+        const oldCollectionIndex = collectionsCopy.findIndex(
+          (oldCollection) =>
+            oldCollection.name === collection.name && oldCollection.marketplace.name === collection.marketplace.name
+        )
+        if (oldCollectionIndex > -1) {
+          const updatedCollection = {
+            ...collectionsCopy[oldCollectionIndex],
+            status,
+            callback: callback ?? collectionsCopy[oldCollectionIndex].callback,
+          }
+          collectionsCopy.splice(oldCollectionIndex, 1, updatedCollection)
+        }
+        return {
+          collectionsRequiringApproval: collectionsCopy,
         }
       }),
   }))


### PR DESCRIPTION
- Previously removing a collection after rejecting/failing would get the user stuck where all approval states would reset and there would be no way to restart the flow. This maintains approved, rejected, and failed statuses to allow the user to continue on. 
- The old method for updating a rows status and callback would did not account for row removal, I've updated the logic to be dynamic and tied to the zustand hook
- Also fixes a bug where removing a collection would create duplicate approval rows.

To test you should try listing and approving multiple collections and markets on V1 and V2 and be able to reject, remove, and retry as expected