### PR TITLE
feat: implement Sentry for state tracking

### DIFF
--- a/src/graphql/thegraph/apollo.ts
+++ b/src/graphql/thegraph/apollo.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, ApolloLink, concat, HttpLink, InMemoryCache } from '@apollo/client'
 import { SupportedChainId } from 'constants/chains'
 
-import store, { AppState } from '../../state/index'
+import store from '../../state/index'
 
 const CHAIN_SUBGRAPH_URL: Record<number, string> = {
   [SupportedChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
@@ -22,7 +22,7 @@ const httpLink = new HttpLink({ uri: CHAIN_SUBGRAPH_URL[SupportedChainId.MAINNET
 // For more information: https://www.apollographql.com/docs/react/networking/advanced-http-networking/
 const authMiddleware = new ApolloLink((operation, forward) => {
   // add the authorization to the headers
-  const chainId = (store.getState() as AppState).application.chainId
+  const chainId = store.getState().application.chainId
 
   operation.setContext(() => ({
     uri:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,7 @@ if (isSentryEnabled()) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     release: process.env.REACT_APP_GIT_COMMIT_HASH,
+    normalizeDepth: 10,
   })
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,12 @@ if (isSentryEnabled()) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     release: process.env.REACT_APP_GIT_COMMIT_HASH,
+    /**
+     * TODO(INFRA-143)
+     * According to Sentry, this shouldn't be necessary, as they default to `3` when not set.
+     * Unfortunately, that doesn't work right now, so we workaround it by explicitly setting
+     * the `normalizeDepth` to `10`. This should be removed once the issue is fixed.
+     */
     normalizeDepth: 10,
   })
 }

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -4,7 +4,7 @@ import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
 
-import { AppState } from '../index'
+import { AppState } from '../types'
 import {
   addPopup,
   ApplicationModal,

--- a/src/state/burn/hooks.tsx
+++ b/src/state/burn/hooks.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { useTotalSupply } from '../../hooks/useTotalSupply'
 import { useV2Pair } from '../../hooks/useV2Pairs'
 import { useTokenBalances } from '../connection/hooks'
-import { AppState } from '../index'
+import { AppState } from '../types'
 import { Field, typeInput } from './actions'
 
 export function useBurnState(): AppState['burn'] {

--- a/src/state/burn/v3/hooks.tsx
+++ b/src/state/burn/v3/hooks.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { PositionDetails } from 'types/position'
 import { unwrappedToken } from 'utils/unwrappedToken'
 
-import { AppState } from '../../index'
+import { AppState } from '../../types'
 import { selectPercent } from './actions'
 
 export function useBurnV3State(): AppState['burnV3'] {

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,7 +1,6 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 
 import store from './index'
-import { AppState } from './types'
 
 export const useAppDispatch = () => useDispatch<typeof store.dispatch>()
-export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector
+export const useAppSelector: TypedUseSelectorHook<ReturnType<typeof store.getState>> = useSelector

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,5 +1,7 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
-import { AppDispatch, AppState } from 'state'
 
-export const useAppDispatch = () => useDispatch<AppDispatch>()
+import store from './index'
+import { AppState } from './types'
+
+export const useAppDispatch = () => useDispatch<typeof store.dispatch>()
 export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,61 +1,14 @@
-import { configureStore, Reducer } from '@reduxjs/toolkit'
+import { configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query/react'
-import * as Sentry from '@sentry/react'
-import multicall from 'lib/state/multicall'
 import { load, save } from 'redux-localstorage-simple'
 import { isTestEnv } from 'utils/env'
 
-import application from './application/reducer'
-import burn from './burn/reducer'
-import burnV3 from './burn/v3/reducer'
-import connection from './connection/reducer'
 import { updateVersion } from './global/actions'
-import lists from './lists/reducer'
-import logs from './logs/slice'
-import mint from './mint/reducer'
-import mintV3 from './mint/v3/reducer'
+import { sentryMiddleware } from './logging'
+import reducer from './reducer'
 import { routingApi } from './routing/slice'
-import swap from './swap/reducer'
-import transactions from './transactions/reducer'
-import user from './user/reducer'
-import wallets from './wallets/reducer'
 
 const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
-
-const reducer = {
-  application,
-  user,
-  connection,
-  transactions,
-  wallets,
-  swap,
-  mint,
-  mintV3,
-  burn,
-  burnV3,
-  multicall: multicall.reducer,
-  lists,
-  logs,
-  [routingApi.reducerPath]: routingApi.reducer,
-}
-
-/* Utility type to extract state type out of a @reduxjs/toolkit Reducer type */
-type GetState<T> = T extends Reducer<infer State> ? State : never
-
-/* Utility type to mark all properties of a type as optional */
-type DeepPartial<T> = T extends object
-  ? {
-      [P in keyof T]?: DeepPartial<T[P]>
-    }
-  : T
-
-/* eslint-disable-next-line import/no-unused-modules -- reports false positive error, we use that type in other modules */
-export type AppState = {
-  [K in keyof typeof reducer]: GetState<typeof reducer[K]>
-}
-
-/* eslint-disable-next-line import/no-unused-modules -- reports false positive error, we use that type in other modules */
-export type AppDispatch = typeof store.dispatch
 
 const store = configureStore({
   reducer,
@@ -63,46 +16,7 @@ const store = configureStore({
     getDefaultMiddleware({ thunk: true })
       .concat(routingApi.middleware)
       .concat(save({ states: PERSISTED_KEYS, debounce: 1000 }))
-      .concat(
-        Sentry.createReduxEnhancer({
-          actionTransformer: () => null,
-          /**
-           * This function runs on every state update, so keeping it as fast as possible by avoiding any function
-           * calls and deep object traversals.
-           */
-          stateTransformer: (state: AppState): DeepPartial<AppState> => {
-            return {
-              application: {
-                fiatOnramp: state.application.fiatOnramp,
-                chainId: state.application.chainId,
-                openModal: state.application.openModal,
-                popupList: state.application.popupList,
-              },
-              user: {
-                fiatOnrampAcknowledgments: state.user.fiatOnrampAcknowledgments,
-                selectedWallet: state.user.selectedWallet,
-                lastUpdateVersionTimestamp: state.user.lastUpdateVersionTimestamp,
-                matchesDarkMode: state.user.matchesDarkMode,
-                userDarkMode: state.user.userDarkMode,
-                userLocale: state.user.userLocale,
-                userExpertMode: state.user.userExpertMode,
-                userClientSideRouter: state.user.userClientSideRouter,
-                userHideClosedPositions: state.user.userHideClosedPositions,
-                userSlippageTolerance: state.user.userSlippageTolerance,
-                userSlippageToleranceHasBeenMigratedToAuto: state.user.userSlippageToleranceHasBeenMigratedToAuto,
-                userDeadline: state.user.userDeadline,
-                timestamp: state.user.timestamp,
-                URLWarningVisible: state.user.URLWarningVisible,
-                showSurveyPopup: state.user.showSurveyPopup,
-              },
-              connection: {
-                errorByConnectionType: state.connection.errorByConnectionType,
-              },
-              transactions: state.transactions,
-            }
-          },
-        })
-      ),
+      .concat(sentryMiddleware),
   preloadedState: load({ states: PERSISTED_KEYS, disableWarnings: isTestEnv() }),
 })
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -4,7 +4,7 @@ import { load, save } from 'redux-localstorage-simple'
 import { isTestEnv } from 'utils/env'
 
 import { updateVersion } from './global/actions'
-import { sentryMiddleware } from './logging'
+import { sentryEnhancer } from './logging'
 import reducer from './reducer'
 import { routingApi } from './routing/slice'
 
@@ -12,11 +12,11 @@ const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
 
 const store = configureStore({
   reducer,
+  enhancers: (defaultEnhancers) => defaultEnhancers.concat(sentryEnhancer),
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ thunk: true })
       .concat(routingApi.middleware)
-      .concat(save({ states: PERSISTED_KEYS, debounce: 1000 }))
-      .concat(sentryMiddleware),
+      .concat(save({ states: PERSISTED_KEYS, debounce: 1000 })),
   preloadedState: load({ states: PERSISTED_KEYS, disableWarnings: isTestEnv() }),
 })
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,5 +1,6 @@
-import { configureStore } from '@reduxjs/toolkit'
+import { configureStore, Reducer } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query/react'
+import * as Sentry from '@sentry/react'
 import multicall from 'lib/state/multicall'
 import { load, save } from 'redux-localstorage-simple'
 import { isTestEnv } from 'utils/env'
@@ -21,27 +22,87 @@ import wallets from './wallets/reducer'
 
 const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
 
+const reducer = {
+  application,
+  user,
+  connection,
+  transactions,
+  wallets,
+  swap,
+  mint,
+  mintV3,
+  burn,
+  burnV3,
+  multicall: multicall.reducer,
+  lists,
+  logs,
+  [routingApi.reducerPath]: routingApi.reducer,
+}
+
+/* Utility type to extract state type out of a @reduxjs/toolkit Reducer type */
+type GetState<T> = T extends Reducer<infer State> ? State : never
+
+/* Utility type to mark all properties of a type as optional */
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
+
+/* eslint-disable-next-line import/no-unused-modules -- reports false positive error, we use that type in other modules */
+export type AppState = {
+  [K in keyof typeof reducer]: GetState<typeof reducer[K]>
+}
+
+/* eslint-disable-next-line import/no-unused-modules -- reports false positive error, we use that type in other modules */
+export type AppDispatch = typeof store.dispatch
+
 const store = configureStore({
-  reducer: {
-    application,
-    user,
-    connection,
-    transactions,
-    wallets,
-    swap,
-    mint,
-    mintV3,
-    burn,
-    burnV3,
-    multicall: multicall.reducer,
-    lists,
-    logs,
-    [routingApi.reducerPath]: routingApi.reducer,
-  },
+  reducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ thunk: true })
       .concat(routingApi.middleware)
-      .concat(save({ states: PERSISTED_KEYS, debounce: 1000 })),
+      .concat(save({ states: PERSISTED_KEYS, debounce: 1000 }))
+      .concat(
+        Sentry.createReduxEnhancer({
+          actionTransformer: () => null,
+          /**
+           * This function runs on every state update, so keeping it as fast as possible by avoiding any function
+           * calls and deep object traversals.
+           */
+          stateTransformer: (state: AppState): DeepPartial<AppState> => {
+            return {
+              application: {
+                fiatOnramp: state.application.fiatOnramp,
+                chainId: state.application.chainId,
+                openModal: state.application.openModal,
+                popupList: state.application.popupList,
+              },
+              user: {
+                fiatOnrampAcknowledgments: state.user.fiatOnrampAcknowledgments,
+                selectedWallet: state.user.selectedWallet,
+                lastUpdateVersionTimestamp: state.user.lastUpdateVersionTimestamp,
+                matchesDarkMode: state.user.matchesDarkMode,
+                userDarkMode: state.user.userDarkMode,
+                userLocale: state.user.userLocale,
+                userExpertMode: state.user.userExpertMode,
+                userClientSideRouter: state.user.userClientSideRouter,
+                userHideClosedPositions: state.user.userHideClosedPositions,
+                userSlippageTolerance: state.user.userSlippageTolerance,
+                userSlippageToleranceHasBeenMigratedToAuto: state.user.userSlippageToleranceHasBeenMigratedToAuto,
+                userDeadline: state.user.userDeadline,
+                timestamp: state.user.timestamp,
+                URLWarningVisible: state.user.URLWarningVisible,
+                showSurveyPopup: state.user.showSurveyPopup,
+              },
+              connection: {
+                errorByConnectionType: state.connection.errorByConnectionType,
+              },
+              transactions: state.transactions,
+            }
+          },
+        })
+      ),
   preloadedState: load({ states: PERSISTED_KEYS, disableWarnings: isTestEnv() }),
 })
 
@@ -50,6 +111,3 @@ store.dispatch(updateVersion())
 setupListeners(store.dispatch)
 
 export default store
-
-export type AppState = ReturnType<typeof store.getState>
-export type AppDispatch = typeof store.dispatch

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -4,7 +4,7 @@ import { useAppSelector } from 'state/hooks'
 import sortByListPriority from 'utils/listSort'
 
 import BROKEN_LIST from '../../constants/tokenLists/broken.tokenlist.json'
-import { AppState } from '../index'
+import { AppState } from '../types'
 import { DEFAULT_ACTIVE_LIST_URLS, UNSUPPORTED_LIST_URLS } from './../../constants/lists'
 
 export type TokenAddressMap = ChainTokenMap

--- a/src/state/logging.ts
+++ b/src/state/logging.ts
@@ -23,7 +23,7 @@ export const sentryEnhancer = Sentry.createReduxEnhancer({
    * Note: This function runs on every state update, so we're keeping it as fast as possible by avoiding any function
    * calls and deep object traversals.
    */
-  stateTransformer: (state: AppState): Partial<AppState> => {
+  stateTransformer: (state: AppState): DeepPartial<AppState> => {
     return {
       application: {
         fiatOnramp: state.application.fiatOnramp,

--- a/src/state/logging.ts
+++ b/src/state/logging.ts
@@ -10,10 +10,10 @@ type Partial<T> = T extends object
   : T
 
 /**
- * This middleware will automatically store the latest state in Sentry's scope, so that it will be available
+ * This enhancer will automatically store the latest state in Sentry's scope, so that it will be available
  * in the Sentry dashboard when an exception happens.
  */
-export const sentryMiddleware = Sentry.createReduxEnhancer({
+export const sentryEnhancer = Sentry.createReduxEnhancer({
   /**
    * We don't want to store actions as breadcrumbs in Sentry, so we return null to disable the default behavior.
    */

--- a/src/state/logging.ts
+++ b/src/state/logging.ts
@@ -24,34 +24,35 @@ export const sentryEnhancer = Sentry.createReduxEnhancer({
    * calls and deep object traversals.
    */
   stateTransformer: (state: AppState): DeepPartial<AppState> => {
+    const { application, user, connection, transactions } = state
     return {
       application: {
-        fiatOnramp: state.application.fiatOnramp,
-        chainId: state.application.chainId,
-        openModal: state.application.openModal,
-        popupList: state.application.popupList,
+        fiatOnramp: application.fiatOnramp,
+        chainId: application.chainId,
+        openModal: application.openModal,
+        popupList: application.popupList,
       },
       user: {
-        fiatOnrampAcknowledgments: state.user.fiatOnrampAcknowledgments,
-        selectedWallet: state.user.selectedWallet,
-        lastUpdateVersionTimestamp: state.user.lastUpdateVersionTimestamp,
-        matchesDarkMode: state.user.matchesDarkMode,
-        userDarkMode: state.user.userDarkMode,
-        userLocale: state.user.userLocale,
-        userExpertMode: state.user.userExpertMode,
-        userClientSideRouter: state.user.userClientSideRouter,
-        userHideClosedPositions: state.user.userHideClosedPositions,
-        userSlippageTolerance: state.user.userSlippageTolerance,
-        userSlippageToleranceHasBeenMigratedToAuto: state.user.userSlippageToleranceHasBeenMigratedToAuto,
-        userDeadline: state.user.userDeadline,
-        timestamp: state.user.timestamp,
-        URLWarningVisible: state.user.URLWarningVisible,
-        showSurveyPopup: state.user.showSurveyPopup,
+        fiatOnrampAcknowledgments: user.fiatOnrampAcknowledgments,
+        selectedWallet: user.selectedWallet,
+        lastUpdateVersionTimestamp: user.lastUpdateVersionTimestamp,
+        matchesDarkMode: user.matchesDarkMode,
+        userDarkMode: user.userDarkMode,
+        userLocale: user.userLocale,
+        userExpertMode: user.userExpertMode,
+        userClientSideRouter: user.userClientSideRouter,
+        userHideClosedPositions: user.userHideClosedPositions,
+        userSlippageTolerance: user.userSlippageTolerance,
+        userSlippageToleranceHasBeenMigratedToAuto: user.userSlippageToleranceHasBeenMigratedToAuto,
+        userDeadline: user.userDeadline,
+        timestamp: user.timestamp,
+        URLWarningVisible: user.URLWarningVisible,
+        showSurveyPopup: user.showSurveyPopup,
       },
       connection: {
-        errorByConnectionType: state.connection.errorByConnectionType,
+        errorByConnectionType: connection.errorByConnectionType,
       },
-      transactions: state.transactions,
+      transactions,
     }
   },
 })

--- a/src/state/logging.ts
+++ b/src/state/logging.ts
@@ -3,19 +3,27 @@ import * as Sentry from '@sentry/react'
 import { AppState } from './types'
 
 /* Utility type to mark all properties of a type as optional */
-type DeepPartial<T> = T extends object
+type Partial<T> = T extends object
   ? {
-      [P in keyof T]?: DeepPartial<T[P]>
+      [P in keyof T]?: Partial<T[P]>
     }
   : T
 
-export const middleware = Sentry.createReduxEnhancer({
+/**
+ * This middleware will automatically store the latest state in Sentry's scope, so that it will be available
+ * in the Sentry dashboard when an exception happens.
+ */
+export const sentryMiddleware = Sentry.createReduxEnhancer({
+  /**
+   * We don't want to store actions as breadcrumbs in Sentry, so we return null to disable the default behavior.
+   */
   actionTransformer: () => null,
   /**
-   * This function runs on every state update, so keeping it as fast as possible by avoiding any function
+   * We only want to store a subset of the state in Sentry, containing only the relevant parts for debugging.
+   * Note: This function runs on every state update, so we're keeping it as fast as possible by avoiding any function
    * calls and deep object traversals.
    */
-  stateTransformer: (state: AppState): DeepPartial<AppState> => {
+  stateTransformer: (state: AppState): Partial<AppState> => {
     return {
       application: {
         fiatOnramp: state.application.fiatOnramp,

--- a/src/state/logging.ts
+++ b/src/state/logging.ts
@@ -1,0 +1,49 @@
+import * as Sentry from '@sentry/react'
+
+import { AppState } from './types'
+
+/* Utility type to mark all properties of a type as optional */
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
+
+export const middleware = Sentry.createReduxEnhancer({
+  actionTransformer: () => null,
+  /**
+   * This function runs on every state update, so keeping it as fast as possible by avoiding any function
+   * calls and deep object traversals.
+   */
+  stateTransformer: (state: AppState): DeepPartial<AppState> => {
+    return {
+      application: {
+        fiatOnramp: state.application.fiatOnramp,
+        chainId: state.application.chainId,
+        openModal: state.application.openModal,
+        popupList: state.application.popupList,
+      },
+      user: {
+        fiatOnrampAcknowledgments: state.user.fiatOnrampAcknowledgments,
+        selectedWallet: state.user.selectedWallet,
+        lastUpdateVersionTimestamp: state.user.lastUpdateVersionTimestamp,
+        matchesDarkMode: state.user.matchesDarkMode,
+        userDarkMode: state.user.userDarkMode,
+        userLocale: state.user.userLocale,
+        userExpertMode: state.user.userExpertMode,
+        userClientSideRouter: state.user.userClientSideRouter,
+        userHideClosedPositions: state.user.userHideClosedPositions,
+        userSlippageTolerance: state.user.userSlippageTolerance,
+        userSlippageToleranceHasBeenMigratedToAuto: state.user.userSlippageToleranceHasBeenMigratedToAuto,
+        userDeadline: state.user.userDeadline,
+        timestamp: state.user.timestamp,
+        URLWarningVisible: state.user.URLWarningVisible,
+        showSurveyPopup: state.user.showSurveyPopup,
+      },
+      connection: {
+        errorByConnectionType: state.connection.errorByConnectionType,
+      },
+      transactions: state.transactions,
+    }
+  },
+})

--- a/src/state/logging.ts
+++ b/src/state/logging.ts
@@ -3,9 +3,9 @@ import * as Sentry from '@sentry/react'
 import { AppState } from './types'
 
 /* Utility type to mark all properties of a type as optional */
-type Partial<T> = T extends object
+type DeepPartial<T> = T extends object
   ? {
-      [P in keyof T]?: Partial<T[P]>
+      [P in keyof T]?: DeepPartial<T[P]>
     }
   : T
 

--- a/src/state/mint/hooks.tsx
+++ b/src/state/mint/hooks.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { useTotalSupply } from '../../hooks/useTotalSupply'
 import { PairState, useV2Pair } from '../../hooks/useV2Pairs'
 import { useCurrencyBalances } from '../connection/hooks'
-import { AppState } from '../index'
+import { AppState } from '../types'
 import { Field, typeInput } from './actions'
 
 const ZERO = JSBI.BigInt(0)

--- a/src/state/mint/v3/hooks.tsx
+++ b/src/state/mint/v3/hooks.tsx
@@ -24,7 +24,7 @@ import { replaceURLParam } from 'utils/routes'
 import { BIG_INT_ZERO } from '../../../constants/misc'
 import { PoolState } from '../../../hooks/usePools'
 import { useCurrencyBalances } from '../../connection/hooks'
-import { AppState } from '../../index'
+import { AppState } from '../../types'
 import {
   Bound,
   Field,

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,0 +1,32 @@
+import multicall from 'lib/state/multicall'
+
+import application from './application/reducer'
+import burn from './burn/reducer'
+import burnV3 from './burn/v3/reducer'
+import connection from './connection/reducer'
+import lists from './lists/reducer'
+import logs from './logs/slice'
+import mint from './mint/reducer'
+import mintV3 from './mint/v3/reducer'
+import { routingApi } from './routing/slice'
+import swap from './swap/reducer'
+import transactions from './transactions/reducer'
+import user from './user/reducer'
+import wallets from './wallets/reducer'
+
+export default {
+  application,
+  user,
+  connection,
+  transactions,
+  wallets,
+  swap,
+  mint,
+  mintV3,
+  burn,
+  burnV3,
+  multicall: multicall.reducer,
+  lists,
+  logs,
+  [routingApi.reducerPath]: routingApi.reducer,
+}

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -16,7 +16,7 @@ import useENS from '../../hooks/useENS'
 import useParsedQueryString from '../../hooks/useParsedQueryString'
 import { isAddress } from '../../utils'
 import { useCurrencyBalances } from '../connection/hooks'
-import { AppState } from '../index'
+import { AppState } from '../types'
 import { Field, replaceSwapState, selectCurrency, setRecipient, switchCurrencies, typeInput } from './actions'
 import { SwapState } from './reducer'
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,10 @@
+import { Reducer } from '@reduxjs/toolkit'
+
+import reducer from './reducer'
+
+/* Utility type to extract state type out of a @reduxjs/toolkit Reducer type */
+type GetState<T> = T extends Reducer<infer State> ? State : never
+
+export type AppState = {
+  [K in keyof typeof reducer]: GetState<typeof reducer[K]>
+}

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -13,7 +13,7 @@ import { UserAddedToken } from 'types/tokens'
 import { V2_FACTORY_ADDRESSES } from '../../constants/addresses'
 import { BASES_TO_TRACK_LIQUIDITY_FOR, PINNED_PAIRS } from '../../constants/routing'
 import { useAllTokens } from '../../hooks/Tokens'
-import { AppState } from '../index'
+import { AppState } from '../types'
 import {
   addSerializedPair,
   addSerializedToken,


### PR DESCRIPTION
As per design doc, this PR implements Sentry Redux enhancer with an explicit list of whitelisted keys to track the data we need and to avoid any payload changes in case the underlying state shape changes in the future.

Here's a preview of what it looks like, when enabled:

<img width="500" alt="Screenshot 2023-03-08 at 01 04 34" src="https://user-images.githubusercontent.com/2464966/223555098-7683dae7-7c6b-4543-9391-41a5a05395bd.png">

