### PR TITLE
fix: handle undefined tax service banner counter in state 

### DIFF
--- a/src/components/TaxServiceModal/TaxServiceBanner.tsx
+++ b/src/components/TaxServiceModal/TaxServiceBanner.tsx
@@ -122,7 +122,7 @@ export default function TaxServiceBanner() {
     sessionStorage.setItem(TAX_SERVICE_DISMISSED, 'false')
   }
   const [bannerOpen, setBannerOpen] = useState(
-    sessionStorageTaxServiceDismissed !== 'true' && dismissals < MAX_RENDER_COUNT
+    sessionStorageTaxServiceDismissed !== 'true' && (typeof dismissals === 'undefined' || dismissals < MAX_RENDER_COUNT)
   )
   const onDismiss = useCallback(() => {
     setModalOpen(false)
@@ -131,7 +131,11 @@ export default function TaxServiceBanner() {
   const handleClose = useCallback(() => {
     sessionStorage.setItem(TAX_SERVICE_DISMISSED, 'true')
     setBannerOpen(false)
-    addTaxServiceDismissal(dismissals + 1)
+    if (typeof dismissals === 'undefined') {
+      addTaxServiceDismissal(1)
+    } else {
+      addTaxServiceDismissal(dismissals + 1)
+    }
   }, [addTaxServiceDismissal, dismissals])
 
   const handleLearnMoreClick = useCallback((e: any) => {

--- a/src/components/TaxServiceModal/TaxServiceBanner.tsx
+++ b/src/components/TaxServiceModal/TaxServiceBanner.tsx
@@ -122,7 +122,7 @@ export default function TaxServiceBanner() {
     sessionStorage.setItem(TAX_SERVICE_DISMISSED, 'false')
   }
   const [bannerOpen, setBannerOpen] = useState(
-    sessionStorageTaxServiceDismissed !== 'true' && (typeof dismissals === 'undefined' || dismissals < MAX_RENDER_COUNT)
+    sessionStorageTaxServiceDismissed !== 'true' && (dismissals === undefined || dismissals < MAX_RENDER_COUNT)
   )
   const onDismiss = useCallback(() => {
     setModalOpen(false)
@@ -131,7 +131,7 @@ export default function TaxServiceBanner() {
   const handleClose = useCallback(() => {
     sessionStorage.setItem(TAX_SERVICE_DISMISSED, 'true')
     setBannerOpen(false)
-    typeof dismissals === 'undefined' ? addTaxServiceDismissal(1) : addTaxServiceDismissal(dismissals + 1)
+    dismissals === undefined ? addTaxServiceDismissal(1) : addTaxServiceDismissal(dismissals + 1)
   }, [addTaxServiceDismissal, dismissals])
 
   const handleLearnMoreClick = useCallback((e: any) => {

--- a/src/components/TaxServiceModal/TaxServiceBanner.tsx
+++ b/src/components/TaxServiceModal/TaxServiceBanner.tsx
@@ -131,11 +131,7 @@ export default function TaxServiceBanner() {
   const handleClose = useCallback(() => {
     sessionStorage.setItem(TAX_SERVICE_DISMISSED, 'true')
     setBannerOpen(false)
-    if (typeof dismissals === 'undefined') {
-      addTaxServiceDismissal(1)
-    } else {
-      addTaxServiceDismissal(dismissals + 1)
-    }
+    typeof dismissals === 'undefined' ? addTaxServiceDismissal(1) : addTaxServiceDismissal(dismissals + 1)
   }, [addTaxServiceDismissal, dismissals])
 
   const handleLearnMoreClick = useCallback((e: any) => {

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -93,7 +93,7 @@ export function useIsExpertMode(): boolean {
   return useAppSelector((state) => state.user.userExpertMode)
 }
 
-export function useTaxServiceDismissal(): [number, (dismissals: number) => void] {
+export function useTaxServiceDismissal(): [number | undefined, (dismissals: number) => void] {
   const dispatch = useAppDispatch()
   const taxServiceDismissals = useAppSelector((state) => state.user.taxServiceDismissals)
   const setDismissals = useCallback(

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -9,7 +9,7 @@ import { SerializedPair, SerializedToken } from './types'
 const currentTimestamp = () => new Date().getTime()
 
 export interface UserState {
-  taxServiceDismissals: number
+  taxServiceDismissals: number | undefined
 
   selectedWallet?: ConnectionType
 


### PR DESCRIPTION
tax service banner was not showing for users who had used uniswap before in regular (not incognito) browsers due to cached redux initial state. we are not handling initial state changes correctly atm, so this is a stop gap fix to handle undefined initial state for tax service specifically. we need something to handle this more generally across interface for state updates tho, like mobile does: https://github.com/Uniswap/mobile/blob/main/src/app/migrations.ts (info from @tinaszheng )