### PR TITLE
fix: USD price for WETH + don't call gql for testnets

### DIFF
--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -73,8 +73,16 @@ export function chainIdToBackendName(chainId: number | undefined) {
     : CHAIN_ID_TO_BACKEND_NAME[SupportedChainId.MAINNET]
 }
 
+const GQL_CHAINS: number[] = [
+  SupportedChainId.MAINNET,
+  SupportedChainId.OPTIMISM,
+  SupportedChainId.POLYGON,
+  SupportedChainId.ARBITRUM_ONE,
+  SupportedChainId.CELO,
+]
+
 export function isGqlSupportedChain(chainId: number | undefined): chainId is SupportedChainId {
-  return Boolean(chainId && CHAIN_ID_TO_BACKEND_NAME[chainId])
+  return !!chainId && GQL_CHAINS.includes(chainId)
 }
 
 const URL_CHAIN_PARAM_TO_BACKEND: { [key: string]: Chain } = {

--- a/src/hooks/useUSDPrice.ts
+++ b/src/hooks/useUSDPrice.ts
@@ -27,7 +27,8 @@ function useETHValue(currencyAmount?: CurrencyAmount<Currency>): CurrencyAmount<
     RouterPreference.PRICE
   )
 
-  if (chainId && currencyAmount && currencyAmount.currency.equals(nativeOnChain(chainId))) {
+  // Get ETH value of ETH or WETH
+  if (chainId && currencyAmount && currencyAmount.currency.wrapped.equals(nativeOnChain(chainId).wrapped)) {
     return new Price(currencyAmount.currency, currencyAmount.currency, '1', '1').quote(currencyAmount)
   }
 


### PR DESCRIPTION
- Fix usd price loading case for WETH. To get the price of WETH in ETH, just return 1 lawl.
- GQL calls fail on testnets, so dont send them. Instead, route through old `useStablecoinValue`