### PR TITLE
fix: crash in nft listing flow

### DIFF
--- a/cypress/e2e/nfts.test.ts
+++ b/cypress/e2e/nfts.test.ts
@@ -49,9 +49,8 @@ describe('Testing nfts', () => {
     cy.get(getTestSelector('nft-bag')).should('exist')
   })
 
-  it('should navigate to the listing flow', () => {
+  it('should navigate to the owned nfts page', () => {
     cy.get(getTestSelector('web3-status-connected')).click()
     cy.get(getTestSelector('nft-view-self-nfts')).click()
-    // todo: get goerli NFTs on this wallet, add one to the bag, and navigate to the listing flow
   })
 })

--- a/cypress/e2e/nfts.test.ts
+++ b/cypress/e2e/nfts.test.ts
@@ -48,4 +48,10 @@ describe('Testing nfts', () => {
     cy.get(getTestSelector('nft-details-toggle-bag')).eq(1).click()
     cy.get(getTestSelector('nft-bag')).should('exist')
   })
+
+  it('should navigate to the listing flow', () => {
+    cy.get(getTestSelector('web3-status-connected')).click()
+    cy.get(getTestSelector('nft-view-self-nfts')).click()
+    // todo: get goerli NFTs on this wallet, add one to the bag, and navigate to the listing flow
+  })
 })

--- a/src/nft/components/profile/list/NFTListRow.tsx
+++ b/src/nft/components/profile/list/NFTListRow.tsx
@@ -7,7 +7,6 @@ import { Dispatch, useEffect, useReducer, useState } from 'react'
 import { Trash2 } from 'react-feather'
 import styled, { css, useTheme } from 'styled-components/macro'
 import { BREAKPOINTS, ThemedText } from 'theme'
-import { opacify } from 'theme/utils'
 
 import { MarketplaceRow } from './MarketplaceRow'
 import { SetPriceMethod } from './shared'
@@ -20,7 +19,7 @@ const NFTListRowWrapper = styled(Row)`
   border-radius: 8px;
 
   &:hover {
-    background: ${({ theme }) => opacify(24, theme.backgroundOutline)};
+    background: ${({ theme }) => theme.backgroundOutline};
   }
 `
 


### PR DESCRIPTION
fixes a crash when trying to list an NFT 

the crash happens to me every time i try to list an NFT. repro steps:
- go to your NFTs
- click "list for sale" on an NFT
- click "continue" in sidebar

```
Error: opacify: provided color #98A1C03d was not in hexadecimal format (e.g. #000000)
```


### test plan

i also added the first half of an e2e test that would prevent this from happening in the future, but need to check w/ the team about they typically test goerli NFTs in e2e tests.

otherwise, i've manually tested and verified that this fixes the listing flow for me