### PR TITLE
fix: set user properties before event properties

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -135,13 +135,8 @@ const sendAnalyticsEventAndUserInfo = (
   isReconnect: boolean,
   peerWalletAgent: string | undefined
 ) => {
-  sendAnalyticsEvent(InterfaceEventName.WALLET_CONNECT_TXN_COMPLETED, {
-    result: WalletConnectionResult.SUCCEEDED,
-    wallet_address: account,
-    wallet_type: walletType,
-    is_reconnect: isReconnect,
-    peer_wallet_agent: peerWalletAgent,
-  })
+  // User properties *must* be set before sending corresponding event properties,
+  // so that the event contains the correct and up-to-date user properties.
   user.set(CustomUserProperties.WALLET_ADDRESS, account)
   user.set(CustomUserProperties.WALLET_TYPE, walletType)
   user.set(CustomUserProperties.PEER_WALLET_AGENT, peerWalletAgent ?? '')
@@ -149,6 +144,14 @@ const sendAnalyticsEventAndUserInfo = (
     user.postInsert(CustomUserProperties.ALL_WALLET_CHAIN_IDS, chainId)
   }
   user.postInsert(CustomUserProperties.ALL_WALLET_ADDRESSES_CONNECTED, account)
+
+  sendAnalyticsEvent(InterfaceEventName.WALLET_CONNECT_TXN_COMPLETED, {
+    result: WalletConnectionResult.SUCCEEDED,
+    wallet_address: account,
+    wallet_type: walletType,
+    is_reconnect: isReconnect,
+    peer_wallet_agent: peerWalletAgent,
+  })
 }
 
 export default function WalletModal({

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -145,11 +145,14 @@ export default function App() {
   }, [pathname])
 
   useEffect(() => {
-    sendAnalyticsEvent(SharedEventName.APP_LOADED)
+    // User properties *must* be set before sending corresponding event properties,
+    // so that the event contains the correct and up-to-date user properties.
     user.set(CustomUserProperties.USER_AGENT, navigator.userAgent)
     user.set(CustomUserProperties.BROWSER, getBrowser())
     user.set(CustomUserProperties.SCREEN_RESOLUTION_HEIGHT, window.screen.height)
     user.set(CustomUserProperties.SCREEN_RESOLUTION_WIDTH, window.screen.width)
+
+    sendAnalyticsEvent(SharedEventName.APP_LOADED)
     getCLS(({ delta }: Metric) => sendAnalyticsEvent(SharedEventName.WEB_VITALS, { cumulative_layout_shift: delta }))
     getFCP(({ delta }: Metric) => sendAnalyticsEvent(SharedEventName.WEB_VITALS, { first_contentful_paint_ms: delta }))
     getFID(({ delta }: Metric) => sendAnalyticsEvent(SharedEventName.WEB_VITALS, { first_input_delay_ms: delta }))


### PR DESCRIPTION
Sets user properties before sending events with those properties, so that queries those events will include populated user properties. Current queries for those events - the first time the event occurs - include unpopulated user properties, so we assume they must be set prior to sending the event.

We believe this to be the cause of WEB-2998.