### PR TITLE
fix: back button should lead to /pools not /pools/v2

### DIFF
--- a/src/pages/PoolFinder/index.tsx
+++ b/src/pages/PoolFinder/index.tsx
@@ -100,7 +100,7 @@ export default function PoolFinder() {
     <Trace page={InterfacePageName.POOL_PAGE} shouldLogImpression>
       <>
         <AppBody>
-          <FindPoolTabs origin={query.get('origin') ?? '/pools/v2'} />
+          <FindPoolTabs origin={query.get('origin') ?? '/pools'} />
           <AutoColumn style={{ padding: '1rem' }} gap="md">
             <BlueCard>
               <AutoColumn gap="10px">


### PR DESCRIPTION
This was leading to an issue where the user would get to the migration flow from the /pool menu, click into import and then back would lead them to the v2 pools page.

Instead, we'll default to taking them to the main pools page.

Test:
- Go to /pool
- Click menu near "add position"
- Click migrate v2 liquidity
- Click import
- Click back
- You should be on /pool again now