### PR TITLE
refactor: variable for goerli in test

### DIFF
--- a/cypress/support/ethereum.ts
+++ b/cypress/support/ethereum.ts
@@ -7,17 +7,21 @@ import { Eip1193Bridge } from '@ethersproject/experimental/lib/eip1193-bridge'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
 
+import { SupportedChainId } from '../../src/constants/chains'
+
 // todo: figure out how env vars actually work in CI
 // const TEST_PRIVATE_KEY = Cypress.env('INTEGRATION_TEST_PRIVATE_KEY')
 const TEST_PRIVATE_KEY = '0xe580410d7c37d26c6ad1a837bbae46bc27f9066a466fb3a66e770523b4666d19'
 
 // address of the above key
 const TEST_ADDRESS_NEVER_USE = new Wallet(TEST_PRIVATE_KEY).address
+const CHAIN_ID = SupportedChainId.GOERLI
+const HEXLIFIED_CHAIN_ID = `$0x${CHAIN_ID}`
 
 const provider = new JsonRpcProvider('https://goerli.infura.io/v3/4bf032f2d38a4ed6bb975b80d6340847', 5)
 const signer = new Wallet(TEST_PRIVATE_KEY, provider)
 export const injected = new (class extends Eip1193Bridge {
-  chainId = /* GOERLI= */ 5
+  chainId = CHAIN_ID
 
   async sendAsync(...args: any[]) {
     console.debug('sendAsync called', ...args)
@@ -46,9 +50,9 @@ export const injected = new (class extends Eip1193Bridge {
     }
     if (method === 'eth_chainId') {
       if (isCallbackForm) {
-        callback(null, { result: '0x5' })
+        callback(null, { result: HEXLIFIED_CHAIN_ID })
       } else {
-        return Promise.resolve('0x5')
+        return Promise.resolve(HEXLIFIED_CHAIN_ID)
       }
     }
     try {


### PR DESCRIPTION
This will avoid bugs in the future where people don't know that the hex return is tied to the expected testnet id.