### PR TITLE
fix: show error message when token is not found

### DIFF
--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -77,7 +77,7 @@ const Buttons = ({
   showCancel,
 }: {
   warning: Warning
-  onContinue: () => void
+  onContinue?: () => void
   onCancel: () => void
   onBlocked?: () => void
   showCancel?: boolean
@@ -292,7 +292,7 @@ export default function TokenSafety({
             {heading} {description} {learnMoreUrl}
           </InfoText>
         </ShortColumn>
-        <Buttons warning={tokenNotFoundWarning} onCancel={onCancel} showCancel={true} onContinue={() => undefined} />
+        <Buttons warning={tokenNotFoundWarning} onCancel={onCancel} showCancel={true} />
       </Container>
     </Wrapper>
   )

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -4,7 +4,7 @@ import { ButtonPrimary } from 'components/Button'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/Logo/CurrencyLogo'
 import TokenSafetyLabel from 'components/TokenSafety/TokenSafetyLabel'
-import { checkWarning, getWarningCopy, TOKEN_SAFETY_ARTICLE, Warning } from 'constants/tokenSafety'
+import { checkWarning, getWarningCopy, TOKEN_SAFETY_ARTICLE, Warning, WARNING_LEVEL } from 'constants/tokenSafety'
 import { useToken } from 'hooks/Tokens'
 import { ExternalLink as LinkIconFeather } from 'react-feather'
 import { Text } from 'rebass'
@@ -251,32 +251,49 @@ export default function TokenSafety({
       <Trans>Learn more</Trans>
     </StyledExternalLink>
   )
+  const tokenNotFoundWarning = {
+    level: WARNING_LEVEL.UNKNOWN,
+    message: <Trans>Token not found</Trans>,
+    canProceed: false,
+  }
 
-  return (
-    displayWarning && (
-      <Wrapper>
-        <Container>
-          <AutoColumn>
-            <LogoContainer>{logos}</LogoContainer>
-          </AutoColumn>
-          <ShortColumn>
-            <SafetyLabel warning={displayWarning} />
-          </ShortColumn>
-          <ShortColumn>
-            <InfoText>
-              {heading} {description} {learnMoreUrl}
-            </InfoText>
-          </ShortColumn>
-          <LinkColumn>{urls}</LinkColumn>
-          <Buttons
-            warning={displayWarning}
-            onContinue={acknowledge}
-            onCancel={onCancel}
-            onBlocked={onBlocked}
-            showCancel={showCancel}
-          />
-        </Container>
-      </Wrapper>
-    )
+  return displayWarning ? (
+    <Wrapper>
+      <Container>
+        <AutoColumn>
+          <LogoContainer>{logos}</LogoContainer>
+        </AutoColumn>
+        <ShortColumn>
+          <SafetyLabel warning={displayWarning} />
+        </ShortColumn>
+        <ShortColumn>
+          <InfoText>
+            {heading} {description} {learnMoreUrl}
+          </InfoText>
+        </ShortColumn>
+        <LinkColumn>{urls}</LinkColumn>
+        <Buttons
+          warning={displayWarning}
+          onContinue={acknowledge}
+          onCancel={onCancel}
+          onBlocked={onBlocked}
+          showCancel={showCancel}
+        />
+      </Container>
+    </Wrapper>
+  ) : (
+    <Wrapper>
+      <Container>
+        <ShortColumn>
+          <SafetyLabel warning={tokenNotFoundWarning} />
+        </ShortColumn>
+        <ShortColumn>
+          <InfoText>
+            {heading} {description} {learnMoreUrl}
+          </InfoText>
+        </ShortColumn>
+        <Buttons warning={tokenNotFoundWarning} onCancel={onCancel} showCancel={true} onContinue={() => undefined} />
+      </Container>
+    </Wrapper>
   )
 }


### PR DESCRIPTION
fixes a live bug in prod where we show an empty modal for tokens that don't match the current chain

i think we should use this as a short term fix, so we show _something_ in the case that we can't find the token. 

in the future, we may want to try auto-switching chains, or showing a message that says "try a different chain"

to test, append `?outputCurrency=0x4200000000000000000000000000000000000006` to the preview link (after `/swap`)

# before
https://user-images.githubusercontent.com/66155195/223544058-aabd47c6-3114-4033-9369-7de492bc7e7a.mov

# after 






https://user-images.githubusercontent.com/66155195/223544401-d4011331-f019-4259-a539-1d86693dc7d7.mov



