### PR TITLE
build: fix vanilla-extract for M1

### DIFF
--- a/craco.config.cjs
+++ b/craco.config.cjs
@@ -22,7 +22,7 @@ module.exports = {
   },
   webpack: {
     plugins: [
-      new VanillaExtractPlugin(),
+      new VanillaExtractPlugin({ identifiers: 'short' }),
       new DefinePlugin({
         'process.env.REACT_APP_GIT_COMMIT_HASH': JSON.stringify(commitHash.toString()),
       }),


### PR DESCRIPTION
Works around a bug where vanilla-extract compilation hangs on M1 macs, causing `yarn start` to never resolve.
See https://github.com/vanilla-extract-css/vanilla-extract/issues/771#issuecomment-1249524366.

This configures vanilla-extract class names to use 7+ character hashes, which will make them more difficult to debug. However, I don't know that the debug names are being used, and they are making it very difficult to develop with an M1 macbook, so this seems worthwhile.