### PR TITLE
fix: Eth price fetch cache miss and use default fetch policy to remove extra network requests

### DIFF
--- a/src/graphql/data/TokenSpotPrice.ts
+++ b/src/graphql/data/TokenSpotPrice.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 gql`
-  query TokenSpotPrice($chain: Chain!, $address: String) {
+  query TokenSpotPrice($chain: Chain!, $address: String = null) {
     token(chain: $chain, address: $address) {
       id
       address

--- a/src/hooks/useUSDPrice.ts
+++ b/src/hooks/useUSDPrice.ts
@@ -63,6 +63,7 @@ export function useUSDPrice(currencyAmount?: CurrencyAmount<Currency>): {
     skip: !chain || !isGqlSupportedChain(currency?.chainId),
     pollInterval: PollingInterval.Normal,
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'cache-first',
   })
 
   // Use USDC price for chains not supported by backend yet


### PR DESCRIPTION
### Overview
This PR fixes an issue where we make extraneous network requests for ETH price.

### Implementation
Two parts:
1. Our default fetch-policy of `cache-and-network` means that every time the gql query hook runs, it will fire a network request regardless of cache status. Use the default `cache-first` policy so that it skips network requests if there exists a price in cache. We have a polling interval on the query, so I'm not too worried about data staleness.
2. We were also passing in `address = undefined` and saving `address = null` so we wouldn't hit the cache properly.

### Followups
Is `cache-and-network` the right default policy? Am noticing that it is fetching extra network requests on the Token details page as well, but we should figure out a way to do TTLs on the apollo cache so we don't serve stale data. Look into [this](https://www.npmjs.com/package/apollo-invalidation-policies) maybe?

### How to test
In preview link, type inputs into swap input or output, and see in the network tab that it's not making a separate gql request when you clear input and type input.