### PR TITLE
feat: Use ETH based pricing instead of USDC based pricing for quote USD values

### DIFF
--- a/src/components/CurrencyInputPanel/FiatValue.tsx
+++ b/src/components/CurrencyInputPanel/FiatValue.tsx
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
-import { formatCurrencyAmount, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
-import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
+import { formatNumber, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
+import { Percent } from '@uniswap/sdk-core'
 import { LoadingBubble } from 'components/Tokens/loading'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { useEffect, useMemo, useState } from 'react'
@@ -22,7 +22,7 @@ export function FiatValue({
   priceImpact,
   isLoading = false,
 }: {
-  fiatValue: CurrencyAmount<Currency> | null | undefined
+  fiatValue: number | null | undefined
   priceImpact?: Percent
   isLoading?: boolean
 }) {
@@ -56,7 +56,7 @@ export function FiatValue({
         <FiatLoadingBubble />
       ) : (
         <div>
-          {fiatValue && <>{formatCurrencyAmount(fiatValue, NumberType.FiatTokenPrice)}</>}
+          {fiatValue ? formatNumber(fiatValue, NumberType.FiatTokenPrice) : undefined}
           {priceImpact && (
             <span style={{ color: priceImpactColor }}>
               {' '}

--- a/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
+++ b/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { TraceEvent } from '@uniswap/analytics'
 import { BrowserEvent, InterfaceElementName, SwapEventName } from '@uniswap/analytics-events'
-import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { AutoColumn } from 'components/Column'
@@ -195,7 +195,7 @@ interface SwapCurrencyInputPanelProps {
   pair?: Pair | null
   hideInput?: boolean
   otherCurrency?: Currency | null
-  fiatValue?: CurrencyAmount<Token> | null
+  fiatValue?: number | null
   priceImpact?: Percent
   id: string
   showCommonBases?: boolean

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { TraceEvent } from '@uniswap/analytics'
 import { BrowserEvent, InterfaceElementName, SwapEventName } from '@uniswap/analytics-events'
-import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { AutoColumn } from 'components/Column'
@@ -182,7 +182,7 @@ interface CurrencyInputPanelProps {
   pair?: Pair | null
   hideInput?: boolean
   otherCurrency?: Currency | null
-  fiatValue?: CurrencyAmount<Token> | null
+  fiatValue?: number | null
   priceImpact?: Percent
   id: string
   showCommonBases?: boolean

--- a/src/components/Widget/transactions.ts
+++ b/src/components/Widget/transactions.ts
@@ -108,7 +108,7 @@ export function useSyncWidgetTransactions() {
           ...formatSwapSignedAnalyticsEventProperties({
             trade,
             // TODO: add once Widgets adds fiat values to callback
-            fiatValues: { amountIn: null, amountOut: null },
+            fiatValues: { amountIn: undefined, amountOut: undefined },
             txHash: transaction.receipt?.transactionHash ?? '',
           }),
           ...trace,

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Trace } from '@uniswap/analytics'
 import { InterfaceModalName } from '@uniswap/analytics-events'
 import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Percent, Token, TradeType } from '@uniswap/sdk-core'
+import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { ReactNode, useCallback, useMemo, useState } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import { tradeMeaningfullyDiffers } from 'utils/tradeMeaningFullyDiffer'
@@ -42,8 +42,8 @@ export default function ConfirmSwapModal({
   swapErrorMessage: ReactNode | undefined
   onDismiss: () => void
   swapQuoteReceivedDate: Date | undefined
-  fiatValueInput?: CurrencyAmount<Token> | null
-  fiatValueOutput?: CurrencyAmount<Token> | null
+  fiatValueInput?: number
+  fiatValueOutput?: number
 }) {
   // shouldLogModalCloseEvent lets the child SwapModalHeader component know when modal has been closed
   // and an event triggered by modal closing should be logged.

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { TraceEvent } from '@uniswap/analytics'
 import { BrowserEvent, InterfaceElementName, SwapEventName } from '@uniswap/analytics-events'
-import { Currency, CurrencyAmount, Percent, Token, TradeType } from '@uniswap/sdk-core'
+import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
 import {
   formatPercentInBasisPointsNumber,
@@ -31,8 +31,8 @@ interface AnalyticsEventProps {
   isAutoRouterApi: boolean
   swapQuoteReceivedDate: Date | undefined
   routes: RoutingDiagramEntry[]
-  fiatValueInput?: CurrencyAmount<Token> | null
-  fiatValueOutput?: CurrencyAmount<Token> | null
+  fiatValueInput?: number
+  fiatValueOutput?: number
 }
 
 const formatRoutesEventProperties = (routes: RoutingDiagramEntry[]) => {
@@ -83,8 +83,8 @@ const formatAnalyticsEventProperties = ({
   token_out_symbol: trade.outputAmount.currency.symbol,
   token_in_amount: formatToDecimal(trade.inputAmount, trade.inputAmount.currency.decimals),
   token_out_amount: formatToDecimal(trade.outputAmount, trade.outputAmount.currency.decimals),
-  token_in_amount_usd: fiatValueInput ? parseFloat(fiatValueInput.toFixed(2)) : undefined,
-  token_out_amount_usd: fiatValueOutput ? parseFloat(fiatValueOutput.toFixed(2)) : undefined,
+  token_in_amount_usd: fiatValueInput,
+  token_out_amount_usd: fiatValueOutput,
   price_impact_basis_points: formatPercentInBasisPointsNumber(computeRealizedPriceImpact(trade)),
   allowed_slippage_basis_points: formatPercentInBasisPointsNumber(allowedSlippage),
   is_auto_router_api: isAutoRouterApi,
@@ -118,8 +118,8 @@ export default function SwapModalFooter({
   swapErrorMessage: ReactNode | undefined
   disabledConfirm: boolean
   swapQuoteReceivedDate: Date | undefined
-  fiatValueInput?: CurrencyAmount<Token> | null
-  fiatValueOutput?: CurrencyAmount<Token> | null
+  fiatValueInput?: number
+  fiatValueOutput?: number
 }) {
   const transactionDeadlineSecondsSinceEpoch = useTransactionDeadline()?.toNumber() // in seconds since epoch
   const isAutoSlippage = useUserSlippageTolerance()[0] === 'auto'

--- a/src/components/swap/SwapModalHeader.tsx
+++ b/src/components/swap/SwapModalHeader.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/macro'
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { SwapEventName, SwapPriceUpdateUserResponse } from '@uniswap/analytics-events'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
+import { useUSDPrice } from 'hooks/useUSDPrice'
 import { getPriceUpdateBasisPoints } from 'lib/utils/analytics'
 import { useEffect, useState } from 'react'
 import { AlertTriangle, ArrowDown } from 'react-feather'
@@ -9,7 +10,6 @@ import { Text } from 'rebass'
 import { InterfaceTrade } from 'state/routing/types'
 import styled, { useTheme } from 'styled-components/macro'
 
-import { useStablecoinValue } from '../../hooks/useStablecoinPrice'
 import { ThemedText } from '../../theme'
 import { isAddress, shortenAddress } from '../../utils'
 import { computeFiatValuePriceImpact } from '../../utils/computeFiatValuePriceImpact'
@@ -78,8 +78,8 @@ export default function SwapModalHeader({
   const [lastExecutionPrice, setLastExecutionPrice] = useState(trade.executionPrice)
   const [priceUpdate, setPriceUpdate] = useState<number | undefined>()
 
-  const fiatValueInput = useStablecoinValue(trade.inputAmount)
-  const fiatValueOutput = useStablecoinValue(trade.outputAmount)
+  const fiatValueInput = useUSDPrice(trade.inputAmount)
+  const fiatValueOutput = useUSDPrice(trade.outputAmount)
 
   useEffect(() => {
     if (!trade.executionPrice.equalTo(lastExecutionPrice)) {

--- a/src/components/swap/TradePrice.tsx
+++ b/src/components/swap/TradePrice.tsx
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro'
 import { formatNumber, NumberType } from '@uniswap/conedison/format'
-import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
-import { parseUnits } from 'ethers/lib/utils'
+import { Currency, Price } from '@uniswap/sdk-core'
 import { useUSDPrice } from 'hooks/useUSDPrice'
+import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useCallback, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -29,18 +29,11 @@ const StyledPriceContainer = styled.button`
   user-select: text;
 `
 
-function getOneCurrencyRawAmount(currency: Currency): string {
-  return parseUnits('1', currency.decimals).toString()
-}
-
 export default function TradePrice({ price }: TradePriceProps) {
   const [showInverted, setShowInverted] = useState<boolean>(false)
 
-  const usdPrice = useUSDPrice(
-    showInverted
-      ? CurrencyAmount.fromRawAmount(price.baseCurrency, getOneCurrencyRawAmount(price.baseCurrency))
-      : CurrencyAmount.fromRawAmount(price.quoteCurrency, getOneCurrencyRawAmount(price.quoteCurrency))
-  )
+  const { baseCurrency, quoteCurrency } = price
+  const usdPrice = useUSDPrice(tryParseCurrencyAmount('1', showInverted ? baseCurrency : quoteCurrency))
 
   let formattedPrice: string
   try {

--- a/src/graphql/data/TokenSpotPrice.ts
+++ b/src/graphql/data/TokenSpotPrice.ts
@@ -1,16 +1,21 @@
 import gql from 'graphql-tag'
 
 gql`
-  query TokenSpotPrice($chain: Chain!, $address: String = null) {
+  query TokenSpotPrice($chain: Chain!, $address: String) {
     token(chain: $chain, address: $address) {
       id
       address
       chain
-      market(currency: USD) {
+      name
+      symbol
+      project {
         id
-        price {
+        markets(currencies: [USD]) {
           id
-          value
+          price {
+            id
+            value
+          }
         }
       }
     }

--- a/src/graphql/data/TokenSpotPrice.ts
+++ b/src/graphql/data/TokenSpotPrice.ts
@@ -1,0 +1,18 @@
+import gql from 'graphql-tag'
+
+gql`
+  query TokenSpotPrice($chain: Chain!, $address: String = null) {
+    token(chain: $chain, address: $address) {
+      id
+      address
+      chain
+      market(currency: USD) {
+        id
+        price {
+          id
+          value
+        }
+      }
+    }
+  }
+`

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -73,6 +73,10 @@ export function chainIdToBackendName(chainId: number | undefined) {
     : CHAIN_ID_TO_BACKEND_NAME[SupportedChainId.MAINNET]
 }
 
+export function isGqlSupportedChain(chainId: number | undefined): chainId is SupportedChainId {
+  return Boolean(chainId && CHAIN_ID_TO_BACKEND_NAME[chainId])
+}
+
 const URL_CHAIN_PARAM_TO_BACKEND: { [key: string]: Chain } = {
   ethereum: Chain.Ethereum,
   polygon: Chain.Polygon,

--- a/src/hooks/useSwapCallback.tsx
+++ b/src/hooks/useSwapCallback.tsx
@@ -1,5 +1,5 @@
 import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
+import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { PermitSignature } from 'hooks/usePermitAllowance'
 import { useMemo } from 'react'
 
@@ -13,7 +13,7 @@ import { useUniversalRouterSwapCallback } from './useUniversalRouter'
 // and the user has approved the slippage adjusted input amount for the trade
 export function useSwapCallback(
   trade: Trade<Currency, Currency, TradeType> | undefined, // trade to execute, required
-  fiatValues: { amountIn: CurrencyAmount<Currency> | null; amountOut: CurrencyAmount<Currency> | null }, // usd values for amount in and out, logged for analytics
+  fiatValues: { amountIn: number | undefined; amountOut: number | undefined }, // usd values for amount in and out, logged for analytics
   allowedSlippage: Percent, // in bips
   permitSignature: PermitSignature | undefined
 ): { callback: null | (() => Promise<string>) } {

--- a/src/hooks/useUSDPrice.ts
+++ b/src/hooks/useUSDPrice.ts
@@ -1,7 +1,7 @@
 import { Currency, CurrencyAmount, Price, SupportedChainId, TradeType } from '@uniswap/sdk-core'
 import { nativeOnChain } from 'constants/tokens'
 import { Chain, useTokenSpotPriceQuery } from 'graphql/data/__generated__/types-and-hooks'
-import { chainIdToBackendName, isGqlSupportedChain } from 'graphql/data/util'
+import { chainIdToBackendName, isGqlSupportedChain, PollingInterval } from 'graphql/data/util'
 import { RouterPreference } from 'state/routing/slice'
 import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
 import { getNativeTokenDBAddress } from 'utils/nativeTokens'
@@ -46,6 +46,7 @@ export function useUSDPrice(currencyAmount?: CurrencyAmount<Currency>): number |
   const { data } = useTokenSpotPriceQuery({
     variables: { chain: chain ?? Chain.Ethereum, address: getNativeTokenDBAddress(chain ?? Chain.Ethereum) },
     skip: !chain || !isGqlSupportedChain(currency?.chainId),
+    pollInterval: PollingInterval.Normal,
   })
 
   // Use USDC price for chains not supported by backend yet

--- a/src/hooks/useUSDPrice.ts
+++ b/src/hooks/useUSDPrice.ts
@@ -1,0 +1,53 @@
+import { Currency, CurrencyAmount, Price, SupportedChainId, TradeType } from '@uniswap/sdk-core'
+import { nativeOnChain } from 'constants/tokens'
+import { useTokenSpotPriceQuery } from 'graphql/data/__generated__/types-and-hooks'
+import { chainIdToBackendName, isGqlSupportedChain } from 'graphql/data/util'
+import { RouterPreference } from 'state/routing/slice'
+import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
+
+// ETH amounts used when calculating spot price for a given currency.
+// The amount is large enough to filter low liquidity pairs.
+const ETH_AMOUNT_OUT: { [chainId: number]: CurrencyAmount<Currency> } = {
+  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.MAINNET), 100),
+  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.ARBITRUM_ONE), 100),
+  [SupportedChainId.OPTIMISM]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.OPTIMISM), 100),
+  [SupportedChainId.POLYGON]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.POLYGON), 10_000e6),
+}
+
+function useETHValue(currencyAmount?: CurrencyAmount<Currency>): CurrencyAmount<Currency> | undefined {
+  const chainId = currencyAmount?.currency?.chainId
+  const amountOut = isGqlSupportedChain(chainId) ? ETH_AMOUNT_OUT[chainId] : undefined
+  const { trade } = useRoutingAPITrade(
+    TradeType.EXACT_OUTPUT,
+    amountOut,
+    currencyAmount?.currency,
+    RouterPreference.PRICE
+  )
+
+  if (chainId && currencyAmount && currencyAmount.currency.equals(nativeOnChain(chainId))) {
+    return new Price(currencyAmount.currency, currencyAmount.currency, '1', '1').quote(currencyAmount)
+  }
+
+  if (!trade || !currencyAmount?.currency || !isGqlSupportedChain(chainId)) return
+
+  const { numerator, denominator } = trade.routes[0].midPrice
+  const price = new Price(currencyAmount?.currency, nativeOnChain(chainId), denominator, numerator)
+  return price.quote(currencyAmount)
+}
+
+export function useUSDPrice(currencyAmount?: CurrencyAmount<Currency>) {
+  const chain = chainIdToBackendName(currencyAmount?.currency.chainId)
+
+  const ethValue = useETHValue(currencyAmount)
+  console.log('ethValue', ethValue?.toSignificant())
+
+  const { data } = useTokenSpotPriceQuery({
+    variables: { chain },
+    skip: !isGqlSupportedChain(currencyAmount?.currency.chainId),
+  })
+
+  const ethUSDPrice = data?.token?.market?.price?.value
+  if (!ethUSDPrice || !ethValue) return undefined
+  console.log('ethUSDPrice', ethUSDPrice)
+  return parseFloat(ethValue.toExact()) * ethUSDPrice
+}

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro'
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { SwapEventName } from '@uniswap/analytics-events'
 import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
+import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { SwapRouter, UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
 import { FeeOptions, toHex } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
@@ -27,7 +27,7 @@ interface SwapOptions {
 
 export function useUniversalRouterSwapCallback(
   trade: Trade<Currency, Currency, TradeType> | undefined,
-  fiatValues: { amountIn: CurrencyAmount<Currency> | null; amountOut: CurrencyAmount<Currency> | null },
+  fiatValues: { amountIn: number | undefined; amountOut: number | undefined },
   options: SwapOptions
 ) {
   const { account, chainId, provider } = useWeb3React()

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -40,7 +40,7 @@ export const formatSwapSignedAnalyticsEventProperties = ({
   txHash,
 }: {
   trade: InterfaceTrade<Currency, Currency, TradeType> | Trade<Currency, Currency, TradeType>
-  fiatValues: { amountIn: CurrencyAmount<Currency> | null; amountOut: CurrencyAmount<Currency> | null }
+  fiatValues: { amountIn: number | undefined; amountOut: number | undefined }
   txHash: string
 }) => ({
   transaction_hash: txHash,
@@ -50,8 +50,8 @@ export const formatSwapSignedAnalyticsEventProperties = ({
   token_out_symbol: trade.outputAmount.currency.symbol,
   token_in_amount: formatToDecimal(trade.inputAmount, trade.inputAmount.currency.decimals),
   token_out_amount: formatToDecimal(trade.outputAmount, trade.outputAmount.currency.decimals),
-  token_in_amount_usd: fiatValues.amountIn ? parseFloat(fiatValues.amountIn.toFixed(2)) : undefined,
-  token_out_amount_usd: fiatValues.amountOut ? parseFloat(fiatValues.amountOut.toFixed(2)) : undefined,
+  token_in_amount_usd: fiatValues.amountIn,
+  token_out_amount_usd: fiatValues.amountOut,
   price_impact_basis_points: formatPercentInBasisPointsNumber(computeRealizedPriceImpact(trade)),
   chain_id:
     trade.inputAmount.currency.chainId === trade.outputAmount.currency.chainId

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -501,6 +501,8 @@ export default function AddLiquidity() {
       </AutoColumn>
     )
 
+  const currencyAFiat = usdcValues[Field.CURRENCY_A]
+  const currencyBFiat = usdcValues[Field.CURRENCY_B]
   return (
     <>
       <ScrollablePage>
@@ -651,7 +653,7 @@ export default function AddLiquidity() {
                       showMaxButton={!atMaxAmounts[Field.CURRENCY_A]}
                       currency={currencies[Field.CURRENCY_A] ?? null}
                       id="add-liquidity-input-tokena"
-                      fiatValue={usdcValues[Field.CURRENCY_A]}
+                      fiatValue={currencyAFiat && parseFloat(currencyAFiat.toSignificant())}
                       showCommonBases
                       locked={depositADisabled}
                     />
@@ -663,7 +665,7 @@ export default function AddLiquidity() {
                         onFieldBInput(maxAmounts[Field.CURRENCY_B]?.toExact() ?? '')
                       }}
                       showMaxButton={!atMaxAmounts[Field.CURRENCY_B]}
-                      fiatValue={usdcValues[Field.CURRENCY_B]}
+                      fiatValue={currencyBFiat && parseFloat(currencyBFiat.toSignificant())}
                       currency={currencies[Field.CURRENCY_B] ?? null}
                       id="add-liquidity-input-tokenb"
                       showCommonBases

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -25,6 +25,7 @@ import { useSwapWidgetEnabled } from 'featureFlags/flags/swapWidget'
 import useENSAddress from 'hooks/useENSAddress'
 import usePermit2Allowance, { AllowanceState } from 'hooks/usePermit2Allowance'
 import { useSwapCallback } from 'hooks/useSwapCallback'
+import { useUSDPrice } from 'hooks/useUSDPrice'
 import JSBI from 'jsbi'
 import { formatSwapQuoteReceivedEventProperties } from 'lib/utils/analytics'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -231,6 +232,8 @@ export default function Swap({ className }: { className?: string }) {
     [independentField, parsedAmount, showWrap, trade]
   )
   const fiatValueInput = useStablecoinValue(parsedAmounts[Field.INPUT])
+  const fiatValueInput2 = useUSDPrice(parsedAmounts[Field.INPUT])
+  console.log('fiatValueInput2', fiatValueInput2)
   const fiatValueOutput = useStablecoinValue(parsedAmounts[Field.OUTPUT])
 
   const [routeNotFound, routeIsLoading, routeIsSyncing] = useMemo(

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -55,7 +55,6 @@ import { SwitchLocaleLink } from '../../components/SwitchLocaleLink'
 import { TOKEN_SHORTHANDS } from '../../constants/tokens'
 import { useAllTokens, useCurrency } from '../../hooks/Tokens'
 import { useIsSwapUnsupported } from '../../hooks/useIsSwapUnsupported'
-import { useStablecoinValue } from '../../hooks/useStablecoinPrice'
 import useWrapCallback, { WrapErrorText, WrapType } from '../../hooks/useWrapCallback'
 import { Field } from '../../state/swap/actions'
 import {
@@ -231,18 +230,16 @@ export default function Swap({ className }: { className?: string }) {
           },
     [independentField, parsedAmount, showWrap, trade]
   )
-  const fiatValueInput = useStablecoinValue(parsedAmounts[Field.INPUT])
-  const fiatValueInput2 = useUSDPrice(parsedAmounts[Field.INPUT])
-  console.log('fiatValueInput2', fiatValueInput2)
-  const fiatValueOutput = useStablecoinValue(parsedAmounts[Field.OUTPUT])
+  const fiatValueInput = useUSDPrice(parsedAmounts[Field.INPUT])
+  const fiatValueOutput = useUSDPrice(parsedAmounts[Field.OUTPUT])
 
   const [routeNotFound, routeIsLoading, routeIsSyncing] = useMemo(
     () => [!trade?.swaps, TradeState.LOADING === tradeState, TradeState.SYNCING === tradeState],
     [trade, tradeState]
   )
 
-  const fiatValueTradeInput = useStablecoinValue(trade?.inputAmount)
-  const fiatValueTradeOutput = useStablecoinValue(trade?.outputAmount)
+  const fiatValueTradeInput = useUSDPrice(trade?.inputAmount)
+  const fiatValueTradeOutput = useUSDPrice(trade?.outputAmount)
   const stablecoinPriceImpact = useMemo(
     () =>
       routeIsSyncing || !trade ? undefined : computeFiatValuePriceImpact(fiatValueTradeInput, fiatValueTradeOutput),

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -62,7 +62,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
   const isSyncing = currentData !== data
 
   return useMemo(() => {
-    if (!currencyIn || !currencyOut) {
+    if (!currencyIn || !currencyOut || currencyIn.equals(currencyOut)) {
       return {
         state: TradeState.INVALID,
         trade: undefined,

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -5,6 +5,7 @@ import { sendTiming } from 'components/analytics'
 import { AVERAGE_L1_BLOCK_TIME } from 'constants/chainInfo'
 import { useStablecoinAmountFromFiatValue } from 'hooks/useStablecoinPrice'
 import { useRoutingAPIArguments } from 'lib/hooks/routing/useRoutingAPIArguments'
+import useIsValidBlock from 'lib/hooks/useIsValidBlock'
 import ms from 'ms.macro'
 import { useMemo } from 'react'
 import { RouterPreference, useGetQuoteQuery } from 'state/routing/slice'
@@ -48,7 +49,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     pollingInterval: routerPreference === RouterPreference.PRICE ? ms`2m` : AVERAGE_L1_BLOCK_TIME,
   })
 
-  const quoteResult: GetQuoteResult | undefined = data
+  const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(data?.blockNumber) || 0) ? data : undefined
 
   const route = useMemo(
     () => computeRoutes(currencyIn, currencyOut, tradeType, quoteResult),

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -5,7 +5,6 @@ import { sendTiming } from 'components/analytics'
 import { AVERAGE_L1_BLOCK_TIME } from 'constants/chainInfo'
 import { useStablecoinAmountFromFiatValue } from 'hooks/useStablecoinPrice'
 import { useRoutingAPIArguments } from 'lib/hooks/routing/useRoutingAPIArguments'
-import useIsValidBlock from 'lib/hooks/useIsValidBlock'
 import ms from 'ms.macro'
 import { useMemo } from 'react'
 import { RouterPreference, useGetQuoteQuery } from 'state/routing/slice'
@@ -49,7 +48,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     pollingInterval: routerPreference === RouterPreference.PRICE ? ms`2m` : AVERAGE_L1_BLOCK_TIME,
   })
 
-  const quoteResult: GetQuoteResult | undefined = useIsValidBlock(Number(data?.blockNumber) || 0) ? data : undefined
+  const quoteResult: GetQuoteResult | undefined = data
 
   const route = useMemo(
     () => computeRoutes(currencyIn, currencyOut, tradeType, quoteResult),

--- a/src/utils/computeFiatValuePriceImpact.tsx
+++ b/src/utils/computeFiatValuePriceImpact.tsx
@@ -1,5 +1,6 @@
 import { Percent } from '@uniswap/sdk-core'
 
+const PRECISION = 10000
 export function computeFiatValuePriceImpact(
   fiatValueInput: number | undefined | null,
   fiatValueOutput: number | undefined | null
@@ -8,6 +9,6 @@ export function computeFiatValuePriceImpact(
   if (fiatValueInput === 0) return undefined
 
   const ratio = 1 - fiatValueOutput / fiatValueInput
-  const numerator = Math.floor(ratio * 10000)
-  return new Percent(numerator, 10000)
+  const numerator = Math.floor(ratio * PRECISION)
+  return new Percent(numerator, PRECISION)
 }

--- a/src/utils/computeFiatValuePriceImpact.tsx
+++ b/src/utils/computeFiatValuePriceImpact.tsx
@@ -1,15 +1,14 @@
-import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
-import JSBI from 'jsbi'
-
-import { ONE_HUNDRED_PERCENT } from '../constants/misc'
+import { Percent } from '@uniswap/sdk-core'
 
 export function computeFiatValuePriceImpact(
-  fiatValueInput: CurrencyAmount<Currency> | undefined | null,
-  fiatValueOutput: CurrencyAmount<Currency> | undefined | null
+  fiatValueInput: number | undefined | null,
+  fiatValueOutput: number | undefined | null
 ): Percent | undefined {
   if (!fiatValueOutput || !fiatValueInput) return undefined
-  if (!fiatValueInput.currency.equals(fiatValueOutput.currency)) return undefined
-  if (JSBI.equal(fiatValueInput.quotient, JSBI.BigInt(0))) return undefined
-  const pct = ONE_HUNDRED_PERCENT.subtract(fiatValueOutput.divide(fiatValueInput))
-  return new Percent(pct.numerator, pct.denominator)
+  if (fiatValueInput === 0) return undefined
+
+  console.log('fiatValueOutput', fiatValueOutput, fiatValueInput)
+  const ratio = 1 - fiatValueOutput / fiatValueInput
+  const numerator = Math.floor(ratio * 10000)
+  return new Percent(numerator, 10000)
 }

--- a/src/utils/computeFiatValuePriceImpact.tsx
+++ b/src/utils/computeFiatValuePriceImpact.tsx
@@ -7,7 +7,6 @@ export function computeFiatValuePriceImpact(
   if (!fiatValueOutput || !fiatValueInput) return undefined
   if (fiatValueInput === 0) return undefined
 
-  console.log('fiatValueOutput', fiatValueOutput, fiatValueInput)
   const ratio = 1 - fiatValueOutput / fiatValueInput
   const numerator = Math.floor(ratio * 10000)
   return new Percent(numerator, 10000)


### PR DESCRIPTION
[will add more in the morning]

We were previously assuming USDC = $1 and routing all pricing through a token <-> USDC swap. That is sadgely no longer the case. This new algo does a route through ETH:

Token -> ETH -> USD where the ETH -> USD quote uses our gql endpoint to fetch ETH price.

![image](https://user-images.githubusercontent.com/59578595/224470032-9e3d4f15-de03-4642-acf2-5a14279ca641.png)
