### PR TITLE
feat: improved injected connection display logic

### DIFF
--- a/src/components/WalletDropdown/UniwalletModal.tsx
+++ b/src/components/WalletDropdown/UniwalletModal.tsx
@@ -5,7 +5,7 @@ import { WalletConnect } from '@web3-react/walletconnect'
 import Column, { AutoColumn } from 'components/Column'
 import Modal from 'components/Modal'
 import { RowBetween } from 'components/Row'
-import { uniwalletConnectConnection } from 'connection'
+import { getUniwalletConnectConnection } from 'connection'
 import { UniwalletConnect } from 'connection/WalletConnect'
 import { QRCodeSVG } from 'qrcode.react'
 import { useCallback, useEffect, useState } from 'react'
@@ -37,19 +37,18 @@ const Divider = styled.div`
   width: 100%;
 `
 
+const connector = getUniwalletConnectConnection().connector as WalletConnect
+
 export default function UniwalletModal() {
   const open = useModalIsOpen(ApplicationModal.UNIWALLET_CONNECT)
   const toggle = useToggleUniwalletModal()
 
   const [uri, setUri] = useState<string>()
   useEffect(() => {
-    ;(uniwalletConnectConnection.connector as WalletConnect).events.addListener(
-      UniwalletConnect.UNI_URI_AVAILABLE,
-      (uri) => {
-        uri && setUri(uri)
-        toggle()
-      }
-    )
+    connector.events.addListener(UniwalletConnect.UNI_URI_AVAILABLE, (uri) => {
+      uri && setUri(uri)
+      toggle()
+    })
   }, [toggle])
 
   const { account } = useWeb3React()
@@ -63,7 +62,7 @@ export default function UniwalletModal() {
   }, [account, open, toggle])
 
   const onClose = useCallback(() => {
-    uniwalletConnectConnection.connector.deactivate?.()
+    connector.deactivate?.()
     toggle()
   }, [toggle])
 

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -7,7 +7,7 @@ import { AutoColumn } from 'components/Column'
 import { AutoRow } from 'components/Row'
 import { useWalletDrawer } from 'components/WalletDropdown'
 import IconButton from 'components/WalletDropdown/IconButton'
-import { Connection, ConnectionType, networkConnection, useConnections } from 'connection'
+import { Connection, ConnectionType, getNetworkConnection, useConnections } from 'connection'
 import { useGetConnection } from 'connection'
 import { ErrorCode } from 'connection/utils'
 import { isSupportedChain } from 'constants/chains'
@@ -108,8 +108,8 @@ export default function WalletModal({ openSettings }: { openSettings: () => void
 
   // Keep the network connector in sync with any active user connector to prevent chain-switching on wallet disconnection.
   useEffect(() => {
-    if (chainId && isSupportedChain(chainId) && connector !== networkConnection.connector) {
-      networkConnection.connector.activate(chainId)
+    if (chainId && isSupportedChain(chainId) && connector !== getNetworkConnection().connector) {
+      getNetworkConnection().connector.activate(chainId)
     }
   }, [chainId, connector])
 

--- a/src/connection/index.test.tsx
+++ b/src/connection/index.test.tsx
@@ -1,111 +1,163 @@
-// eslint-disable-next-line jest/no-export
-export {}
+import { ConnectionType, getConnections, useGetConnection } from 'connection'
+import { renderHook } from 'test-utils'
 
 beforeEach(() => {
   jest.resetModules()
   jest.resetAllMocks()
 })
 
+const UserAgentMock = jest.requireMock('utils/userAgent')
+jest.mock('utils/userAgent', () => ({
+  isMobile: false,
+}))
+
 it('Non-injected Desktop', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: false, isMetaMaskWallet: false, isCoinbaseWallet: false }))
-  jest.mock('utils/userAgent', () => ({ isMobile: false }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('MetaMask')
-  expect(connection.darkInjectedConnection.overrideActivate).toBeDefined()
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.uniwalletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.walletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
+  UserAgentMock.isMobile = false
+  global.window.ethereum = undefined
+
+  const { result } = renderHook(() => useGetConnection())
+  const getConnection = result.current
+  const injectedConnection = getConnection(ConnectionType.INJECTED)
+
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('Install MetaMask')
+  expect(injectedConnection.overrideActivate).toBeDefined()
+  expect(injectedConnection.shouldDisplay).toBe(true)
+
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
 })
 
 it('MetaMask Injected Desktop', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: true, isCoinbaseWallet: false }))
-  jest.mock('utils/userAgent', () => ({ isMobile: false }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('MetaMask')
-  expect(connection.darkInjectedConnection.overrideActivate).toBeUndefined()
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.uniwalletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.walletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
+  UserAgentMock.isMobile = false
+  global.window.ethereum = { isMetaMask: true }
+
+  const { result } = renderHook(() => useGetConnection())
+  const getConnection = result.current
+  const injectedConnection = getConnection(ConnectionType.INJECTED)
+
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('MetaMask')
+  expect(injectedConnection.overrideActivate).toBeUndefined()
+  expect(injectedConnection.shouldDisplay).toBe(true)
+
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
 })
 
 it('Coinbase Injected Desktop', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: false, isCoinbaseWallet: true }))
-  jest.mock('utils/userAgent', () => ({ isMobile: false }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('MetaMask')
-  expect(connection.darkInjectedConnection.overrideActivate).toBeDefined()
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.uniwalletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.walletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
+  UserAgentMock.isMobile = false
+  global.window.ethereum = { isCoinbaseWallet: true }
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const injectedConnection = getConnection.current(ConnectionType.INJECTED)
+  const cbConnection = getConnection.current(ConnectionType.COINBASE_WALLET)
+
+  expect(cbConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('Install MetaMask')
+  expect(injectedConnection.overrideActivate).toBeDefined()
+
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
 })
 
 it('Coinbase and MetaMask Injected Desktop', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: true, isCoinbaseWallet: true }))
-  jest.mock('utils/userAgent', () => ({ isMobile: false }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('MetaMask')
-  expect(connection.darkInjectedConnection.overrideActivate).toBeUndefined()
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.uniwalletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.walletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
+  UserAgentMock.isMobile = false
+  global.window.ethereum = { isCoinbaseWallet: true, isMetaMask: true }
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const injectedConnection = getConnection.current(ConnectionType.INJECTED)
+  const cbConnection = getConnection.current(ConnectionType.COINBASE_WALLET)
+
+  expect(cbConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('MetaMask')
+  expect(injectedConnection.overrideActivate).toBeUndefined()
+
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
 })
 
 it('Generic Injected Desktop', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: false, isCoinbaseWallet: false }))
-  jest.mock('utils/userAgent', () => ({ isMobile: false }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('Browser Wallet')
-  expect(connection.darkInjectedConnection.overrideActivate).toBeUndefined()
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.uniwalletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.walletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
+  UserAgentMock.isMobile = false
+  global.window.ethereum = { isTrustWallet: true }
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const injectedConnection = getConnection.current(ConnectionType.INJECTED)
+
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('Browser Wallet')
+  expect(injectedConnection.overrideActivate).toBeUndefined()
+
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(4)
+})
+
+it('Generic Wallet Browser with delayed injection', async () => {
+  UserAgentMock.isMobile = false
+  global.window.ethereum = undefined
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const preInjectedConnection = getConnection.current(ConnectionType.INJECTED)
+
+  expect(preInjectedConnection.shouldDisplay).toBe(true)
+  expect(preInjectedConnection.name).toBe('Install MetaMask')
+
+  global.window.ethereum = { isTrustWallet: true }
+  const postInjectedConnection = getConnection.current(ConnectionType.INJECTED)
+
+  expect(postInjectedConnection.shouldDisplay).toBe(true)
+  expect(postInjectedConnection.name).toBe('Browser Wallet')
 })
 
 it('Generic Injected Mobile Browser', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: false, isCoinbaseWallet: false }))
-  jest.mock('utils/userAgent', () => ({ isMobile: true }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('Browser Wallet')
+  global.window.ethereum = { isTrustWallet: true }
+  UserAgentMock.isMobile = true
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const injectedConnection = getConnection.current(ConnectionType.INJECTED)
+
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('Browser Wallet')
 })
 
 it('MetaMask Mobile Browser', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: true, isCoinbaseWallet: false }))
-  jest.mock('utils/userAgent', () => ({ isMobile: true }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(true)
-  expect(connection.darkInjectedConnection.name).toBe('MetaMask')
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(1)
+  global.window.ethereum = { isMetaMask: true }
+  UserAgentMock.isMobile = true
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const injectedConnection = getConnection.current(ConnectionType.INJECTED)
+
+  expect(injectedConnection.shouldDisplay).toBe(true)
+  expect(injectedConnection.name).toBe('MetaMask')
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(1)
 })
 
 it('Coinbase Mobile Browser', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: true, isMetaMaskWallet: false, isCoinbaseWallet: true }))
-  jest.mock('utils/userAgent', () => ({ isMobile: true }))
-  const connection = await import('connection')
+  global.window.ethereum = { isCoinbaseWallet: true }
+  UserAgentMock.isMobile = true
 
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.coinbaseWalletConnection.overrideActivate).toBeUndefined()
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(1)
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const cbConnection = getConnection.current(ConnectionType.COINBASE_WALLET)
+
+  expect(cbConnection.shouldDisplay).toBe(true)
+  expect(cbConnection.overrideActivate).toBeUndefined()
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(1)
 })
 
-it('mWeb Browser', async () => {
-  jest.mock('connection/utils', () => ({ isInjected: false, isMetaMaskWallet: false, isCoinbaseWallet: false }))
-  jest.mock('utils/userAgent', () => ({ isMobile: true }))
-  const connection = await import('connection')
-  expect(connection.darkInjectedConnection.shouldDisplay).toBe(false)
-  expect(connection.coinbaseWalletConnection.shouldDisplay).toBe(true)
-  expect(connection.coinbaseWalletConnection.overrideActivate).toBeDefined()
-  expect(connection.uniwalletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.walletConnectConnection.shouldDisplay).toBe(true)
-  expect(connection.getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(3)
+it('Uninjected mWeb Browser', async () => {
+  global.window.ethereum = undefined
+  UserAgentMock.isMobile = true
+
+  const { result: getConnection } = renderHook(() => useGetConnection())
+  const uniConnection = getConnection.current(ConnectionType.UNIWALLET)
+  const wcConnection = getConnection.current(ConnectionType.WALLET_CONNECT)
+  const cbConnection = getConnection.current(ConnectionType.COINBASE_WALLET)
+  const injectedConnection = getConnection.current(ConnectionType.INJECTED)
+
+  expect(uniConnection.shouldDisplay).toBe(true)
+  expect(wcConnection.shouldDisplay).toBe(true)
+  // Don't show injected connection on plain mWeb browser
+  expect(injectedConnection.shouldDisplay).toBe(false)
+  // Expect coinbase option to launch coinbase app in a regular mobile browser
+  expect(cbConnection.shouldDisplay).toBe(true)
+  expect(cbConnection.overrideActivate).toBeDefined()
+
+  expect(getConnections(true).filter((c) => c.shouldDisplay).length).toEqual(3)
 })

--- a/src/connection/utils.ts
+++ b/src/connection/utils.ts
@@ -1,15 +1,19 @@
-export const isInjected = Boolean(window.ethereum)
+import { isMobile } from 'utils/userAgent'
+
+export const getIsInjected = () => Boolean(window.ethereum)
 
 // When using Brave browser, `isMetaMask` is set to true when using the built-in wallet
 // This variable should be true only when using the MetaMask extension
 // https://wallet-docs.brave.com/ethereum/wallet-detection#compatability-with-metamask
 type NonMetaMaskFlag = 'isRabby' | 'isBraveWallet' | 'isTrustWallet'
 const allNonMetamaskFlags: NonMetaMaskFlag[] = ['isRabby', 'isBraveWallet', 'isTrustWallet']
-export const isMetaMaskWallet = Boolean(
-  window.ethereum?.isMetaMask && !allNonMetamaskFlags.some((flag) => window.ethereum?.[flag])
-)
+export const getIsMetaMaskWallet = () =>
+  Boolean(window.ethereum?.isMetaMask && !allNonMetamaskFlags.some((flag) => window.ethereum?.[flag]))
 
-export const isCoinbaseWallet = Boolean(window.ethereum?.isCoinbaseWallet)
+export const getIsCoinbaseWallet = () => Boolean(window.ethereum?.isCoinbaseWallet)
+export const getIsCoinbaseWalletBrowser = () => isMobile && Boolean(window.ethereum?.isCoinbaseWallet)
+
+export const getIsInjectedMobileBrowser = () => isMobile && (getIsCoinbaseWallet() || getIsMetaMaskWallet())
 
 // https://eips.ethereum.org/EIPS/eip-1193#provider-errors
 export enum ErrorCode {

--- a/src/connection/utils.ts
+++ b/src/connection/utils.ts
@@ -7,13 +7,15 @@ export const getIsInjected = () => Boolean(window.ethereum)
 // https://wallet-docs.brave.com/ethereum/wallet-detection#compatability-with-metamask
 type NonMetaMaskFlag = 'isRabby' | 'isBraveWallet' | 'isTrustWallet'
 const allNonMetamaskFlags: NonMetaMaskFlag[] = ['isRabby', 'isBraveWallet', 'isTrustWallet']
-export const getIsMetaMaskWallet = () =>
-  Boolean(window.ethereum?.isMetaMask && !allNonMetamaskFlags.some((flag) => window.ethereum?.[flag]))
+const getIsKnownGenericInjector = () => allNonMetamaskFlags.some((flag) => window.ethereum?.[flag])
+
+export const getIsMetaMaskWallet = () => Boolean(window.ethereum?.isMetaMask && !getIsKnownGenericInjector())
 
 export const getIsCoinbaseWallet = () => Boolean(window.ethereum?.isCoinbaseWallet)
 export const getIsCoinbaseWalletBrowser = () => isMobile && Boolean(window.ethereum?.isCoinbaseWallet)
 
-export const getIsInjectedMobileBrowser = () => isMobile && (getIsCoinbaseWallet() || getIsMetaMaskWallet())
+export const getIsKnownWalletBrowser = () =>
+  isMobile && (getIsCoinbaseWallet() || getIsMetaMaskWallet() || getIsKnownGenericInjector())
 
 // https://eips.ethereum.org/EIPS/eip-1193#provider-errors
 export enum ErrorCode {

--- a/src/hooks/useEagerlyConnect.ts
+++ b/src/hooks/useEagerlyConnect.ts
@@ -1,5 +1,5 @@
 import { Connector } from '@web3-react/types'
-import { Connection, gnosisSafeConnection, networkConnection } from 'connection'
+import { Connection, getGnosisSafeConnection, getNetworkConnection } from 'connection'
 import { useGetConnection } from 'connection'
 import { useEffect } from 'react'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
@@ -33,8 +33,8 @@ export default function useEagerlyConnect() {
   }
 
   useEffect(() => {
-    connect(gnosisSafeConnection.connector)
-    connect(networkConnection.connector)
+    connect(getGnosisSafeConnection().connector)
+    connect(getNetworkConnection().connector)
 
     if (selectedConnection) {
       connect(selectedConnection.connector)

--- a/src/utils/switchChain.ts
+++ b/src/utils/switchChain.ts
@@ -1,5 +1,5 @@
 import { Connector } from '@web3-react/types'
-import { networkConnection, uniwalletConnectConnection, walletConnectConnection } from 'connection'
+import { getNetworkConnection, getUniwalletConnectConnection, getWalletConnectConnection } from 'connection'
 import { getChainInfo } from 'constants/chainInfo'
 import { isSupportedChain, SupportedChainId } from 'constants/chains'
 import { FALLBACK_URLS, RPC_URLS } from 'constants/networks'
@@ -21,9 +21,9 @@ export const switchChain = async (connector: Connector, chainId: SupportedChainI
   if (!isSupportedChain(chainId)) {
     throw new Error(`Chain ${chainId} not supported for connector (${typeof connector})`)
   } else if (
-    connector === walletConnectConnection.connector ||
-    connector === uniwalletConnectConnection.connector ||
-    connector === networkConnection.connector
+    connector === getWalletConnectConnection().connector ||
+    connector === getUniwalletConnectConnection().connector ||
+    connector === getNetworkConnection().connector
   ) {
     await connector.activate(chainId)
   } else {


### PR DESCRIPTION
returns checks for `isInjected` / `isMetaMask` & other utilities to being function calls, rather than checking static vars initialized on page load, in order to fix issue where wallets that don't immediately inject display as 'MetaMask' rather than 'Browser Wallet'

also tweaks display logic to ensure the follow the following:
* on a _known_ wallet browser (MM, CB, TrustWallet, etc) , display only the injected connector; while on an _unknown_ wallet browser, display injected options alongside wallet connect & coinbase
* display "Install MetaMask" rather than just "MetaMask" while on a non-injected desktop browser