### PR TITLE
feat: don't cache recent search history

### DIFF
--- a/src/components/NavBar/RecentlySearchedAssets.ts
+++ b/src/components/NavBar/RecentlySearchedAssets.ts
@@ -53,6 +53,7 @@ export function useRecentlySearchedAssets() {
           chain: token.chain,
         })),
     },
+    fetchPolicy: 'no-cache',
   })
 
   const data = useMemo(() => {

--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -120,7 +120,8 @@ export const SearchBarDropdown = ({
 }: SearchBarDropdownProps) => {
   const [hoveredIndex, setHoveredIndex] = useState<number | undefined>(0)
 
-  const { data: searchHistory } = useRecentlySearchedAssets()
+  const { data: searchHistory, loading: searchHistoryLoading } = useRecentlySearchedAssets()
+  console.log(searchHistoryLoading, searchHistory)
   const shortenedHistory = useMemo(() => searchHistory?.slice(0, 2) ?? [...Array<SearchToken>(2)], [searchHistory])
 
   const { pathname } = useLocation()

--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -120,8 +120,7 @@ export const SearchBarDropdown = ({
 }: SearchBarDropdownProps) => {
   const [hoveredIndex, setHoveredIndex] = useState<number | undefined>(0)
 
-  const { data: searchHistory, loading: searchHistoryLoading } = useRecentlySearchedAssets()
-  console.log(searchHistoryLoading, searchHistory)
+  const { data: searchHistory } = useRecentlySearchedAssets()
   const shortenedHistory = useMemo(() => searchHistory?.slice(0, 2) ?? [...Array<SearchToken>(2)], [searchHistory])
 
   const { pathname } = useLocation()


### PR DESCRIPTION
We updated our recent search history to re-query to update prices however we still allowed caching which could lead to outdated price history. This sets the query fetch-policy to 'no-cache' to always take the latest price info.