### PR TITLE
build: upgrade sdk-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@uniswap/permit2-sdk": "1.2.0",
     "@uniswap/redux-multicall": "^1.1.8",
     "@uniswap/router-sdk": "^1.3.0",
-    "@uniswap/sdk-core": "^3.0.1",
+    "@uniswap/sdk-core": "^3.2.0",
     "@uniswap/smart-order-router": "^3.6.0",
     "@uniswap/token-lists": "^1.0.0-beta.30",
     "@uniswap/universal-router-sdk": "^1.3.6",


### PR DESCRIPTION
Updates to latest now that we don't need sdk-core's SupportedChainId to match up.

This won't actually change yarn.lock since 3.2.0 was already installed because of widget's requirement