### PR TITLE
fix: mini portfolio layout fixes

### DIFF
--- a/src/components/WalletDropdown/AuthenticatedHeader.tsx
+++ b/src/components/WalletDropdown/AuthenticatedHeader.tsx
@@ -34,7 +34,7 @@ import MiniPortfolio from './MiniPortfolio'
 import { portfolioFadeInAnimation } from './MiniPortfolio/PortfolioRow'
 
 const AuthenticatedHeaderWrapper = styled.div`
-  padding: 14px 12px 16px 16px;
+  padding: 20px 16px 16px;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/src/components/WalletDropdown/AuthenticatedHeader.tsx
+++ b/src/components/WalletDropdown/AuthenticatedHeader.tsx
@@ -34,7 +34,7 @@ import MiniPortfolio from './MiniPortfolio'
 import { portfolioFadeInAnimation } from './MiniPortfolio/PortfolioRow'
 
 const AuthenticatedHeaderWrapper = styled.div`
-  padding: 20px 16px 16px;
+  padding: 20px 16px;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/src/components/WalletDropdown/index.tsx
+++ b/src/components/WalletDropdown/index.tsx
@@ -126,7 +126,7 @@ const CloseDrawer = styled.div`
   height: calc(100% - 2 * ${DRAWER_MARGIN});
   position: fixed;
   right: calc(${DRAWER_MARGIN} + ${DRAWER_WIDTH} - ${DRAWER_OFFSET});
-  top: 4px;
+  top: ${DRAWER_MARGIN};
   z-index: ${Z_INDEX.dropdown};
   // When the drawer is not hovered, the icon should be 18px from the edge of the sidebar.
   padding: 24px calc(18px + ${DRAWER_OFFSET}) 24px 14px;

--- a/src/components/WalletDropdown/index.tsx
+++ b/src/components/WalletDropdown/index.tsx
@@ -76,15 +76,21 @@ const WalletDropdownScrollWrapper = styled.div`
   border-radius: 12px;
 `
 
-const WalletDropdownWrapper = styled.div<{ open: boolean }>`
-  position: fixed;
-  top: ${DRAWER_MARGIN};
-  right: ${({ open }) => (open ? DRAWER_MARGIN : '-' + DRAWER_WIDTH)};
-  z-index: ${Z_INDEX.fixed};
-
-  overflow: hidden;
-
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
   height: calc(100% - 2 * ${DRAWER_MARGIN});
+  overflow: hidden;
+  position: fixed;
+  right: ${DRAWER_MARGIN};
+  top: ${DRAWER_MARGIN};
+  z-index: ${Z_INDEX.fixed};
+`
+
+const WalletDropdownWrapper = styled.div<{ open: boolean }>`
+  margin-right: ${({ open }) => (open ? 0 : '-' + DRAWER_WIDTH)};
+  height: 100%;
+  overflow: hidden;
 
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     z-index: ${Z_INDEX.modal};
@@ -101,7 +107,7 @@ const WalletDropdownWrapper = styled.div<{ open: boolean }>`
   }
 
   @media screen and (min-width: 1440px) {
-    right: ${({ open }) => (open ? DRAWER_MARGIN : '-' + DRAWER_WIDTH_XL)};
+    margin-right: ${({ open }) => (open ? 0 : '-' + DRAWER_WIDTH_XL)};
     width: ${DRAWER_WIDTH_XL};
   }
 
@@ -112,7 +118,7 @@ const WalletDropdownWrapper = styled.div<{ open: boolean }>`
   border: ${({ theme }) => `1px solid ${theme.backgroundOutline}`};
 
   box-shadow: ${({ theme }) => theme.deepShadow};
-  transition: right ${({ theme }) => theme.transition.duration.medium},
+  transition: margin-right ${({ theme }) => theme.transition.duration.medium},
     bottom ${({ theme }) => theme.transition.duration.medium};
 `
 
@@ -123,11 +129,7 @@ const CloseIcon = styled(ChevronsRight).attrs({ size: 24 })`
 const CloseDrawer = styled.div`
   ${ClickableStyle}
   cursor: pointer;
-  height: calc(100% - 2 * ${DRAWER_MARGIN});
-  position: fixed;
-  right: calc(${DRAWER_MARGIN} + ${DRAWER_WIDTH} - ${DRAWER_OFFSET});
-  top: ${DRAWER_MARGIN};
-  z-index: ${Z_INDEX.dropdown};
+  height: 100%;
   // When the drawer is not hovered, the icon should be 18px from the edge of the sidebar.
   padding: 24px calc(18px + ${DRAWER_OFFSET}) 24px 14px;
   border-radius: 20px 0 0 20px;
@@ -139,9 +141,6 @@ const CloseDrawer = styled.div`
   }
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     display: none;
-  }
-  @media screen and (min-width: 1440px) {
-    right: calc(${DRAWER_MARGIN} + ${DRAWER_WIDTH_XL} - ${DRAWER_OFFSET});
   }
 `
 
@@ -187,7 +186,7 @@ function WalletDropdown() {
   }, [walletDrawerOpen, toggleWalletDrawer])
 
   return (
-    <>
+    <Wrapper>
       {walletDrawerOpen && (
         <TraceEvent
           events={[BrowserEvent.onClick]}
@@ -206,7 +205,7 @@ function WalletDropdown() {
           <DefaultMenu />
         </WalletDropdownScrollWrapper>
       </WalletDropdownWrapper>
-    </>
+    </Wrapper>
   )
 }
 


### PR DESCRIPTION
- change the "close" button's margin to match the drawer's

https://uniswaplabs.atlassian.net/browse/WEB-3117?atlOrigin=eyJpIjoiZjJiYTUxYmM4NTVkNGEyOGFlZTE1NTcwYjAyMDZlOWEiLCJwIjoiaiJ9

- change the drawer's padding values to match the design [here](https://www.figma.com/file/MOvvpkzygJdxCA3BY9mN1O/Mini-portfolio-v1?node-id=601-191098&t=9e3uPF7hb3KF5esR-0)

https://uniswaplabs.atlassian.net/browse/WEB-3095?atlOrigin=eyJpIjoiNWNkNzEwZGYxM2Q5NDYxY2E0M2YxNDljY2FmYTg0OGQiLCJwIjoiaiJ9

## Screen Capture

| Before           | After           |
| ---------------- |-----------------|
|  ![image](https://user-images.githubusercontent.com/66155195/228090122-43659ae9-53a3-46e8-8e88-4728447d3e6a.png) | <img width="468" alt="image" src="https://user-images.githubusercontent.com/66155195/228089921-394fcaa4-7090-4e4d-80fb-b351c6639634.png"> |
