### PR TITLE
fix: use `chain` query param properly when activating

### DIFF
--- a/src/hooks/useSyncChainQuery.ts
+++ b/src/hooks/useSyncChainQuery.ts
@@ -27,12 +27,13 @@ export default function useSyncChainQuery() {
 
   const urlChainId = getParsedChainId(parsedQs)
   const previousUrlChainId = usePrevious(urlChainId)
-  const [nextChainId, setNextChainId] = useState<number | undefined>(undefined)
 
   const selectChain = useSelectChain()
 
   // Can't use `usePrevious` because `chainId` can be undefined while activating.
   const [previousChainId, setPreviousChainId] = useState<number | undefined>(undefined)
+  const [nextChainId, setNextChainId] = useState<number | undefined>(undefined)
+
   useEffect(() => {
     if (chainId && chainId !== previousChainId) {
       setPreviousChainId(chainId)

--- a/src/hooks/useSyncChainQuery.ts
+++ b/src/hooks/useSyncChainQuery.ts
@@ -52,10 +52,11 @@ export default function useSyncChainQuery() {
   return useEffect(() => {
     if (nextChainId && isActive) {
       // If the query param changed, and the chain didn't change, then activate the new chain
-      selectChain(nextChainId)
-      searchParams.delete('chain')
-      setSearchParams(searchParams)
-      setNextChainId(undefined)
+      selectChain(nextChainId).then(() => {
+        searchParams.delete('chain')
+        setSearchParams(searchParams)
+        setNextChainId(undefined)
+      })
     }
   }, [nextChainId, urlChainId, selectChain, searchParams, setSearchParams, isActive])
 }

--- a/src/hooks/useSyncChainQuery.ts
+++ b/src/hooks/useSyncChainQuery.ts
@@ -27,6 +27,7 @@ export default function useSyncChainQuery() {
 
   const urlChainId = getParsedChainId(parsedQs)
   const previousUrlChainId = usePrevious(urlChainId)
+  const [nextChainId, setNextChainId] = useState<number | undefined>(undefined)
 
   const selectChain = useSelectChain()
 
@@ -40,14 +41,20 @@ export default function useSyncChainQuery() {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const chainQueryManuallyUpdated = urlChainId && urlChainId !== previousUrlChainId && isActive
+  useEffect(() => {
+    const chainQueryManuallyUpdated = urlChainId && urlChainId !== previousUrlChainId
+    if (chainQueryManuallyUpdated) {
+      setNextChainId(urlChainId)
+    }
+  }, [previousUrlChainId, urlChainId])
 
   return useEffect(() => {
-    if (chainQueryManuallyUpdated) {
+    if (nextChainId && isActive) {
       // If the query param changed, and the chain didn't change, then activate the new chain
-      selectChain(urlChainId)
+      selectChain(nextChainId)
       searchParams.delete('chain')
       setSearchParams(searchParams)
+      setNextChainId(undefined)
     }
-  }, [chainQueryManuallyUpdated, urlChainId, selectChain, searchParams, setSearchParams])
+  }, [nextChainId, urlChainId, selectChain, searchParams, setSearchParams, isActive])
 }


### PR DESCRIPTION
Previously, if the connector was still activating while a chain param came in, we'd ignore the update. Now, we cache the value until the connecter has activated, then update the chain.
