### PR TITLE
feat: add Peer Wallet Name to WALLET_CONNECT_TXN_COMPLETED event

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@sentry/react": "^7.29.0",
     "@types/react-window-infinite-loader": "^1.0.6",
     "@uniswap/analytics": "^1.3.1",
-    "@uniswap/analytics-events": "^2.5.0",
+    "@uniswap/analytics-events": "^2.5.1",
     "@uniswap/conedison": "^1.5.1",
     "@uniswap/governance": "^1.0.2",
     "@uniswap/liquidity-staker": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@sentry/react": "^7.29.0",
     "@types/react-window-infinite-loader": "^1.0.6",
     "@uniswap/analytics": "^1.3.1",
-    "@uniswap/analytics-events": "^2.4.0",
+    "@uniswap/analytics-events": "^2.5.0",
     "@uniswap/conedison": "^1.5.1",
     "@uniswap/governance": "^1.0.2",
     "@uniswap/liquidity-staker": "^1.0.2",

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -132,18 +132,18 @@ const sendAnalyticsEventAndUserInfo = (
   walletType: string,
   chainId: number | undefined,
   isReconnect: boolean,
-  peerWalletName: string | undefined
+  peerWalletAgent: string | undefined
 ) => {
   sendAnalyticsEvent(InterfaceEventName.WALLET_CONNECT_TXN_COMPLETED, {
     result: WalletConnectionResult.SUCCEEDED,
     wallet_address: account,
     wallet_type: walletType,
     is_reconnect: isReconnect,
-    peer_wallet_name: peerWalletName,
+    peer_wallet_name: peerWalletAgent,
   })
   user.set(CustomUserProperties.WALLET_ADDRESS, account)
   user.set(CustomUserProperties.WALLET_TYPE, walletType)
-  user.set(CustomUserProperties.PEER_WALLET_NAME, peerWalletName ?? '')
+  user.set(CustomUserProperties.PEER_WALLET_NAME, peerWalletAgent ?? '')
   if (chainId) {
     user.postInsert(CustomUserProperties.ALL_WALLET_CHAIN_IDS, chainId)
   }
@@ -216,10 +216,10 @@ export default function WalletModal({
   useEffect(() => {
     if (account && account !== lastActiveWalletAddress) {
       const walletType = getConnectionName(getConnection(connector).type)
-      const peerWalletName = provider ? getWalletMeta(provider)?.name : undefined
+      const peerWalletAgent = provider ? getWalletMeta(provider)?.agent : undefined
       const isReconnect =
         connectedWallets.filter((wallet) => wallet.account === account && wallet.walletType === walletType).length > 0
-      sendAnalyticsEventAndUserInfo(account, walletType, chainId, isReconnect, peerWalletName)
+      sendAnalyticsEventAndUserInfo(account, walletType, chainId, isReconnect, peerWalletAgent)
       if (!isReconnect) addWalletToConnectedWallets({ account, walletType })
     }
     setLastActiveWalletAddress(account)

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -139,11 +139,11 @@ const sendAnalyticsEventAndUserInfo = (
     wallet_address: account,
     wallet_type: walletType,
     is_reconnect: isReconnect,
-    peer_wallet_name: peerWalletAgent,
+    peer_wallet_agent: peerWalletAgent,
   })
   user.set(CustomUserProperties.WALLET_ADDRESS, account)
   user.set(CustomUserProperties.WALLET_TYPE, walletType)
-  user.set(CustomUserProperties.PEER_WALLET_NAME, peerWalletAgent ?? '')
+  user.set(CustomUserProperties.PEER_WALLET_AGENT, peerWalletAgent ?? '')
   if (chainId) {
     user.postInsert(CustomUserProperties.ALL_WALLET_CHAIN_IDS, chainId)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4989,10 +4989,10 @@
     "@typescript-eslint/types" "5.47.0"
     eslint-visitor-keys "^3.3.0"
 
-"@uniswap/analytics-events@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.4.0.tgz#910f727bf4c72f5d1890f17daec4687dc44ee6c0"
-  integrity sha512-oZl2KRCSTAO8C3sxEFX6BEdGujdPs8tk/Zyx7UwOZOUDcim3mxx6rsdRvnwsAgkZAJjV9I1HSUR7JEeJmQkRmQ==
+"@uniswap/analytics-events@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.5.0.tgz#0956231afede2ed04f051d0f54c11ac34ea7df25"
+  integrity sha512-DFI3awVgVaO/gthl9lQ3jfJu/lmAfJCXeuUcfzGURFyr3NjOxpdkDq68OMGKmKvTceofx3V1qCMG0lrXuDGCog==
 
 "@uniswap/analytics@^1.3.1":
   version "1.3.1"
@@ -5003,7 +5003,12 @@
     react "^18.2.0"
     react-dom "^18.2.0"
 
-"@uniswap/conedison@^1.3.0", "@uniswap/conedison@^1.5.1":
+"@uniswap/conedison@^1.3.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.4.0.tgz#44ad96333b92913a57be34bf5effcfee6534cba1"
+  integrity sha512-ZZMfPTjUiYpLvO0SuMPGNzkFrRpzf+bQYSL/CzaYKGSVdorRUj4XpeMdjlbuKUtHqUEunOWE8eDL3J1Hl4HOUg==
+
+"@uniswap/conedison@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.5.1.tgz#91527cc9928ce0187f30a5eb4abb705b8f0cd013"
   integrity sha512-VJqUW4l54QVj5a4vAzAlWWd193iCcT8HMugFPB28S2Uqhs2elAg/RDQmiPOf9TOFB635MdBlD0S6xUuqo7FB4A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5003,12 +5003,7 @@
     react "^18.2.0"
     react-dom "^18.2.0"
 
-"@uniswap/conedison@^1.3.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.4.0.tgz#44ad96333b92913a57be34bf5effcfee6534cba1"
-  integrity sha512-ZZMfPTjUiYpLvO0SuMPGNzkFrRpzf+bQYSL/CzaYKGSVdorRUj4XpeMdjlbuKUtHqUEunOWE8eDL3J1Hl4HOUg==
-
-"@uniswap/conedison@^1.5.1":
+"@uniswap/conedison@^1.3.0", "@uniswap/conedison@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.5.1.tgz#91527cc9928ce0187f30a5eb4abb705b8f0cd013"
   integrity sha512-VJqUW4l54QVj5a4vAzAlWWd193iCcT8HMugFPB28S2Uqhs2elAg/RDQmiPOf9TOFB635MdBlD0S6xUuqo7FB4A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4989,10 +4989,10 @@
     "@typescript-eslint/types" "5.47.0"
     eslint-visitor-keys "^3.3.0"
 
-"@uniswap/analytics-events@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.5.0.tgz#0956231afede2ed04f051d0f54c11ac34ea7df25"
-  integrity sha512-DFI3awVgVaO/gthl9lQ3jfJu/lmAfJCXeuUcfzGURFyr3NjOxpdkDq68OMGKmKvTceofx3V1qCMG0lrXuDGCog==
+"@uniswap/analytics-events@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.5.1.tgz#26095391518954dd3c1248703b3996f07f034579"
+  integrity sha512-CkatfcWlKZFIQat+/j53AuxhpVntwrgizBYiUgnxcjVQ0Qh87XrCFqgwfTq44QD5bYwgbYjjw263MXujdEqUYg==
 
 "@uniswap/analytics@^1.3.1":
   version "1.3.1"


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-2879?atlOrigin=eyJpIjoiZGQ1NTVmNDU2MzY1NGRmMjgwMzU4ZTM2MGYzYmEwMTMiLCJwIjoiaiJ9

log the "Peer wallet name" to the `WALLET_CONNECT_TXN_COMPLETED` event - this is the WalletConnect-ed wallet (i.e. if you use wallet connect to connect to Rainbow, this field will be Rainbow)
<img width="586" alt="Screenshot 2023-03-06 at 2 00 35 PM" src="https://user-images.githubusercontent.com/66155195/223246567-66e32153-8016-4538-b4c4-6fe9cf1cdda1.png">

update: the actual value will be the Peer Wallet "Agent" which includes some more technical details about the connected wallet.
