### PR TITLE
fix: use localStorage to dismiss FoR announcement in test

### DIFF
--- a/cypress/e2e/pool.test.ts
+++ b/cypress/e2e/pool.test.ts
@@ -1,10 +1,11 @@
-import { getTestSelector } from '../utils'
-
 describe('Pool', () => {
-  beforeEach(() => cy.visit('/pool'))
+  beforeEach(() => {
+    cy.visit('/pool').then(() => {
+      window.localStorage.setItem('FiatOnrampAnnouncement-dismissed', 'true')
+    })
+  })
 
   it('add liquidity links to /add/ETH', () => {
-    cy.get(getTestSelector('FiatOnrampAnnouncement-close')).first().click()
     cy.get('#join-pool-button').click()
     cy.url().should('contain', '/add/ETH')
   })


### PR DESCRIPTION
attempting to reduce flakiness in some e2e tests