### PR TITLE
revert: dont hideConnectionUI for widget

### DIFF
--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -162,6 +162,7 @@ export default function Widget({
   return (
     <>
       <SwapWidget
+        hideConnectionUI
         brandedFooter={false}
         permit2={permit2Enabled}
         routerUrl={WIDGET_ROUTER_URL}


### PR DESCRIPTION
Reverts Uniswap/interface#6010

based on design feedback, we actually want a different solution here - `hideConnectionUI` should still be true, but it should not hide the actual "connect wallet" button. (this part will require a PR in the Widget repo)