### PR TITLE
fix: fetch same tokens for topTokens and sparkline queries

### DIFF
--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -67,7 +67,7 @@ gql`
   }
 `
 
-// We separate query sparklines data so that the large download time does not block Token Explore rendering
+// We separately query sparkline data so that the large download time does not block Token Explore rendering
 gql`
   query TopTokensSparkline($duration: HistoryDuration!, $chain: Chain!) {
     topTokens(pageSize: 100, page: 1, chain: $chain, orderBy: VOLUME) {

--- a/src/graphql/data/TopTokens.ts
+++ b/src/graphql/data/TopTokens.ts
@@ -67,9 +67,10 @@ gql`
   }
 `
 
+// We separate query sparklines data so that the large download time does not block Token Explore rendering
 gql`
   query TopTokensSparkline($duration: HistoryDuration!, $chain: Chain!) {
-    topTokens(pageSize: 100, page: 1, chain: $chain) {
+    topTokens(pageSize: 100, page: 1, chain: $chain, orderBy: VOLUME) {
       id
       address
       chain


### PR DESCRIPTION
@matteenm noticed we were not fetching sparklines by volume; this fixes a bug where any tokens that were not in the top 100 TVL did not have a sparkline

before:
<img width="1355" alt="image" src="https://user-images.githubusercontent.com/39385577/224518821-87bf4ea6-f508-46e9-934e-7e2446ca3e0c.png">
after:
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/39385577/224518825-ccfab5fe-c3ad-46a8-ae22-972f7dcba2b4.png">
