### PR TITLE
fix: only use local txs for current account

### DIFF
--- a/src/components/WalletDropdown/MiniPortfolio/Activity/ActivityTab.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/ActivityTab.tsx
@@ -101,7 +101,7 @@ export function ActivityTab({ account }: { account: string }) {
   const [drawerOpen, toggleWalletDrawer] = useWalletDrawer()
   const [lastFetched, setLastFetched] = useAtom(lastFetchedAtom)
 
-  const localMap = useLocalActivities()
+  const localMap = useLocalActivities(account)
 
   const { data, loading, refetch } = useTransactionListQuery({
     variables: { account },

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.ts
@@ -188,13 +188,11 @@ export function useLocalActivities(account: string): ActivityMap {
   return useMemo(
     () =>
       allTransactions.reduce((acc: { [hash: string]: Activity }, [transaction, chainId]) => {
-        if (transaction.from !== account) return acc
-        try {
+        if (transaction.from === account) {
           const localActivity = parseLocalActivity(transaction, chainId, tokens)
           if (localActivity) acc[localActivity.hash] = localActivity
-        } catch (error) {
-          console.error('Failed to parse local activity', transaction)
         }
+
         return acc
       }, {}),
     [account, allTransactions, tokens]


### PR DESCRIPTION
## Description

Updates useLocalActivity to only return activity for TX's that are related to a given account

https://uniswaplabs.atlassian.net/browse/WEB-3106

## Screen Capture
| Before (local tx's from diff account)           | After           |
| --------- |-----------------|
|  <img width="320" alt="image" src="https://user-images.githubusercontent.com/39385577/229193531-b88a46a4-f917-4071-9aff-5cd961faefdf.png"> | <img width="321" alt="image" src="https://user-images.githubusercontent.com/39385577/229193661-701c3c6d-5558-479f-9bd9-a8754b1eaf3c.png">  |


## Test Plan
#### Manual

1. Make a transaction (i.e. swap) and view it on the acitivty tab
2. Switch to another account
3. Ensure the previous account's transaction is no longer populating the activity tab

#### Automated
Added a test in parseLocal.test.tsx that confirms the right number of transactions appear for the input account when multiple accounts have tx history in redux store