### PR TITLE
chore: remove deprecated zustand import

### DIFF
--- a/src/components/NavBar/Bag.tsx
+++ b/src/components/NavBar/Bag.tsx
@@ -4,7 +4,7 @@ import { BagIcon, HundredsOverflowIcon, TagIcon } from 'nft/components/icons'
 import { useBag, useSellAsset } from 'nft/hooks'
 import { useCallback } from 'react'
 import styled from 'styled-components/macro'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 const CounterDot = styled.div`
   background-color: ${({ theme }) => theme.accentAction};

--- a/src/nft/components/bag/Bag.tsx
+++ b/src/nft/components/bag/Bag.tsx
@@ -35,7 +35,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryClient } from 'react-query'
 import styled from 'styled-components/macro'
 import { Z_INDEX } from 'theme/zIndex'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 import * as styles from './Bag.css'
 import { BagContent } from './BagContent'

--- a/src/nft/components/bag/BagFooter.tsx
+++ b/src/nft/components/bag/BagFooter.tsx
@@ -36,7 +36,7 @@ import { InterfaceTrade, TradeState } from 'state/routing/types'
 import styled, { useTheme } from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { switchChain } from 'utils/switchChain'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 const FooterContainer = styled.div`
   padding: 0px 12px;

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -26,7 +26,7 @@ import { ArrowLeft } from 'react-feather'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 import { Z_INDEX } from 'theme/zIndex'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 import { ListModal } from './Modal/ListModal'
 import { NFTListingsGrid } from './NFTListingsGrid'

--- a/src/nft/components/profile/list/ListingButton.tsx
+++ b/src/nft/components/profile/list/ListingButton.tsx
@@ -7,7 +7,7 @@ import { Listing, WalletAsset } from 'nft/types'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 const BELOW_FLOOR_PRICE_THRESHOLD = 0.8
 

--- a/src/nft/components/profile/list/Modal/ListModal.tsx
+++ b/src/nft/components/profile/list/Modal/ListModal.tsx
@@ -16,7 +16,7 @@ import { X } from 'react-feather'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
 import { Z_INDEX } from 'theme/zIndex'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 import { TitleRow } from '../shared'
 import { ListModalSection, Section } from './ListModalSection'

--- a/src/nft/components/profile/list/utils.ts
+++ b/src/nft/components/profile/list/utils.ts
@@ -7,7 +7,7 @@ import { OPENSEA_CROSS_CHAIN_CONDUIT } from 'nft/queries/openSea'
 import { CollectionRow, ListingMarket, ListingRow, ListingStatus, WalletAsset } from 'nft/types'
 import { approveCollection, LOOKS_RARE_CREATOR_BASIS_POINTS, signListing } from 'nft/utils/listNfts'
 import { Dispatch, useEffect } from 'react'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 export async function approveCollectionRow(
   collectionRow: CollectionRow,

--- a/src/nft/components/profile/view/ProfilePage.tsx
+++ b/src/nft/components/profile/view/ProfilePage.tsx
@@ -24,7 +24,7 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import { useInfiniteQuery } from 'react-query'
 import { easings, useSpring } from 'react-spring'
 import styled from 'styled-components/macro'
-import shallow from 'zustand/shallow'
+import { shallow } from 'zustand/shallow'
 
 import { EmptyWalletContent } from './EmptyWalletContent'
 import * as styles from './ProfilePage.css'


### PR DESCRIPTION
shallow default export is deprecated in favor of a named export. this removes a lot of warnings in the dev console.
