### PR TITLE
fix: network downtime warning is not positioned correctly #2730

### DIFF
--- a/src/components/Polling/ChainConnectivityWarning.tsx
+++ b/src/components/Polling/ChainConnectivityWarning.tsx
@@ -38,6 +38,7 @@ const Wrapper = styled.div`
   border-radius: 12px;
   border: 1px solid ${({ theme }) => theme.backgroundOutline};
   bottom: 60px;
+  z-index: 2;
   display: none;
   max-width: 348px;
   padding: 16px 20px;


### PR DESCRIPTION
fixes [#2730](https://github.com/Uniswap/interface/issues/2730) Network downtime warning was't always shown on top.