### PR TITLE
refactor: remove universal-router logic in pay with any token flag

### DIFF
--- a/src/featureFlags/flags/payWithAnyToken.ts
+++ b/src/featureFlags/flags/payWithAnyToken.ts
@@ -1,6 +1,3 @@
-import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
-import { useWeb3React } from '@web3-react/core'
-
 import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
 
 export function usePayWithAnyTokenFlag(): BaseVariant {
@@ -8,17 +5,7 @@ export function usePayWithAnyTokenFlag(): BaseVariant {
 }
 
 export function usePayWithAnyTokenEnabled(): boolean {
-  const flagEnabled = usePayWithAnyTokenFlag() === BaseVariant.Enabled
-  const { chainId } = useWeb3React()
-  try {
-    // Detect if the Universal Router is not yet deployed to chainId.
-    // This is necessary so that we can fallback correctly on chains without a Universal Router deployment.
-    // It will be removed once Universal Router is deployed on all supported chains.
-    chainId && UNIVERSAL_ROUTER_ADDRESS(chainId)
-    return flagEnabled
-  } catch {
-    return false
-  }
+  return usePayWithAnyTokenFlag() === BaseVariant.Enabled
 }
 
 export { BaseVariant as PayWithAnyTokenVariant }


### PR DESCRIPTION
Universal router is supported for all chains in the interface, so this logic is no longer necessary.

Test:
- Make sure PWAT continues to load in both enabled and disabled states