### PR TITLE
fix: dismiss tax service toast after 1 dismissal instead of 3

### DIFF
--- a/src/components/TaxServiceModal/TaxServiceBanner.tsx
+++ b/src/components/TaxServiceModal/TaxServiceBanner.tsx
@@ -110,7 +110,7 @@ export const StyledXButton = styled(X)`
 
 const TAX_SERVICE_DISMISSED = 'TaxServiceToast-dismissed'
 
-const MAX_RENDER_COUNT = 3
+const MAX_RENDER_COUNT = 1
 
 export default function TaxServiceBanner() {
   const isDarkMode = useIsDarkMode()

--- a/src/components/TaxServiceModal/TaxServiceBanner.tsx
+++ b/src/components/TaxServiceModal/TaxServiceBanner.tsx
@@ -110,6 +110,8 @@ export const StyledXButton = styled(X)`
 
 const TAX_SERVICE_DISMISSED = 'TaxServiceToast-dismissed'
 
+// TODO(lynnshaoyu): remove this count and change taxServiceDismissals in UserState to be a boolean
+// flag instead after upgrading to redux-persist.
 const MAX_RENDER_COUNT = 1
 
 export default function TaxServiceBanner() {


### PR DESCRIPTION
note: I didn't want to change the type of taxServiceDismissals to a boolean flag in redux UserState because of the current data persistence issues of redux-localstorage-simple. Once we update to redux-persist I will remove the MAX_RENDER_COUNT variable altogether and change it to a boolean flag. 