### PR TITLE
fix: align /pools CTAs to the top

### DIFF
--- a/src/pages/Pool/CTACards.tsx
+++ b/src/pages/Pool/CTACards.tsx
@@ -19,14 +19,10 @@ const CTASection = styled.section`
   `};
 `
 
-const CTA1 = styled(ExternalLink)`
+const CTA = styled(ExternalLink)`
   padding: 16px;
   border-radius: 20px;
-  display: flex;
-  flex-direction: column;
   position: relative;
-  justify-content: center;
-  align-items: center;
   overflow: hidden;
   border: 1px solid ${({ theme }) => theme.deprecated_bg3};
 
@@ -39,30 +35,6 @@ const CTA1 = styled(ExternalLink)`
     border: 1px solid ${({ theme }) => theme.deprecated_bg4};
 
     text-decoration: none;
-    * {
-      text-decoration: none !important;
-    }
-  }
-`
-
-const CTA2 = styled(ExternalLink)`
-  position: relative;
-  overflow: hidden;
-  padding: 16px;
-  border-radius: 20px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  border: 1px solid ${({ theme }) => theme.deprecated_bg3};
-
-  * {
-    color: ${({ theme }) => theme.textPrimary};
-    text-decoration: none !important;
-  }
-
-  :hover {
-    border: 1px solid ${({ theme }) => theme.deprecated_bg4};
-    text-decoration: none !important;
     * {
       text-decoration: none !important;
     }
@@ -97,7 +69,7 @@ export default function CTACards() {
 
   return (
     <CTASection>
-      <CTA1 href="https://support.uniswap.org/hc/en-us/categories/8122334631437-Providing-Liquidity-">
+      <CTA href="https://support.uniswap.org/hc/en-us/categories/8122334631437-Providing-Liquidity-">
         <ResponsiveColumn>
           <HeaderText>
             <Trans>Learn about providing liquidity</Trans> ↗
@@ -106,8 +78,8 @@ export default function CTACards() {
             <Trans>Check out our v3 LP walkthrough and migration guides.</Trans>
           </ThemedText.DeprecatedBody>
         </ResponsiveColumn>
-      </CTA1>
-      <CTA2 data-testid="cta-infolink" href={infoLink + 'pools'}>
+      </CTA>
+      <CTA data-testid="cta-infolink" href={infoLink + 'pools'}>
         <ResponsiveColumn>
           <HeaderText style={{ alignSelf: 'flex-start' }}>
             <Trans>Top pools</Trans> ↗
@@ -116,7 +88,7 @@ export default function CTACards() {
             <Trans>Explore Uniswap Analytics.</Trans>
           </ThemedText.DeprecatedBody>
         </ResponsiveColumn>
-      </CTA2>
+      </CTA>
     </CTASection>
   )
 }

--- a/src/pages/Pool/CTACards.tsx
+++ b/src/pages/Pool/CTACards.tsx
@@ -8,13 +8,18 @@ import { ThemedText } from 'theme'
 import { ExternalLink } from '../../theme'
 
 const CTASection = styled.section`
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 8px;
   opacity: 0.8;
+
+  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  `};
 `
 
 const CTA = styled(ExternalLink)`
-  flex: 1;
   padding: 16px;
   border-radius: 20px;
   position: relative;
@@ -42,12 +47,19 @@ const HeaderText = styled(ThemedText.DeprecatedLabel)`
 
   font-weight: 400;
   font-size: 16px;
+  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
+    font-size: 16px;
+  `};
 `
 
 const ResponsiveColumn = styled(AutoColumn)`
   grid-template-columns: 1fr;
   width: 100%;
   gap: 8px;
+
+  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
+    gap: 8px;
+  `};
   justify-content: space-between;
 `
 

--- a/src/pages/Pool/CTACards.tsx
+++ b/src/pages/Pool/CTACards.tsx
@@ -8,18 +8,13 @@ import { ThemedText } from 'theme'
 import { ExternalLink } from '../../theme'
 
 const CTASection = styled.section`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
   gap: 8px;
   opacity: 0.8;
-
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
-    grid-template-columns: auto;
-    grid-template-rows: auto;
-  `};
 `
 
 const CTA = styled(ExternalLink)`
+  flex: 1;
   padding: 16px;
   border-radius: 20px;
   position: relative;
@@ -47,19 +42,12 @@ const HeaderText = styled(ThemedText.DeprecatedLabel)`
 
   font-weight: 400;
   font-size: 16px;
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
-    font-size: 16px;
-  `};
 `
 
 const ResponsiveColumn = styled(AutoColumn)`
   grid-template-columns: 1fr;
   width: 100%;
   gap: 8px;
-
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
-    gap: 8px;
-  `};
   justify-content: space-between;
 `
 


### PR DESCRIPTION
This PR makes sure that the title and description for the "info" CTA in the pools page is aligned to the top. This makes sure it's even with the other CTA.

I simplified the code to just use a single CTA component, as we don't believe we need any style changes between the two. I also removed the display: flex as we don't actually need to use align-items or justify-content center here.

after:
<img width="1319" alt="Screen Shot 2023-03-24 at 4 48 38 PM" src="https://user-images.githubusercontent.com/4899429/227636973-a3845310-a54a-493c-b3d4-0a80de035f5c.png">

before:
<img width="1322" alt="Screen Shot 2023-03-24 at 4 48 46 PM" src="https://user-images.githubusercontent.com/4899429/227636975-549ec706-d19c-4f39-bca6-174c618870e3.png">

Test:
- Go to /pools in the preview
- Play around with how the CTAs look on different view widths
