### PR TITLE
chore: update generated types-and-hooks

### DIFF
--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -95,6 +95,11 @@ export enum Currency {
   Usd = 'USD'
 }
 
+export enum DatasourceProvider {
+  Nxyz = 'NXYZ',
+  Uniswap = 'UNISWAP'
+}
+
 export type Dimensions = {
   __typename?: 'Dimensions';
   height?: Maybe<Scalars['Float']>;


### PR DESCRIPTION
Regenerates types-and-hooks to match the updated schema, as defined in codegen.yml.