### PR TITLE
feat: preserve input currency on TDP when navigating

### DIFF
--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -31,7 +31,7 @@ import { useIsDarkMode } from 'state/user/hooks'
 import { computeRealizedPriceImpact } from 'utils/prices'
 import { switchChain } from 'utils/switchChain'
 
-import { DefaultTokens, useSyncWidgetInputs } from './inputs'
+import { DefaultTokens, SwapTokens, useSyncWidgetInputs } from './inputs'
 import { useSyncWidgetSettings } from './settings'
 import { DARK_THEME, LIGHT_THEME } from './theme'
 import { useSyncWidgetTransactions } from './transactions'
@@ -47,7 +47,7 @@ function useWidgetTheme() {
 interface WidgetProps {
   defaultTokens: DefaultTokens
   width?: number | string
-  onDefaultTokenChange?: (token: Currency) => void
+  onDefaultTokenChange?: (tokens: SwapTokens) => void
   onReviewSwapClick?: OnReviewSwapClick
 }
 

--- a/src/components/Widget/inputs.tsx
+++ b/src/components/Widget/inputs.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 const EMPTY_AMOUNT = ''
 
 type SwapValue = Required<SwapController>['value']
-type SwapTokens = Pick<SwapValue, Field.INPUT | Field.OUTPUT> & { default?: Currency }
+export type SwapTokens = Pick<SwapValue, Field.INPUT | Field.OUTPUT> & { default?: Currency }
 export type DefaultTokens = Partial<SwapTokens>
 
 function missingDefaultToken(tokens: SwapTokens) {
@@ -47,7 +47,7 @@ export function useSyncWidgetInputs({
   onDefaultTokenChange,
 }: {
   defaultTokens: DefaultTokens
-  onDefaultTokenChange?: (token: Currency) => void
+  onDefaultTokenChange?: (tokens: SwapTokens) => void
 }) {
   const trace = useTrace({ section: InterfaceSectionName.WIDGET })
 
@@ -137,7 +137,10 @@ export function useSyncWidgetInputs({
       })
 
       if (missingDefaultToken(update)) {
-        onDefaultTokenChange?.(update[Field.OUTPUT] ?? selectingToken)
+        onDefaultTokenChange?.({
+          ...update,
+          default: update[Field.OUTPUT] ?? selectingToken,
+        })
         return
       }
       setTokens(update)

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -108,8 +108,18 @@ export const CHAIN_NAME_TO_CHAIN_ID: { [key: string]: SupportedChainId } = {
 
 export const BACKEND_CHAIN_NAMES: Chain[] = [Chain.Ethereum, Chain.Polygon, Chain.Optimism, Chain.Arbitrum, Chain.Celo]
 
-export function getTokenDetailsURL({ address, chain }: { address?: string | null; chain: Chain }) {
-  return `/tokens/${chain.toLowerCase()}/${address ?? NATIVE_CHAIN_ID}`
+export function getTokenDetailsURL({
+  address,
+  chain,
+  inputAddress,
+}: {
+  address?: string | null
+  chain: Chain
+  inputAddress?: string | null
+}) {
+  return `/tokens/${chain.toLowerCase()}/${address ?? NATIVE_CHAIN_ID}${
+    inputAddress ? `?inputCurrency=${inputAddress}` : ''
+  }`
 }
 
 export function unwrapToken<

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -117,9 +117,10 @@ export function getTokenDetailsURL({
   chain: Chain
   inputAddress?: string | null
 }) {
-  return `/tokens/${chain.toLowerCase()}/${address ?? NATIVE_CHAIN_ID}${
-    inputAddress ? `?inputCurrency=${inputAddress}` : ''
-  }`
+  const chainName = chain.toLowerCase()
+  const tokenAddress = address ?? NATIVE_CHAIN_ID
+  const inputAddressSuffix = inputAddress ? `?inputCurrency=${inputAddress}` : ''
+  return `/tokens/${chainName}/${tokenAddress}${inputAddressSuffix}`
 }
 
 export function unwrapToken<

--- a/src/hooks/useOrderedConnections.ts
+++ b/src/hooks/useOrderedConnections.ts
@@ -22,6 +22,6 @@ export default function useOrderedConnections() {
     // Add network connection last as it should be the fallback.
     orderedConnectionTypes.push(ConnectionType.NETWORK)
 
-    return orderedConnectionTypes.map(getConnection).filter((c) => c)
+    return orderedConnectionTypes.map(getConnection)
   }, [selectedWallet])
 }

--- a/src/hooks/useOrderedConnections.ts
+++ b/src/hooks/useOrderedConnections.ts
@@ -22,6 +22,6 @@ export default function useOrderedConnections() {
     // Add network connection last as it should be the fallback.
     orderedConnectionTypes.push(ConnectionType.NETWORK)
 
-    return orderedConnectionTypes.map(getConnection)
+    return orderedConnectionTypes.map(getConnection).filter((c) => c)
   }, [selectedWallet])
 }

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -3,6 +3,7 @@ import { TokenDetailsPageSkeleton } from 'components/Tokens/TokenDetails/Skeleto
 import { NATIVE_CHAIN_ID } from 'constants/tokens'
 import { useTokenPriceQuery, useTokenQuery } from 'graphql/data/__generated__/types-and-hooks'
 import { TimePeriod, toHistoryDuration, validateUrlChainParam } from 'graphql/data/util'
+import useParsedQueryString from 'hooks/useParsedQueryString'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { useEffect, useMemo, useState } from 'react'
@@ -12,27 +13,36 @@ import { getNativeTokenDBAddress } from 'utils/nativeTokens'
 export const pageTimePeriodAtom = atomWithStorage<TimePeriod>('tokenDetailsTimePeriod', TimePeriod.DAY)
 
 export default function TokenDetailsPage() {
-  const { tokenAddress, chainName } = useParams<{ tokenAddress: string; chainName?: string }>()
+  const { tokenAddress, chainName } = useParams<{
+    tokenAddress: string
+    chainName?: string
+  }>()
   const chain = validateUrlChainParam(chainName)
   const isNative = tokenAddress === NATIVE_CHAIN_ID
   const [timePeriod, setTimePeriod] = useAtom(pageTimePeriodAtom)
-  const [address, duration] = useMemo(
+  const [detailedTokenAddress, duration] = useMemo(
     /* tokenAddress will always be defined in the path for for this page to render, but useParams will always
       return optional arguments; nullish coalescing operator is present here to appease typechecker */
     () => [isNative ? getNativeTokenDBAddress(chain) : tokenAddress ?? '', toHistoryDuration(timePeriod)],
     [chain, isNative, timePeriod, tokenAddress]
   )
 
+  const parsedQs = useParsedQueryString()
+
+  const parsedInputTokenAddress: string | undefined = useMemo(() => {
+    return typeof parsedQs.inputCurrency === 'string' ? (parsedQs.inputCurrency as string) : undefined
+  }, [parsedQs])
+
   const { data: tokenQuery } = useTokenQuery({
     variables: {
-      address,
+      address: detailedTokenAddress,
       chain,
     },
   })
 
   const { data: tokenPriceQuery } = useTokenPriceQuery({
     variables: {
-      address,
+      address: detailedTokenAddress,
       chain,
       duration,
     },
@@ -53,6 +63,7 @@ export default function TokenDetailsPage() {
       tokenQuery={tokenQuery}
       tokenPriceQuery={currentPriceQuery}
       onChangeTimePeriod={setTimePeriod}
+      inputTokenAddress={parsedInputTokenAddress}
     />
   )
 }


### PR DESCRIPTION
this preserves the input/output currency on the TDP when you replace the "default" (detailed) token.

behavior:
1. when navigating to TDP, the detailed/default token is the output and input is empty
2. you can reverse input/output, and select a token to trade in either direction
3. when you replace the detailed token, we automatically navigate to the TDP for the output in the current selections (this could be the newly selected if you replaced the output, or the other token if you replaced the input)
4. <This PR>  we add a query param to the destination URL allowing us to preserve the input token when navigating


this seemed like a simple solution, but there may be alternatives - if we used a global state variable (jotai atom) we could preserve the input without a URL change. the downside there would be the complexity of determining when to clear the value (or conversely, knowing when to use it i.e. after a navigation caused by the flow above).