### PR TITLE
feat: support both /pool and /pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For steps on local deployment, development, and code contribution, please see [C
 The Uniswap Interface supports swapping, adding liquidity, removing liquidity and migrating liquidity for Uniswap protocol V2.
 
 - Swap on Uniswap V2: <https://app.uniswap.org/#/swap?use=v2>
-- View V2 liquidity: <https://app.uniswap.org/#/pool/v2>
+- View V2 liquidity: <https://app.uniswap.org/#/pools/v2>
 - Add V2 liquidity: <https://app.uniswap.org/#/add/v2>
 - Migrate V2 liquidity to V3: <https://app.uniswap.org/#/migrate/v2>
 

--- a/cypress/e2e/landing.test.ts
+++ b/cypress/e2e/landing.test.ts
@@ -26,6 +26,6 @@ describe('Landing Page', () => {
 
   it('allows navigation to pool', () => {
     cy.get(getTestSelector('pool-nav-link')).first().click()
-    cy.url().should('include', '/pool')
+    cy.url().should('include', '/pools')
   })
 })

--- a/cypress/e2e/pool.test.ts
+++ b/cypress/e2e/pool.test.ts
@@ -1,6 +1,6 @@
 describe('Pool', () => {
   beforeEach(() => {
-    cy.visit('/pool').then(() => {
+    cy.visit('/pools').then(() => {
       cy.wait('@eth_blockNumber')
     })
   })

--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -2,7 +2,7 @@ import { getTestSelector } from '../utils'
 
 describe('Wallet Dropdown', () => {
   before(() => {
-    cy.visit('/pool')
+    cy.visit('/pools')
   })
 
   it('should change the theme', () => {

--- a/src/components/About/AboutFooter.tsx
+++ b/src/components/About/AboutFooter.tsx
@@ -149,7 +149,7 @@ export const AboutFooter = () => {
           <TextLink to="/swap">Swap</TextLink>
           <TextLink to="/tokens">Tokens</TextLink>
           <TextLink to="/nfts">NFTs</TextLink>
-          <TextLink to="/pool">Pools</TextLink>
+          <TextLink to="/pools">Pools</TextLink>
         </LinkGroup>
         <LinkGroup>
           <LinkGroupTitle>Protocol</LinkGroupTitle>

--- a/src/components/About/constants.tsx
+++ b/src/components/About/constants.tsx
@@ -50,7 +50,7 @@ export const MORE_CARDS = [
     elementName: InterfaceElementName.ABOUT_PAGE_BUY_CRYPTO_CARD,
   },
   {
-    to: '/pool',
+    to: '/pools',
     title: 'Earn',
     description: 'Provide liquidity to pools on Uniswap and earn fees on swaps.',
     lightIcon: <StyledCardLogo src={lightArrowImgSrc} alt="Analytics" />,

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -67,8 +67,8 @@ export const PageTabs = () => {
       <MenuItem dataTestId="nft-nav" href="/nfts" isActive={isNftPage}>
         <Trans>NFTs</Trans>
       </MenuItem>
-      <MenuItem href="/pool" dataTestId="pool-nav-link" isActive={isPoolActive}>
-        <Trans>Pool</Trans>
+      <MenuItem href="/pools" dataTestId="pool-nav-link" isActive={isPoolActive}>
+        <Trans>Pools</Trans>
       </MenuItem>
     </>
   )

--- a/src/components/NavigationTabs/index.tsx
+++ b/src/components/NavigationTabs/index.tsx
@@ -75,8 +75,8 @@ export function AddRemoveTabs({
 
   // detect if back should redirect to v3 or v2 pool page
   const poolLink = location.pathname.includes('add/v2')
-    ? '/pool/v2'
-    : '/pool' + (positionID ? `/${positionID.toString()}` : '')
+    ? '/pools/v2'
+    : '/pools' + (positionID ? `/${positionID.toString()}` : '')
 
   return (
     <Tabs>

--- a/src/components/PositionListItem/index.tsx
+++ b/src/components/PositionListItem/index.tsx
@@ -210,7 +210,7 @@ export default function PositionListItem({
   // check if price is within range
   const outOfRange: boolean = pool ? pool.tickCurrent < tickLower || pool.tickCurrent >= tickUpper : false
 
-  const positionSummaryLink = '/pool/' + tokenId
+  const positionSummaryLink = '/pools/' + tokenId
 
   const removed = liquidity?.eq(0)
 

--- a/src/hooks/useIsPoolPage.ts
+++ b/src/hooks/useIsPoolPage.ts
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 export function useIsPoolPage() {
   const { pathname } = useLocation()
   return (
-    pathname.startsWith('/pool') ||
+    pathname.startsWith('/pools') ||
     pathname.startsWith('/add') ||
     pathname.startsWith('/remove') ||
     pathname.startsWith('/increase')

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -372,7 +372,7 @@ export default function AddLiquidity() {
     if (txHash) {
       onFieldAInput('')
       // dont jump to pool page if creating
-      navigate('/pool')
+      navigate('/pools')
     }
     setTxHash('')
   }, [navigate, onFieldAInput, txHash])

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -97,6 +97,7 @@ function getCurrentPageFromLocation(locationPathname: string): InterfacePageName
       return InterfacePageName.SWAP_PAGE
     case locationPathname.startsWith('/vote'):
       return InterfacePageName.VOTE_PAGE
+    case locationPathname.startsWith('/pools'):
     case locationPathname.startsWith('/pool'):
       return InterfacePageName.POOL_PAGE
     case locationPathname.startsWith('/tokens'):
@@ -236,6 +237,11 @@ export default function App() {
                   <Route path="pool/v2" element={<PoolV2 />} />
                   <Route path="pool" element={<Pool />} />
                   <Route path="pool/:tokenId" element={<PositionPage />} />
+
+                  <Route path="pools/v2/find" element={<PoolFinder />} />
+                  <Route path="pools/v2" element={<PoolV2 />} />
+                  <Route path="pools" element={<Pool />} />
+                  <Route path="pools/:tokenId" element={<PositionPage />} />
 
                   <Route path="add/v2" element={<RedirectDuplicateTokenIdsV2 />}>
                     <Route path=":currencyIdA" />

--- a/src/pages/MigrateV2/index.tsx
+++ b/src/pages/MigrateV2/index.tsx
@@ -116,7 +116,7 @@ export default function MigrateV2() {
       <BodyWrapper style={{ padding: 24 }}>
         <AutoColumn gap="16px">
           <AutoRow style={{ alignItems: 'center', justifyContent: 'space-between' }} gap="8px">
-            <BackArrow to="/pool" />
+            <BackArrow to="/pools" />
             <ThemedText.DeprecatedMediumHeader>
               <Trans>Migrate V2 Liquidity</Trans>
             </ThemedText.DeprecatedMediumHeader>
@@ -173,7 +173,7 @@ export default function MigrateV2() {
             <Text textAlign="center" fontSize={14} style={{ padding: '.5rem 0 .5rem 0' }}>
               <Trans>
                 Don’t see one of your v2 positions?{' '}
-                <StyledInternalLink id="import-pool-link" to="/pool/v2/find">
+                <StyledInternalLink id="import-pool-link" to="/pools/v2/find">
                   Import it.
                 </StyledInternalLink>
               </Trans>

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -605,7 +605,7 @@ export function PositionPage() {
               <Link
                 data-cy="visit-pool"
                 style={{ textDecoration: 'none', width: 'fit-content', marginBottom: '0.5rem' }}
-                to="/pool"
+                to="/pools"
               >
                 <HoverText>
                   <Trans>← Back to Pools</Trans>

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -251,7 +251,7 @@ export default function Pool() {
           <Layers size={16} />
         </PoolMenuItem>
       ),
-      link: '/pool/v2',
+      link: '/pools/v2',
       external: false,
     },
     {

--- a/src/pages/Pool/v2.tsx
+++ b/src/pages/Pool/v2.tsx
@@ -199,7 +199,7 @@ export default function Pool() {
                     <ResponsiveButtonSecondary as={Link} padding="6px 8px" to="/add/v2/ETH">
                       <Trans>Create a pair</Trans>
                     </ResponsiveButtonSecondary>
-                    <ResponsiveButtonPrimary id="find-pool-button" as={Link} to="/pool/v2/find" padding="6px 8px">
+                    <ResponsiveButtonPrimary id="find-pool-button" as={Link} to="/pools/v2/find" padding="6px 8px">
                       <Text fontWeight={500} fontSize={16}>
                         <Trans>Import Pool</Trans>
                       </Text>

--- a/src/pages/PoolFinder/index.tsx
+++ b/src/pages/PoolFinder/index.tsx
@@ -100,7 +100,7 @@ export default function PoolFinder() {
     <Trace page={InterfacePageName.POOL_PAGE} shouldLogImpression>
       <>
         <AppBody>
-          <FindPoolTabs origin={query.get('origin') ?? '/pool/v2'} />
+          <FindPoolTabs origin={query.get('origin') ?? '/pools/v2'} />
           <AutoColumn style={{ padding: '1rem' }} gap="md">
             <BlueCard>
               <AutoColumn gap="10px">
@@ -162,7 +162,7 @@ export default function PoolFinder() {
                 <Text textAlign="center" fontWeight={500}>
                   <Trans>Pool Found!</Trans>
                 </Text>
-                <StyledInternalLink to="/pool/v2">
+                <StyledInternalLink to="pools/v2">
                   <Text textAlign="center">
                     <Trans>Manage this pool.</Trans>
                   </Text>

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -55,7 +55,7 @@ export default function RemoveLiquidityV3() {
   }, [tokenId])
 
   if (parsedTokenId === null || parsedTokenId.eq(0)) {
-    return <Navigate to={{ ...location, pathname: '/pool' }} replace />
+    return <Navigate to={{ ...location, pathname: '/pools' }} replace />
   }
 
   return <Remove tokenId={parsedTokenId} />


### PR DESCRIPTION
We want to have the nav say Pools instead of Pool, and be /pools instead of /pool. This is so we are consistent in the Nav (ex: Tokens, NFTs are pluralized).

Plan:
- Support both /pool and /pools for a bit. This is so external links don't break.
- Change all internal links to use /pools. Can happen in tandem with ^.
- Add a server redirect in CloudFlare to switch external links from /pool to /pools.

After this we should check that /pool isn't being logged in Amplitude.

Finally:
- Remove /pool Routes in codebase (since they will not be hit anymore).

This PR handles the first 2 steps of this plan.