### PR TITLE
feat: adds Ledger Connect to non-MetaMask wallet list

### DIFF
--- a/src/connection/utils.ts
+++ b/src/connection/utils.ts
@@ -3,8 +3,8 @@ export const isInjected = Boolean(window.ethereum)
 // When using Brave browser, `isMetaMask` is set to true when using the built-in wallet
 // This variable should be true only when using the MetaMask extension
 // https://wallet-docs.brave.com/ethereum/wallet-detection#compatability-with-metamask
-type NonMetaMaskFlag = 'isRabby' | 'isBraveWallet' | 'isTrustWallet'
-const allNonMetamaskFlags: NonMetaMaskFlag[] = ['isRabby', 'isBraveWallet', 'isTrustWallet']
+type NonMetaMaskFlag = 'isRabby' | 'isBraveWallet' | 'isTrustWallet' | 'isLedgerConnect'
+const allNonMetamaskFlags: NonMetaMaskFlag[] = ['isRabby', 'isBraveWallet', 'isTrustWallet', 'isLedgerConnect']
 export const isMetaMaskWallet = Boolean(
   window.ethereum?.isMetaMask && !allNonMetamaskFlags.some((flag) => window.ethereum?.[flag])
 )

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -20,6 +20,8 @@ interface Window {
     isRabby?: true
     // set by the Trust Wallet browser extension
     isTrustWallet?: true
+    // set by the Ledger Extension Web 3 browser extension
+    isLedgerConnect?: true
     autoRefreshOnNetworkChange?: boolean
   }
   web3?: Record<string, unknown>


### PR DESCRIPTION
Adding the IsLedgerConnect flag to the list of NonMetaMaskFlags that's used by the [ Ledger Extension](https://www.ledger.com/ledger-extension) so it wouldn't hi-jack the MetaMask button but rather rely on the Browser Wallet option.