### PR TITLE
feat: upgrade conedison to improve signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@types/react-window-infinite-loader": "^1.0.6",
     "@uniswap/analytics": "1.2.0",
     "@uniswap/analytics-events": "^2.1.0",
-    "@uniswap/conedison": "^1.2.1",
+    "@uniswap/conedison": "^1.3.0",
     "@uniswap/governance": "^1.0.2",
     "@uniswap/liquidity-staker": "^1.0.2",
     "@uniswap/merkle-distributor": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4945,12 +4945,7 @@
     react "^18.2.0"
     react-dom "^18.2.0"
 
-"@uniswap/conedison@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.2.1.tgz#c3dbfe14f4320fc5c60cde23c4bd70ed8a39c782"
-  integrity sha512-ir6j7RQOyREXtW5YlmPjskfl7oDeHWtMFai57snThAkKgrb+8KTX5b0a5nbXeIuaW2RNHAaWTGoSoTneIHCAnQ==
-
-"@uniswap/conedison@^1.3.0":
+"@uniswap/conedison@^1.2.1", "@uniswap/conedison@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.3.0.tgz#998aca2bad27f0780a05b40e4512acfcadfece79"
   integrity sha512-zpZ52svBJ2btwl09mLOw7HlBxFDuYAjAZXLAR7WQZJeRgjD1yD2QuI3v7JliXvHzJh3ePYH6820EMp7xQbdAGQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4950,6 +4950,11 @@
   resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.2.1.tgz#c3dbfe14f4320fc5c60cde23c4bd70ed8a39c782"
   integrity sha512-ir6j7RQOyREXtW5YlmPjskfl7oDeHWtMFai57snThAkKgrb+8KTX5b0a5nbXeIuaW2RNHAaWTGoSoTneIHCAnQ==
 
+"@uniswap/conedison@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.3.0.tgz#998aca2bad27f0780a05b40e4512acfcadfece79"
+  integrity sha512-zpZ52svBJ2btwl09mLOw7HlBxFDuYAjAZXLAR7WQZJeRgjD1yD2QuI3v7JliXvHzJh3ePYH6820EMp7xQbdAGQ==
+
 "@uniswap/default-token-list@^2.0.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-2.2.0.tgz#d85a5c2520f57f4920bd989dfc9f01e1b701a567"


### PR DESCRIPTION
Upgrades conedison to improve signing.
conedison@1.3 updates signTypedData to default to eth_signTypedData_v4 and only use eth_signTypedData for special-cased wallets.

---

Manually tested on:

- [x] MetaMask (extension)
- [x] MetaMask (mobile)
- [x] MetaMask (in-app browser)
- [x] Rabby
- [x] SafePal (extension)
- [x] SafePal Mobile
- [x] Zerion
- [x] Rainbow
- [x] Trust
- [x] CoinBase Wallet
- [x] Frame
- [x] Argent