### PR TITLE
fix: ignore known provider exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "src/lib/utils/**/*.ts*",
       "src/pages/**/*.ts*",
       "src/state/**/*.ts*",
+      "src/tracing/**/*.ts*",
       "src/utils/**/*.ts*"
     ],
     "coverageThreshold": {

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -1,24 +1,21 @@
 import * as Sentry from '@sentry/react'
 
-import { beforeSendAddMechanism, onerror, onunhandledrejection } from './errors'
+import { beforeSendAddMechanism, onUnhandledRejection } from './errors'
 
 jest.mock('@sentry/react', () => ({
   captureException: jest.fn(),
 }))
 
 describe('beforeSendAddMechanism', () => {
-  it.each(['onerror', 'onunhandledrejection'])(
-    'adds mechanism to events with extra.mechanism set to "%s"',
-    (mechanism) => {
-      const event = {
-        exception: { values: [{} as Record<'mechanism', unknown>] },
-        extra: { mechanism },
-      }
-      beforeSendAddMechanism(event as Sentry.Event)
-      expect(event.extra.mechanism).toBeUndefined()
-      expect(event.exception.values[0].mechanism).toEqual({ handled: false, type: mechanism })
+  it.each(['onunhandledrejection'])('adds mechanism to events with extra.mechanism set to "%s"', (mechanism) => {
+    const event = {
+      exception: { values: [{} as Record<'mechanism', unknown>] },
+      extra: { mechanism },
     }
-  )
+    beforeSendAddMechanism(event as Sentry.Event)
+    expect(event.extra.mechanism).toBeUndefined()
+    expect(event.exception.values[0].mechanism).toEqual({ handled: false, type: mechanism })
+  })
 
   it('does not add mechanism to other events', () => {
     const event = {
@@ -31,24 +28,10 @@ describe('beforeSendAddMechanism', () => {
   })
 })
 
-describe('onerror', () => {
-  it('calls Sentry.captureException with the error', () => {
-    const error = new Error('test')
-    onerror({} as Event, 'source', 1, 2, error)
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, { extra: { mechanism: 'onerror' } })
-  })
-
-  it('calls Sentry.captureException with the event if there is no error', () => {
-    const event = {}
-    onerror({} as Event)
-    expect(Sentry.captureException).toHaveBeenCalledWith(event, { extra: { mechanism: 'onerror' } })
-  })
-})
-
-describe('onunhandledrejection', () => {
+describe('onUnhandledRejection', () => {
   it('calls Sentry.captureException with the reason', () => {
     const reason = new Error('test')
-    onunhandledrejection({ reason })
+    onUnhandledRejection({ reason })
     expect(Sentry.captureException).toHaveBeenCalledWith(reason, { extra: { mechanism: 'onunhandledrejection' } })
   })
 
@@ -56,14 +39,14 @@ describe('onunhandledrejection', () => {
     const reason = new (class extends Error {
       requestBody = JSON.stringify({ method: 'eth_blockNumber', params: [] })
     })()
-    onunhandledrejection({ reason })
+    onUnhandledRejection({ reason })
     expect(Sentry.captureException).not.toHaveBeenCalled()
   })
 
   it('ignores network change exceptions', () => {
     const reason = new Error('~~~underlying network changed~~~')
     jest.spyOn(console, 'warn').mockImplementation(() => undefined)
-    onunhandledrejection({ reason })
+    onUnhandledRejection({ reason })
     expect(Sentry.captureException).not.toHaveBeenCalled()
     expect(console.warn).toHaveBeenCalledWith(reason)
   })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -36,4 +36,12 @@ describe('onunhandledrejection', () => {
     onunhandledrejection({ reason })
     expect(Sentry.captureException).not.toHaveBeenCalled()
   })
+
+  it('ignores network change exceptions', () => {
+    const reason = new Error('~~~underlying network changed~~~')
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    onunhandledrejection({ reason })
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(reason)
+  })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -1,22 +1,47 @@
 import * as Sentry from '@sentry/react'
 
-import { onerror, onunhandledrejection } from './errors'
+import { beforeSendAddMechanism, onerror, onunhandledrejection } from './errors'
 
 jest.mock('@sentry/react', () => ({
   captureException: jest.fn(),
 }))
 
+describe('beforeSendAddMechanism', () => {
+  it.each(['onerror', 'onunhandledrejection'])(
+    'adds mechanism to events with extra.mechanism set to "%s"',
+    (mechanism) => {
+      const event = {
+        exception: { values: [{} as Record<'mechanism', unknown>] },
+        extra: { mechanism },
+      }
+      beforeSendAddMechanism(event as Sentry.Event)
+      expect(event.extra.mechanism).toBeUndefined()
+      expect(event.exception.values[0].mechanism).toEqual({ handled: false, type: mechanism })
+    }
+  )
+
+  it('does not add mechanism to other events', () => {
+    const event = {
+      exception: { values: [{} as Record<'mechanism', unknown>] },
+      extra: { mechanism: 'onother' },
+    }
+    beforeSendAddMechanism(event as Sentry.Event)
+    expect(event.extra.mechanism).toBe('onother')
+    expect(event.exception.values[0].mechanism).toBeUndefined()
+  })
+})
+
 describe('onerror', () => {
   it('calls Sentry.captureException with the error', () => {
     const error = new Error('test')
     onerror({} as Event, 'source', 1, 2, error)
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, { tags: { handled: 'no', mechanism: 'onerror' } })
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, { extra: { mechanism: 'onerror' } })
   })
 
   it('calls Sentry.captureException with the event if there is no error', () => {
     const event = {}
     onerror({} as Event)
-    expect(Sentry.captureException).toHaveBeenCalledWith(event, { tags: { handled: 'no', mechanism: 'onerror' } })
+    expect(Sentry.captureException).toHaveBeenCalledWith(event, { extra: { mechanism: 'onerror' } })
   })
 })
 
@@ -24,9 +49,7 @@ describe('onunhandledrejection', () => {
   it('calls Sentry.captureException with the reason', () => {
     const reason = new Error('test')
     onunhandledrejection({ reason })
-    expect(Sentry.captureException).toHaveBeenCalledWith(reason, {
-      tags: { handled: 'no', mechanism: 'onunhandledrejection' },
-    })
+    expect(Sentry.captureException).toHaveBeenCalledWith(reason, { extra: { mechanism: 'onunhandledrejection' } })
   })
 
   it('ignores eth_blockNumber exceptions', () => {

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -1,0 +1,31 @@
+import * as Sentry from '@sentry/react'
+
+import { onerror, onunhandledrejection } from './errors'
+
+jest.mock('@sentry/react', () => ({
+  captureException: jest.fn(),
+}))
+
+describe('onerror', () => {
+  it('calls Sentry.captureException with the error', () => {
+    const error = new Error('test')
+    onerror({} as Event, 'source', 1, 2, error)
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, { tags: { handled: 'no', mechanism: 'onerror' } })
+  })
+
+  it('calls Sentry.captureException with the event if there is no error', () => {
+    const event = {}
+    onerror({} as Event)
+    expect(Sentry.captureException).toHaveBeenCalledWith(event, { tags: { handled: 'no', mechanism: 'onerror' } })
+  })
+})
+
+describe('onunhandledrejection', () => {
+  it('calls Sentry.captureException with the reason', () => {
+    const reason = new Error('test')
+    onunhandledrejection({ reason })
+    expect(Sentry.captureException).toHaveBeenCalledWith(reason, {
+      tags: { handled: 'no', mechanism: 'onunhandledrejection' },
+    })
+  })
+})

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -28,4 +28,12 @@ describe('onunhandledrejection', () => {
       tags: { handled: 'no', mechanism: 'onunhandledrejection' },
     })
   })
+
+  it('ignores eth_blockNumber exceptions', () => {
+    const reason = new (class extends Error {
+      requestBody = JSON.stringify({ method: 'eth_blockNumber', params: [] })
+    })()
+    onunhandledrejection({ reason })
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,9 +1,11 @@
 import * as Sentry from '@sentry/react'
 
+// We still want handled/mechanism tags despite using our own handler. These exceptions are still unhandled.
+const ON_ERROR_TAGS = { handled: 'no', mechanism: 'onerror' }
+const ON_UNHANDLED_REJECTION_TAGS = { handled: 'no', mechanism: 'onunhandledrejection' }
+
 export function onerror(event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error) {
-  // We still send handled/mechanism tags despite using our own handler. These errors are still unhandled.
-  const tags = { handled: 'no', mechanism: 'onerror' }
-  Sentry.captureException(error ?? event, { tags })
+  Sentry.captureException(error ?? event, { tags: ON_ERROR_TAGS })
 }
 
 export function onunhandledrejection({ reason }: { reason: unknown }) {
@@ -24,7 +26,5 @@ export function onunhandledrejection({ reason }: { reason: unknown }) {
     }
   }
 
-  // We still send handled/mechanism tags despite using our own handler. These rejections are still unhandled.
-  const tags = { handled: 'no', mechanism: 'onunhandledrejection' }
-  Sentry.captureException(reason, { tags })
+  Sentry.captureException(reason, { tags: ON_UNHANDLED_REJECTION_TAGS })
 }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -16,6 +16,12 @@ export function onunhandledrejection({ reason }: { reason: unknown }) {
       // If it fails, it should not be considered an exception.
       if (method === 'eth_blockNumber') return
     }
+
+    // If the error is a network change, it should not be considered an exception, but should still be breadcrumbed.
+    if (reason.message.match(/underlying network changed/)) {
+      console.warn(reason) // logging adds the message to the breadcrumbs
+      return
+    }
   }
 
   // We still send handled/mechanism tags despite using our own handler. These rejections are still unhandled.

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/react'
+
+export function onerror(event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error) {
+  // We still send handled/mechanism tags despite using our own handler. These errors are still unhandled.
+  const tags = { handled: 'no', mechanism: 'onerror' }
+  Sentry.captureException(error ?? event, { tags })
+}
+
+export function onunhandledrejection({ reason }: { reason: unknown }) {
+  // We still send handled/mechanism tags despite using our own handler. These rejections are still unhandled.
+  const tags = { handled: 'no', mechanism: 'onunhandledrejection' }
+  Sentry.captureException(reason, { tags })
+}

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -10,8 +10,7 @@ export function onerror(event: Event | string, source?: string, lineno?: number,
 
 export function onunhandledrejection({ reason }: { reason: unknown }) {
   if (reason instanceof Error) {
-    // Parse ethers request errors (formated by {@type import(@ethersproject/web).fetchJson}):
-    if ('requestBody' in reason && typeof reason.requestBody === 'string') {
+    if (isEthersRequestError(reason)) {
       const method = JSON.parse(reason.requestBody).method
 
       // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
@@ -27,4 +26,9 @@ export function onunhandledrejection({ reason }: { reason: unknown }) {
   }
 
   Sentry.captureException(reason, { tags: ON_UNHANDLED_REJECTION_TAGS })
+}
+
+/** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
+function isEthersRequestError(error: Error): error is Error & { requestBody: string } {
+  return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -7,6 +7,17 @@ export function onerror(event: Event | string, source?: string, lineno?: number,
 }
 
 export function onunhandledrejection({ reason }: { reason: unknown }) {
+  if (reason instanceof Error) {
+    // Parse ethers request errors (formated by {@type import(@ethersproject/web).fetchJson}):
+    if ('requestBody' in reason && typeof reason.requestBody === 'string') {
+      const method = JSON.parse(reason.requestBody).method
+
+      // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
+      // If it fails, it should not be considered an exception.
+      if (method === 'eth_blockNumber') return
+    }
+  }
+
   // We still send handled/mechanism tags despite using our own handler. These rejections are still unhandled.
   const tags = { handled: 'no', mechanism: 'onunhandledrejection' }
   Sentry.captureException(reason, { tags })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,16 +1,20 @@
 import * as Sentry from '@sentry/react'
 import { addExceptionMechanism } from '@sentry/utils'
 
-const ON_ERROR = 'onerror'
 const ON_UNHANDLED_REJECTION = 'onunhandledrejection'
 
-/** Adds a mechanism to events which have been sent from our global exception handlers. */
+/**
+ * Adds a mechanism to events which have been sent from onUnhandledRejection.
+ *
+ * This is necessary to access the Sentry.Event directly, in order to call addExceptionMechanism. Alternatively
+ * Alternatively, we could create a Sentry.Event in onUnhandledRejection, but custom events are non-trivial and poorly documented.
+ */
 export function beforeSendAddMechanism(event: Sentry.Event): Sentry.Event {
   // Global exception handlers set an extra.mechanism, but the actual mechanism must be set on the event explicitly for
   // Sentry to correctly process and display it in the Sentry UI. We still want mechanism to be set, despite using our
   // own handler, because it aids in identifying unhandled errors and rejections.
   if (event.extra?.mechanism) {
-    if (event.extra.mechanism === ON_ERROR || event.extra.mechanism === ON_UNHANDLED_REJECTION) {
+    if (event.extra.mechanism === ON_UNHANDLED_REJECTION) {
       addExceptionMechanism(event, { handled: false, type: event.extra.mechanism })
       delete event.extra.mechanism // delete this so it doesn't clutter the Sentry UI
     }
@@ -19,11 +23,12 @@ export function beforeSendAddMechanism(event: Sentry.Event): Sentry.Event {
   return event
 }
 
-export function onerror(event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error) {
-  Sentry.captureException(error ?? event, { extra: { mechanism: ON_ERROR } })
+/** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
+function isEthersRequestError(error: Error): error is Error & { requestBody: string } {
+  return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }
 
-export function onunhandledrejection({ reason }: { reason: unknown }) {
+export function onUnhandledRejection({ reason }: { reason: unknown }) {
   if (reason instanceof Error) {
     if (isEthersRequestError(reason)) {
       const method = JSON.parse(reason.requestBody).method
@@ -33,17 +38,14 @@ export function onunhandledrejection({ reason }: { reason: unknown }) {
       if (method === 'eth_blockNumber') return
     }
 
-    // If the error is a network change, it should not be considered an exception, but should still be breadcrumbed.
+    // If the error is a network change, it should not be considered an exception.
     if (reason.message.match(/underlying network changed/)) {
-      console.warn(reason) // logging adds the message to the breadcrumbs
+      // It should still be logged so that it is available as a Sentry breadcrumb for other exceptions (logs are
+      // captured as breadcrumbs via Sentry's CaptureConsole integration).
+      console.warn(reason)
       return
     }
   }
 
   Sentry.captureException(reason, { extra: { mechanism: ON_UNHANDLED_REJECTION } })
-}
-
-/** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
-function isEthersRequestError(error: Error): error is Error & { requestBody: string } {
-  return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -8,7 +8,7 @@ import { SharedEventName } from '@uniswap/analytics-events'
 import { isSentryEnabled } from 'utils/env'
 import { getEnvName, isProductionEnv } from 'utils/env'
 
-import { onerror, onunhandledrejection } from './errors'
+import { beforeSendAddMechanism, onerror, onunhandledrejection } from './errors'
 
 export { trace } from './trace'
 
@@ -27,10 +27,6 @@ Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
   release: process.env.REACT_APP_GIT_COMMIT_HASH,
   environment: getEnvName(),
-  // Exception reporting configuration:
-  enabled: isSentryEnabled(),
-  // Performance tracing configuration:
-  tracesSampleRate: Number(process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE ?? 0),
   integrations: [
     new GlobalHandlers({
       // Global handlers are set above, not defaulted.
@@ -42,6 +38,9 @@ Sentry.init({
       startTransactionOnPageLoad: true,
     }),
   ],
+  enabled: isSentryEnabled(),
+  beforeSend: beforeSendAddMechanism,
+  tracesSampleRate: Number(process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE ?? 0),
 })
 
 initializeAnalytics(AMPLITUDE_DUMMY_KEY, OriginApplication.INTERFACE, {

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -1,20 +1,26 @@
 import 'components/analytics'
 
 import * as Sentry from '@sentry/react'
+import { GlobalHandlers } from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'
 import { initializeAnalytics, OriginApplication } from '@uniswap/analytics'
 import { SharedEventName } from '@uniswap/analytics-events'
 import { isSentryEnabled } from 'utils/env'
 import { getEnvName, isProductionEnv } from 'utils/env'
 
-export { trace } from './trace'
+import { onerror, onunhandledrejection } from './errors'
 
-// Dump some metadata into the window to allow client verification.
-window.GIT_COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
+export { trace } from './trace'
 
 // Actual KEYs are set by proxy servers.
 const AMPLITUDE_DUMMY_KEY = '00000000000000000000000000000000'
 export const STATSIG_DUMMY_KEY = 'client-0000000000000000000000000000000000000000000'
+
+// Dump some metadata into the window to allow client verification.
+window.GIT_COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
+
+window.onerror = onerror
+window.onunhandledrejection = onunhandledrejection
 
 Sentry.init({
   // General configuration:
@@ -26,6 +32,11 @@ Sentry.init({
   // Performance tracing configuration:
   tracesSampleRate: Number(process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE ?? 0),
   integrations: [
+    new GlobalHandlers({
+      // Global handlers are set above, not defaulted.
+      onerror: false,
+      onunhandledrejection: false,
+    }),
     new BrowserTracing({
       startTransactionOnLocationChange: false,
       startTransactionOnPageLoad: true,

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -8,7 +8,7 @@ import { SharedEventName } from '@uniswap/analytics-events'
 import { isSentryEnabled } from 'utils/env'
 import { getEnvName, isProductionEnv } from 'utils/env'
 
-import { beforeSendAddMechanism, onUnhandledRejection } from './errors'
+import { onUnhandledRejection } from './errors'
 
 export { trace } from './trace'
 
@@ -30,7 +30,7 @@ Sentry.init({
     new GlobalHandlers({
       onerror: true,
       // Use our own handler for unhandled rejections; we want to have more control over which rejections are reported,
-      // as many originate in third-party libraries and can be safely ignored.
+      // because many originate in third-party libraries and can be safely ignored.
       onunhandledrejection: false,
     }),
     new BrowserTracing({
@@ -39,7 +39,6 @@ Sentry.init({
     }),
   ],
   enabled: isSentryEnabled(),
-  beforeSend: beforeSendAddMechanism,
   tracesSampleRate: Number(process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE ?? 0),
 })
 

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -8,7 +8,7 @@ import { SharedEventName } from '@uniswap/analytics-events'
 import { isSentryEnabled } from 'utils/env'
 import { getEnvName, isProductionEnv } from 'utils/env'
 
-import { beforeSendAddMechanism, onerror, onunhandledrejection } from './errors'
+import { beforeSendAddMechanism, onUnhandledRejection } from './errors'
 
 export { trace } from './trace'
 
@@ -19,8 +19,7 @@ export const STATSIG_DUMMY_KEY = 'client-000000000000000000000000000000000000000
 // Dump some metadata into the window to allow client verification.
 window.GIT_COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
 
-window.onerror = onerror
-window.onunhandledrejection = onunhandledrejection
+window.onunhandledrejection = onUnhandledRejection
 
 Sentry.init({
   // General configuration:
@@ -29,8 +28,9 @@ Sentry.init({
   environment: getEnvName(),
   integrations: [
     new GlobalHandlers({
-      // Global handlers are set above, not defaulted.
-      onerror: false,
+      onerror: true,
+      // Use our own handler for unhandled rejections; we want to have more control over which rejections are reported,
+      // as many originate in third-party libraries and can be safely ignored.
       onunhandledrejection: false,
     }),
     new BrowserTracing({


### PR DESCRIPTION
## Description

### Motivation

The noisiest Sentry issue is eth_blockNumber request failure, which is expected to happen (either spuriously or because they are rate-limited) because it is polled so frequently. Logging it floods our Sentry issues.

### Summary

Ignores eth_blockNumber request failures and network changes, which should not be fatal errors. Both of these are provider-originated, non-fatal, and currently unhandled errors.

Instead of just omitting sending them to Sentry, this PR implements a global exception handler (`onunhandledrejection`) to replace the default Sentry integration (`GlobalHandlers`), so that we also do not log the unhandled error in the console.

For discussion, please use #web-sentry-squad in Slack.


## Test Plan
#### Manual

This is difficult to test without either debugging or modifying code. I tested this locally, with a modified build, using the debugging Sentry DSN.
- [X] Induced an eth_blockNumber request failure (using the _Network request blocking_ pane) and verified that it hit the codepath and did not log nor report to Sentry
- [X] Induced a network change (by modifying code) and verified that it hit the codepath and logged but did not report to Sentry
- [x] Induced a rejection to log to Sentry, and verified that it was recorded as an `handled: no` with `mechanism: onunhandledrejection` (these are native fields to Sentry)

I then codified these behaviors with unit tests.

#### Automated
- [X] Unit test
- [ ] <s>Integration/E2E test</s>
