### PR TITLE
fix: don't show the add liquidity warning when no position currently …

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -555,7 +555,7 @@ export default function AddLiquidity() {
   const owner = useSingleCallResult(tokenId ? positionManager : null, 'ownerOf', [tokenId]).result?.[0]
   const ownsNFT =
     addressesAreEquivalent(owner, account) || addressesAreEquivalent(existingPositionDetails?.operator, account)
-  const showOwnershipWarning = Boolean(account && !ownsNFT)
+  const showOwnershipWarning = Boolean(hasExistingPosition && account && !ownsNFT)
 
   return (
     <>


### PR DESCRIPTION
fix for an issue in #6219 caught during QA

the prior implementation would return true for `showOwnershipWarning` if the LP NFT id did not exist (i.e., during the initial mint)