### PR TITLE
fix: remove Create a pool menu option

### DIFF
--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -11,7 +11,7 @@ import { SwitchLocaleLink } from 'components/SwitchLocaleLink'
 import { isSupportedChain } from 'constants/chains'
 import { useV3Positions } from 'hooks/useV3Positions'
 import { useMemo } from 'react'
-import { AlertTriangle, BookOpen, ChevronDown, ChevronsRight, Inbox, Layers, PlusCircle } from 'react-feather'
+import { AlertTriangle, BookOpen, ChevronDown, ChevronsRight, Inbox, Layers } from 'react-feather'
 import { Link } from 'react-router-dom'
 import { useToggleWalletModal } from 'state/application/hooks'
 import { useUserHideClosedPositions } from 'state/user/hooks'
@@ -224,16 +224,6 @@ export default function Pool() {
   const showV2Features = Boolean(V2_FACTORY_ADDRESSES[chainId])
 
   const menuItems = [
-    {
-      content: (
-        <PoolMenuItem>
-          <Trans>Create a pool</Trans>
-          <PlusCircle size={16} />
-        </PoolMenuItem>
-      ),
-      link: '/add/ETH',
-      external: false,
-    },
     {
       content: (
         <PoolMenuItem>


### PR DESCRIPTION
This menu option was leading to the same place as "Create position" above.

To test this, go to the /pool and make sure the menu does not have "Create position" as an option.
