### PR TITLE
fix: use latest version of tokenlists over cache

### DIFF
--- a/src/hooks/useFetchListCallback.ts
+++ b/src/hooks/useFetchListCallback.ts
@@ -9,30 +9,25 @@ import { useAppDispatch } from 'state/hooks'
 
 import { fetchTokenList } from '../state/lists/actions'
 
-export function useFetchListCallback(): (
-  listUrl: string,
-  sendDispatch?: boolean,
-  skipValidation?: boolean
-) => Promise<TokenList> {
+export function useFetchListCallback(): (listUrl: string, skipValidation?: boolean) => Promise<TokenList> {
   const dispatch = useAppDispatch()
 
-  // note: prevent dispatch if using for list search or unsupported list
   return useCallback(
-    async (listUrl: string, sendDispatch = true, skipValidation?: boolean) => {
+    async (listUrl: string, skipValidation?: boolean) => {
       const requestId = nanoid()
-      sendDispatch && dispatch(fetchTokenList.pending({ requestId, url: listUrl }))
+      dispatch(fetchTokenList.pending({ requestId, url: listUrl }))
       return getTokenList(
         listUrl,
         (ensName: string) => resolveENSContentHash(ensName, RPC_PROVIDERS[SupportedChainId.MAINNET]),
         skipValidation
       )
         .then((tokenList) => {
-          sendDispatch && dispatch(fetchTokenList.fulfilled({ url: listUrl, tokenList, requestId }))
+          dispatch(fetchTokenList.fulfilled({ url: listUrl, tokenList, requestId }))
           return tokenList
         })
         .catch((error) => {
           console.debug(`Failed to get list at url ${listUrl}`, error)
-          sendDispatch && dispatch(fetchTokenList.rejected({ url: listUrl, requestId, errorMessage: error.message }))
+          dispatch(fetchTokenList.rejected({ url: listUrl, requestId, errorMessage: error.message }))
           throw error
         })
     },

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -1,7 +1,8 @@
 import { getVersionUpgrade, minVersionBump, VersionUpgrade } from '@uniswap/token-lists'
 import { useWeb3React } from '@web3-react/core'
-import { UNSUPPORTED_LIST_URLS } from 'constants/lists'
+import { DEFAULT_LIST_OF_LISTS, UNSUPPORTED_LIST_URLS } from 'constants/lists'
 import useInterval from 'lib/hooks/useInterval'
+import ms from 'ms.macro'
 import { useCallback, useEffect } from 'react'
 import { useAppDispatch } from 'state/hooks'
 import { useAllLists } from 'state/lists/hooks'
@@ -20,15 +21,15 @@ export default function Updater(): null {
   const fetchList = useFetchListCallback()
   const fetchAllListsCallback = useCallback(() => {
     if (!isWindowVisible) return
-    Object.keys(lists).forEach((url) => {
+    DEFAULT_LIST_OF_LISTS.forEach((url) => {
       // Skip validation on unsupported lists
       const isUnsupportedList = UNSUPPORTED_LIST_URLS.includes(url)
-      fetchList(url, false, isUnsupportedList).catch((error) => console.debug('interval list fetching error', error))
+      fetchList(url, isUnsupportedList).catch((error) => console.debug('interval list fetching error', error))
     })
-  }, [fetchList, isWindowVisible, lists])
+  }, [fetchList, isWindowVisible])
 
   // fetch all lists every 10 minutes, but only after we initialize provider
-  useInterval(fetchAllListsCallback, provider ? 1000 * 60 * 10 : null)
+  useInterval(fetchAllListsCallback, provider ? ms`10m` : null)
 
   // whenever a list is not loaded and not loading, try again to load it
   useEffect(() => {
@@ -45,7 +46,9 @@ export default function Updater(): null {
     UNSUPPORTED_LIST_URLS.forEach((listUrl) => {
       const list = lists[listUrl]
       if (!list || (!list.current && !list.loadingRequestId && !list.error)) {
-        fetchList(listUrl, undefined, true).catch((error) => console.debug('list added fetching error', error))
+        fetchList(listUrl, /* isUnsupportedList= */ true).catch((error) =>
+          console.debug('list added fetching error', error)
+        )
       }
     })
   }, [dispatch, fetchList, lists])


### PR DESCRIPTION
fixes bug where new versions of tokenlists weren't being checked into cache

before (Gold1 is supposed to be blocked): 
<img width="382" alt="image" src="https://user-images.githubusercontent.com/39385577/218849751-6aa41d43-96b3-4147-9735-7a7313ae9358.png">

after:
<img width="397" alt="Screen Shot 2023-02-14 at 3 05 34 PM" src="https://user-images.githubusercontent.com/39385577/218849588-b7d81623-ed93-4448-af6b-9bf43e0b1308.png">
