### PR TITLE
fix: cards floating point error

### DIFF
--- a/src/nft/components/card/containers.tsx
+++ b/src/nft/components/card/containers.tsx
@@ -119,7 +119,7 @@ const StyledCardContainer = styled.div<{ selected: boolean; isDisabled: boolean 
     right: 0px;
     bottom: 0px;
     left: 0px;
-    border: ${({ selected, theme }) => (selected ? '3px' : !theme.darkMode ? '0px' : '1px')} solid;
+    border: ${({ selected }) => (selected ? '3px' : '1px')} solid;
     border-radius: ${BORDER_RADIUS}px;
     border-color: ${({ theme, selected }) => (selected ? theme.accentAction : theme.backgroundOutline)};
     pointer-events: none;


### PR DESCRIPTION
there is actually a floating point error when setting width to 100% because of the way the columns are setup, and hiding the outline on lightmode shows this problem. So we decided to put the outline back in for lightmode to hide the off by 1