### PR TITLE
fix: remove backend name check from badge flag

### DIFF
--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -360,7 +360,7 @@ export const SearchBarDropdown = ({
     searchHistory,
   ])
 
-  const showBNBComingSoonBadge = Boolean(chainId === SupportedChainId.BNB && !isLoading)
+  const showBNBComingSoonBadge = chainId === SupportedChainId.BNB && !isLoading
 
   return (
     <Box className={styles.searchBarDropdownNft}>

--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -9,7 +9,6 @@ import { HistoryDuration, SafetyLevel } from 'graphql/data/__generated__/types-a
 import { useTrendingCollections } from 'graphql/data/nft/TrendingCollections'
 import { SearchToken } from 'graphql/data/SearchTokens'
 import useTrendingTokens from 'graphql/data/TrendingTokens'
-import { CHAIN_ID_TO_BACKEND_NAME } from 'graphql/data/util'
 import { useIsNftPage } from 'hooks/useIsNftPage'
 import { Box } from 'nft/components/Box'
 import { Column, Row } from 'nft/components/Flex'
@@ -361,9 +360,7 @@ export const SearchBarDropdown = ({
     searchHistory,
   ])
 
-  const showBNBComingSoonBadge = Boolean(
-    chainId !== undefined && chainId === SupportedChainId.BNB && !isLoading && !CHAIN_ID_TO_BACKEND_NAME[chainId]
-  )
+  const showBNBComingSoonBadge = Boolean(chainId !== undefined && chainId === SupportedChainId.BNB && !isLoading)
 
   return (
     <Box className={styles.searchBarDropdownNft}>

--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -360,7 +360,7 @@ export const SearchBarDropdown = ({
     searchHistory,
   ])
 
-  const showBNBComingSoonBadge = Boolean(chainId !== undefined && chainId === SupportedChainId.BNB && !isLoading)
+  const showBNBComingSoonBadge = Boolean(chainId === SupportedChainId.BNB && !isLoading)
 
   return (
     <Box className={styles.searchBarDropdownNft}>


### PR DESCRIPTION
The prior implementation assumed backend support would be rolled out comprehensively, but right now assets/portfolio info is supported, but search is not.

https://uniswaplabs.atlassian.net/browse/WEB-3014

## Updated
![image](https://user-images.githubusercontent.com/5773490/227246001-c5f55e59-ad99-4985-b457-bf941dcad2eb.png)


## Current
![image](https://user-images.githubusercontent.com/5773490/227245368-cffd48cd-6de2-4b1d-a99d-01fba2d48b91.png)
