### PR TITLE
fix: set height on vote and v2 liquidity buttons

### DIFF
--- a/src/pages/Pool/v2.tsx
+++ b/src/pages/Pool/v2.tsx
@@ -59,6 +59,7 @@ const ButtonRow = styled(RowFixed)`
 `
 
 const ResponsiveButtonPrimary = styled(ButtonPrimary)`
+  height: 40px;
   width: fit-content;
   border-radius: 12px;
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
@@ -67,6 +68,7 @@ const ResponsiveButtonPrimary = styled(ButtonPrimary)`
 `
 
 const ResponsiveButtonSecondary = styled(ButtonSecondary)`
+  height: 40px;
   width: fit-content;
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
     width: 48%;

--- a/src/pages/Vote/Landing.tsx
+++ b/src/pages/Vote/Landing.tsx
@@ -3,7 +3,7 @@ import { Trace } from '@uniswap/analytics'
 import { InterfacePageName } from '@uniswap/analytics-events'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { ButtonPrimary, SmallButtonPrimary } from 'components/Button'
+import { ButtonPrimary } from 'components/Button'
 import { AutoColumn } from 'components/Column'
 import { CardBGImage, CardNoise, CardSection, DataCard } from 'components/earn/styled'
 import FormattedCurrencyAmount from 'components/FormattedCurrencyAmount'
@@ -198,7 +198,7 @@ export default function Landing() {
                 {loadingProposals || loadingAvailableVotes ? <Loader /> : null}
                 {showUnlockVoting ? (
                   <ButtonPrimary
-                    style={{ width: 'fit-content' }}
+                    style={{ width: 'fit-content', height: '40px' }}
                     padding="8px"
                     $borderRadius="8px"
                     onClick={toggleDelegateModal}
@@ -223,14 +223,14 @@ export default function Landing() {
                 ) : (
                   ''
                 )}
-                <SmallButtonPrimary
+                <ButtonPrimary
                   as={Link}
                   to="/create-proposal"
-                  style={{ width: 'fit-content', borderRadius: '8px' }}
-                  padding="6px 8px"
+                  style={{ width: 'fit-content', borderRadius: '8px', height: '40px' }}
+                  padding="8px"
                 >
                   <Trans>Create Proposal</Trans>
-                </SmallButtonPrimary>
+                </ButtonPrimary>
               </AutoRow>
             </WrapSmall>
             {!showUnlockVoting && (


### PR DESCRIPTION
<img width="783" alt="Screen Shot 2023-03-21 at 11 09 47 PM" src="https://user-images.githubusercontent.com/4899429/226792577-6688bbfe-89a0-4600-9554-f34ba3772f72.png">
<img width="1264" alt="Screen Shot 2023-03-21 at 11 10 11 PM" src="https://user-images.githubusercontent.com/4899429/226792579-04e98d28-1e45-4bf7-b0f3-5e8927cee99f.png">

Ideally, these buttons would have height based on a prop passed in (sm, md, lg) but for now setting a fixed height solves the issue. I'm open to a smaller height, but I think this fits the text size most reasonably.

To test:
- Go to /pools/v2 and make sure buttons are same height
- Go to /vote and make sure buttons are same height
