### PR TITLE
feat: trace swap.send

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -10,13 +10,15 @@ import { FeeOptions, toHex } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { formatSwapSignedAnalyticsEventProperties } from 'lib/utils/analytics'
 import { useCallback } from 'react'
+import { trace } from 'tracing'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import isZero from 'utils/isZero'
-import { swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
+import { didUserReject, swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
 
 import { PermitSignature } from './usePermitAllowance'
 
-class InvalidSwapError extends Error {}
+class ModifiedSwapError extends Error {}
+class GasEstimationError extends Error {}
 
 interface SwapOptions {
   slippageTolerance: Percent
@@ -33,55 +35,63 @@ export function useUniversalRouterSwapCallback(
   const { account, chainId, provider } = useWeb3React()
 
   return useCallback(async (): Promise<TransactionResponse> => {
-    try {
-      if (!account) throw new Error('missing account')
-      if (!chainId) throw new Error('missing chainId')
-      if (!provider) throw new Error('missing provider')
-      if (!trade) throw new Error('missing trade')
-
-      const { calldata: data, value } = SwapRouter.swapERC20CallParameters(trade, {
-        slippageTolerance: options.slippageTolerance,
-        deadlineOrPreviousBlockhash: options.deadline?.toString(),
-        inputTokenPermit: options.permit,
-        fee: options.feeOptions,
-      })
-      const tx = {
-        from: account,
-        to: UNIVERSAL_ROUTER_ADDRESS(chainId),
-        data,
-        // TODO: universal-router-sdk returns a non-hexlified value.
-        ...(value && !isZero(value) ? { value: toHex(value) } : {}),
-      }
-
-      let gasEstimate: BigNumber
+    return trace('swap.send', async ({ setTraceData, setTraceStatus, setTraceError }) => {
       try {
-        gasEstimate = await provider.estimateGas(tx)
-      } catch (gasError) {
-        console.warn(gasError)
-        throw new Error('Your swap is expected to fail')
-      }
-      const gasLimit = calculateGasMargin(gasEstimate)
-      const response = await provider
-        .getSigner()
-        .sendTransaction({ ...tx, gasLimit })
-        .then((response) => {
-          sendAnalyticsEvent(
-            SwapEventName.SWAP_SIGNED,
-            formatSwapSignedAnalyticsEventProperties({ trade, fiatValues, txHash: response.hash })
-          )
-          if (tx.data !== response.data) {
-            sendAnalyticsEvent(SwapEventName.SWAP_MODIFIED_IN_WALLET, { txHash: response.hash })
-            throw new InvalidSwapError(
-              t`Your swap was modified through your wallet. If this was a mistake, please cancel immediately or risk losing your funds.`
-            )
-          }
-          return response
+        if (!account) throw new Error('missing account')
+        if (!chainId) throw new Error('missing chainId')
+        if (!provider) throw new Error('missing provider')
+        if (!trade) throw new Error('missing trade')
+
+        setTraceData('slippageTolerance', options.slippageTolerance.toFixed(2))
+        const { calldata: data, value } = SwapRouter.swapERC20CallParameters(trade, {
+          slippageTolerance: options.slippageTolerance,
+          deadlineOrPreviousBlockhash: options.deadline?.toString(),
+          inputTokenPermit: options.permit,
+          fee: options.feeOptions,
         })
-      return response
-    } catch (swapError: unknown) {
-      if (swapError instanceof InvalidSwapError) throw swapError
-      throw new Error(swapErrorToUserReadableMessage(swapError))
-    }
+        const tx = {
+          from: account,
+          to: UNIVERSAL_ROUTER_ADDRESS(chainId),
+          data,
+          // TODO: universal-router-sdk returns a non-hexlified value.
+          ...(value && !isZero(value) ? { value: toHex(value) } : {}),
+        }
+
+        let gasEstimate: BigNumber
+        try {
+          gasEstimate = await provider.estimateGas(tx)
+        } catch (gasError) {
+          setTraceStatus('failed_precondition')
+          setTraceError(gasError)
+          console.warn(gasError)
+          throw new GasEstimationError('Your swap is expected to fail.')
+        }
+        const gasLimit = calculateGasMargin(gasEstimate)
+        setTraceData('gasLimit', gasLimit.toNumber())
+        const response = await provider
+          .getSigner()
+          .sendTransaction({ ...tx, gasLimit })
+          .then((response) => {
+            sendAnalyticsEvent(
+              SwapEventName.SWAP_SIGNED,
+              formatSwapSignedAnalyticsEventProperties({ trade, fiatValues, txHash: response.hash })
+            )
+            if (tx.data !== response.data) {
+              sendAnalyticsEvent(SwapEventName.SWAP_MODIFIED_IN_WALLET, { txHash: response.hash })
+              throw new ModifiedSwapError(
+                t`Your swap was modified through your wallet. If this was a mistake, please cancel immediately or risk losing your funds.`
+              )
+            }
+            return response
+          })
+        return response
+      } catch (swapError: unknown) {
+        if (swapError instanceof ModifiedSwapError) throw swapError
+        if (didUserReject(swapError)) setTraceStatus('cancelled')
+        if (!(swapError instanceof GasEstimationError)) setTraceError(swapError)
+        throw new Error(swapErrorToUserReadableMessage(swapError))
+      }
+    })
   }, [
     account,
     chainId,

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -113,7 +113,7 @@ export function useUniversalRouterSwapCallback(
           throw new Error(swapErrorToUserReadableMessage(swapError))
         }
       },
-      { tags: { widget: false } }
+      { tags: { is_widget: false } }
     )
   }, [
     account,

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -87,8 +87,13 @@ export function useUniversalRouterSwapCallback(
         return response
       } catch (swapError: unknown) {
         if (swapError instanceof ModifiedSwapError) throw swapError
+
+        // Cancellations are not failures, and must be accounted for as 'cancelled'.
         if (didUserReject(swapError)) setTraceStatus('cancelled')
+
+        // GasEstimationErrors are already traced when they are thrown.
         if (!(swapError instanceof GasEstimationError)) setTraceError(swapError)
+
         throw new Error(swapErrorToUserReadableMessage(swapError))
       }
     })

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -7,6 +7,8 @@ import { SharedEventName } from '@uniswap/analytics-events'
 import { isSentryEnabled } from 'utils/env'
 import { getEnvName, isProductionEnv } from 'utils/env'
 
+export { trace } from './trace'
+
 // Dump some metadata into the window to allow client verification.
 window.GIT_COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
 

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -1,0 +1,145 @@
+import '@sentry/tracing' // required to populate Sentry.startTransaction, which is not included in the core module
+
+import * as Sentry from '@sentry/react'
+import { Transaction } from '@sentry/tracing'
+import assert from 'assert'
+
+import { trace } from './trace'
+
+jest.mock('@sentry/react', () => {
+  return {
+    startTransaction: jest.fn(),
+  }
+})
+const startTransaction = Sentry.startTransaction as jest.Mock
+
+function getTransaction(index = 0): Transaction {
+  const transactions = startTransaction.mock.results.map(({ value }) => value)
+  expect(transactions).toHaveLength(index + 1)
+  const transaction = transactions[index]
+  expect(transaction).toBeDefined()
+  return transaction
+}
+
+describe('trace', () => {
+  beforeEach(() => {
+    const Sentry = jest.requireActual('@sentry/react')
+    startTransaction.mockReset().mockImplementation((context) => {
+      const transaction: Transaction = Sentry.startTransaction(context)
+      transaction.initSpanRecorder()
+      return transaction
+    })
+  })
+
+  it('propagates callback', async () => {
+    await expect(trace('test', () => Promise.resolve('resolved'))).resolves.toBe('resolved')
+    await expect(trace('test', () => Promise.reject('rejected'))).rejects.toBe('rejected')
+  })
+
+  it('records transaction', async () => {
+    const metadata = { data: { a: 'a', b: 2 }, tags: { c: 'c', d: 4 } }
+    await trace('test', () => Promise.resolve(), metadata)
+    const transaction = getTransaction()
+    expect(transaction.name).toBe('test')
+    expect(transaction.data).toEqual({ a: 'a', b: 2 })
+    expect(transaction.tags).toEqual({ c: 'c', d: 4 })
+  })
+
+  describe('defaults status', () => {
+    it('"ok" if resolved', async () => {
+      await trace('test', () => Promise.resolve())
+      const transaction = getTransaction()
+      expect(transaction.status).toBe('ok')
+    })
+
+    it('"internal_error" if rejected, with data.error set to rejection', async () => {
+      const error = new Error('Test error')
+      await expect(trace('test', () => Promise.reject(error))).rejects.toBe(error)
+      const transaction = getTransaction()
+      expect(transaction.status).toBe('internal_error')
+      expect(transaction.data).toEqual({ error })
+    })
+  })
+
+  describe('setTraceData', () => {
+    it('sets transaction data', async () => {
+      await trace('test', ({ setTraceData }) => {
+        setTraceData('a', 'a')
+        setTraceData('b', 2)
+        return Promise.resolve()
+      })
+      const transaction = getTransaction()
+      expect(transaction.data).toEqual({ a: 'a', b: 2 })
+    })
+  })
+
+  describe('setTraceTag', () => {
+    it('sets a transaction tag', async () => {
+      await trace('test', ({ setTraceTag }) => {
+        setTraceTag('c', 'c')
+        setTraceTag('d', 4)
+        return Promise.resolve()
+      })
+      const transaction = getTransaction()
+      expect(transaction.tags).toEqual({ c: 'c', d: 4 })
+    })
+  })
+
+  describe('setTraceStatus', () => {
+    it('sets a transaction status with a string', async () => {
+      await trace('test', ({ setTraceStatus }) => {
+        setTraceStatus('cancelled')
+        return Promise.resolve()
+      })
+      let transaction = getTransaction(0)
+      expect(transaction.status).toBe('cancelled')
+
+      await expect(
+        trace('test', ({ setTraceStatus }) => {
+          setTraceStatus('failed_precondition')
+          return Promise.reject()
+        })
+      ).rejects.toBeUndefined()
+      transaction = getTransaction(1)
+      expect(transaction.status).toBe('failed_precondition')
+    })
+
+    it('sets a transaction http status with a number', async () => {
+      await trace('test', ({ setTraceStatus }) => {
+        setTraceStatus(429)
+        return Promise.resolve()
+      })
+      const transaction = getTransaction()
+      expect(transaction.status).toBe('resource_exhausted')
+    })
+  })
+
+  describe('setTraceError', () => {
+    it('sets transaction data.error', async () => {
+      const error = new Error('Test error')
+      await expect(
+        trace('test', ({ setTraceError }) => {
+          setTraceError(error)
+          return Promise.reject(new Error(`Wrapped ${error.message}`))
+        })
+      ).rejects.toBeDefined()
+      const transaction = getTransaction()
+      expect(transaction.data).toEqual({ error })
+    })
+  })
+
+  describe('traceChild', () => {
+    it('starts a span under a transaction', async () => {
+      await trace('test', ({ traceChild }) => {
+        traceChild('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { f: 6 } })
+        return Promise.resolve()
+      })
+      const transaction = getTransaction()
+      const span = transaction.spanRecorder?.spans[1]
+      assert(span)
+      expect(span.op).toBe('child')
+      expect(span.data).toEqual({ e: 'e' })
+      expect(span.tags).toEqual({ f: 6 })
+    })
+  })
+})

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -37,12 +37,12 @@ describe('trace', () => {
   })
 
   it('records transaction', async () => {
-    const metadata = { data: { a: 'a', b: 2 }, tags: { widget: true } }
+    const metadata = { data: { a: 'a', b: 2 }, tags: { is_widget: true } }
     await trace('test', () => Promise.resolve(), metadata)
     const transaction = getTransaction()
     expect(transaction.name).toBe('test')
     expect(transaction.data).toEqual({ a: 'a', b: 2 })
-    expect(transaction.tags).toEqual({ widget: true })
+    expect(transaction.tags).toEqual({ is_widget: true })
   })
 
   describe('defaults status', () => {
@@ -76,11 +76,11 @@ describe('trace', () => {
   describe('setTraceTag', () => {
     it('sets a transaction tag', async () => {
       await trace('test', ({ setTraceTag }) => {
-        setTraceTag('widget', true)
+        setTraceTag('is_widget', true)
         return Promise.resolve()
       })
       const transaction = getTransaction()
-      expect(transaction.tags).toEqual({ widget: true })
+      expect(transaction.tags).toEqual({ is_widget: true })
     })
   })
 
@@ -130,7 +130,7 @@ describe('trace', () => {
   describe('traceChild', () => {
     it('starts a span under a transaction', async () => {
       await trace('test', ({ traceChild }) => {
-        traceChild('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { widget: true } })
+        traceChild('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { is_widget: true } })
         return Promise.resolve()
       })
       const transaction = getTransaction()
@@ -138,7 +138,7 @@ describe('trace', () => {
       assert(span)
       expect(span.op).toBe('child')
       expect(span.data).toEqual({ e: 'e' })
-      expect(span.tags).toEqual({ widget: true })
+      expect(span.tags).toEqual({ is_widget: true })
     })
   })
 })

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -37,12 +37,12 @@ describe('trace', () => {
   })
 
   it('records transaction', async () => {
-    const metadata = { data: { a: 'a', b: 2 }, tags: { c: 'c', d: 4 } }
+    const metadata = { data: { a: 'a', b: 2 }, tags: { widget: true } }
     await trace('test', () => Promise.resolve(), metadata)
     const transaction = getTransaction()
     expect(transaction.name).toBe('test')
     expect(transaction.data).toEqual({ a: 'a', b: 2 })
-    expect(transaction.tags).toEqual({ c: 'c', d: 4 })
+    expect(transaction.tags).toEqual({ widget: true })
   })
 
   describe('defaults status', () => {
@@ -76,12 +76,11 @@ describe('trace', () => {
   describe('setTraceTag', () => {
     it('sets a transaction tag', async () => {
       await trace('test', ({ setTraceTag }) => {
-        setTraceTag('c', 'c')
-        setTraceTag('d', 4)
+        setTraceTag('widget', true)
         return Promise.resolve()
       })
       const transaction = getTransaction()
-      expect(transaction.tags).toEqual({ c: 'c', d: 4 })
+      expect(transaction.tags).toEqual({ widget: true })
     })
   })
 
@@ -131,7 +130,7 @@ describe('trace', () => {
   describe('traceChild', () => {
     it('starts a span under a transaction', async () => {
       await trace('test', ({ traceChild }) => {
-        traceChild('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { f: 6 } })
+        traceChild('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { widget: true } })
         return Promise.resolve()
       })
       const transaction = getTransaction()
@@ -139,7 +138,7 @@ describe('trace', () => {
       assert(span)
       expect(span.op).toBe('child')
       expect(span.data).toEqual({ e: 'e' })
-      expect(span.tags).toEqual({ f: 6 })
+      expect(span.tags).toEqual({ widget: true })
     })
   })
 })

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -1,0 +1,53 @@
+import * as Sentry from '@sentry/react'
+import { SpanStatusType } from '@sentry/tracing'
+import { Span, Transaction } from '@sentry/types'
+
+interface TraceMetadata {
+  data?: Record<string, unknown>
+  tags?: Record<string, string | number | boolean>
+}
+
+interface TraceCallbackOptions {
+  traceChild<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T>
+  setTraceData(key: string, value: unknown): void
+  setTraceTag(key: string, value: string | number | boolean): void
+  setTraceStatus(status: SpanStatusType): void
+  setTraceError(error: unknown): void
+}
+type TraceCallback<T> = (options: TraceCallbackOptions) => Promise<T>
+
+function traceTransaction(transaction?: Transaction | Span) {
+  const traceChild = <T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata) => {
+    const child = transaction?.startChild({ ...metadata, op: name })
+    return traceTransaction(child)(name, callback)
+  }
+  const setTraceData = (key: string, value: unknown) => void transaction?.setData(key, value)
+  const setTraceTag = (key: string, value: string | number | boolean) => void transaction?.setTag(key, value)
+  const setTraceStatus = (status: number | SpanStatusType) => {
+    if (typeof status === 'number') {
+      transaction?.setHttpStatus(status)
+    } else {
+      transaction?.setStatus(status)
+    }
+  }
+  const setTraceError = (error: unknown) => void transaction?.setData('error', error)
+
+  return async function boundTrace<T>(name: string, callback: TraceCallback<T>): Promise<T> {
+    try {
+      return await callback({ traceChild, setTraceData, setTraceTag, setTraceStatus, setTraceError })
+    } catch (error) {
+      if (!transaction?.status) transaction?.setStatus('internal_error')
+      if (!transaction?.data.error) transaction?.setData('error', error)
+      throw error
+    } finally {
+      if (!transaction?.status) transaction?.setStatus('ok')
+      transaction?.finish()
+    }
+  }
+}
+
+/** Traces the callback, adding any metadata to the trace. */
+export async function trace<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T> {
+  const transaction = Sentry.startTransaction({ name, data: metadata?.data, tags: metadata?.tags })
+  return traceTransaction(transaction)(name, callback)
+}

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -15,10 +15,21 @@ interface TraceMetadata {
 // These methods are provided as an abstraction so that users will not interact with Sentry directly.
 // This avoids tightly coupling Sentry to our instrumentation outside of this file, in case we swap services.
 interface TraceCallbackOptions {
+  /**
+   * Traces the callback as a child of the active trace.
+   * @param name - The name of the child. (On Sentry, this will appear as the "op".)
+   * @param callback - The callback to trace. The child trace will run for the duration of the callback.
+   * @param metadata - Any data or tags to include in the child trace.
+   */
   traceChild<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T>
   setTraceData(key: string, value: unknown): void
   setTraceTag<K extends keyof TraceTags>(key: K, value: TraceTags[K]): void
+  /**
+   * Sets the status of a trace. If unset, the status will be set to 'ok' (or 'internal_error' if the callback throws).
+   * @param status - If a number is passed, the corresponding http status will be used.
+   */
   setTraceStatus(status: number | SpanStatusType): void
+  /** Sets the error data of a trace. If unset and the callback throws, the thrown error will be set. */
   setTraceError(error: unknown): void
 }
 type TraceCallback<T> = (options: TraceCallbackOptions) => Promise<T>
@@ -66,7 +77,12 @@ function traceSpan(span?: Span) {
   }
 }
 
-/** Traces the callback, adding any metadata to the trace. */
+/**
+ * Traces the callback, adding any metadata to the trace.
+ * @param name - The name of your trace.
+ * @param callback - The callback to trace. The trace will run for the duration of the callback.
+ * @param metadata - Any data or tags to include in the trace.
+ */
 export async function trace<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T> {
   const transaction = Sentry.startTransaction({ name, data: metadata?.data, tags: metadata?.tags })
   return traceSpan(transaction)(callback)

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react'
 import { Span, SpanStatusType } from '@sentry/tracing'
 
 type TraceTags = {
-  widget: boolean
+  is_widget: boolean
 }
 
 interface TraceMetadata {

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -24,8 +24,12 @@ function traceTransaction(transaction?: Span) {
     const child = transaction?.startChild({ ...metadata, op: name })
     return traceTransaction(child)(name, callback)
   }
-  const setTraceData = (key: string, value: unknown) => void transaction?.setData(key, value)
-  const setTraceTag = (key: string, value: string | number | boolean) => void transaction?.setTag(key, value)
+  const setTraceData = (key: string, value: unknown) => {
+    transaction?.setData(key, value)
+  }
+  const setTraceTag = (key: string, value: string | number | boolean) => {
+    transaction?.setTag(key, value)
+  }
   const setTraceStatus = (status: number | SpanStatusType) => {
     if (typeof status === 'number') {
       transaction?.setHttpStatus(status)
@@ -33,7 +37,9 @@ function traceTransaction(transaction?: Span) {
       transaction?.setStatus(status)
     }
   }
-  const setTraceError = (error: unknown) => void transaction?.setData('error', error)
+  const setTraceError = (error: unknown) => {
+    transaction?.setData('error', error)
+  }
 
   return async function boundTrace<T>(name: string, callback: TraceCallback<T>): Promise<T> {
     try {

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -3,10 +3,14 @@ import { SpanStatusType } from '@sentry/tracing'
 import { Span, Transaction } from '@sentry/types'
 
 interface TraceMetadata {
+  /** Arbitrary data stored on a trace. */
   data?: Record<string, unknown>
+  /** Indexed (ie searchable) tags associated with a trace. */
   tags?: Record<string, string | number | boolean>
 }
 
+// These methods are provided as an abstraction so that users will not interact with Sentry directly.
+// This avoids tightly coupling Sentry to our instrumentation outside of this file, in case we swap services.
 interface TraceCallbackOptions {
   traceChild<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T>
   setTraceData(key: string, value: unknown): void
@@ -36,10 +40,13 @@ function traceTransaction(transaction?: Transaction | Span) {
     try {
       return await callback({ traceChild, setTraceData, setTraceTag, setTraceStatus, setTraceError })
     } catch (error) {
+      // Do not overwrite any custom status or error data that was already set.
       if (!transaction?.status) transaction?.setStatus('internal_error')
       if (!transaction?.data.error) transaction?.setData('error', error)
+
       throw error
     } finally {
+      // If no status was reported, assume that it was 'ok'. Otherwise, it will default to 'unknown'.
       if (!transaction?.status) transaction?.setStatus('ok')
       transaction?.finish()
     }

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/react'
-import { SpanStatusType } from '@sentry/tracing'
-import { Span, Transaction } from '@sentry/types'
+import { Span, SpanStatusType } from '@sentry/tracing'
 
 interface TraceMetadata {
   /** Arbitrary data stored on a trace. */
@@ -15,12 +14,12 @@ interface TraceCallbackOptions {
   traceChild<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T>
   setTraceData(key: string, value: unknown): void
   setTraceTag(key: string, value: string | number | boolean): void
-  setTraceStatus(status: SpanStatusType): void
+  setTraceStatus(status: number | SpanStatusType): void
   setTraceError(error: unknown): void
 }
 type TraceCallback<T> = (options: TraceCallbackOptions) => Promise<T>
 
-function traceTransaction(transaction?: Transaction | Span) {
+function traceTransaction(transaction?: Span) {
   const traceChild = <T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata) => {
     const child = transaction?.startChild({ ...metadata, op: name })
     return traceTransaction(child)(name, callback)

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -36,7 +36,7 @@ export function didUserReject(error: any): boolean {
 /**
  * This is hacking out the revert reason from the ethers provider thrown error however it can.
  * This object seems to be undocumented by ethers.
- * @param error an error from the ethers provider
+ * @param error - An error from the ethers provider
  */
 export function swapErrorToUserReadableMessage(error: any): string {
   if (didUserReject(error)) {

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -1,30 +1,18 @@
-// eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
-/**
- * This is hacking out the revert reason from the ethers provider thrown error however it can.
- * This object seems to be undocumented by ethers.
- * @param error an error from the ethers provider
- */
-export function swapErrorToUserReadableMessage(error: any): string {
+
+function getReason(error: any): string | undefined {
   let reason: string | undefined
-
-  if (error.code) {
-    switch (error.code) {
-      case 4001:
-        return t`Transaction rejected`
-    }
-  }
-
-  console.warn('Swap error:', error)
-
   while (error) {
     reason = error.reason ?? error.message ?? reason
     error = error.error ?? error.data?.originalError
   }
+  return reason
+}
 
-  // The 4001 error code doesn't capture the case where users reject a transaction for all wallets,
-  // so we need to parse the reason for these special cases:
+export function didUserReject(error: any): boolean {
+  const reason = getReason(error)
   if (
+    error?.code === 4001 ||
     // ethers v5.7.0 wrapped error
     error?.code === 'ACTION_REJECTED' ||
     // For Rainbow :
@@ -32,20 +20,35 @@ export function swapErrorToUserReadableMessage(error: any): string {
     // For Frame:
     reason?.match(/declined/i) ||
     // For SafePal:
-    reason?.match(/cancelled by user/i) ||
+    reason?.match(/cancell?ed by user/i) ||
+    // For Trust:
+    reason?.match(/user cancell?ed/i) ||
     // For Coinbase:
     reason?.match(/user denied/i) ||
     // For Fireblocks
     reason?.match(/user rejected/i)
   ) {
+    return true
+  }
+  return false
+}
+
+/**
+ * This is hacking out the revert reason from the ethers provider thrown error however it can.
+ * This object seems to be undocumented by ethers.
+ * @param error an error from the ethers provider
+ */
+export function swapErrorToUserReadableMessage(error: any): string {
+  if (didUserReject(error)) {
     return t`Transaction rejected`
   }
 
+  let reason = getReason(error)
   if (reason?.indexOf('execution reverted: ') === 0) reason = reason.substr('execution reverted: '.length)
 
   switch (reason) {
     case 'UniswapV2Router: EXPIRED':
-      return t`The transaction could not be sent because the deadline has passed. Please check that your transaction deadline is not too low.`
+      return t`This transaction could not be sent because the deadline has passed. Please check that your transaction deadline is not too low.`
     case 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT':
     case 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT':
       return t`This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.`
@@ -63,6 +66,7 @@ export function swapErrorToUserReadableMessage(error: any): string {
       return t`The output token cannot be transferred. There may be an issue with the output token. Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
     default:
       if (reason?.indexOf('undefined is not an object') !== -1) {
+        console.error(error, reason)
         return t`An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If that does not work, there may be an incompatibility with the token you are trading. Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
       }
       return t`${reason ? reason : 'Unknown error'}. Try increasing your slippage tolerance.


### PR DESCRIPTION
Adds a performance trace for `swap.send`
Also adds the necessary abstraction for collecting that trace, in `src/tracing`.