### PR TITLE
test: run cypress on one machine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,30 +62,12 @@ jobs:
       - run: yarn test:size
 
 
-  cypress-build:
+  cypress-tests:
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - uses: actions/cache@v3
-        id: cypress-cache
-        with:
-          path: /home/runner/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('node_modules/cypress') }}
-      - if: steps.cypress-cache.outputs.cache-hit != 'true'
-        run: yarn cypress install
-
-  cypress-test-matrix:
-    needs: [build, cypress-build]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-
       - uses: actions/download-artifact@v2
         with:
           name: build
@@ -110,10 +92,3 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Included as a single job to check against for cypress test success, as cypress runs in a matrix.
-  cypress-tests:
-    needs: [cypress-test-matrix]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo 'Finished cypress tests https\://dashboard.cypress.io/projects/yp82ef'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,6 @@ jobs:
           wait-on: 'http://localhost:3000'
           browser: chrome
           record: true
-          parallel: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Turns off cypress parallelization because machines are often started with different settings, requiring tests to be re-run.
Running them on one machine may take longer for a successful run, but is shorter overall if you assume that you may need to retry the run due to configuration.