### PR TITLE
fix: make token list version bump error quieter

### DIFF
--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -10,7 +10,8 @@ import { useAllLists } from 'state/lists/hooks'
 import { useFetchListCallback } from '../../hooks/useFetchListCallback'
 import useIsWindowVisible from '../../hooks/useIsWindowVisible'
 import { acceptListUpdate } from './actions'
-import { shouldAcceptMinorVersionUpdate } from './utils'
+import { shouldAcceptVersionUpdate } from './utils'
+
 export default function Updater(): null {
   const { provider } = useWeb3React()
   const dispatch = useAppDispatch()
@@ -65,7 +66,7 @@ export default function Updater(): null {
             throw new Error('unexpected no version bump')
           case VersionUpgrade.PATCH:
           case VersionUpgrade.MINOR: {
-            if (shouldAcceptMinorVersionUpdate(listUrl, list.current, list.pendingUpdate, bump)) {
+            if (shouldAcceptVersionUpdate(listUrl, list.current, list.pendingUpdate, bump)) {
               dispatch(acceptListUpdate(listUrl))
             }
             break

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -1,4 +1,4 @@
-import { getVersionUpgrade, minVersionBump, VersionUpgrade } from '@uniswap/token-lists'
+import { getVersionUpgrade, VersionUpgrade } from '@uniswap/token-lists'
 import { useWeb3React } from '@web3-react/core'
 import { DEFAULT_LIST_OF_LISTS, UNSUPPORTED_LIST_URLS } from 'constants/lists'
 import useInterval from 'lib/hooks/useInterval'
@@ -10,6 +10,7 @@ import { useAllLists } from 'state/lists/hooks'
 import { useFetchListCallback } from '../../hooks/useFetchListCallback'
 import useIsWindowVisible from '../../hooks/useIsWindowVisible'
 import { acceptListUpdate } from './actions'
+import { shouldAcceptMinorVersionUpdate } from './utils'
 export default function Updater(): null {
   const { provider } = useWeb3React()
   const dispatch = useAppDispatch()
@@ -64,14 +65,8 @@ export default function Updater(): null {
             throw new Error('unexpected no version bump')
           case VersionUpgrade.PATCH:
           case VersionUpgrade.MINOR: {
-            const min = minVersionBump(list.current.tokens, list.pendingUpdate.tokens)
-            // automatically update minor/patch as long as bump matches the min update
-            if (bump >= min) {
+            if (shouldAcceptMinorVersionUpdate(listUrl, list.current, list.pendingUpdate, bump)) {
               dispatch(acceptListUpdate(listUrl))
-            } else {
-              console.debug(
-                `List at url ${listUrl} could not automatically update because the version bump was only PATCH/MINOR while the update had breaking changes and should have been MAJOR`
-              )
             }
             break
           }

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -69,7 +69,7 @@ export default function Updater(): null {
             if (bump >= min) {
               dispatch(acceptListUpdate(listUrl))
             } else {
-              console.error(
+              console.debug(
                 `List at url ${listUrl} could not automatically update because the version bump was only PATCH/MINOR while the update had breaking changes and should have been MAJOR`
               )
             }

--- a/src/state/lists/utils.test.ts
+++ b/src/state/lists/utils.test.ts
@@ -1,6 +1,6 @@
 import { TokenList, VersionUpgrade } from '@uniswap/token-lists'
 
-import { shouldAcceptMinorVersionUpdate } from './utils'
+import { shouldAcceptVersionUpdate } from './utils'
 
 function buildTokenList(count: number): TokenList {
   const tokens = []
@@ -33,32 +33,32 @@ function buildTokenList(count: number): TokenList {
 
 describe('shouldAcceptMinorVersionUpdate', () => {
   it('returns false for patch when tokens have changed', () => {
-    expect(
-      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.PATCH)
-    ).toEqual(false)
+    expect(shouldAcceptVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.PATCH)).toEqual(
+      false
+    )
   })
 
   it('returns true for patch when tokens are the same', () => {
-    expect(
-      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(1), VersionUpgrade.PATCH)
-    ).toEqual(true)
+    expect(shouldAcceptVersionUpdate('test_list', buildTokenList(1), buildTokenList(1), VersionUpgrade.PATCH)).toEqual(
+      true
+    )
   })
 
   it('returns true for minor version bump with tokens added', () => {
-    expect(
-      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.MINOR)
-    ).toEqual(true)
+    expect(shouldAcceptVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.MINOR)).toEqual(
+      true
+    )
   })
 
   it('returns true for no version bump', () => {
-    expect(
-      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.MINOR)
-    ).toEqual(true)
+    expect(shouldAcceptVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.MINOR)).toEqual(
+      true
+    )
   })
 
   it('returns false for minor version bump with tokens removed', () => {
-    expect(
-      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(2), buildTokenList(1), VersionUpgrade.MINOR)
-    ).toEqual(false)
+    expect(shouldAcceptVersionUpdate('test_list', buildTokenList(2), buildTokenList(1), VersionUpgrade.MINOR)).toEqual(
+      false
+    )
   })
 })

--- a/src/state/lists/utils.test.ts
+++ b/src/state/lists/utils.test.ts
@@ -1,0 +1,64 @@
+import { TokenList, VersionUpgrade } from '@uniswap/token-lists'
+
+import { shouldAcceptMinorVersionUpdate } from './utils'
+
+function buildTokenList(count: number): TokenList {
+  const tokens = []
+  for (let i = 0; i < count; i++) {
+    tokens.push({
+      name: `Token ${i}`,
+      address: `0x${i.toString().padStart(40, '0')}`,
+      symbol: `T${i}`,
+      decimals: 18,
+      chainId: 1,
+      logoURI: `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x${i
+        .toString()
+        .padStart(40, '0')}/logo.png`,
+    })
+  }
+  return {
+    name: 'Defi',
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png',
+    keywords: ['defi', 'uniswap'],
+    timestamp: '2021-03-12T00:00:00.000Z',
+    version: {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    },
+    tokens,
+  }
+}
+
+describe('shouldAcceptMinorVersionUpdate', () => {
+  it('returns false for patch when tokens have changed', () => {
+    expect(
+      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.PATCH)
+    ).toEqual(false)
+  })
+
+  it('returns true for patch when tokens are the same', () => {
+    expect(
+      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(1), VersionUpgrade.PATCH)
+    ).toEqual(true)
+  })
+
+  it('returns true for minor version bump with tokens added', () => {
+    expect(
+      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.MINOR)
+    ).toEqual(true)
+  })
+
+  it('returns true for no version bump', () => {
+    expect(
+      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(1), buildTokenList(2), VersionUpgrade.MINOR)
+    ).toEqual(true)
+  })
+
+  it('returns false for minor version bump with tokens removed', () => {
+    expect(
+      shouldAcceptMinorVersionUpdate('test_list', buildTokenList(2), buildTokenList(1), VersionUpgrade.MINOR)
+    ).toEqual(false)
+  })
+})

--- a/src/state/lists/utils.ts
+++ b/src/state/lists/utils.ts
@@ -1,0 +1,19 @@
+import { minVersionBump, TokenList, VersionUpgrade } from '@uniswap/token-lists'
+
+export function shouldAcceptMinorVersionUpdate(
+  listUrl: string,
+  current: TokenList,
+  update: TokenList,
+  targetBump: VersionUpgrade.PATCH | VersionUpgrade.MINOR
+): boolean {
+  const min = minVersionBump(current.tokens, update.tokens)
+  // automatically update minor/patch as long as bump matches the min update
+  if (targetBump >= min) {
+    return true
+  } else {
+    console.debug(
+      `List at url ${listUrl} could not automatically update because the version bump was only PATCH/MINOR while the update had breaking changes and should have been MAJOR`
+    )
+    return false
+  }
+}

--- a/src/state/lists/utils.ts
+++ b/src/state/lists/utils.ts
@@ -1,13 +1,13 @@
 import { minVersionBump, TokenList, VersionUpgrade } from '@uniswap/token-lists'
 
-export function shouldAcceptMinorVersionUpdate(
+export function shouldAcceptVersionUpdate(
   listUrl: string,
   current: TokenList,
   update: TokenList,
   targetBump: VersionUpgrade.PATCH | VersionUpgrade.MINOR
 ): boolean {
   const min = minVersionBump(current.tokens, update.tokens)
-  // automatically update minor/patch as long as bump matches the min update
+  // Automatically update minor/patch as long as bump matches the min update.
   if (targetBump >= min) {
     return true
   } else {


### PR DESCRIPTION
## Description

use `console. debug` for this warning instead of `console.error`, so it doesn't appear in prod.

https://uniswaplabs.atlassian.net/browse/WEB-1566

## Test Plan
#### Manual

manually tested by running the app and verifying that the optimism token list error wasn't shown unless i used the "verbose" console setting.

this error is currently firing in [prod](https://app.uniswap.org/) because the optimism token list needs to do a major version bump.

#### Automated
- [ ] Unit test
- [ ] Integration/E2E test
