### PR TITLE
fix: NPE when connector is undefined

### DIFF
--- a/src/hooks/useOrderedConnections.ts
+++ b/src/hooks/useOrderedConnections.ts
@@ -22,6 +22,6 @@ export default function useOrderedConnections() {
     // Add network connection last as it should be the fallback.
     orderedConnectionTypes.push(ConnectionType.NETWORK)
 
-    return orderedConnectionTypes.map(getConnection)
+    return orderedConnectionTypes.map(getConnection).filter((c) => c)
   }, [selectedWallet])
 }


### PR DESCRIPTION
this fixes a page crash that happens when `getConnection` returns undefined. this is happening to me because I selected `UNIWALLET` on a different build, but it's not available in the current branch/build.
