### PR TITLE
fix: Market icons displaying over dropdown

### DIFF
--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -236,11 +236,11 @@ export const MarketplaceRow = ({
                 key={market.name + asset.collection?.address + asset.tokenId}
                 onClick={(e) => {
                   e.stopPropagation()
-                  removeAssetMarketplace(asset, selectedMarkets[0])
+                  removeAssetMarketplace(asset, market)
                   removeMarket && removeMarket()
                 }}
               >
-                <MarketIcon alt={selectedMarkets[0].name} src={market.icon} index={index} />
+                <MarketIcon alt={market.name} src={market.icon} index={index} />
                 <RemoveMarketplaceWrap hovered={marketIconHovered && (expandMarketplaceRows ?? false)}>
                   <img width="20px" src="/nft/svgs/minusCircle.svg" alt="Remove item" />
                 </RemoveMarketplaceWrap>

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -20,7 +20,7 @@ const TableHeader = styled.div`
   top: 72px;
   padding-top: 24px;
   padding-bottom: 24px;
-  z-index: 1;
+  z-index: 3;
   background-color: ${({ theme }) => theme.backgroundBackdrop};
   color: ${({ theme }) => theme.textSecondary};
   font-size: 14px;


### PR DESCRIPTION
The table headers Z-Index was below the multiple marketplace icons layering which causes them to display over the set price by dropdown. This fixes that bug. There was also a bug where the remove marketplace on an expanded row just removed the first marketplace and not the one clicked.

After
![Screen Shot 2023-02-16 at 11 57 13 ](https://user-images.githubusercontent.com/11512321/219473822-f6ec2b3a-f8d7-4fbd-b58a-a80f9d82f57b.png)
Before
<img width="498" alt="Screen Shot 2023-02-16 at 10 53 00 " src="https://user-images.githubusercontent.com/11512321/219473844-d554f2d0-568c-438f-b634-58f1d8ed8fd7.png">
