### PR TITLE
fix: don't fire off a graphql query on an empty search

### DIFF
--- a/src/graphql/data/SearchTokens.ts
+++ b/src/graphql/data/SearchTokens.ts
@@ -79,6 +79,7 @@ export function useSearchTokens(searchQuery: string, chainId: number) {
     variables: {
       searchQuery,
     },
+    skip: !searchQuery,
   })
 
   const sortedTokens = useMemo(() => {

--- a/src/graphql/data/nft/CollectionSearch.ts
+++ b/src/graphql/data/nft/CollectionSearch.ts
@@ -57,7 +57,7 @@ function useCollectionQuerySearch(query: string, skip?: boolean): useCollectionS
     variables: {
       query,
     },
-    skip,
+    skip: skip || !query,
   })
 
   return useMemo(() => {


### PR DESCRIPTION
In an effort to cut down on extraneous graphql queries, previously every pageload would do an empty query to SearchTokens with blank input. This skips all queries with empty input. We currently have collection search via graphql behind a feature flag so I've added this fix there as well.