### PR TITLE
fix: link to providing liquidity help doc

### DIFF
--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -261,7 +261,7 @@ export default function Pool() {
           <BookOpen size={16} />
         </PoolMenuItem>
       ),
-      link: 'https://docs.uniswap.org/',
+      link: 'https://support.uniswap.org/hc/en-us/categories/8122334631437-Providing-Liquidity-',
       external: true,
     },
   ]


### PR DESCRIPTION
Links directly to https://support.uniswap.org/hc/en-us/categories/8122334631437-Providing-Liquidity- instead of just the top level docs site.

To test:
- Go to /pool
- Open the submenu
- Click on the "Learn" button to lead to this doc