### PR TITLE
fix: Mixed success modal wrapping

### DIFF
--- a/src/nft/components/collection/TransactionCompleteModal.css.ts
+++ b/src/nft/components/collection/TransactionCompleteModal.css.ts
@@ -5,7 +5,6 @@ export const modalContainer = style([
   sprinkles({
     display: 'flex',
     position: 'fixed',
-    flexWrap: 'wrap',
     height: 'full',
     width: { sm: 'full', md: 'min' },
     left: { sm: '0', md: '1/2' },

--- a/src/nft/components/collection/TransactionCompleteModal.tsx
+++ b/src/nft/components/collection/TransactionCompleteModal.tsx
@@ -201,7 +201,6 @@ const TxCompleteModal = () => {
                 >
                   <Box className={styles.mixedRefundModal} onClick={stopPropagation}>
                     <Box
-                      height="full"
                       display="inline-flex"
                       flexWrap="wrap"
                       width={{ sm: 'full', md: 'half' }}


### PR DESCRIPTION
When 1 asset would get purchased and the rest refunded the modal would wrap. This is a quick fix to address that problem.

Out of scope: refactor the TxComplete modals to styled components

Screenshots:
<img width="1727" alt="Screen Shot 2023-02-13 at 15 33 33 " src="https://user-images.githubusercontent.com/11512321/218598891-02acaf5b-1f4e-4f73-a46d-ae429f7ed9b3.png">
<img width="393" alt="Screen Shot 2023-02-13 at 15 37 26 " src="https://user-images.githubusercontent.com/11512321/218598900-6e07c156-b9b5-49fa-89ce-00790b970f87.png">
