### PR TITLE
feat: sort tokens in selector by USD value

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -15,7 +15,7 @@ import { ChangeEvent, KeyboardEvent, RefObject, useCallback, useEffect, useMemo,
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeList } from 'react-window'
 import { Text } from 'rebass'
-import { useAllTokenBalances } from 'state/connection/hooks'
+import { useAllTokenBalances, useTokenPrices } from 'state/connection/hooks'
 import styled, { useTheme } from 'styled-components/macro'
 import { UserAddedToken } from 'types/tokens'
 
@@ -91,9 +91,11 @@ export function CurrencySearch({
   }, [defaultTokens, debouncedQuery])
 
   const [balances, balancesAreLoading] = useAllTokenBalances()
+  const balancePrices = useTokenPrices(balances)
+
   const sortedTokens: Token[] = useMemo(
     () =>
-      !balancesAreLoading
+      !balancesAreLoading && balancePrices
         ? filteredTokens
             .filter((token) => {
               if (onlyShowCurrenciesWithBalance) {
@@ -107,16 +109,17 @@ export function CurrencySearch({
               }
               return true
             })
-            .sort(tokenComparator.bind(null, balances))
+            .sort(tokenComparator.bind(null, balances, balancePrices))
         : [],
     [
-      balances,
       balancesAreLoading,
-      debouncedQuery,
       filteredTokens,
-      otherSelectedCurrency,
-      selectedCurrency,
+      balances,
+      balancePrices,
       onlyShowCurrenciesWithBalance,
+      debouncedQuery,
+      selectedCurrency,
+      otherSelectedCurrency,
     ]
   )
   const isLoading = Boolean(balancesAreLoading && !tokenLoaderTimerElapsed)

--- a/src/lib/hooks/useTokenList/sorting.test.ts
+++ b/src/lib/hooks/useTokenList/sorting.test.ts
@@ -1,0 +1,60 @@
+import { CurrencyAmount } from '@uniswap/sdk-core'
+import { DAI, FRAX, WBTC } from 'constants/tokens'
+
+import { tokenComparator } from './sorting'
+
+describe('tokenComparator', () => {
+  it('sorts tokens by USD value (descending)', () => {
+    const result = tokenComparator(
+      {
+        // Balances
+        [DAI.address]: CurrencyAmount.fromRawAmount(DAI, 1),
+        [WBTC.address]: CurrencyAmount.fromRawAmount(WBTC, 1),
+      },
+      {
+        // Prices
+        [DAI.address]: 1,
+        [WBTC.address]: 1000000,
+      },
+      DAI,
+      WBTC
+    )
+    expect(result).toBe(1) // tokenB has a higher USD value than tokenA, while balances are equal
+  })
+
+  it('sorts tokens by currency amount (descending)', () => {
+    const result = tokenComparator(
+      {
+        // Balances
+        [FRAX.address]: CurrencyAmount.fromFractionalAmount(FRAX, 1, 10),
+        [DAI.address]: CurrencyAmount.fromRawAmount(DAI, 1),
+      },
+      {
+        // Prices
+        [FRAX.address]: 1,
+        [DAI.address]: 1,
+      },
+      FRAX,
+      DAI
+    )
+    expect(result).toBe(1) // tokenB has a higher balance amount than tokenA, while USD values are equal
+  })
+
+  it('sorts tokens by symbol (ascending)', () => {
+    const result = tokenComparator(
+      {
+        // Balances
+        [FRAX.address]: CurrencyAmount.fromFractionalAmount(FRAX, 1, 10),
+        [DAI.address]: CurrencyAmount.fromRawAmount(DAI, 1),
+      },
+      {
+        // Prices
+        [FRAX.address]: 1,
+        [DAI.address]: 1,
+      },
+      FRAX,
+      DAI
+    )
+    expect(result).toBe(1) // tokenB is before tokenA alphabetically
+  })
+})

--- a/src/lib/hooks/useTokenList/sorting.ts
+++ b/src/lib/hooks/useTokenList/sorting.ts
@@ -2,6 +2,7 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { TokenInfo } from '@uniswap/token-lists'
 import { useMemo } from 'react'
 import { BalancesResult, PricesResult } from 'state/connection/hooks'
+import { currencyAmountToPreciseFloat } from 'utils/formatNumbers'
 
 /** Sorts currency amounts (descending). */
 function balanceComparator(a?: CurrencyAmount<Currency>, b?: CurrencyAmount<Currency>) {
@@ -10,8 +11,8 @@ function balanceComparator(a?: CurrencyAmount<Currency>, b?: CurrencyAmount<Curr
 
 /** Sorts currency amounts by value (descending). */
 function valueComparator(a?: CurrencyAmount<Currency>, b?: CurrencyAmount<Currency>, aPrice?: number, bPrice?: number) {
-  const aBalance: number = parseFloat(a?.toFixed(2) ?? '0')
-  const bBalance: number = parseFloat(b?.toFixed(2) ?? '0')
+  const aBalance = currencyAmountToPreciseFloat(a) ?? 1
+  const bBalance = currencyAmountToPreciseFloat(b) ?? 1
   if (a && b) {
     return aBalance * (aPrice ?? 1) > bBalance * (bPrice ?? 1)
       ? -1
@@ -26,7 +27,7 @@ function valueComparator(a?: CurrencyAmount<Currency>, b?: CurrencyAmount<Curren
   return 0
 }
 
-/** Sorts tokens by USD Value (descending), then currency amount (descending), then safety, then symbol (ascending). */
+/** Sorts tokens by USD Value (descending), then currency amount (descending), then symbol (ascending). */
 export function tokenComparator(balances: BalancesResult, prices: PricesResult, a: Token, b: Token) {
   // Sorts by USD value
   const valueComparison = valueComparator(

--- a/src/nft/utils/fetchUSDPrice.ts
+++ b/src/nft/utils/fetchUSDPrice.ts
@@ -1,0 +1,28 @@
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import {
+  TokenSpotPriceDocument,
+  TokenSpotPriceQuery,
+  TokenSpotPriceQueryVariables,
+} from 'graphql/data/__generated__/types-and-hooks'
+import { apolloClient } from 'graphql/data/apollo'
+import { CHAIN_ID_TO_BACKEND_NAME, chainIdToBackendName } from 'graphql/data/util'
+import { getNativeTokenDBAddress } from 'utils/nativeTokens'
+
+export async function fetchUSDPrice(
+  currencyAmount: CurrencyAmount<Currency> | undefined | null
+): Promise<number | undefined> {
+  if (!currencyAmount) {
+    return undefined
+  }
+  const isNative = currencyAmount?.currency.isNative
+  const data = await apolloClient.query<TokenSpotPriceQuery>({
+    query: TokenSpotPriceDocument,
+    variables: {
+      address: isNative
+        ? getNativeTokenDBAddress(CHAIN_ID_TO_BACKEND_NAME[currencyAmount.currency.chainId])
+        : currencyAmount?.currency.address ?? '',
+      chain: chainIdToBackendName(currencyAmount?.currency.chainId),
+    } as TokenSpotPriceQueryVariables,
+  })
+  return data?.data?.token?.project?.markets?.[0]?.price?.value
+}

--- a/src/state/connection/hooks.ts
+++ b/src/state/connection/hooks.ts
@@ -1,7 +1,8 @@
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { useTokenBalancesWithLoadingIndicator } from 'lib/hooks/useCurrencyBalance'
-import { useMemo } from 'react'
+import { fetchUSDPrice } from 'nft/utils/fetchUSDPrice'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useDefaultActiveTokens } from '../../hooks/Tokens'
 
@@ -14,11 +15,35 @@ export {
   useTokenBalancesWithLoadingIndicator,
 } from 'lib/hooks/useCurrencyBalance'
 
+export type BalancesResult = { [tokenAddress: string]: CurrencyAmount<Token> | undefined }
+export type PricesResult = { [tokenAddress: string]: number | undefined } | undefined
+
 // mimics useAllBalances
-export function useAllTokenBalances(): [{ [tokenAddress: string]: CurrencyAmount<Token> | undefined }, boolean] {
+export function useAllTokenBalances(): [BalancesResult, boolean] {
   const { account } = useWeb3React()
   const allTokens = useDefaultActiveTokens()
   const allTokensArray = useMemo(() => Object.values(allTokens ?? {}), [allTokens])
   const [balances, balancesIsLoading] = useTokenBalancesWithLoadingIndicator(account ?? undefined, allTokensArray)
   return [balances ?? {}, balancesIsLoading]
+}
+
+export function useTokenPrices(balances: BalancesResult): PricesResult {
+  const [prices, setPrices] = useState<PricesResult | undefined>(undefined)
+  useEffect(() => {
+    loadPrices()
+    async function loadPrices() {
+      const tokensWithBalance: CurrencyAmount<Token>[] = Object.values(balances).filter(
+        (balance) => balance?.greaterThan(0) // filters undefined values so we can cast safely
+      ) as CurrencyAmount<Token>[]
+      const pricesEntries = await Promise.all(
+        tokensWithBalance.map(async (token) => {
+          const price = await fetchUSDPrice(token)
+          return [token.currency.address, price]
+        })
+      )
+
+      setPrices(Object.fromEntries(pricesEntries))
+    }
+  }, [balances])
+  return prices
 }


### PR DESCRIPTION
## Description

When loading the token selector, fetches the USD prices for all tokens with a balance so we can take into account the USD value when sorting.

https://uniswaplabs.atlassian.net/browse/WEB-2990?atlOrigin=eyJpIjoiZTYzZjZkMzRhNzI0NGQxNWI1MzIxYTJkMzUxZDJkMjkiLCJwIjoiaiJ9


## Screen Capture
| Before           | After           |
| ---------------- |-----------------|
|  <img width="441" alt="image" src="https://user-images.githubusercontent.com/66155195/227383779-617637a4-50eb-4517-8df1-cd341375ef79.png"> | <img width="441" alt="image" src="https://user-images.githubusercontent.com/66155195/227383620-a11bc1f6-464e-453a-a398-47ec81e0df73.png">  |


## Test Plan
#### Manual

- open the token selector on all Supported Chains and make sure the set of tokens with balances is unchanged, but the order is updated

#### Automated
- [x] Unit test - added for the sorting helper function
- [x] Integration/E2E test - we have e2e test (`swap-widget.cy.ts`) which test opening this component so it's covered a little bit