### PR TITLE
test: parallelize cypress (again) with a consistent container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,5 +119,5 @@ jobs:
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - if: needs.cypress-test-matrix.result == 'success'
+      - if: needs.cypress-test-matrix.result != 'success'
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,5 @@ jobs:
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - run: echo needs.cypress-test-matrix.result
-      - if: needs.cypress-test-matrix.result != 'success'
+      - if: needs.cypress-test-matrix.result == 'success'
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,6 @@ jobs:
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "${{ needs.cypress-test-matrix.result }}"
-      - if: "${{ needs.cypress-test-matrix.result }}" != "success"
+      - run: echo needs.cypress-test-matrix.result
+      - if: needs.cypress-test-matrix.result != 'success'
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,4 +120,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: exit 1
-        if: ${{ needs.build.result }} != "success"
+        if: ${{ needs.cypress-test-matrix.result }} != "success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,5 +119,7 @@ jobs:
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
+      - run: echo "${{ needs.cypress-test-matrix.result }}"
+      - run: echo ${{ "${{ needs.cypress-test-matrix.result }}" != "success" }}
       - run: exit 1
-        if: ${{ needs.cypress-test-matrix.result }} != "success"
+        if: "${{ needs.cypress-test-matrix.result }}" != "success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,6 @@ jobs:
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "${{ needs.cypress-test-matrix.result }}"
-      - run: exit 1
-        if: "${{ needs.cypress-test-matrix.result }}" != "success"
+      - run: echo ${{ needs.cypress-test-matrix.result }}
+      - if: "${{ needs.cypress-test-matrix.result }}" != "success"
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,6 @@ jobs:
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ needs.cypress-test-matrix.result }}
+      - run: echo "${{ needs.cypress-test-matrix.result }}"
       - if: "${{ needs.cypress-test-matrix.result }}" != "success"
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,9 +113,11 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Included as a single job to check against for cypress test success, as cypress runs in a matrix.
+  # Included as a single job to check for cypress-test-matrix success, as a matrix cannot be checked.
   cypress-tests:
+    if: ${{ always() }}
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - run: echo 'Finished cypress tests https\://dashboard.cypress.io/projects/yp82ef'
+      - run: exit 1
+        if: ${{ needs.build.result }} != "success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "${{ needs.cypress-test-matrix.result }}"
-      - run: echo ${{ "${{ needs.cypress-test-matrix.result }}" != "success" }}
       - run: exit 1
         if: "${{ needs.cypress-test-matrix.result }}" != "success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,30 @@ jobs:
       - run: yarn test:size
 
 
-  cypress-tests:
-    needs: [build]
+  cypress-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - uses: actions/cache@v3
+        id: cypress-cache
+        with:
+          path: /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('node_modules/cypress') }}
+      - if: steps.cypress-cache.outputs.cache-hit != 'true'
+        run: yarn cypress install
+
+  cypress-test-matrix:
+    needs: [build, cypress-build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+
       - uses: actions/download-artifact@v2
         with:
           name: build
@@ -88,6 +106,14 @@ jobs:
           wait-on: 'http://localhost:3000'
           browser: chrome
           record: true
+          parallel: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Included as a single job to check against for cypress test success, as cypress runs in a matrix.
+  cypress-tests:
+    needs: [cypress-test-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Finished cypress tests https\://dashboard.cypress.io/projects/yp82ef'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,20 +64,24 @@ jobs:
 
   cypress-build:
     runs-on: ubuntu-latest
+    container: cypress/browsers:node-18.14.1-chrome-111.0.5563.64-1-ff-111.0-edge-111.0.1661.43-1
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3
         id: cypress-cache
         with:
-          path: /home/runner/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('node_modules/cypress') }}
+          path: /root/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
       - if: steps.cypress-cache.outputs.cache-hit != 'true'
-        run: yarn cypress install
+        run: |
+          yarn cypress install
+          yarn cypress info
 
   cypress-test-matrix:
     needs: [build, cypress-build]
     runs-on: ubuntu-latest
+    container: cypress/browsers:node-18.14.1-chrome-111.0.5563.64-1-ff-111.0-edge-111.0.1661.43-1
     strategy:
       fail-fast: false
       matrix:
@@ -85,17 +89,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-
       - uses: actions/download-artifact@v2
         with:
           name: build
           path: build
-
       - uses: actions/cache@v3
         id: cypress-cache
         with:
-          path: /home/runner/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('node_modules/cypress') }}
+          path: /root/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
       - if: steps.cypress-cache.outputs.cache-hit != 'true'
         run: yarn cypress install
 


### PR DESCRIPTION
Parallelizes cypress tests by using a consistent container across them
Fixes cypress-tests to accurately reflect the status of cypress-test-matrix