### PR TITLE
fix: Auto-slippage logic

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -13,10 +13,10 @@ import { InterfaceTrade } from 'state/routing/types'
 import useGasPrice from './useGasPrice'
 import useStablecoinPrice, { useStablecoinValue } from './useStablecoinPrice'
 
-const V3_SWAP_DEFAULT_SLIPPAGE = new Percent(50, 10_000) // .50%
+const V3_SWAP_DEFAULT_SLIPPAGE = new Percent(10, 10_000) // .10%
 const ONE_TENTHS_PERCENT = new Percent(10, 10_000) // .10%
 const DEFAULT_AUTO_SLIPPAGE = ONE_TENTHS_PERCENT
-const GAS_ESTIMATE_BUFFER = new Percent(10, 100) // 10%
+const GAS_ESTIMATE_BUFFER = new Percent(110, 100) // 110%
 
 // Base costs regardless of how many hops in the route
 const V3_SWAP_BASE_GAS_ESTIMATE = 100_000
@@ -67,8 +67,8 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
   return undefined
 }
 
-const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 1000) // 0.5%
-const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(25, 100) // 25%
+const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(1, 1000) // 0.1%
+const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 100) // 5%
 
 /**
  * Returns slippage tolerance based on values from current trade, gas estimates from api, and active network.
@@ -110,6 +110,7 @@ export default function useAutoSlippageTolerance(
       // the cost of the gas of the failed transaction
       const fraction = dollarCostToUse.asFraction.divide(outputDollarValue.asFraction)
       const result = new Percent(fraction.numerator, fraction.denominator)
+
       if (result.greaterThan(MAX_AUTO_SLIPPAGE_TOLERANCE)) {
         return MAX_AUTO_SLIPPAGE_TOLERANCE
       }

--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -110,7 +110,6 @@ export default function useAutoSlippageTolerance(
       // the cost of the gas of the failed transaction
       const fraction = dollarCostToUse.asFraction.divide(outputDollarValue.asFraction)
       const result = new Percent(fraction.numerator, fraction.denominator)
-
       if (result.greaterThan(MAX_AUTO_SLIPPAGE_TOLERANCE)) {
         return MAX_AUTO_SLIPPAGE_TOLERANCE
       }

--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -13,9 +13,7 @@ import { InterfaceTrade } from 'state/routing/types'
 import useGasPrice from './useGasPrice'
 import useStablecoinPrice, { useStablecoinValue } from './useStablecoinPrice'
 
-const V3_SWAP_DEFAULT_SLIPPAGE = new Percent(10, 10_000) // .10%
-const ONE_TENTHS_PERCENT = new Percent(10, 10_000) // .10%
-const DEFAULT_AUTO_SLIPPAGE = ONE_TENTHS_PERCENT
+const DEFAULT_AUTO_SLIPPAGE = new Percent(1, 1000) // .10%
 
 // Base costs regardless of how many hops in the route
 const V3_SWAP_BASE_GAS_ESTIMATE = 100_000
@@ -66,7 +64,7 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
   return undefined
 }
 
-const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(1, 1000) // 0.1%
+const MIN_AUTO_SLIPPAGE_TOLERANCE = DEFAULT_AUTO_SLIPPAGE
 // assuming normal gas speeds, most swaps complete within 3 blocks and
 // there's rarely price movement >5% in that time period
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 100) // 5%
@@ -122,6 +120,6 @@ export default function useAutoSlippageTolerance(
       return result
     }
 
-    return V3_SWAP_DEFAULT_SLIPPAGE
+    return DEFAULT_AUTO_SLIPPAGE
   }, [trade, onL2, nativeGasPrice, gasEstimate, nativeCurrency, nativeCurrencyPrice, chainId, outputDollarValue])
 }

--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -16,7 +16,6 @@ import useStablecoinPrice, { useStablecoinValue } from './useStablecoinPrice'
 const V3_SWAP_DEFAULT_SLIPPAGE = new Percent(10, 10_000) // .10%
 const ONE_TENTHS_PERCENT = new Percent(10, 10_000) // .10%
 const DEFAULT_AUTO_SLIPPAGE = ONE_TENTHS_PERCENT
-const GAS_ESTIMATE_BUFFER = new Percent(110, 100) // 110%
 
 // Base costs regardless of how many hops in the route
 const V3_SWAP_BASE_GAS_ESTIMATE = 100_000
@@ -68,6 +67,8 @@ function guesstimateGas(trade: Trade<Currency, Currency, TradeType> | undefined)
 }
 
 const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(1, 1000) // 0.1%
+// assuming normal gas speeds, most swaps complete within 3 blocks and
+// there's rarely price movement >5% in that time period
 const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(5, 100) // 5%
 
 /**
@@ -102,12 +103,12 @@ export default function useAutoSlippageTolerance(
     // if not, use local heuristic
     const dollarCostToUse =
       chainId && SUPPORTED_GAS_ESTIMATE_CHAIN_IDS.includes(chainId) && trade?.gasUseEstimateUSD
-        ? trade.gasUseEstimateUSD.multiply(GAS_ESTIMATE_BUFFER)
-        : dollarGasCost?.multiply(GAS_ESTIMATE_BUFFER)
+        ? trade.gasUseEstimateUSD
+        : dollarGasCost
 
     if (outputDollarValue && dollarCostToUse) {
-      // the rationale is that a user will not want their trade to fail for a loss due to slippage that is less than
-      // the cost of the gas of the failed transaction
+      // optimize for highest possible slippage without getting MEV'd
+      // so set slippage % such that the difference between expected amount out and minimum amount out < gas fee to sandwich the trade
       const fraction = dollarCostToUse.asFraction.divide(outputDollarValue.asFraction)
       const result = new Percent(fraction.numerator, fraction.denominator)
       if (result.greaterThan(MAX_AUTO_SLIPPAGE_TOLERANCE)) {


### PR DESCRIPTION
- Instead of weighing gas by 10%, keep gas multiplier at 100%
- Change the range from [.5%, 25%] to [0.1%, 5%] 