### PR TITLE
fix: update user rejected txn errors to stay up to date with widget

### DIFF
--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -25,6 +25,8 @@ export function swapErrorToUserReadableMessage(error: any): string {
   // The 4001 error code doesn't capture the case where users reject a transaction for all wallets,
   // so we need to parse the reason for these special cases:
   if (
+    // ethers v5.7.0 wrapped error
+    error?.code === 'ACTION_REJECTED' ||
     // For Rainbow :
     (reason?.match(/request/i) && reason?.match(/reject/i)) ||
     // For Frame:
@@ -32,7 +34,9 @@ export function swapErrorToUserReadableMessage(error: any): string {
     // For SafePal:
     reason?.match(/cancelled by user/i) ||
     // For Coinbase:
-    reason?.match(/user denied/i)
+    reason?.match(/user denied/i) ||
+    // For Fireblocks
+    reason?.match(/user rejected/i)
   ) {
     return t`Transaction rejected`
   }


### PR DESCRIPTION
keep up to date with widget

context: ethers upgrade to 5.7.0 changed error code when user rejects txn, so we need to handle the extra edge case. 