### PR TITLE
docs: Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,21 @@
-Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary), and should start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):
+## Description
 
-- build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
-- ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
-- docs: Documentation only changes
-- feat: A new feature
-- fix: A bug fix
-- perf: A code change that improves performance
-- refactor: A code change that neither fixes a bug nor adds a feature
-- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-- test: Adding missing tests or correcting existing tests
+[Replace this with the description of your change. Be explicit and mention the problem being solved, how it's being solved, and why it's being solved. Link to JIRA ticket, slack thread, design doc, or relevant resources helpful for providing context to reviewers.]
 
-Example commit messages:
+## Test Plan
 
-- feat: adds support for gnosis safe wallet
-- fix: removes a polling memory leak
-- chore: bumps redux version
+#### Manual
 
-Other things to note:
+[Replace this with the description of how you are testing the change and validating there is no regression. Include screenshots where applicable.]
 
-- Please describe the change using verb statements (ex: Removes X from Y)
-- PRs with multiple changes should use a list of verb statements
-- Add any relevant unit / integration tests
-- Changes will be previewable via vercel. Non-obvious changes should include instructions for how to reproduce them
+
+#### Automated
+- [ ] Unit test
+- [ ] Integration/E2E test
+
+[Remove this line. Guidance here is that code coverage on each PR should increase OR at minimum remain the same.]
+
+
+## Monitoring
+
+[If applicable, replace this with alerts and metrics you added to monitor this change.]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,9 @@
 
 _[Summary of change, motivation, and context.]_
 
-_[Link to JIRA ticket, slack thread, or relevant docs helpful for providing context to reviewers.]_
+- _Link to JIRA ticket, slack thread, or relevant docs helpful for providing context to reviewers._
+
+- _Note: Your PR title must follow conventions [outlined here](https://github.com/Uniswap/interface#contributions)._
 
 ## Screen Capture
 | Before           | After           |
@@ -18,7 +20,3 @@ _[Steps of how you are testing the change and ensuring no regression.]_
 #### Automated
 - [ ] Unit test
 - [ ] Integration/E2E test
-
-## Monitoring
-
-_[If applicable, alerts and metrics you added to monitor this change.]_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,24 @@
 ## Description
 
-[Replace this with the description of your change. Be explicit and mention the problem being solved, how it's being solved, and why it's being solved. Link to JIRA ticket, slack thread, design doc, or relevant resources helpful for providing context to reviewers.]
+_[Summary of change, motivation, and context.]_
+
+_[Link to JIRA ticket, slack thread, or relevant docs helpful for providing context to reviewers.]_
+
+## Screen Capture
+| Before           | After           |
+| ---------------- |-----------------|
+|  _insert_before_ | _insert_after_  |
+
 
 ## Test Plan
-
 #### Manual
 
-[Replace this with the description of how you are testing the change and validating there is no regression. Include screenshots where applicable.]
-
+_[Steps of how you are testing the change and ensuring no regression.]_
 
 #### Automated
 - [ ] Unit test
 - [ ] Integration/E2E test
 
-[Remove this line. Guidance here is that code coverage on each PR should increase OR at minimum remain the same.]
-
-
 ## Monitoring
 
-[If applicable, replace this with alerts and metrics you added to monitor this change.]
+_[If applicable, alerts and metrics you added to monitor this change.]_

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ You can block an entire list of tokens by passing in a tokenlist like [here](./s
 
 For steps on local deployment, development, and code contribution, please see [CONTRIBUTING](./CONTRIBUTING.md).
 
+#### PR Title
+Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary), and should start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):
+
+- build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
+- ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
+- docs: Documentation only changes
+- feat: A new feature
+- fix: A bug fix
+- perf: A code change that improves performance
+- refactor: A code change that neither fixes a bug nor adds a feature
+- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- test: Adding missing tests or correcting existing tests
+
+Example commit messages:
+
+- feat: adds support for gnosis safe wallet
+- fix: removes a polling memory leak
+- chore: bumps redux version
+
+Other things to note:
+
+- Please describe the change using verb statements (ex: Removes X from Y)
+- PRs with multiple changes should use a list of verb statements
+- Add any relevant unit / integration tests
+- Changes will be previewable via vercel. Non-obvious changes should include instructions for how to reproduce them
+
+
 ## Accessing Uniswap V2
 
 The Uniswap Interface supports swapping, adding liquidity, removing liquidity and migrating liquidity for Uniswap protocol V2.


### PR DESCRIPTION
## Description
Updating the PR template to standardize how PR descriptions are written. The purpose is to help contributors provide useful context to reviewers to understand the changes being made and how they're being tested.

- Moved PR Title convention to `README.md`
- Took inspiration from backend + mobile PR templates.

## Test Plan
n/a