### PR TITLE
fix: showCommonBases for widget token selector

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -106,6 +106,7 @@ export function useSyncWidgetInputs({
     },
     [onTokenChange, selectingField, tokens]
   )
+
   const tokenSelector = (
     <CurrencySearchModal
       isOpen={selectingField !== undefined}
@@ -113,6 +114,7 @@ export function useSyncWidgetInputs({
       selectedCurrency={selectingField && tokens[selectingField]}
       otherSelectedCurrency={selectingField && tokens[invertField(selectingField)]}
       onCurrencySelect={onTokenSelect}
+      showCommonBases
     />
   )
 


### PR DESCRIPTION
enables the "common bases" feature for the token selector that the widget uses