### PR TITLE
chore: Remove limit from topCollections query

### DIFF
--- a/src/graphql/data/__generated__/types-and-hooks.ts
+++ b/src/graphql/data/__generated__/types-and-hooks.ts
@@ -662,10 +662,10 @@ export type Query = {
 
 
 export type QueryNftActivityArgs = {
+  after?: InputMaybe<Scalars['String']>;
   chain?: InputMaybe<Chain>;
-  cursor?: InputMaybe<Scalars['String']>;
   filter?: InputMaybe<NftActivityFilterInput>;
-  limit?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -675,11 +675,9 @@ export type QueryNftAssetsArgs = {
   asc?: InputMaybe<Scalars['Boolean']>;
   before?: InputMaybe<Scalars['String']>;
   chain?: InputMaybe<Chain>;
-  cursor?: InputMaybe<Scalars['String']>;
   filter?: InputMaybe<NftAssetsFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<NftAssetSortableField>;
 };
 
@@ -688,20 +686,18 @@ export type QueryNftBalancesArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   chain?: InputMaybe<Chain>;
-  cursor?: InputMaybe<Scalars['String']>;
   filter?: InputMaybe<NftBalancesFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
   ownerAddress: Scalars['String'];
 };
 
 
 export type QueryNftCollectionsArgs = {
+  after?: InputMaybe<Scalars['String']>;
   chain?: InputMaybe<Chain>;
-  cursor?: InputMaybe<Scalars['String']>;
   filter?: InputMaybe<NftCollectionsFilterInput>;
-  limit?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -750,9 +746,11 @@ export type QueryTokensArgs = {
 
 
 export type QueryTopCollectionsArgs = {
+  after?: InputMaybe<Scalars['String']>;
   chains?: InputMaybe<Array<Chain>>;
   cursor?: InputMaybe<Scalars['String']>;
   duration?: InputMaybe<HistoryDuration>;
+  first?: InputMaybe<Scalars['Int']>;
   limit?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<CollectionSortableField>;
 };
@@ -2201,7 +2199,7 @@ export type NftRouteLazyQueryHookResult = ReturnType<typeof useNftRouteLazyQuery
 export type NftRouteQueryResult = Apollo.QueryResult<NftRouteQuery, NftRouteQueryVariables>;
 export const TrendingCollectionsDocument = gql`
     query TrendingCollections($size: Int, $timePeriod: HistoryDuration) {
-  topCollections(limit: $size, duration: $timePeriod) {
+  topCollections(first: $size, duration: $timePeriod) {
     edges {
       node {
         name

--- a/src/graphql/data/nft/TrendingCollections.ts
+++ b/src/graphql/data/nft/TrendingCollections.ts
@@ -7,7 +7,7 @@ import { HistoryDuration, useTrendingCollectionsQuery } from '../__generated__/t
 
 gql`
   query TrendingCollections($size: Int, $timePeriod: HistoryDuration) {
-    topCollections(limit: $size, duration: $timePeriod) {
+    topCollections(first: $size, duration: $timePeriod) {
       edges {
         node {
           name


### PR DESCRIPTION
For ease of use with relay style pagination, infra is removing `cursor` and `limit` from the new gql queries. This only affects the merged in topCollections query.