### PR TITLE
feat: show error state when on invalid position

### DIFF
--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -61,6 +61,14 @@ const getTokenLink = (chainId: SupportedChainId, address: string) => {
   }
 }
 
+const PositionPageButtonPrimary = styled(ButtonPrimary)`
+  width: 228px;
+  height: 40px;
+  font-size: 16px;
+  line-height: 20px;
+  border-radius: 12px;
+`
+
 const PageWrapper = styled.div`
   padding: 68px 16px 16px 16px;
 
@@ -577,6 +585,24 @@ export function PositionPage() {
       (currency0.isNative || currency1.isNative) &&
       !collectMigrationHash
   )
+
+  if (!positionDetails && !loading) {
+    return (
+      <PageWrapper>
+        <div style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+          <ThemedText.HeadlineLarge style={{ marginBottom: '8px' }}>
+            <Trans>Position unavailable</Trans>
+          </ThemedText.HeadlineLarge>
+          <ThemedText.BodyPrimary style={{ marginBottom: '32px' }}>
+            <Trans>To view a position, you must be connected to the network it belongs to.</Trans>
+          </ThemedText.BodyPrimary>
+          <PositionPageButtonPrimary as={Link} to="/pools" width="fit-content">
+            <Trans>Back to Pools</Trans>
+          </PositionPageButtonPrimary>
+        </div>
+      </PageWrapper>
+    )
+  }
 
   return loading || poolState === PoolState.LOADING || !feeAmount ? (
     <LoadingRows>


### PR DESCRIPTION
This cherry-picks one part of https://github.com/Uniswap/interface/pull/6201, which is a more complete solution for handling position pages across chains. However, we want to wait on that until we make sure that it fits with our multichain plans.

For now, this makes sure that we show an invalid state when there is no position information to render, instead of showing an infinite loading state.

To test this...
- Go to pools/364815 on mainnet to see the position render
- Switch chain to Polygon to see the error state

On main...:
- Go to pools/364815 on mainnet to see the position render
- Switch chain to Polygon to see an infinite loading state

Resolves https://uniswaplabs.atlassian.net/browse/WEB-3006 and resolves https://uniswaplabs.atlassian.net/browse/WEB-3010