### PR TITLE
feat: [ListV2] Changes to Multiple Market handling and row hovering

### DIFF
--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -74,10 +74,6 @@ const ListingHeader = styled(Row)`
 const GridWrapper = styled.div`
   margin-top: 24px;
   margin-bottom: 48px;
-
-  @media screen and (min-width: ${SMALL_MEDIA_BREAKPOINT}) {
-    margin-left: 40px;
-  }
 `
 
 const MobileListButtonWrapper = styled.div`

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -9,7 +9,7 @@ import { ListingMarket, ListingWarning, WalletAsset } from 'nft/types'
 import { LOOKS_RARE_CREATOR_BASIS_POINTS } from 'nft/utils'
 import { formatEth, formatUsdPrice } from 'nft/utils/currency'
 import { fetchPrice } from 'nft/utils/fetchPrice'
-import React, { Dispatch, useEffect, useMemo, useState } from 'react'
+import React, { Dispatch, useEffect, useMemo, useReducer, useState } from 'react'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 
@@ -112,8 +112,8 @@ export const MarketplaceRow = ({
   const showGlobalPrice = globalPriceMethod === SetPriceMethod.SAME_PRICE && !globalOverride && globalPrice
   const setAssetListPrice = useSellAsset((state) => state.setAssetListPrice)
   const removeAssetMarketplace = useSellAsset((state) => state.removeAssetMarketplace)
-  const [hovered, setHovered] = useState(false)
-  const handleHover = () => setHovered(!hovered)
+  const [marketIconHovered, toggleMarketIconHovered] = useReducer((s) => !s, false)
+  const [marketRowHovered, toggleMarketRowHovered] = useReducer((s) => !s, false)
 
   const price = showGlobalPrice ? globalPrice : listPrice
 
@@ -197,7 +197,7 @@ export const MarketplaceRow = ({
   }
 
   return (
-    <Row>
+    <Row onMouseEnter={toggleMarketRowHovered} onMouseLeave={toggleMarketRowHovered}>
       <PastPriceInfo>
         <ThemedText.BodySmall color="textSecondary" lineHeight="20px">
           {asset.floorPrice ? `${asset.floorPrice.toFixed(3)} ETH` : '-'}
@@ -213,8 +213,8 @@ export const MarketplaceRow = ({
         {/* change this logic to be show multiple stacked or single or none */}
         {showMarketplaceLogo && (
           <MarketIconWrapper
-            onMouseEnter={handleHover}
-            onMouseLeave={handleHover}
+            onMouseEnter={toggleMarketIconHovered}
+            onMouseLeave={toggleMarketIconHovered}
             onClick={(e) => {
               e.stopPropagation()
               removeAssetMarketplace(asset, selectedMarkets[0])
@@ -222,7 +222,7 @@ export const MarketplaceRow = ({
             }}
           >
             <MarketIcon alt={selectedMarkets[0].name} src={selectedMarkets[0].icon} />
-            <RemoveMarketplaceWrap hovered={hovered}>
+            <RemoveMarketplaceWrap hovered={marketIconHovered}>
               <img width="32px" src="/nft/svgs/minusCircle.svg" alt="Remove item" />
             </RemoveMarketplaceWrap>
           </MarketIconWrapper>
@@ -250,7 +250,7 @@ export const MarketplaceRow = ({
             shrink={expandMarketplaceRows}
           />
         )}
-        {rowHovered && (showMarketplaceLogo || selectedMarkets.length > 1) && (
+        {rowHovered && ((showMarketplaceLogo && marketRowHovered) || selectedMarkets.length > 1) && (
           <ExpandMarketIconWrapper onClick={toggleExpandMarketplaceRows}>
             {expandMarketplaceRows ? <RowsExpandedIcon /> : <RowsCollpsedIcon />}
           </ExpandMarketIconWrapper>

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -237,7 +237,6 @@ export const MarketplaceRow = ({
                 </RemoveMarketplaceWrap>
               </MarketIconWrapper>
             ))}
-            {/* */}
           </MarketIconsWrapper>
         )}
         {globalPriceMethod === SetPriceMethod.SAME_PRICE && !globalOverride ? (

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -47,7 +47,7 @@ const MarketIcon = styled.img`
 
 const ExpandMarketIconWrapper = styled.div`
   cursor: pointer;
-  margin-left: 14px;
+  margin-left: 4px;
   height: 28px;
 `
 

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -9,7 +9,7 @@ import { ListingMarket, ListingWarning, WalletAsset } from 'nft/types'
 import { LOOKS_RARE_CREATOR_BASIS_POINTS } from 'nft/utils'
 import { formatEth, formatUsdPrice } from 'nft/utils/currency'
 import { fetchPrice } from 'nft/utils/fetchPrice'
-import React, { Dispatch, useEffect, useMemo, useReducer, useState } from 'react'
+import React, { Dispatch, DispatchWithoutAction, useEffect, useMemo, useReducer, useState } from 'react'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 
@@ -57,6 +57,7 @@ const MarketIcon = styled.img<{ index: number }>`
   object-fit: cover;
   z-index: ${({ index }) => 2 - index};
   margin-left: ${({ index }) => `${index === 0 ? 0 : -8}px`};
+  outline: 1px solid ${({ theme }) => theme.backgroundInteractive};
 `
 
 const ExpandMarketIconWrapper = styled.div`
@@ -110,7 +111,7 @@ interface MarketplaceRowProps {
   showMarketplaceLogo: boolean
   expandMarketplaceRows?: boolean
   rowHovered?: boolean
-  toggleExpandMarketplaceRows: React.DispatchWithoutAction
+  toggleExpandMarketplaceRows: DispatchWithoutAction
 }
 
 export const MarketplaceRow = ({
@@ -232,7 +233,7 @@ export const MarketplaceRow = ({
           <MarketIconsWrapper onMouseEnter={toggleMarketIconHovered} onMouseLeave={toggleMarketIconHovered}>
             {selectedMarkets.map((market, index) => (
               <MarketIconWrapper
-                key={market.name + index}
+                key={market.name + asset.collection?.address + asset.tokenId}
                 onClick={(e) => {
                   e.stopPropagation()
                   removeAssetMarketplace(asset, selectedMarkets[0])

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -29,20 +29,30 @@ const PastPriceInfo = styled(Column)`
 `
 
 const RemoveMarketplaceWrap = styled(RemoveIconWrap)`
-  top: 11px;
+  top: 8px;
+  left: 16px;
+  z-index: 3;
+`
+
+const MarketIconsWrapper = styled(Row)`
+  position: relative;
+  margin-right: 12px;
+  width: 44px;
+  justify-content: flex-end;
 `
 
 const MarketIconWrapper = styled(Column)`
   position: relative;
   cursor: pointer;
-  margin-right: 16px;
 `
 
-const MarketIcon = styled.img`
-  width: 28px;
-  height: 28px;
+const MarketIcon = styled.img<{ index: number }>`
+  width: 20px;
+  height: 20px;
   border-radius: 4px;
   object-fit: cover;
+  z-index: ${({ index }) => 2 - index};
+  margin-left: ${({ index }) => `${index === 0 ? 0 : -8}px`};
 `
 
 const ExpandMarketIconWrapper = styled.div`
@@ -209,23 +219,26 @@ export const MarketplaceRow = ({
         </ThemedText.BodySmall>
       </PastPriceInfo>
 
-      <Row flex="2">
-        {/* change this logic to be show multiple stacked or single or none */}
-        {showMarketplaceLogo && (
-          <MarketIconWrapper
-            onMouseEnter={toggleMarketIconHovered}
-            onMouseLeave={toggleMarketIconHovered}
-            onClick={(e) => {
-              e.stopPropagation()
-              removeAssetMarketplace(asset, selectedMarkets[0])
-              removeMarket && removeMarket()
-            }}
-          >
-            <MarketIcon alt={selectedMarkets[0].name} src={selectedMarkets[0].icon} />
-            <RemoveMarketplaceWrap hovered={marketIconHovered}>
-              <img width="32px" src="/nft/svgs/minusCircle.svg" alt="Remove item" />
-            </RemoveMarketplaceWrap>
-          </MarketIconWrapper>
+      <Row flex="3">
+        {(expandMarketplaceRows || selectedMarkets.length > 1) && (
+          <MarketIconsWrapper onMouseEnter={toggleMarketIconHovered} onMouseLeave={toggleMarketIconHovered}>
+            {selectedMarkets.map((market, index) => (
+              <MarketIconWrapper
+                key={market.name + index}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  removeAssetMarketplace(asset, selectedMarkets[0])
+                  removeMarket && removeMarket()
+                }}
+              >
+                <MarketIcon alt={selectedMarkets[0].name} src={market.icon} index={index} />
+                <RemoveMarketplaceWrap hovered={marketIconHovered && (expandMarketplaceRows ?? false)}>
+                  <img width="20px" src="/nft/svgs/minusCircle.svg" alt="Remove item" />
+                </RemoveMarketplaceWrap>
+              </MarketIconWrapper>
+            ))}
+            {/* */}
+          </MarketIconsWrapper>
         )}
         {globalPriceMethod === SetPriceMethod.SAME_PRICE && !globalOverride ? (
           <PriceTextInput
@@ -236,7 +249,6 @@ export const MarketplaceRow = ({
             globalOverride={globalOverride}
             warning={warning}
             asset={asset}
-            shrink={expandMarketplaceRows}
           />
         ) : (
           <PriceTextInput
@@ -247,10 +259,9 @@ export const MarketplaceRow = ({
             globalOverride={globalOverride}
             warning={warning}
             asset={asset}
-            shrink={expandMarketplaceRows}
           />
         )}
-        {rowHovered && ((showMarketplaceLogo && marketRowHovered) || selectedMarkets.length > 1) && (
+        {rowHovered && ((expandMarketplaceRows && marketRowHovered) || selectedMarkets.length > 1) && (
           <ExpandMarketIconWrapper onClick={toggleExpandMarketplaceRows}>
             {expandMarketplaceRows ? <RowsExpandedIcon /> : <RowsCollpsedIcon />}
           </ExpandMarketIconWrapper>

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -3,12 +3,13 @@ import { t } from '@lingui/macro'
 import Column from 'components/Column'
 import Row from 'components/Row'
 import { MouseoverTooltip } from 'components/Tooltip'
+import { RowsCollpsedIcon, RowsExpandedIcon } from 'nft/components/icons'
 import { useSellAsset } from 'nft/hooks'
 import { ListingMarket, ListingWarning, WalletAsset } from 'nft/types'
 import { LOOKS_RARE_CREATOR_BASIS_POINTS } from 'nft/utils'
 import { formatEth, formatUsdPrice } from 'nft/utils/currency'
 import { fetchPrice } from 'nft/utils/fetchPrice'
-import { Dispatch, useEffect, useMemo, useState } from 'react'
+import React, { Dispatch, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 
@@ -42,6 +43,12 @@ const MarketIcon = styled.img`
   height: 28px;
   border-radius: 4px;
   object-fit: cover;
+`
+
+const ExpandMarketIconWrapper = styled.div`
+  cursor: pointer;
+  margin-left: 14px;
+  height: 28px;
 `
 
 const FeeColumnWrapper = styled(Column)`
@@ -84,6 +91,8 @@ interface MarketplaceRowProps {
   asset: WalletAsset
   showMarketplaceLogo: boolean
   expandMarketplaceRows?: boolean
+  rowHovered?: boolean
+  toggleExpandMarketplaceRows: React.DispatchWithoutAction
 }
 
 export const MarketplaceRow = ({
@@ -95,6 +104,8 @@ export const MarketplaceRow = ({
   asset,
   showMarketplaceLogo,
   expandMarketplaceRows,
+  toggleExpandMarketplaceRows,
+  rowHovered,
 }: MarketplaceRowProps) => {
   const [listPrice, setListPrice] = useState<number>()
   const [globalOverride, setGlobalOverride] = useState(false)
@@ -199,6 +210,7 @@ export const MarketplaceRow = ({
       </PastPriceInfo>
 
       <Row flex="2">
+        {/* change this logic to be show multiple stacked or single or none */}
         {showMarketplaceLogo && (
           <MarketIconWrapper
             onMouseEnter={handleHover}
@@ -237,6 +249,11 @@ export const MarketplaceRow = ({
             asset={asset}
             shrink={expandMarketplaceRows}
           />
+        )}
+        {rowHovered && (showMarketplaceLogo || selectedMarkets.length > 1) && (
+          <ExpandMarketIconWrapper onClick={toggleExpandMarketplaceRows}>
+            {expandMarketplaceRows ? <RowsExpandedIcon /> : <RowsCollpsedIcon />}
+          </ExpandMarketIconWrapper>
         )}
       </Row>
 

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -39,6 +39,10 @@ const MarketIconsWrapper = styled(Row)`
   margin-right: 12px;
   width: 44px;
   justify-content: flex-end;
+
+  @media screen and (max-width: ${BREAKPOINTS.sm}px) {
+    display: none;
+  }
 `
 
 const MarketIconWrapper = styled(Column)`
@@ -59,6 +63,10 @@ const ExpandMarketIconWrapper = styled.div`
   cursor: pointer;
   margin-left: 4px;
   height: 28px;
+
+  @media screen and (max-width: ${BREAKPOINTS.sm}px) {
+    display: none;
+  }
 `
 
 const FeeColumnWrapper = styled(Column)`

--- a/src/nft/components/profile/list/NFTListRow.tsx
+++ b/src/nft/components/profile/list/NFTListRow.tsx
@@ -1,28 +1,29 @@
 import Column from 'components/Column'
 import Row from 'components/Row'
-import { RowsCollpsedIcon, RowsExpandedIcon, VerifiedIcon } from 'nft/components/icons'
-import { useSellAsset } from 'nft/hooks'
+import { VerifiedIcon } from 'nft/components/icons'
+import { useIsMobile, useSellAsset } from 'nft/hooks'
 import { ListingMarket, WalletAsset } from 'nft/types'
 import { Dispatch, useEffect, useState } from 'react'
-import styled, { css } from 'styled-components/macro'
+import { Trash2 } from 'react-feather'
+import styled, { css, useTheme } from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 import { opacify } from 'theme/utils'
 
 import { MarketplaceRow } from './MarketplaceRow'
 import { SetPriceMethod } from './NFTListingsGrid'
-import { RemoveIconWrap } from './shared'
 
 const NFTListRowWrapper = styled(Row)`
   padding: 24px 0px;
   align-items: center;
 
-  @media screen and (min-width: ${BREAKPOINTS.sm}px) {
-    padding-left: 40px;
-  }
-
   &:hover {
     background: ${({ theme }) => opacify(24, theme.backgroundOutline)};
   }
+`
+
+const RemoveIconContainer = styled.div`
+  width: 40px;
+  padding-left: 10px;
 `
 
 const NFTInfoWrapper = styled(Row)`
@@ -37,22 +38,11 @@ const ExpandMarketIconWrapper = styled.div`
   margin-right: 8px;
 `
 
-const NFTImageWrapper = styled.div`
-  position: relative;
-  cursor: pointer;
-  height: 48px;
-  margin-right: 8px;
-`
-
 const NFTImage = styled.img`
   width: 48px;
   height: 48px;
   border-radius: 8px;
-`
-
-const RemoveIcon = styled.img`
-  width: 32px;
-  height: 32px;
+  margin-right: 8px;
 `
 
 const HideTextOverflow = css`
@@ -117,6 +107,8 @@ export const NFTListRow = ({
   const [localMarkets, setLocalMarkets] = useState([])
   const [hovered, setHovered] = useState(false)
   const handleHover = () => setHovered(!hovered)
+  const theme = useTheme()
+  const isMobile = useIsMobile()
 
   useEffect(() => {
     setLocalMarkets(JSON.parse(JSON.stringify(selectedMarkets)))
@@ -124,25 +116,29 @@ export const NFTListRow = ({
   }, [selectedMarkets])
 
   return (
-    <NFTListRowWrapper>
+    <NFTListRowWrapper onMouseEnter={handleHover} onMouseLeave={handleHover}>
+      {!isMobile && (
+        <RemoveIconContainer>
+          {hovered && (
+            <Trash2
+              height={20}
+              width={20}
+              color={theme.textSecondary}
+              cursor="pointer"
+              onClick={() => {
+                removeAsset(asset)
+              }}
+            />
+          )}
+        </RemoveIconContainer>
+      )}
       <NFTInfoWrapper>
-        {localMarkets.length > 1 && (
+        {/* {localMarkets.length > 1 && (
           <ExpandMarketIconWrapper onClick={() => setExpandMarketplaceRows(!expandMarketplaceRows)}>
             {expandMarketplaceRows ? <RowsExpandedIcon /> : <RowsCollpsedIcon />}
           </ExpandMarketIconWrapper>
-        )}
-        <NFTImageWrapper
-          onMouseEnter={handleHover}
-          onMouseLeave={handleHover}
-          onClick={() => {
-            removeAsset(asset)
-          }}
-        >
-          <RemoveIconWrap hovered={hovered}>
-            <RemoveIcon src="/nft/svgs/minusCircle.svg" alt="Remove item" />
-          </RemoveIconWrap>
-          <NFTImage alt={asset.name} src={asset.imageUrl || '/nft/svgs/image-placeholder.svg'} />
-        </NFTImageWrapper>
+        )} */}
+        <NFTImage alt={asset.name} src={asset.imageUrl || '/nft/svgs/image-placeholder.svg'} />
         <TokenInfoWrapper>
           <TokenName>{asset.name ? asset.name : `#${asset.tokenId}`}</TokenName>
           <CollectionName>

--- a/src/nft/components/profile/list/NFTListRow.tsx
+++ b/src/nft/components/profile/list/NFTListRow.tsx
@@ -3,7 +3,7 @@ import Row from 'components/Row'
 import { VerifiedIcon } from 'nft/components/icons'
 import { useSellAsset } from 'nft/hooks'
 import { ListingMarket, WalletAsset } from 'nft/types'
-import React, { Dispatch, useEffect, useReducer, useState } from 'react'
+import { Dispatch, useEffect, useReducer, useState } from 'react'
 import { Trash2 } from 'react-feather'
 import styled, { css, useTheme } from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
@@ -32,6 +32,10 @@ const RemoveIconContainer = styled.div`
 
   @media screen and (max-width: ${BREAKPOINTS.sm}px) {
     display: none;
+  }
+
+  &:hover {
+    opacity: ${({ theme }) => theme.opacity.hover};
   }
 `
 
@@ -130,8 +134,7 @@ export const NFTListRow = ({
       <RemoveIconContainer>
         {hovered && (
           <Trash2
-            height={20}
-            width={20}
+            size={20}
             color={theme.textSecondary}
             cursor="pointer"
             onClick={() => {

--- a/src/nft/components/profile/list/NFTListRow.tsx
+++ b/src/nft/components/profile/list/NFTListRow.tsx
@@ -1,7 +1,7 @@
 import Column from 'components/Column'
 import Row from 'components/Row'
 import { VerifiedIcon } from 'nft/components/icons'
-import { useIsMobile, useSellAsset } from 'nft/hooks'
+import { useSellAsset } from 'nft/hooks'
 import { ListingMarket, WalletAsset } from 'nft/types'
 import React, { Dispatch, useEffect, useReducer, useState } from 'react'
 import { Trash2 } from 'react-feather'
@@ -28,6 +28,10 @@ const RemoveIconContainer = styled.div`
   align-self: flex-start;
   align-items: center;
   display: flex;
+
+  @media screen and (max-width: ${BREAKPOINTS.sm}px) {
+    display: none;
+  }
 `
 
 const NFTInfoWrapper = styled(Row)`
@@ -106,7 +110,6 @@ export const NFTListRow = ({
   const [localMarkets, setLocalMarkets] = useState<ListingMarket[]>([])
   const [hovered, toggleHovered] = useReducer((s) => !s, false)
   const theme = useTheme()
-  const isMobile = useIsMobile()
 
   useEffect(() => {
     setLocalMarkets(JSON.parse(JSON.stringify(selectedMarkets)))
@@ -122,21 +125,20 @@ export const NFTListRow = ({
         hovered && toggleHovered()
       }}
     >
-      {!isMobile && (
-        <RemoveIconContainer>
-          {hovered && (
-            <Trash2
-              height={20}
-              width={20}
-              color={theme.textSecondary}
-              cursor="pointer"
-              onClick={() => {
-                removeAsset(asset)
-              }}
-            />
-          )}
-        </RemoveIconContainer>
-      )}
+      <RemoveIconContainer>
+        {hovered && (
+          <Trash2
+            height={20}
+            width={20}
+            color={theme.textSecondary}
+            cursor="pointer"
+            onClick={() => {
+              removeAsset(asset)
+            }}
+          />
+        )}
+      </RemoveIconContainer>
+
       <NFTInfoWrapper>
         <NFTImage alt={asset.name} src={asset.imageUrl || '/nft/svgs/image-placeholder.svg'} />
         <TokenInfoWrapper>

--- a/src/nft/components/profile/list/NFTListRow.tsx
+++ b/src/nft/components/profile/list/NFTListRow.tsx
@@ -6,14 +6,23 @@ import { ListingMarket, WalletAsset } from 'nft/types'
 import { Dispatch, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
+import { opacify } from 'theme/utils'
 
 import { MarketplaceRow } from './MarketplaceRow'
 import { SetPriceMethod } from './NFTListingsGrid'
 import { RemoveIconWrap } from './shared'
 
 const NFTListRowWrapper = styled(Row)`
-  margin: 24px 0px;
+  padding: 24px 0px;
   align-items: center;
+
+  @media screen and (min-width: ${BREAKPOINTS.sm}px) {
+    padding-left: 40px;
+  }
+
+  &:hover {
+    background: ${({ theme }) => opacify(24, theme.backgroundOutline)};
+  }
 `
 
 const NFTInfoWrapper = styled(Row)`

--- a/src/nft/components/profile/list/NFTListRow.tsx
+++ b/src/nft/components/profile/list/NFTListRow.tsx
@@ -15,6 +15,7 @@ import { SetPriceMethod } from './NFTListingsGrid'
 const NFTListRowWrapper = styled(Row)`
   padding: 24px 0px;
   align-items: center;
+  border-radius: 8px;
 
   &:hover {
     background: ${({ theme }) => opacify(24, theme.backgroundOutline)};
@@ -22,9 +23,9 @@ const NFTListRowWrapper = styled(Row)`
 `
 
 const RemoveIconContainer = styled.div`
-  width: 40px;
+  width: 48px;
   height: 44px;
-  padding-left: 10px;
+  padding-left: 12px;
   align-self: flex-start;
   align-items: center;
   display: flex;
@@ -76,6 +77,7 @@ const CollectionName = styled(ThemedText.BodySmall)`
 const MarketPlaceRowWrapper = styled(Column)`
   gap: 24px;
   flex: 1.5;
+  margin-right: 12px;
 
   @media screen and (min-width: ${BREAKPOINTS.md}px) {
     flex: 2;

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -54,7 +54,7 @@ const PriceInfoHeader = styled.div`
 `
 
 const DropdownAndHeaderWrapper = styled(Row)`
-  flex: 2;
+  flex: 3;
   gap: 4px;
 `
 

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -28,7 +28,7 @@ const TableHeader = styled.div`
   line-height: 20px;
 
   @media screen and (min-width: ${BREAKPOINTS.sm}px) {
-    margin-left: 40px;
+    margin-left: 48px;
   }
 `
 
@@ -38,6 +38,7 @@ const NFTHeader = styled.div`
 
 const PriceHeaders = styled(Row)`
   flex: 1.5;
+  margin-right: 12px;
 
   @media screen and (min-width: ${BREAKPOINTS.md}px) {
     flex: 3;

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -26,6 +26,10 @@ const TableHeader = styled.div`
   font-size: 14px;
   font-weight: normal;
   line-height: 20px;
+
+  @media screen and (min-width: ${BREAKPOINTS.sm}px) {
+    margin-left: 40px;
+  }
 `
 
 const NFTHeader = styled.div`
@@ -34,10 +38,6 @@ const NFTHeader = styled.div`
 
 const PriceHeaders = styled(Row)`
   flex: 1.5;
-
-  @media screen and (min-width: ${BREAKPOINTS.md}px) {
-    flex: 2;
-  }
 
   @media screen and (min-width: ${BREAKPOINTS.md}px) {
     flex: 3;

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -125,6 +125,7 @@ const RowDivider = styled.hr`
   border-radius: 20px;
   border-width: 0.5px;
   border-style: solid;
+  margin: 0;
   border-color: ${({ theme }) => theme.backgroundInteractive};
 `
 


### PR DESCRIPTION
- Adds a hover state to listing rows
  - When hovering display trash icon for removing listing
- When listing to multiple markets display all selected markets next to price
  - When hovering over with multiple markets show expand/collapse icon to modify specific market listings
  - specs: https://uniswaplabs.atlassian.net/browse/NFT-1088
  
 Screenshots:
![hoverAndMarkets](https://user-images.githubusercontent.com/11512321/217713492-e8318a01-418f-40ef-a502-51563dd9477b.gif)
