### PR TITLE
feat: link to token details from /pool/{}

### DIFF
--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -20,6 +20,7 @@ import { RowBetween, RowFixed } from 'components/Row'
 import { Dots } from 'components/swap/styleds'
 import Toggle from 'components/Toggle'
 import TransactionConfirmationModal, { ConfirmationModalContent } from 'components/TransactionConfirmationModal'
+import { CHAIN_ID_TO_BACKEND_NAME } from 'graphql/data/util'
 import { useToken } from 'hooks/Tokens'
 import { useV3NFTPositionManagerContract } from 'hooks/useContract'
 import useIsTickAtLimit from 'hooks/useIsTickAtLimit'
@@ -51,20 +52,20 @@ import { calculateGasMargin } from '../../utils/calculateGasMargin'
 import { ExplorerDataType, getExplorerLink } from '../../utils/getExplorerLink'
 import { LoadingRows } from './styleds'
 
+const SUPPORTED_CHAIN_IDS = [
+  SupportedChainId.MAINNET,
+  SupportedChainId.ARBITRUM_ONE,
+  SupportedChainId.OPTIMISM,
+  SupportedChainId.CELO,
+]
+
 const getTokenLink = (chainId: SupportedChainId, address: string) => {
-  const chainName = CHAIN_ID_TO_NAME[chainId]
-  if (chainName) {
+  if (SUPPORTED_CHAIN_IDS.includes(chainId)) {
+    const chainName = CHAIN_ID_TO_BACKEND_NAME[chainId]
     return `${window.location.origin}/#/tokens/${chainName}/${address}`
   } else {
     return getExplorerLink(chainId, address, ExplorerDataType.TOKEN)
   }
-}
-
-const CHAIN_ID_TO_NAME: Partial<Record<SupportedChainId, string>> = {
-  [SupportedChainId.ARBITRUM_ONE]: 'arbitrum',
-  [SupportedChainId.OPTIMISM]: 'optimism',
-  [SupportedChainId.MAINNET]: 'ethereum',
-  [SupportedChainId.CELO]: 'celo',
 }
 
 const PageWrapper = styled.div`

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -6,6 +6,7 @@ import { InterfacePageName } from '@uniswap/analytics-events'
 import { formatPrice, NumberType } from '@uniswap/conedison/format'
 import { Currency, CurrencyAmount, Fraction, Percent, Price, Token } from '@uniswap/sdk-core'
 import { NonfungiblePositionManager, Pool, Position } from '@uniswap/v3-sdk'
+import { SupportedChainId } from '@uniswap/widgets'
 import { useWeb3React } from '@web3-react/core'
 import { sendEvent } from 'components/analytics'
 import Badge from 'components/Badge'
@@ -49,6 +50,22 @@ import { TransactionType } from '../../state/transactions/types'
 import { calculateGasMargin } from '../../utils/calculateGasMargin'
 import { ExplorerDataType, getExplorerLink } from '../../utils/getExplorerLink'
 import { LoadingRows } from './styleds'
+
+const getTokenLink = (chainId: SupportedChainId, address: string) => {
+  const chainName = CHAIN_ID_TO_NAME[chainId]
+  if (chainName) {
+    return `${window.location.origin}/#/tokens/${chainName}/${address}`
+  } else {
+    return getExplorerLink(chainId, address, ExplorerDataType.TOKEN)
+  }
+}
+
+const CHAIN_ID_TO_NAME: Partial<Record<SupportedChainId, string>> = {
+  [SupportedChainId.ARBITRUM_ONE]: 'arbitrum',
+  [SupportedChainId.OPTIMISM]: 'optimism',
+  [SupportedChainId.MAINNET]: 'ethereum',
+  [SupportedChainId.CELO]: 'celo',
+}
 
 const PageWrapper = styled.div`
   padding: 68px 16px 16px 16px;
@@ -196,7 +213,7 @@ function LinkedCurrency({ chainId, currency }: { chainId?: number; currency?: Cu
 
   if (typeof chainId === 'number' && address) {
     return (
-      <ExternalLink href={getExplorerLink(chainId, address, ExplorerDataType.TOKEN)}>
+      <ExternalLink href={getTokenLink(chainId, address)}>
         <RowFixed>
           <CurrencyLogo currency={currency} size="20px" style={{ marginRight: '0.5rem' }} />
           <ThemedText.DeprecatedMain>{currency?.symbol} ↗</ThemedText.DeprecatedMain>

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -20,7 +20,7 @@ import { RowBetween, RowFixed } from 'components/Row'
 import { Dots } from 'components/swap/styleds'
 import Toggle from 'components/Toggle'
 import TransactionConfirmationModal, { ConfirmationModalContent } from 'components/TransactionConfirmationModal'
-import { CHAIN_ID_TO_BACKEND_NAME } from 'graphql/data/util'
+import { CHAIN_ID_TO_BACKEND_NAME, isGqlSupportedChain } from 'graphql/data/util'
 import { useToken } from 'hooks/Tokens'
 import { useV3NFTPositionManagerContract } from 'hooks/useContract'
 import useIsTickAtLimit from 'hooks/useIsTickAtLimit'
@@ -52,15 +52,8 @@ import { calculateGasMargin } from '../../utils/calculateGasMargin'
 import { ExplorerDataType, getExplorerLink } from '../../utils/getExplorerLink'
 import { LoadingRows } from './styleds'
 
-const SUPPORTED_CHAIN_IDS = [
-  SupportedChainId.MAINNET,
-  SupportedChainId.ARBITRUM_ONE,
-  SupportedChainId.OPTIMISM,
-  SupportedChainId.CELO,
-]
-
 const getTokenLink = (chainId: SupportedChainId, address: string) => {
-  if (SUPPORTED_CHAIN_IDS.includes(chainId)) {
+  if (isGqlSupportedChain(chainId)) {
     const chainName = CHAIN_ID_TO_BACKEND_NAME[chainId]
     return `${window.location.origin}/#/tokens/${chainName}/${address}`
   } else {


### PR DESCRIPTION
This is a cherry-pick commit from the work related to https://uniswaplabs.atlassian.net/browse/WEB-3011

We want to link to a TDP link instead of an external explorer when possible. However, for chains that don't have support in the Uniswap interface we'll continue to link externally.

This also will open in a new tab regardless. That's to prevent the user from losing their existing page state.


https://user-images.githubusercontent.com/4899429/225652763-5a17e129-cdfb-40f5-b45c-8782bbd6fa98.mov



Test:
- Go to a position page on Mainnet, Arbitrum
- Click on one of the token links --  should be a TDP link
- Go to a position page on Goerli
- Click on one of the token links -- should be a scanner link