### PR TITLE
fix: round corners of CurrencySearch

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -35,6 +35,7 @@ const ContentWrapper = styled(Column)`
   overflow: hidden;
   flex: 1 1;
   position: relative;
+  border-radius: 20px;
 `
 
 interface CurrencySearchProps {


### PR DESCRIPTION
adds a border radius to the CurrencySearch component explicitly, because Safari wasn't displaying this content correctly

https://uniswaplabs.atlassian.net/browse/WEB-2871?atlOrigin=eyJpIjoiMzczNmZkOWM2MGY0NGI5MGJiYWEzYTY5ZmU3NjdjOWEiLCJwIjoiaiJ9