### PR TITLE
feat: add data-source agnostic token constant lookup cache mechanism (WIP)

### DIFF
--- a/src/constants/TokenConstantsLookupTable.ts
+++ b/src/constants/TokenConstantsLookupTable.ts
@@ -1,0 +1,58 @@
+import store from 'state'
+
+import { SupportedChainId } from './chains'
+import { DEFAULT_LIST_OF_LISTS } from './lists'
+
+type lookupKey = `0x${string}:${SupportedChainId}`
+interface TokenConstants {
+  decimals?: number // uint8
+  name?: string
+  symbol?: string
+  chainChecked: boolean
+}
+class TokenConstantsLookupTable {
+  private dict: Record<lookupKey, TokenConstants | undefined> = {}
+  private initialized = false
+
+  initialize() {
+    const dict: Record<lookupKey, TokenConstants | undefined> = {}
+
+    DEFAULT_LIST_OF_LISTS.forEach((list) => {
+      const listData = store.getState().lists.byUrl[list]
+      if (!listData) {
+        return
+      }
+      listData.current?.tokens.forEach((token) => {
+        const lowercaseAddress = token.address.toLowerCase()
+        const key = `${lowercaseAddress}:${token.chainId}` as lookupKey
+        const entry: TokenConstants = { chainChecked: false }
+        if (token.decimals) entry.decimals = token.decimals
+        if (token.name) entry.name = token.name
+        if (token.symbol) entry.symbol = token.symbol
+        if (Object.keys(entry).length > 0) dict[key] = entry
+      })
+    })
+    this.dict = dict
+    this.initialized = true
+  }
+  getField(field: 'decimals' | 'name' | 'symbol', chainId: SupportedChainId | null = 1, address?: string | null) {
+    if (!address) return undefined
+
+    if (!this.initialized) {
+      this.initialize()
+    }
+    const lowercaseAddress = address.toLowerCase()
+    const key = `${lowercaseAddress}:${chainId}` as lookupKey
+    const tokenData = this.dict[key]
+
+    // case if token data was available from list data accessible during initialization
+    if (tokenData && tokenData[field]) return tokenData[field]
+
+    // todo: fetch field from the contract
+    // todo: set this.dict[key][field] to null if the field isn't defined by the contract
+    // todo: set this.dict[key][field] to value fetched from the contract
+    return tokenData[field]
+  }
+}
+
+export default new TokenConstantsLookupTable()


### PR DESCRIPTION
## Description

If a token constant field like name, symbol, or decimals exists on a token list it can be easily queried with negligible performance impact. But if the token at a given address is not already available then we have to use a provider to query chain state. We currently have no mechanism for persisting the result of that query such that future requests for the data resolve to a local cache and do not incur unnecessary network request overhead. This class aims to be a general query tool to address this problem.

### Context

original code which prompted this: https://github.com/Uniswap/interface/pull/6249/files#r1149720580

![image](https://user-images.githubusercontent.com/5773490/228599751-4a834811-b1d6-4350-8e9d-4f76c72bd83a.png)

### Possible work to be done

- batch fetch mechanism
![image](https://user-images.githubusercontent.com/5773490/228601342-b8760a5f-67f5-45fe-9af1-32c6f3404a21.png)

- decide between async getter to allow for chain data fetching and a standalone setter to be called by external data fetching mechanisms

## Test Plan
#### Manual

_[Steps of how you are testing the change and ensuring no regression.]_

#### Automated
- [ ] Unit test
- [ ] Integration/E2E test
