### PR TITLE
fix: link to lowercase chain name from position page

### DIFF
--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -93,20 +93,6 @@ const URL_CHAIN_PARAM_TO_BACKEND: { [key: string]: Chain } = {
   optimism: Chain.Optimism,
 }
 
-export const CHAIN_ID_TO_URL_NAME: Record<SupportedChainId, string> = {
-  [SupportedChainId.ARBITRUM_ONE]: 'arbitrum',
-  [SupportedChainId.ARBITRUM_GOERLI]: 'arbitrum_goerli',
-  [SupportedChainId.BNB]: 'bnb',
-  [SupportedChainId.CELO]: 'celo',
-  [SupportedChainId.CELO_ALFAJORES]: 'celo_alfajores',
-  [SupportedChainId.MAINNET]: 'ethereum',
-  [SupportedChainId.GOERLI]: 'goerli',
-  [SupportedChainId.OPTIMISM]: 'optimism',
-  [SupportedChainId.OPTIMISM_GOERLI]: 'optimism_goerli',
-  [SupportedChainId.POLYGON]: 'polygon',
-  [SupportedChainId.POLYGON_MUMBAI]: 'polygon_mumbai',
-}
-
 export function validateUrlChainParam(chainName: string | undefined) {
   return chainName && URL_CHAIN_PARAM_TO_BACKEND[chainName] ? URL_CHAIN_PARAM_TO_BACKEND[chainName] : Chain.Ethereum
 }

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -93,6 +93,20 @@ const URL_CHAIN_PARAM_TO_BACKEND: { [key: string]: Chain } = {
   optimism: Chain.Optimism,
 }
 
+export const CHAIN_ID_TO_URL_NAME: Record<SupportedChainId, string> = {
+  [SupportedChainId.ARBITRUM_ONE]: 'arbitrum',
+  [SupportedChainId.ARBITRUM_GOERLI]: 'arbitrum_goerli',
+  [SupportedChainId.BNB]: 'bnb',
+  [SupportedChainId.CELO]: 'celo',
+  [SupportedChainId.CELO_ALFAJORES]: 'celo_alfajores',
+  [SupportedChainId.MAINNET]: 'ethereum',
+  [SupportedChainId.GOERLI]: 'goerli',
+  [SupportedChainId.OPTIMISM]: 'optimism',
+  [SupportedChainId.OPTIMISM_GOERLI]: 'optimism_goerli',
+  [SupportedChainId.POLYGON]: 'polygon',
+  [SupportedChainId.POLYGON_MUMBAI]: 'polygon_mumbai',
+}
+
 export function validateUrlChainParam(chainName: string | undefined) {
   return chainName && URL_CHAIN_PARAM_TO_BACKEND[chainName] ? URL_CHAIN_PARAM_TO_BACKEND[chainName] : Chain.Ethereum
 }

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -20,7 +20,7 @@ import { RowBetween, RowFixed } from 'components/Row'
 import { Dots } from 'components/swap/styleds'
 import Toggle from 'components/Toggle'
 import TransactionConfirmationModal, { ConfirmationModalContent } from 'components/TransactionConfirmationModal'
-import { CHAIN_ID_TO_BACKEND_NAME, isGqlSupportedChain } from 'graphql/data/util'
+import { CHAIN_ID_TO_URL_NAME, isGqlSupportedChain } from 'graphql/data/util'
 import { useToken } from 'hooks/Tokens'
 import { useV3NFTPositionManagerContract } from 'hooks/useContract'
 import useIsTickAtLimit from 'hooks/useIsTickAtLimit'
@@ -54,7 +54,7 @@ import { LoadingRows } from './styleds'
 
 const getTokenLink = (chainId: SupportedChainId, address: string) => {
   if (isGqlSupportedChain(chainId)) {
-    const chainName = CHAIN_ID_TO_BACKEND_NAME[chainId]
+    const chainName = CHAIN_ID_TO_URL_NAME[chainId]
     return `${window.location.origin}/#/tokens/${chainName}/${address}`
   } else {
     return getExplorerLink(chainId, address, ExplorerDataType.TOKEN)

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -20,7 +20,8 @@ import { RowBetween, RowFixed } from 'components/Row'
 import { Dots } from 'components/swap/styleds'
 import Toggle from 'components/Toggle'
 import TransactionConfirmationModal, { ConfirmationModalContent } from 'components/TransactionConfirmationModal'
-import { CHAIN_ID_TO_URL_NAME, isGqlSupportedChain } from 'graphql/data/util'
+import { CHAIN_IDS_TO_NAMES } from 'constants/chains'
+import { isGqlSupportedChain } from 'graphql/data/util'
 import { useToken } from 'hooks/Tokens'
 import { useV3NFTPositionManagerContract } from 'hooks/useContract'
 import useIsTickAtLimit from 'hooks/useIsTickAtLimit'
@@ -54,7 +55,7 @@ import { LoadingRows } from './styleds'
 
 const getTokenLink = (chainId: SupportedChainId, address: string) => {
   if (isGqlSupportedChain(chainId)) {
-    const chainName = CHAIN_ID_TO_URL_NAME[chainId]
+    const chainName = CHAIN_IDS_TO_NAMES[chainId]
     return `${window.location.origin}/#/tokens/${chainName}/${address}`
   } else {
     return getExplorerLink(chainId, address, ExplorerDataType.TOKEN)


### PR DESCRIPTION
Previously, the backend chain name was used for linking purposes. However, this is not ideal because those values are uppercased. Similarly, they won't support any chains that aren't supported by the backend (ex: Optimism Goerli).

Instead, we use the existing CHAIN_IDS_TO_NAME mapping.

Test:
- Go to a position page on a chain which the graphql API supports (ex: mainnet) and click on a token (should take to token details with a lowercase chain in url.
- Go to a position page on a chain which the graphql API does not support (ex: goerli) and click on a token (should take to etherscan).