### PR TITLE
build: prevent re-init errors on local builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "@sentry/react": "^7.29.0",
     "@types/react-window-infinite-loader": "^1.0.6",
-    "@uniswap/analytics": "1.2.0",
+    "@uniswap/analytics": "1.3.1",
     "@uniswap/analytics-events": "^2.1.0",
     "@uniswap/conedison": "^1.3.0",
     "@uniswap/governance": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4936,10 +4936,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.1.0.tgz#0a112f642d0121fdf69b5dc9a17639f06aa63085"
   integrity sha512-HkWyri7PxnIS6B5sysym1LCMPnenkeAFyI41fYGDUNq3a5aEDuD77jyyFSwdW4yZfUOxq3zBUTmeQOIf/GT+tQ==
 
-"@uniswap/analytics@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/analytics/-/analytics-1.2.0.tgz#38452f31ca249903e0bdc8739f42ed437fdc4911"
-  integrity sha512-oO9+mhDJVGm2tqFic6PVQ8v75snbLaGymqs3wauwMXrdy4fMeNSCrKfnaGAKElRUYus3eDLMy/cbXy3Md3iRZA==
+"@uniswap/analytics@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics/-/analytics-1.3.1.tgz#086a681fc483c08e1b3d896cce287bc162ad0c1d"
+  integrity sha512-wB8J+e9oeu+VSx3tgfA304g7MKf6zuAesFeEGKdD1pI2LNOoMQHczbnf8I8lPjPYnXxLvdbGVKRQZXWaI+jTGw==
   dependencies:
     "@amplitude/analytics-browser" "^1.5.8"
     react "^18.2.0"


### PR DESCRIPTION
Fixes re-initialization errors stemming from the analytics library, by upgrading @Uniswap/analytics to include https://github.com/Uniswap/analytics/pull/22.