### PR TITLE
fix: reset tokens, amounts when switching chains

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -40,27 +40,25 @@ export function useSyncWidgetInputs({
 
   useEffect(() => {
     if (!tokens[Field.INPUT] && !tokens[Field.OUTPUT]) {
-      setTokens((tokens) => {
-        const update = {
-          ...tokens,
-          [Field.INPUT]: defaultTokens[Field.INPUT] ?? tokens[Field.INPUT],
-          [Field.OUTPUT]: defaultTokens[Field.OUTPUT] ?? tokens[Field.OUTPUT] ?? defaultTokens.default,
-          default: defaultTokens.default,
-        }
-        return update
+      setTokens({
+        ...tokens,
+        [Field.INPUT]: defaultTokens[Field.INPUT] ?? tokens[Field.INPUT],
+        [Field.OUTPUT]: defaultTokens[Field.OUTPUT] ?? tokens[Field.OUTPUT] ?? defaultTokens.default,
+        default: defaultTokens.default,
       })
     }
   }, [defaultTokens, tokens])
 
   useEffect(() => {
     if (chainId !== previousChainId && !!previousChainId) {
-      setTokens((tokens) => ({
+      setTokens({
         ...tokens,
         [Field.INPUT]: undefined,
         [Field.OUTPUT]: undefined,
-      }))
+      })
+      setAmount(EMPTY_AMOUNT)
     }
-  }, [chainId, previousChainId])
+  }, [chainId, previousChainId, tokens])
 
   const onAmountChange = useCallback(
     (field: Field, amount: string, origin?: 'max') => {


### PR DESCRIPTION
This makes sure that you can't get to a state where the selected tokens are disabled.