### PR TITLE
feat: add new statsig backed feature flag for nft graphql migration

### DIFF
--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -1,5 +1,6 @@
 import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'featureFlags'
 import { GqlRoutingVariant, useGqlRoutingFlag } from 'featureFlags/flags/gqlRouting'
+import { NftGraphqlVariant, useNftGraphqlFlag } from 'featureFlags/flags/nftlGraphql'
 import { PayWithAnyTokenVariant, usePayWithAnyTokenFlag } from 'featureFlags/flags/payWithAnyToken'
 import { Permit2Variant, usePermit2Flag } from 'featureFlags/flags/permit2'
 import { SwapWidgetVariant, useSwapWidgetFlag } from 'featureFlags/flags/swapWidget'
@@ -228,6 +229,12 @@ export default function FeatureFlagModal() {
         value={useGqlRoutingFlag()}
         featureFlag={FeatureFlag.gqlRouting}
         label="GraphQL NFT Routing"
+      />
+      <FeatureFlagOption
+        variant={NftGraphqlVariant}
+        value={useNftGraphqlFlag()}
+        featureFlag={FeatureFlag.nftGraphql}
+        label="Migrate NFT read endpoints to GQL"
       />
       <FeatureFlagGroup name="Debug">
         <FeatureFlagOption

--- a/src/featureFlags/flags/featureFlags.ts
+++ b/src/featureFlags/flags/featureFlags.ts
@@ -8,4 +8,5 @@ export enum FeatureFlag {
   swapWidget = 'swap_widget_replacement_enabled',
   gqlRouting = 'gqlRouting',
   statsigDummy = 'web_dummy_gate_amplitude_id',
+  nftGraphql = 'nft_graphql_migration',
 }

--- a/src/featureFlags/flags/nftlGraphql.ts
+++ b/src/featureFlags/flags/nftlGraphql.ts
@@ -1,0 +1,12 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+export function useNftGraphqlFlag(): BaseVariant {
+  return useBaseFlag(FeatureFlag.nftGraphql)
+}
+
+// TODO Enable when flag is ready to be used
+// export function useNftGraphqlEnabled(): boolean {
+//   return useNftGraphqlFlag() === BaseVariant.Enabled
+// }
+
+export { BaseVariant as NftGraphqlVariant }

--- a/src/featureFlags/flags/nftlGraphql.ts
+++ b/src/featureFlags/flags/nftlGraphql.ts
@@ -4,9 +4,4 @@ export function useNftGraphqlFlag(): BaseVariant {
   return useBaseFlag(FeatureFlag.nftGraphql)
 }
 
-// TODO Enable when flag is ready to be used
-// export function useNftGraphqlEnabled(): boolean {
-//   return useNftGraphqlFlag() === BaseVariant.Enabled
-// }
-
 export { BaseVariant as NftGraphqlVariant }


### PR DESCRIPTION
We're migrating 3 nft endpoints to GraphQL: activity, search collections, and trending. To facilitate this I've created a feature flag. This feature flag should be able to be toggled both by the local feature flag modal as well as via the statsig portal. The statsig gate is `nft_graphql_migration`.