### PR TITLE
feat: add 1bps pool to arbitrum

### DIFF
--- a/src/components/FeeSelector/shared.tsx
+++ b/src/components/FeeSelector/shared.tsx
@@ -11,13 +11,14 @@ export const FEE_AMOUNT_DETAIL: Record<
     label: '0.01',
     description: <Trans>Best for very stable pairs.</Trans>,
     supportedChains: [
-      SupportedChainId.MAINNET,
-      SupportedChainId.POLYGON,
-      SupportedChainId.POLYGON_MUMBAI,
+      SupportedChainId.ARBITRUM_ONE,
+      SupportedChainId.BNB,
       SupportedChainId.CELO,
       SupportedChainId.CELO_ALFAJORES,
+      SupportedChainId.MAINNET,
       SupportedChainId.OPTIMISM,
-      SupportedChainId.BNB,
+      SupportedChainId.POLYGON,
+      SupportedChainId.POLYGON_MUMBAI,
     ],
   },
   [FeeAmount.LOW]: {


### PR DESCRIPTION
when viewing the /add page you should see the 1bps pool option while connected to Arbitrum

https://interface-git-add-1bp-fee-tier-to-arbitrum-uniswap.vercel.app/#/add/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9/0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8/100

![image](https://user-images.githubusercontent.com/5773490/227004337-3feb91fb-d988-4ab3-93ff-df1e661b0f09.png)
