### PR TITLE
fix: widget defaultChainId

### DIFF
--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -57,7 +57,7 @@ export default function Widget({
   onDefaultTokenChange,
   onReviewSwapClick,
 }: WidgetProps) {
-  const { connector, provider } = useWeb3React()
+  const { connector, provider, chainId } = useWeb3React()
   const locale = useActiveLocale()
   const theme = useWidgetTheme()
   const { inputs, tokenSelector } = useSyncWidgetInputs({
@@ -169,7 +169,7 @@ export default function Widget({
         locale={locale}
         theme={theme}
         width={width}
-        // defaultChainId is excluded - it is always inferred from the passed provider
+        defaultChainId={chainId}
         onConnectWalletClick={onConnectWalletClick}
         provider={provider}
         onSwitchChain={onSwitchChain}


### PR DESCRIPTION
specify the default Chain ID for the widget - it should just match the current provider.

we actually weren't/aren't defaulting to the chain of the provider in the widget, so this change fixes some undesired behavior