### PR TITLE
fix: fix token link

### DIFF
--- a/src/components/Tokens/TokenDetails/About.tsx
+++ b/src/components/Tokens/TokenDetails/About.tsx
@@ -82,7 +82,7 @@ export function AboutSection({ address, chainId, description, homepageUrl, twitt
 
   const baseExplorerUrl = getChainInfo(chainId).explorer
 
-  const { label } = getChainInfo(isSupportedChain(chainId) ? chainId : SupportedChainId.MAINNET)
+  const { infoLink } = getChainInfo(isSupportedChain(chainId) ? chainId : SupportedChainId.MAINNET)
 
   return (
     <AboutContainer data-testid="token-details-about-section">
@@ -111,12 +111,7 @@ export function AboutSection({ address, chainId, description, homepageUrl, twitt
           name={chainId === SupportedChainId.MAINNET ? 'Etherscan' : 'Block Explorer'}
           link={`${baseExplorerUrl}${address === 'NATIVE' ? '' : 'address/' + address}`}
         />
-        <Resource
-          name="More analytics"
-          link={`https://info.uniswap.org/#/${
-            chainId === SupportedChainId.MAINNET ? '' : label.toLowerCase() + '/'
-          }tokens/${address}`}
-        />
+        <Resource name="More analytics" link={`${infoLink}/tokens/${address}`} />
         {homepageUrl && <Resource name="Website" link={homepageUrl} />}
         {twitterName && <Resource name="Twitter" link={`https://twitter.com/${twitterName}`} />}
       </ResourcesContainer>

--- a/src/components/Tokens/TokenDetails/About.tsx
+++ b/src/components/Tokens/TokenDetails/About.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { SupportedChainId } from '@uniswap/sdk-core'
 import { getChainInfo } from 'constants/chainInfo'
+import { isSupportedChain } from 'constants/chains'
 import { darken } from 'polished'
 import { useState } from 'react'
 import styled from 'styled-components/macro'
@@ -81,6 +82,8 @@ export function AboutSection({ address, chainId, description, homepageUrl, twitt
 
   const baseExplorerUrl = getChainInfo(chainId).explorer
 
+  const { label } = getChainInfo(isSupportedChain(chainId) ? chainId : SupportedChainId.MAINNET)
+
   return (
     <AboutContainer data-testid="token-details-about-section">
       <AboutHeader>
@@ -108,7 +111,12 @@ export function AboutSection({ address, chainId, description, homepageUrl, twitt
           name={chainId === SupportedChainId.MAINNET ? 'Etherscan' : 'Block Explorer'}
           link={`${baseExplorerUrl}${address === 'NATIVE' ? '' : 'address/' + address}`}
         />
-        <Resource name="More analytics" link={`https://info.uniswap.org/#/tokens/${address}`} />
+        <Resource
+          name="More analytics"
+          link={`https://info.uniswap.org/#/${
+            chainId === SupportedChainId.MAINNET ? '' : label.toLowerCase() + '/'
+          }tokens/${address}`}
+        />
         {homepageUrl && <Resource name="Website" link={homepageUrl} />}
         {twitterName && <Resource name="Twitter" link={`https://twitter.com/${twitterName}`} />}
       </ResourcesContainer>


### PR DESCRIPTION
Say I'm on this USDT token page https://app.uniswap.org/#/tokens/arbitrum/0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9

`More analytics` button links to `https://info.uniswap.org/#/tokens/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9` which is wrong since it doesn't exist under mainnet.

![CleanShot 2023-02-17 at 10 46 30@2x](https://user-images.githubusercontent.com/1091472/219536774-92cf50e2-c3ea-4624-9a46-2227a0e37584.png)

This pull request would include the network label in url which would update the `More analytics` link to `https://info.uniswap.org/#/arbitrum/tokens/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9`.