### PR TITLE
fix: use correct chain var when switching

### DIFF
--- a/src/components/Tokens/TokenDetails/index.tsx
+++ b/src/components/Tokens/TokenDetails/index.tsx
@@ -137,12 +137,12 @@ export default function TokenDetails({
       if (!address) return
       const bridgedAddress = crossChainMap[update]
       if (bridgedAddress) {
-        startTokenTransition(() => navigate(getTokenDetailsURL({ address: bridgedAddress, chain })))
+        startTokenTransition(() => navigate(getTokenDetailsURL({ address: bridgedAddress, chain: update })))
       } else if (didFetchFromChain || detailedToken?.isNative) {
-        startTokenTransition(() => navigate(getTokenDetailsURL({ address, chain })))
+        startTokenTransition(() => navigate(getTokenDetailsURL({ address, chain: update })))
       }
     },
-    [address, chain, crossChainMap, didFetchFromChain, navigate, detailedToken?.isNative]
+    [address, crossChainMap, didFetchFromChain, navigate, detailedToken?.isNative]
   )
   useOnGlobalChainSwitch(navigateToTokenForChain)
 


### PR DESCRIPTION
fixes the token details chain updater to use the new chain rather than the current chain when switching to the address of a cross-chain token provided by the backend