### PR TITLE
fix: remove deprecated default imports from zustand

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
               {
                 name: 'zustand',
                 importNames: ['default'],
-                message: 'Default import from zustand is depracated. Use named import instead.',
+                message: 'Default import from zustand is deprecated. Import `{ create }` instead.',
               },
             ],
           },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,4 +4,23 @@ require('@uniswap/eslint-config/load')
 
 module.exports = {
   extends: '@uniswap/eslint-config/react',
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'zustand',
+                importNames: ['default'],
+                message: 'Default import from zustand is depracated. Use named import instead.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 }

--- a/src/nft/hooks/useBag.ts
+++ b/src/nft/hooks/useBag.ts
@@ -1,7 +1,7 @@
 import { NftStandard } from 'graphql/data/__generated__/types-and-hooks'
 import { BagItem, BagItemStatus, BagStatus, UpdatedGenieAsset } from 'nft/types'
 import { v4 as uuidv4 } from 'uuid'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface BagState {

--- a/src/nft/hooks/useCollectionFilters.ts
+++ b/src/nft/hooks/useCollectionFilters.ts
@@ -1,5 +1,5 @@
 import { NftAssetSortableField } from 'graphql/data/__generated__/types-and-hooks'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 export enum SortBy {

--- a/src/nft/hooks/useFiltersExpanded.ts
+++ b/src/nft/hooks/useFiltersExpanded.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
 interface State {

--- a/src/nft/hooks/useIsCollectionLoading.ts
+++ b/src/nft/hooks/useIsCollectionLoading.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface State {

--- a/src/nft/hooks/useIsNftClaimAvailable.ts
+++ b/src/nft/hooks/useIsNftClaimAvailable.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface NFTClaim {

--- a/src/nft/hooks/useMarketplaceSelect.ts
+++ b/src/nft/hooks/useMarketplaceSelect.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 export type MarketplaceOption = { name: string; icon: string }

--- a/src/nft/hooks/useNFTList.ts
+++ b/src/nft/hooks/useNFTList.ts
@@ -1,5 +1,5 @@
 import { CollectionRow, ListingRow, ListingStatus } from 'nft/types'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface NFTListState {

--- a/src/nft/hooks/useNFTSelect.ts
+++ b/src/nft/hooks/useNFTSelect.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 import { OpenSeaAsset } from '../types'

--- a/src/nft/hooks/usePriceRange.ts
+++ b/src/nft/hooks/usePriceRange.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface PriceRangeProps {

--- a/src/nft/hooks/useProfilePageState.ts
+++ b/src/nft/hooks/useProfilePageState.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 import { ProfilePageStateType } from '../types'

--- a/src/nft/hooks/useSelectAsset.ts
+++ b/src/nft/hooks/useSelectAsset.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 import { GenieAsset } from '../types'

--- a/src/nft/hooks/useSellAsset.ts
+++ b/src/nft/hooks/useSellAsset.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 import { ListingMarket, WalletAsset } from '../types'

--- a/src/nft/hooks/useSendTransaction.ts
+++ b/src/nft/hooks/useSendTransaction.ts
@@ -5,7 +5,7 @@ import { ContractReceipt } from '@ethersproject/contracts'
 import type { JsonRpcSigner } from '@ethersproject/providers'
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { NFTEventName } from '@uniswap/analytics-events'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 import ERC721 from '../../abis/erc721.json'

--- a/src/nft/hooks/useSweep.ts
+++ b/src/nft/hooks/useSweep.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
 import { GenieAsset } from '../types'

--- a/src/nft/hooks/useTokenInput.ts
+++ b/src/nft/hooks/useTokenInput.ts
@@ -1,6 +1,6 @@
 import { Currency } from '@uniswap/sdk-core'
 import { TokenTradeInput } from 'graphql/data/__generated__/types-and-hooks'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface TokenInputState {

--- a/src/nft/hooks/useTraitsOpen.ts
+++ b/src/nft/hooks/useTraitsOpen.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface traitOpen {

--- a/src/nft/hooks/useTransactionResponse.ts
+++ b/src/nft/hooks/useTransactionResponse.ts
@@ -1,5 +1,5 @@
 import { TxResponse } from 'nft/types'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 type TransactionResponseValue = TxResponse | undefined

--- a/src/nft/hooks/useWalletCollections.ts
+++ b/src/nft/hooks/useWalletCollections.ts
@@ -1,5 +1,5 @@
 import { NftStandard } from 'graphql/data/__generated__/types-and-hooks'
-import create from 'zustand'
+import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 import { WalletAsset, WalletCollection } from '../types'


### PR DESCRIPTION
## Description

the default import from `zustand` is deprecated, we should be using a named import instead. this fixes the console warnings and adds an eslint rule to prevent this from happening in the future.

https://uniswaplabs.atlassian.net/browse/WEB-1566?atlOrigin=eyJpIjoiMWUyZTM4NmExNDIwNGQ1MDkyZTVkZTVlYjFmNjcyOTkiLCJwIjoiaiJ9


## Screen Capture
<img width="940" alt="Screenshot 2023-03-29 at 10 39 24 AM" src="https://user-images.githubusercontent.com/66155195/228622919-8e208ff6-fe02-4657-9d94-48498b65bcde.png">



## Test Plan
#### Manual
- [X] Ran the app and verified that the warnings don't appear in the console anymore.
- [X] Tested the new lint rule.

#### Automated
- [ ] Unit test
- [ ] Integration/E2E test
- [x] lint rule
