### PR TITLE
fix: catch json parse error in fetchTokenList

### DIFF
--- a/src/lib/hooks/useTokenList/fetchTokenList.test.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.test.ts
@@ -42,7 +42,7 @@ describe('fetchTokenList', () => {
   })
 
   it('fetches and validates a list from an ENS address', async () => {
-    jest.mock('lib/utils/contentHashToUri', () =>
+    jest.mock('../../utils/contenthashToUri', () =>
       jest.fn().mockImplementation(() => 'ipfs://QmPgEqyV3m8SB52BS2j2mJpu9zGprhj2BGCHtRiiw2fdM1')
     )
     const url = 'example.eth'

--- a/src/lib/hooks/useTokenList/fetchTokenList.test.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.test.ts
@@ -38,4 +38,12 @@ describe('fetchTokenList', () => {
     await expect(fetchTokenList(DEFAULT_TOKEN_LIST, resolver)).resolves.toStrictEqual(defaultTokenList)
     expect(resolver).not.toHaveBeenCalled()
   })
+
+  it('throws for a list with invalid json response', async () => {
+    const url = 'https://example.com/invalid-tokenlist.json'
+    fetch.mockOnceIf(url, () => Promise.resolve('invalid json'))
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`failed to parse list response: ${url}`)
+    expect(console.debug).toHaveBeenCalled()
+    expect(resolver).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/hooks/useTokenList/fetchTokenList.test.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.test.ts
@@ -18,7 +18,7 @@ describe('fetchTokenList', () => {
     fetch.mockOnceIf(url, () => {
       throw new Error()
     })
-    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`failed to fetch list: ${url}`)
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`No valid list URL provided for ${url}.`)
     expect(console.debug).toHaveBeenCalled()
     expect(resolver).not.toHaveBeenCalled()
   })
@@ -33,6 +33,40 @@ describe('fetchTokenList', () => {
     expect(resolver).toHaveBeenCalledWith(url)
   })
 
+  it('throws an error when the ENS resolver throws', async () => {
+    const url = 'example.eth'
+    const error = new Error('ENS resolver error')
+    resolver.mockRejectedValue(error)
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`failed to resolve ENS name: ${url}`)
+    expect(resolver).toHaveBeenCalledWith(url)
+  })
+
+  it('fetches and validates a list from an ENS address', async () => {
+    jest.mock('lib/utils/contentHashToUri', () =>
+      jest.fn().mockImplementation(() => 'ipfs://QmPgEqyV3m8SB52BS2j2mJpu9zGprhj2BGCHtRiiw2fdM1')
+    )
+    const url = 'example.eth'
+    const contenthash = '0xe3010170122013e051d1cfff20606de36845d4fe28deb9861a319a5bc8596fa4e610e8803918'
+    const translatedUri = 'https://cloudflare-ipfs.com/ipfs/QmPgEqyV3m8SB52BS2j2mJpu9zGprhj2BGCHtRiiw2fdM1/'
+    resolver.mockResolvedValue(contenthash)
+    fetch.mockOnceIf(translatedUri, () => Promise.resolve(JSON.stringify(defaultTokenList)))
+    await expect(fetchTokenList(url, resolver)).resolves.toStrictEqual(defaultTokenList)
+  })
+
+  it('throws for an unrecognized list URL protocol', async () => {
+    const url = 'unknown://example.com/invalid-tokenlist.json'
+    fetch.mockOnceIf(url, () => Promise.resolve(''))
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`Unrecognized list URL protocol.`)
+  })
+
+  it('logs a debug statement if the response is not successful', async () => {
+    const url = 'https://example.com/invalid-tokenlist.json'
+    fetch.mockOnceIf(url, () => Promise.resolve({ status: 404 }))
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`No valid list URL provided for ${url}.`)
+    expect(console.debug).toHaveBeenCalled()
+    expect(resolver).not.toHaveBeenCalled()
+  })
+
   it('fetches and validates the default token list', async () => {
     fetch.mockOnceIf(DEFAULT_TOKEN_LIST, () => Promise.resolve(JSON.stringify(defaultTokenList)))
     await expect(fetchTokenList(DEFAULT_TOKEN_LIST, resolver)).resolves.toStrictEqual(defaultTokenList)
@@ -42,8 +76,16 @@ describe('fetchTokenList', () => {
   it('throws for a list with invalid json response', async () => {
     const url = 'https://example.com/invalid-tokenlist.json'
     fetch.mockOnceIf(url, () => Promise.resolve('invalid json'))
-    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`failed to parse list response: ${url}`)
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`No valid list URL provided for ${url}.`)
     expect(console.debug).toHaveBeenCalled()
     expect(resolver).not.toHaveBeenCalled()
+  })
+
+  it('uses cached value the second time', async () => {
+    const url = 'https://example.com/invalid-tokenlist.json'
+    fetch.mockOnceIf(url, () => Promise.resolve(JSON.stringify(defaultTokenList)))
+    await expect(fetchTokenList(url, resolver)).resolves.toStrictEqual(defaultTokenList)
+    await expect(fetchTokenList(url, resolver)).resolves.toStrictEqual(defaultTokenList)
+    expect(fetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/lib/hooks/useTokenList/fetchTokenList.test.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.test.ts
@@ -18,7 +18,9 @@ describe('fetchTokenList', () => {
     fetch.mockOnceIf(url, () => {
       throw new Error()
     })
-    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`No valid list URL provided for ${url}.`)
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(
+      `No valid token list found at any URLs derived from ${url}.`
+    )
     expect(console.debug).toHaveBeenCalled()
     expect(resolver).not.toHaveBeenCalled()
   })
@@ -62,7 +64,9 @@ describe('fetchTokenList', () => {
   it('logs a debug statement if the response is not successful', async () => {
     const url = 'https://example.com/invalid-tokenlist.json'
     fetch.mockOnceIf(url, () => Promise.resolve({ status: 404 }))
-    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`No valid list URL provided for ${url}.`)
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(
+      `No valid token list found at any URLs derived from ${url}.`
+    )
     expect(console.debug).toHaveBeenCalled()
     expect(resolver).not.toHaveBeenCalled()
   })
@@ -76,7 +80,9 @@ describe('fetchTokenList', () => {
   it('throws for a list with invalid json response', async () => {
     const url = 'https://example.com/invalid-tokenlist.json'
     fetch.mockOnceIf(url, () => Promise.resolve('invalid json'))
-    await expect(fetchTokenList(url, resolver)).rejects.toThrow(`No valid list URL provided for ${url}.`)
+    await expect(fetchTokenList(url, resolver)).rejects.toThrow(
+      `No valid token list found at any URLs derived from ${url}.`
+    )
     expect(console.debug).toHaveBeenCalled()
     expect(resolver).not.toHaveBeenCalled()
   })

--- a/src/lib/hooks/useTokenList/fetchTokenList.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.ts
@@ -51,9 +51,7 @@ export default async function fetchTokenList(
     throw new Error('Unrecognized list URL protocol.')
   }
 
-  /**
-   * Try each of the derived URLs until one succeeds.
-   */
+  // Try each of the derived URLs until one succeeds.
   for (let i = 0; i < urls.length; i++) {
     const url = urls[i]
     let response

--- a/src/lib/hooks/useTokenList/fetchTokenList.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.ts
@@ -63,10 +63,17 @@ export default async function fetchTokenList(
       continue
     }
 
-    const json = await response.json()
-    const list = skipValidation ? json : await validateTokenList(json)
-    listCache?.set(listUrl, list)
-    return list
+    try {
+      const json = await response.json()
+      const list = skipValidation ? json : await validateTokenList(json)
+      listCache?.set(listUrl, list)
+      return list
+    } catch (error) {
+      const message = `failed to parse list response: ${listUrl}`
+      console.debug(message, error)
+      if (isLast) throw new Error(message)
+      continue
+    }
   }
 
   throw new Error('Unrecognized list URL protocol.')

--- a/src/lib/hooks/useTokenList/fetchTokenList.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.ts
@@ -43,23 +43,24 @@ export default async function fetchTokenList(
     urls = uriToHttp(listUrl)
   }
 
+  if (urls.length === 0) {
+    throw new Error('Unrecognized list URL protocol.')
+  }
+
   for (let i = 0; i < urls.length; i++) {
     const url = urls[i]
-    const isLast = i === urls.length - 1
     let response
     try {
       response = await fetch(url, { credentials: 'omit' })
     } catch (error) {
       const message = `failed to fetch list: ${listUrl}`
       console.debug(message, error)
-      if (isLast) throw new Error(message)
       continue
     }
 
     if (!response.ok) {
       const message = `failed to fetch list: ${listUrl}`
       console.debug(message, response.statusText)
-      if (isLast) throw new Error(message)
       continue
     }
 
@@ -71,10 +72,9 @@ export default async function fetchTokenList(
     } catch (error) {
       const message = `failed to parse list response: ${listUrl}`
       console.debug(message, error)
-      if (isLast) throw new Error(message)
       continue
     }
   }
 
-  throw new Error('Unrecognized list URL protocol.')
+  throw new Error(`No valid list URL provided for ${listUrl}.`)
 }

--- a/src/lib/hooks/useTokenList/fetchTokenList.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.ts
@@ -8,7 +8,11 @@ export const DEFAULT_TOKEN_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.o
 
 const listCache = new Map<string, TokenList>()
 
-/** Fetches and validates a token list. */
+/**
+ * Fetches and validates a token list.
+ * For a given token list URL, we try to fetch the list from all the possible HTTP URLs.
+ * For example, IPFS URLs can be fetched through multiple gateways.
+ **/
 export default async function fetchTokenList(
   listUrl: string,
   resolveENSContentHash: (ensName: string) => Promise<string>,
@@ -47,34 +51,36 @@ export default async function fetchTokenList(
     throw new Error('Unrecognized list URL protocol.')
   }
 
+  /**
+   * Try each of the derived URLs until one succeeds.
+   */
   for (let i = 0; i < urls.length; i++) {
     const url = urls[i]
     let response
     try {
       response = await fetch(url, { credentials: 'omit' })
     } catch (error) {
-      const message = `failed to fetch list: ${listUrl}`
-      console.debug(message, error)
+      console.debug(`failed to fetch list: ${listUrl} (${url})`, error)
       continue
     }
 
     if (!response.ok) {
-      const message = `failed to fetch list: ${listUrl}`
-      console.debug(message, response.statusText)
+      console.debug(`failed to fetch list ${listUrl} (${url})`, response.statusText)
       continue
     }
 
     try {
+      // The content of the result is sometimes invalid even with a 200 status code.
+      // A response can be invalid if it's not a valid JSON or if it doesn't match the TokenList schema.
       const json = await response.json()
       const list = skipValidation ? json : await validateTokenList(json)
       listCache?.set(listUrl, list)
       return list
     } catch (error) {
-      const message = `failed to parse list response: ${listUrl}`
-      console.debug(message, error)
+      console.debug(`failed to parse and validate list response: ${listUrl} (${url})`, error)
       continue
     }
   }
 
-  throw new Error(`No valid list URL provided for ${listUrl}.`)
+  throw new Error(`No valid token list found at any URLs derived from ${listUrl}.`)
 }

--- a/src/lib/hooks/useTokenList/fetchTokenList.ts
+++ b/src/lib/hooks/useTokenList/fetchTokenList.ts
@@ -12,7 +12,7 @@ const listCache = new Map<string, TokenList>()
  * Fetches and validates a token list.
  * For a given token list URL, we try to fetch the list from all the possible HTTP URLs.
  * For example, IPFS URLs can be fetched through multiple gateways.
- **/
+ */
 export default async function fetchTokenList(
   listUrl: string,
   resolveENSContentHash: (ensName: string) => Promise<string>,


### PR DESCRIPTION
## Description

this is one of the top web sentry errors that happens when the response from fetching a token list is not valid JSON. currently the parsing error is unhandled so it's being reported to sentry. This PR updates `fetchTokenList` so that the parsing error is caught, we log a debug message similar to other errors in the function, and then continue attempting more URLs for this token list.

note that we still log an error if all the token lists fail for any reason.


## Test Plan
#### Manual

manually cleared the token list cache and verified that the normal fetching behavior is unchanged. also, I manually hard-coded invalid json into this function to verify that we do continue to other URLs in the case of a parsing error 

#### Automated
- [x] Unit test
- [ ] Integration/E2E test
