### PR TITLE
fix: equal width for CTA tiles on /pool

### DIFF
--- a/src/pages/Pool/CTACards.tsx
+++ b/src/pages/Pool/CTACards.tsx
@@ -9,7 +9,7 @@ import { ExternalLink } from '../../theme'
 
 const CTASection = styled.section`
   display: grid;
-  grid-template-columns: 2fr 1.5fr;
+  grid-template-columns: 1fr 1fr;
   gap: 8px;
   opacity: 0.8;
 


### PR DESCRIPTION
Previously, one tile was weighted larger which led to the CTAs looking uneven. Now, the grid enforces the same width.

To test:
- Go to /pool
- Make sure the tiles are the same width

<img width="950" alt="Screen Shot 2023-03-16 at 11 02 42 AM" src="https://user-images.githubusercontent.com/4899429/225658817-6c802ad2-e496-497a-8d32-459f5249b9af.png">

