### PR TITLE
fix: full range lp shortcut

### DIFF
--- a/src/components/RangeSelector/PresetsButtons.tsx
+++ b/src/components/RangeSelector/PresetsButtons.tsx
@@ -1,8 +1,6 @@
 import { Trans } from '@lingui/macro'
-import { sendEvent } from 'components/analytics'
 import { ButtonOutlined } from 'components/Button'
 import { AutoRow } from 'components/Row'
-import React from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
@@ -14,18 +12,14 @@ const Button = styled(ButtonOutlined).attrs(() => ({
   flex: 1;
 `
 
-export default function PresetsButtons({ setFullRange }: { setFullRange: () => void }) {
+interface PresetsButtonsProps {
+  onSetFullRange: () => void
+}
+
+export default function PresetsButtons({ onSetFullRange }: PresetsButtonsProps) {
   return (
     <AutoRow gap="4px" width="auto">
-      <Button
-        onClick={() => {
-          setFullRange()
-          sendEvent({
-            category: 'Liquidity',
-            action: 'Full Range Clicked',
-          })
-        }}
-      >
+      <Button onClick={onSetFullRange}>
         <ThemedText.DeprecatedBody fontSize={12}>
           <Trans>Full Range</Trans>
         </ThemedText.DeprecatedBody>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -432,6 +432,19 @@ export default function AddLiquidity() {
     !depositBDisabled ? currencies[Field.CURRENCY_B]?.symbol : ''
   }`
 
+  const handleSetFullRange = useCallback(() => {
+    setShowCapitalEfficiencyWarning(true)
+    sendEvent({
+      category: 'Liquidity',
+      action: 'Full Range Clicked',
+    })
+  }, [])
+
+  const handleFullRangeConfirmationClick = useCallback(() => {
+    setShowCapitalEfficiencyWarning(false)
+    getSetFullRange()
+  }, [getSetFullRange])
+
   const Buttons = () =>
     addIsUnsupported ? (
       <ButtonPrimary disabled={true} $borderRadius="12px" padding="12px">
@@ -828,13 +841,7 @@ export default function AddLiquidity() {
                               feeAmount={feeAmount}
                               ticksAtLimit={ticksAtLimit}
                             />
-                            {!noLiquidity && (
-                              <PresetsButtons
-                                setFullRange={() => {
-                                  setShowCapitalEfficiencyWarning(true)
-                                }}
-                              />
-                            )}
+                            {!noLiquidity && <PresetsButtons onSetFullRange={handleSetFullRange} />}
                           </AutoColumn>
                         </StackedItem>
 
@@ -876,10 +883,7 @@ export default function AddLiquidity() {
                                     marginRight="8px"
                                     $borderRadius="8px"
                                     width="auto"
-                                    onClick={() => {
-                                      setShowCapitalEfficiencyWarning(false)
-                                      getSetFullRange()
-                                    }}
+                                    onClick={handleFullRangeConfirmationClick}
                                   >
                                     <ThemedText.DeprecatedBlack fontSize={13} color="black">
                                       <Trans>I understand</Trans>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -437,6 +437,8 @@ export default function AddLiquidity() {
     ) {
       onLeftRangeInput(minPrice)
     }
+    // disable eslint rule because this hook only cares about the url->input state data flow
+    // input state -> url updates are handled in the input handlers
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
   useEffect(() => {
@@ -450,6 +452,8 @@ export default function AddLiquidity() {
     ) {
       onRightRangeInput(maxPrice)
     }
+    // disable eslint rule because this hook only cares about the url->input state data flow
+    // input state -> url updates are handled in the input handlers
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
   // END: sync values with query string

--- a/src/state/mint/v3/hooks.tsx
+++ b/src/state/mint/v3/hooks.tsx
@@ -16,10 +16,9 @@ import { usePool } from 'hooks/usePools'
 import JSBI from 'jsbi'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ReactNode, useCallback, useMemo } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { getTickToPrice } from 'utils/getTickToPrice'
-import { replaceURLParam } from 'utils/routes'
 
 import { BIG_INT_ZERO } from '../../../constants/misc'
 import { PoolState } from '../../../hooks/usePools'
@@ -48,7 +47,6 @@ export function useV3MintActionHandlers(noLiquidity: boolean | undefined): {
   onStartPriceInput: (typedValue: string) => void
 } {
   const dispatch = useAppDispatch()
-  const navigate = useNavigate()
 
   const onFieldAInput = useCallback(
     (typedValue: string) => {
@@ -64,22 +62,30 @@ export function useV3MintActionHandlers(noLiquidity: boolean | undefined): {
     [dispatch, noLiquidity]
   )
 
-  const { search } = useLocation()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const onLeftRangeInput = useCallback(
     (typedValue: string) => {
       dispatch(typeLeftRangeInput({ typedValue }))
-      navigate({ search: replaceURLParam(search, 'minPrice', typedValue) }, { replace: true })
+      const paramMinPrice = searchParams.get('minPrice')
+      if (!paramMinPrice || (paramMinPrice && paramMinPrice !== typedValue)) {
+        searchParams.set('minPrice', typedValue)
+        setSearchParams(searchParams)
+      }
     },
-    [dispatch, navigate, search]
+    [dispatch, searchParams, setSearchParams]
   )
 
   const onRightRangeInput = useCallback(
     (typedValue: string) => {
       dispatch(typeRightRangeInput({ typedValue }))
-      navigate({ search: replaceURLParam(search, 'maxPrice', typedValue) }, { replace: true })
+      const paramMaxPrice = searchParams.get('maxPrice')
+      if (!paramMaxPrice || (paramMaxPrice && paramMaxPrice !== typedValue)) {
+        searchParams.set('maxPrice', typedValue)
+        setSearchParams(searchParams)
+      }
     },
-    [dispatch, navigate, search]
+    [dispatch, searchParams, setSearchParams]
   )
 
   const onStartPriceInput = useCallback(
@@ -111,6 +117,9 @@ export function useV3DerivedMintInfo(
   ticks: { [bound in Bound]?: number | undefined }
   price?: Price<Token, Token>
   pricesAtTicks: {
+    [bound in Bound]?: Price<Token, Token> | undefined
+  }
+  pricesAtLimit: {
     [bound in Bound]?: Price<Token, Token> | undefined
   }
   currencies: { [field in Field]?: Currency }
@@ -226,9 +235,7 @@ export function useV3DerivedMintInfo(
   const poolForPosition: Pool | undefined = pool ?? mockPool
 
   // lower and upper limits in the tick space for `feeAmoun<Trans>
-  const tickSpaceLimits: {
-    [bound in Bound]: number | undefined
-  } = useMemo(
+  const tickSpaceLimits = useMemo(
     () => ({
       [Bound.LOWER]: feeAmount ? nearestUsableTick(TickMath.MIN_TICK, TICK_SPACINGS[feeAmount]) : undefined,
       [Bound.UPPER]: feeAmount ? nearestUsableTick(TickMath.MAX_TICK, TICK_SPACINGS[feeAmount]) : undefined,
@@ -238,9 +245,7 @@ export function useV3DerivedMintInfo(
 
   // parse typed range values and determine closest ticks
   // lower should always be a smaller tick
-  const ticks: {
-    [key: string]: number | undefined
-  } = useMemo(() => {
+  const ticks = useMemo(() => {
     return {
       [Bound.LOWER]:
         typeof existingPosition?.tickLower === 'number'
@@ -285,6 +290,13 @@ export function useV3DerivedMintInfo(
 
   // mark invalid range
   const invalidRange = Boolean(typeof tickLower === 'number' && typeof tickUpper === 'number' && tickLower >= tickUpper)
+
+  const pricesAtLimit = useMemo(() => {
+    return {
+      [Bound.LOWER]: getTickToPrice(token0, token1, tickSpaceLimits.LOWER),
+      [Bound.UPPER]: getTickToPrice(token0, token1, tickSpaceLimits.UPPER),
+    }
+  }, [token0, token1, tickSpaceLimits.LOWER, tickSpaceLimits.UPPER])
 
   // always returns the price with 0 as base token
   const pricesAtTicks = useMemo(() => {
@@ -472,6 +484,7 @@ export function useV3DerivedMintInfo(
     ticks,
     price,
     pricesAtTicks,
+    pricesAtLimit,
     position,
     noLiquidity,
     errorMessage,

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,5 +1,0 @@
-export const replaceURLParam = (search: string, param: string, newValue: string) => {
-  const searchParams = new URLSearchParams(search)
-  searchParams.set(param, newValue)
-  return searchParams.toString()
-}


### PR DESCRIPTION
- urls should fill the inputs
- updates to the url should update the inputs
- updates to the inputs should update the url
- full range button should function


the following path should pre-fill a full range position on this pool https://interface-git-fork-jfrankfurt-fix-full-range-lp-uniswap.vercel.app/#/add/ETH/0x6B175474E89094C44Da98b954EedeAC495271d0F/3000?minPrice=0.0000000000000000000000000000000000000029543&maxPrice=338490000000000000000000000000000000000

<img width="924" alt="image" src="https://user-images.githubusercontent.com/5773490/224535300-60bee45c-895c-460b-b7e0-765af96474f2.png">
