### PR TITLE
fix: URL params for widget

### DIFF
--- a/src/components/Tokens/TokenDetails/index.tsx
+++ b/src/components/Tokens/TokenDetails/index.tsx
@@ -217,7 +217,6 @@ export default function TokenDetails({
 
         <RightPanel>
           <Widget
-            outputToken={token ?? undefined}
             defaultToken={token ?? undefined}
             onDefaultTokenChange={navigateToWidgetSelectedToken}
             onReviewSwapClick={onReviewSwapClick}

--- a/src/components/Tokens/TokenDetails/index.tsx
+++ b/src/components/Tokens/TokenDetails/index.tsx
@@ -217,7 +217,9 @@ export default function TokenDetails({
 
         <RightPanel>
           <Widget
-            defaultToken={token ?? undefined}
+            defaultTokens={{
+              default: token ?? undefined,
+            }}
             onDefaultTokenChange={navigateToWidgetSelectedToken}
             onReviewSwapClick={onReviewSwapClick}
           />

--- a/src/components/Tokens/TokenDetails/index.tsx
+++ b/src/components/Tokens/TokenDetails/index.tsx
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/macro'
 import { Trace } from '@uniswap/analytics'
 import { InterfacePageName } from '@uniswap/analytics-events'
 import { Currency } from '@uniswap/sdk-core'
-import { Field } from '@uniswap/widgets'
 import { useWeb3React } from '@web3-react/core'
 import CurrencyLogo from 'components/Logo/CurrencyLogo'
 import { AboutSection } from 'components/Tokens/TokenDetails/About'
@@ -218,9 +217,9 @@ export default function TokenDetails({
 
         <RightPanel>
           <Widget
-            token={token ?? undefined}
-            defaultField={Field.OUTPUT}
-            onTokenChange={navigateToWidgetSelectedToken}
+            outputToken={token ?? undefined}
+            defaultToken={token ?? undefined}
+            onDefaultTokenChange={navigateToWidgetSelectedToken}
             onReviewSwapClick={onReviewSwapClick}
           />
           {tokenWarning && <TokenSafetyMessage tokenAddress={address} warning={tokenWarning} />}

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -10,6 +10,7 @@ import { Currency, TradeType } from '@uniswap/sdk-core'
 import {
   AddEthereumChainParameter,
   EMPTY_TOKEN_LIST,
+  Field,
   OnReviewSwapClick,
   SwapWidget,
   SwapWidgetSkeleton,
@@ -45,8 +46,8 @@ function useWidgetTheme() {
 }
 
 interface WidgetProps {
-  inputToken?: Currency
-  outputToken?: Currency
+  initialInputToken?: Currency
+  initialOutputToken?: Currency
   defaultToken?: Currency
   width?: number | string
   onDefaultTokenChange?: (token: Currency) => void
@@ -54,8 +55,8 @@ interface WidgetProps {
 }
 
 export default function Widget({
-  inputToken,
-  outputToken,
+  initialInputToken,
+  initialOutputToken,
   defaultToken,
   width = DEFAULT_WIDGET_WIDTH,
   onDefaultTokenChange,
@@ -64,7 +65,14 @@ export default function Widget({
   const { connector, provider } = useWeb3React()
   const locale = useActiveLocale()
   const theme = useWidgetTheme()
-  const { inputs, tokenSelector } = useSyncWidgetInputs({ inputToken, outputToken, defaultToken, onDefaultTokenChange })
+  const { inputs, tokenSelector } = useSyncWidgetInputs({
+    defaultTokens: {
+      [Field.INPUT]: initialInputToken,
+      [Field.OUTPUT]: initialOutputToken,
+      default: defaultToken,
+    },
+    onDefaultTokenChange,
+  })
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
 

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -31,7 +31,7 @@ import { useIsDarkMode } from 'state/user/hooks'
 import { computeRealizedPriceImpact } from 'utils/prices'
 import { switchChain } from 'utils/switchChain'
 
-import { DefaultSwapTokens, useSyncWidgetInputs } from './inputs'
+import { DefaultTokens, useSyncWidgetInputs } from './inputs'
 import { useSyncWidgetSettings } from './settings'
 import { DARK_THEME, LIGHT_THEME } from './theme'
 import { useSyncWidgetTransactions } from './transactions'
@@ -45,7 +45,7 @@ function useWidgetTheme() {
 }
 
 interface WidgetProps {
-  defaultTokens: DefaultSwapTokens
+  defaultTokens: DefaultTokens
   width?: number | string
   onDefaultTokenChange?: (token: Currency) => void
   onReviewSwapClick?: OnReviewSwapClick

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -10,7 +10,6 @@ import { Currency, TradeType } from '@uniswap/sdk-core'
 import {
   AddEthereumChainParameter,
   EMPTY_TOKEN_LIST,
-  Field,
   OnReviewSwapClick,
   SwapWidget,
   SwapWidgetSkeleton,
@@ -32,7 +31,7 @@ import { useIsDarkMode } from 'state/user/hooks'
 import { computeRealizedPriceImpact } from 'utils/prices'
 import { switchChain } from 'utils/switchChain'
 
-import { useSyncWidgetInputs } from './inputs'
+import { DefaultSwapTokens, useSyncWidgetInputs } from './inputs'
 import { useSyncWidgetSettings } from './settings'
 import { DARK_THEME, LIGHT_THEME } from './theme'
 import { useSyncWidgetTransactions } from './transactions'
@@ -46,18 +45,14 @@ function useWidgetTheme() {
 }
 
 interface WidgetProps {
-  initialInputToken?: Currency
-  initialOutputToken?: Currency
-  defaultToken?: Currency
+  defaultTokens: DefaultSwapTokens
   width?: number | string
   onDefaultTokenChange?: (token: Currency) => void
   onReviewSwapClick?: OnReviewSwapClick
 }
 
 export default function Widget({
-  initialInputToken,
-  initialOutputToken,
-  defaultToken,
+  defaultTokens,
   width = DEFAULT_WIDGET_WIDTH,
   onDefaultTokenChange,
   onReviewSwapClick,
@@ -66,11 +61,7 @@ export default function Widget({
   const locale = useActiveLocale()
   const theme = useWidgetTheme()
   const { inputs, tokenSelector } = useSyncWidgetInputs({
-    defaultTokens: {
-      [Field.INPUT]: initialInputToken,
-      [Field.OUTPUT]: initialOutputToken,
-      default: defaultToken,
-    },
+    defaultTokens,
     onDefaultTokenChange,
   })
   const { settings } = useSyncWidgetSettings()

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -10,7 +10,6 @@ import { Currency, TradeType } from '@uniswap/sdk-core'
 import {
   AddEthereumChainParameter,
   EMPTY_TOKEN_LIST,
-  Field,
   OnReviewSwapClick,
   SwapWidget,
   SwapWidgetSkeleton,
@@ -46,24 +45,26 @@ function useWidgetTheme() {
 }
 
 interface WidgetProps {
-  token?: Currency
+  inputToken?: Currency
+  outputToken?: Currency
+  defaultToken?: Currency
   width?: number | string
-  defaultField: Field
-  onTokenChange?: (token: Currency) => void
+  onDefaultTokenChange?: (token: Currency) => void
   onReviewSwapClick?: OnReviewSwapClick
 }
 
 export default function Widget({
-  token,
+  inputToken,
+  outputToken,
+  defaultToken,
   width = DEFAULT_WIDGET_WIDTH,
-  defaultField,
-  onTokenChange,
+  onDefaultTokenChange,
   onReviewSwapClick,
 }: WidgetProps) {
   const { connector, provider } = useWeb3React()
   const locale = useActiveLocale()
   const theme = useWidgetTheme()
-  const { inputs, tokenSelector } = useSyncWidgetInputs({ token, onTokenChange, defaultField })
+  const { inputs, tokenSelector } = useSyncWidgetInputs({ inputToken, outputToken, defaultToken, onDefaultTokenChange })
   const { settings } = useSyncWidgetSettings()
   const { transactions } = useSyncWidgetTransactions()
 
@@ -189,7 +190,7 @@ export default function Widget({
   )
 }
 
-export function WidgetSkeleton() {
+export function WidgetSkeleton({ width = DEFAULT_WIDGET_WIDTH }: { width?: number | string }) {
   const theme = useWidgetTheme()
-  return <SwapWidgetSkeleton theme={theme} width={DEFAULT_WIDGET_WIDTH} />
+  return <SwapWidgetSkeleton theme={theme} width={width} />
 }

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -41,7 +41,7 @@ export function useSyncWidgetInputs({
   })
 
   useEffect(() => {
-    if ((inputToken || outputToken) && !tokens[Field.INPUT] && !tokens[Field.OUTPUT]) {
+    if (!tokens[Field.INPUT] && !tokens[Field.OUTPUT]) {
       setTokens((tokens) => {
         const update = {
           ...tokens,

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -8,7 +8,7 @@ const EMPTY_AMOUNT = ''
 
 type SwapValue = Required<SwapController>['value']
 type SwapTokens = Pick<SwapValue, Field.INPUT | Field.OUTPUT> & { default?: Currency }
-export type DefaultSwapTokens = Partial<SwapTokens>
+export type DefaultTokens = Partial<SwapTokens>
 
 function missingDefaultToken(tokens: SwapTokens) {
   if (!tokens.default) return false
@@ -24,7 +24,7 @@ export function useSyncWidgetInputs({
   defaultTokens,
   onDefaultTokenChange,
 }: {
-  defaultTokens: DefaultSwapTokens
+  defaultTokens: DefaultTokens
   onDefaultTokenChange?: (token: Currency) => void
 }) {
   const trace = useTrace({ section: InterfaceSectionName.WIDGET })

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -8,6 +8,7 @@ const EMPTY_AMOUNT = ''
 
 type SwapValue = Required<SwapController>['value']
 type SwapTokens = Pick<SwapValue, Field.INPUT | Field.OUTPUT> & { default?: Currency }
+export type DefaultSwapTokens = Partial<SwapTokens>
 
 function missingDefaultToken(tokens: SwapTokens) {
   if (!tokens.default) return false
@@ -23,7 +24,7 @@ export function useSyncWidgetInputs({
   defaultTokens,
   onDefaultTokenChange,
 }: {
-  defaultTokens: SwapTokens
+  defaultTokens: DefaultSwapTokens
   onDefaultTokenChange?: (token: Currency) => void
 }) {
   const trace = useTrace({ section: InterfaceSectionName.WIDGET })

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -563,7 +563,11 @@ export default function Swap({ className }: { className?: string }) {
         />
         <PageWrapper>
           {swapWidgetEnabled ? (
-            <Widget token={loadedInputCurrency ?? undefined} width="100%" defaultField={Field.INPUT} />
+            <Widget
+              inputToken={loadedInputCurrency ?? undefined}
+              outputToken={loadedOutputCurrency ?? undefined}
+              width="100%"
+            />
           ) : (
             <SwapWrapper className={className} id="swap-page">
               <SwapHeader allowedSlippage={allowedSlippage} />

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -564,8 +564,10 @@ export default function Swap({ className }: { className?: string }) {
         <PageWrapper>
           {swapWidgetEnabled ? (
             <Widget
-              initialInputToken={loadedInputCurrency ?? undefined}
-              initialOutputToken={loadedOutputCurrency ?? undefined}
+              defaultTokens={{
+                [Field.INPUT]: loadedInputCurrency ?? undefined,
+                [Field.OUTPUT]: loadedOutputCurrency ?? undefined,
+              }}
               width="100%"
             />
           ) : (

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -564,8 +564,8 @@ export default function Swap({ className }: { className?: string }) {
         <PageWrapper>
           {swapWidgetEnabled ? (
             <Widget
-              inputToken={loadedInputCurrency ?? undefined}
-              outputToken={loadedOutputCurrency ?? undefined}
+              initialInputToken={loadedInputCurrency ?? undefined}
+              initialOutputToken={loadedOutputCurrency ?? undefined}
               width="100%"
             />
           ) : (


### PR DESCRIPTION
enables the callsites of our Widget integration to pass either/both of the input and output currencies. 

this is needed to handle URL params for the /swap page. for example, see this link: 

https://app.uniswap.org/#/swap?inputCurrency=0x6B175474E89094C44Da98b954EedeAC495271d0F&outputCurrency=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48

we still keep support for specifying a "default" token, which is currently just used to do automatic navigations on the token details page.

