### PR TITLE
fix: dont block trade when price impact is favorable

### DIFF
--- a/src/utils/prices.test.ts
+++ b/src/utils/prices.test.ts
@@ -122,6 +122,9 @@ describe('prices', () => {
     it('0 for undefined', () => {
       expect(warningSeverity(undefined)).toEqual(0)
     })
+    it('0 for negative', () => {
+      expect(warningSeverity(new Percent(-1))).toEqual(0)
+    })
     it('correct for 0', () => {
       expect(warningSeverity(new Percent(0))).toEqual(0)
     })

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -84,7 +84,13 @@ const IMPACT_TIERS = [
 
 type WarningSeverity = 0 | 1 | 2 | 3 | 4
 export function warningSeverity(priceImpact: Percent | undefined): WarningSeverity {
-  if (!priceImpact || priceImpact.lessThan(0)) return 0
+  if (!priceImpact) return 0
+  // This function is used to calculate the Severity level for % changes in USD value and Price Impact.
+  // Price Impact is always an absolute value (conceptually always negative, but represented in code with a positive value)
+  // The USD value change can be positive or negative, and it follows the same standard as Price Impact (positive value is the typical case of a loss due to slippage).
+  // We don't want to return a warning level for a favorable/profitable change, so when the USD value change is negative we return 0.
+  // TODO (WEB-3133): Disambiguate Price Impact and USD value change, and flip the sign of USD Value change.
+  if (priceImpact.lessThan(0)) return 0
   let impact: WarningSeverity = IMPACT_TIERS.length as WarningSeverity
   for (const impactLevel of IMPACT_TIERS) {
     if (impactLevel.lessThan(priceImpact)) return impact

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -84,7 +84,7 @@ const IMPACT_TIERS = [
 
 type WarningSeverity = 0 | 1 | 2 | 3 | 4
 export function warningSeverity(priceImpact: Percent | undefined): WarningSeverity {
-  if (!priceImpact) return 0
+  if (!priceImpact || priceImpact.lessThan(0)) return 0
   let impact: WarningSeverity = IMPACT_TIERS.length as WarningSeverity
   for (const impactLevel of IMPACT_TIERS) {
     if (impactLevel.lessThan(priceImpact)) return impact


### PR DESCRIPTION
### context
- [jira ticket](https://uniswaplabs.atlassian.net/browse/WEB-3024?atlOrigin=eyJpIjoiMzcwZWE3MmI4MjU3NDVkYmFhZDY1NjgzOWJkMjIzZmIiLCJwIjoiaiJ9)
- [context for the bug report is here
](https://uniswapteam.slack.com/archives/C04D07TQBT4/p1678829853381139)

the Price Impact value we use to calculate this severity level is typically positive (above zero, not favorable). for a favorable trade the price impact is in the other direction, i.e. negative (less than zero).  note that we flip the sign when displaying the value.



### test plan

- added unit test for `warningSeverity` function to verify the expected behavior
- manually tested a typical trade (in which the slippage is not favorable) to verify that the warning severity is still correct

<img width="493" alt="image" src="https://user-images.githubusercontent.com/66155195/228092558-df6faf5b-a232-410e-9bbf-336abc471f6e.png">
