### PR TITLE
fix: reset to defaultTokens when chain changes

### DIFF
--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -74,14 +74,10 @@ export function useSyncWidgetInputs({
 
   useEffect(() => {
     if (chainId !== previousChainId && !!previousChainId && isSupportedChain(chainId)) {
-      setTokens({
-        ...tokens,
-        [Field.INPUT]: undefined,
-        [Field.OUTPUT]: undefined,
-      })
+      setTokens(defaultTokens)
       setAmount(EMPTY_AMOUNT)
     }
-  }, [chainId, previousChainId, tokens])
+  }, [chainId, defaultTokens, previousChainId, tokens])
 
   const onAmountChange = useCallback(
     (field: Field, amount: string, origin?: 'max') => {


### PR DESCRIPTION
these undefined inputs are not getting reset when we change chains, because of some recent changes to the token state management in the hook above.


https://user-images.githubusercontent.com/66155195/225092236-8f34043e-b3b2-4e33-92c6-53c2db51a8a0.mov

