### PR TITLE
feat: trace jsonrpc

### DIFF
--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -1,4 +1,5 @@
 import 'components/analytics'
+import './jsonrpc'
 
 import * as Sentry from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'

--- a/src/tracing/jsonrpc.ts
+++ b/src/tracing/jsonrpc.ts
@@ -1,0 +1,25 @@
+/**
+ * Traces all JsonRpc requests as spans, reporting them if there is an active transaction.
+ * This is analagous to import("@sentry/tracing").BrowserTracingOptions.shouldCreateSpanForRequest.
+ *
+ * This is able to collect all requests because there is only one copy of @ethersproject/providers, and web3-react wraps
+ * any external (EIP-1193) provider in that prototype - overriding the prototype will override send for all instances.
+ */
+import { JsonRpcProvider } from '@ethersproject/providers'
+
+import { maybeTrace } from './trace'
+
+const JsonRpcProviderSend = JsonRpcProvider.prototype.send
+JsonRpcProvider.prototype.send = async function LoggingAwareSend(this, method, params) {
+  maybeTrace('jsonRpc.send', async ({ setTraceData }) => {
+    setTraceData('method', method)
+    if (method === 'eth_call') {
+      // Trim the calldata to the method hash to avoid recording large payloads and sensitive information.
+      const methodHash = (params[0].data as string).substring(0, 10)
+      setTraceData('params', { ...params, [0]: { ...params[0], data: methodHash } })
+    } else {
+      setTraceData('params', params)
+    }
+    return JsonRpcProviderSend.call(this, method, params)
+  })
+}

--- a/src/tracing/jsonrpc.ts
+++ b/src/tracing/jsonrpc.ts
@@ -9,17 +9,18 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 
 import { maybeTrace } from './trace'
 
-const JsonRpcProviderSend = JsonRpcProvider.prototype.send
+const jsonRpcProviderSend = JsonRpcProvider.prototype.send
 JsonRpcProvider.prototype.send = async function LoggingAwareSend(this, method, params) {
-  maybeTrace('jsonRpc.send', async ({ setTraceData }) => {
+  maybeTrace('json_rpc', async ({ setTraceData }) => {
     setTraceData('method', method)
     if (method === 'eth_call') {
-      // Trim the calldata to the method hash to avoid recording large payloads and sensitive information.
+      // Trim the calldata to the method hash (10 chars) to avoid recording large payloads and sensitive information.
       const methodHash = (params[0].data as string).substring(0, 10)
+      // Override the calldata with the method hash, which is part of the first param.
       setTraceData('params', { ...params, [0]: { ...params[0], data: methodHash } })
     } else {
       setTraceData('params', params)
     }
-    return JsonRpcProviderSend.call(this, method, params)
+    return jsonRpcProviderSend.call(this, method, params)
   })
 }

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -1,13 +1,15 @@
 import '@sentry/tracing' // required to populate Sentry.startTransaction, which is not included in the core module
 
 import * as Sentry from '@sentry/react'
+import { Hub } from '@sentry/react'
 import { Transaction } from '@sentry/tracing'
 import assert from 'assert'
 
-import { trace } from './trace'
+import { maybeTrace, trace } from './trace'
 
 jest.mock('@sentry/react', () => {
   return {
+    getCurrentHub: jest.fn(),
     startTransaction: jest.fn(),
   }
 })
@@ -21,16 +23,16 @@ function getTransaction(index = 0): Transaction {
   return transaction
 }
 
-describe('trace', () => {
-  beforeEach(() => {
-    const Sentry = jest.requireActual('@sentry/react')
-    startTransaction.mockReset().mockImplementation((context) => {
-      const transaction: Transaction = Sentry.startTransaction(context)
-      transaction.initSpanRecorder()
-      return transaction
-    })
+beforeEach(() => {
+  const Sentry = jest.requireActual('@sentry/react')
+  startTransaction.mockReset().mockImplementation((context) => {
+    const transaction: Transaction = Sentry.startTransaction(context)
+    transaction.initSpanRecorder()
+    return transaction
   })
+})
 
+describe('trace', () => {
   it('propagates callback', async () => {
     await expect(trace('test', () => Promise.resolve('resolved'))).resolves.toBe('resolved')
     await expect(trace('test', () => Promise.reject('rejected'))).rejects.toBe('rejected')
@@ -140,5 +142,34 @@ describe('trace', () => {
       expect(span.data).toEqual({ e: 'e' })
       expect(span.tags).toEqual({ is_widget: true })
     })
+  })
+})
+
+describe('maybeTrace', () => {
+  const getScope = jest.fn()
+
+  beforeEach(() => {
+    getScope.mockReset()
+    const hub = { getScope } as unknown as Hub
+    jest.spyOn(Sentry, 'getCurrentHub').mockReturnValue(hub)
+  })
+
+  it('propagates callback', async () => {
+    await expect(maybeTrace('test', () => Promise.resolve('resolved'))).resolves.toBe('resolved')
+    await expect(maybeTrace('test', () => Promise.reject('rejected'))).rejects.toBe('rejected')
+  })
+
+  it('creates a span under the active transaction', async () => {
+    getScope.mockReturnValue({ getTransaction })
+    await trace('test', () => {
+      maybeTrace('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { f: 6 } })
+      return Promise.resolve()
+    })
+    const transaction = getTransaction()
+    const span = transaction.spanRecorder?.spans[1]
+    assert(span)
+    expect(span.op).toBe('child')
+    expect(span.data).toEqual({ e: 'e' })
+    expect(span.tags).toEqual({ f: 6 })
   })
 })

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -162,7 +162,7 @@ describe('maybeTrace', () => {
   it('creates a span under the active transaction', async () => {
     getScope.mockReturnValue({ getTransaction })
     await trace('test', () => {
-      maybeTrace('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { f: 6 } })
+      maybeTrace('child', () => Promise.resolve(), { data: { e: 'e' }, tags: { is_widget: true } })
       return Promise.resolve()
     })
     const transaction = getTransaction()
@@ -170,6 +170,6 @@ describe('maybeTrace', () => {
     assert(span)
     expect(span.op).toBe('child')
     expect(span.data).toEqual({ e: 'e' })
-    expect(span.tags).toEqual({ f: 6 })
+    expect(span.tags).toEqual({ is_widget: true })
   })
 })

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -87,3 +87,12 @@ export async function trace<T>(name: string, callback: TraceCallback<T>, metadat
   const transaction = Sentry.startTransaction({ name, data: metadata?.data, tags: metadata?.tags })
   return traceSpan(transaction)(callback)
 }
+
+/** Traces the callback as part of an already active trace if an active trace exists. */
+export async function maybeTrace<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T> {
+  const span = Sentry.getCurrentHub()
+    .getScope()
+    ?.getTransaction()
+    ?.startChild({ op: name, data: metadata?.data, tags: metadata?.tags })
+  return traceSpan(span)(callback)
+}

--- a/src/tracing/trace.ts
+++ b/src/tracing/trace.ts
@@ -88,7 +88,12 @@ export async function trace<T>(name: string, callback: TraceCallback<T>, metadat
   return traceSpan(transaction)(callback)
 }
 
-/** Traces the callback as part of an already active trace if an active trace exists. */
+/**
+ * Traces the callback as part of an already active trace if an active trace exists.
+ * @param name - The name of your trace.
+ * @param callback - The callback to trace. The trace will run for the duration of the callback.
+ * @param metadata - Any data or tags to include in the trace.
+ */
 export async function maybeTrace<T>(name: string, callback: TraceCallback<T>, metadata?: TraceMetadata): Promise<T> {
   const span = Sentry.getCurrentHub()
     .getScope()


### PR DESCRIPTION
Conditionally adds a performance trace for `jsonrpc.send`, if it occurs during another active trace.
Also adds the necessary abstraction for conditionally collecting trace, in `src/tracing` (`maybeTrace`).