### PR TITLE
refactor: token map types

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -87,7 +87,8 @@ export function CurrencySearch({
 
   const defaultTokens = useDefaultActiveTokens()
   const filteredTokens: Token[] = useMemo(() => {
-    return Object.values(defaultTokens).filter(getTokenFilter(debouncedQuery))
+    const queryFilter = getTokenFilter(debouncedQuery)
+    return Object.values(defaultTokens).filter((token): token is Token => Boolean(token && queryFilter(token)))
   }, [defaultTokens, debouncedQuery])
 
   const [balances, balancesAreLoading] = useAllTokenBalances()

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -19,7 +19,13 @@ import { useAllTokenBalances } from 'state/connection/hooks'
 import styled, { useTheme } from 'styled-components/macro'
 import { UserAddedToken } from 'types/tokens'
 
-import { useDefaultActiveTokens, useIsUserAddedToken, useSearchInactiveTokenLists, useToken } from '../../hooks/Tokens'
+import {
+  tokenMapToArray,
+  useDefaultActiveTokens,
+  useIsUserAddedToken,
+  useSearchInactiveTokenLists,
+  useToken,
+} from '../../hooks/Tokens'
 import { CloseIcon, ThemedText } from '../../theme'
 import { isAddress } from '../../utils'
 import Column from '../Column'
@@ -85,11 +91,11 @@ export function CurrencySearch({
     }
   }, [isAddressSearch])
 
-  const defaultTokens = useDefaultActiveTokens()
+  const defaultTokenMap = useDefaultActiveTokens()
   const filteredTokens: Token[] = useMemo(() => {
-    const queryFilter = getTokenFilter(debouncedQuery)
-    return Object.values(defaultTokens).filter((token): token is Token => Boolean(token && queryFilter(token)))
-  }, [defaultTokens, debouncedQuery])
+    const defaultTokens = tokenMapToArray(defaultTokenMap)
+    return defaultTokens.filter(getTokenFilter(debouncedQuery))
+  }, [defaultTokenMap, debouncedQuery])
 
   const [balances, balancesAreLoading] = useAllTokenBalances()
   const sortedTokens: Token[] = useMemo(

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.test.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.test.ts
@@ -46,7 +46,7 @@ function buildSwapInfo(
   }
 }
 
-function buildTokenAddressMap(...tokens: WrappedTokenInfo[]): ChainToTokenInfoMap {
+function buildChainTokenMap(...tokens: WrappedTokenInfo[]): ChainToTokenInfoMap {
   return {
     [SupportedChainId.MAINNET]: Object.fromEntries(tokens.map((token) => [token.address, { token }])),
   }
@@ -62,7 +62,7 @@ describe('parseLocalActivity', () => {
       },
     } as TransactionDetails
     const chainId = SupportedChainId.MAINNET
-    const tokens = buildTokenAddressMap(USDC_MAINNET as WrappedTokenInfo, DAI as WrappedTokenInfo)
+    const tokens = buildChainTokenMap(USDC_MAINNET as WrappedTokenInfo, DAI as WrappedTokenInfo)
     expect(parseLocalActivity(details, chainId, tokens)).toEqual({
       chainId: 1,
       currencies: [USDC_MAINNET, DAI],
@@ -98,7 +98,7 @@ describe('parseLocalActivity', () => {
       },
     } as TransactionDetails
     const chainId = SupportedChainId.MAINNET
-    const tokens = buildTokenAddressMap(USDC_MAINNET as WrappedTokenInfo, DAI as WrappedTokenInfo)
+    const tokens = buildChainTokenMap(USDC_MAINNET as WrappedTokenInfo, DAI as WrappedTokenInfo)
     expect(parseLocalActivity(details, chainId, tokens)).toEqual({
       chainId: 1,
       currencies: [USDC_MAINNET, DAI],
@@ -134,7 +134,7 @@ describe('parseLocalActivity', () => {
       },
     } as TransactionDetails
     const chainId = SupportedChainId.MAINNET
-    const tokens = {} as TokenAddressMap
+    const tokens = {} as ChainToTokenInfoMap
     expect(parseLocalActivity(details, chainId, tokens)).toEqual({
       chainId: 1,
       currencies: [undefined, undefined],

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.test.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.test.ts
@@ -2,7 +2,7 @@
 
 import { SupportedChainId, Token, TradeType } from '@uniswap/sdk-core'
 import { DAI, USDC_MAINNET } from 'constants/tokens'
-import { TokenAddressMap } from 'state/lists/hooks'
+import { ChainToTokenInfoMap } from 'lib/hooks/useTokenList/utils'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import {
   ExactInputSwapTransactionInfo,
@@ -46,7 +46,7 @@ function buildSwapInfo(
   }
 }
 
-function buildTokenAddressMap(...tokens: WrappedTokenInfo[]): TokenAddressMap {
+function buildTokenAddressMap(...tokens: WrappedTokenInfo[]): ChainToTokenInfoMap {
   return {
     [SupportedChainId.MAINNET]: Object.fromEntries(tokens.map((token) => [token.address, { token }])),
   }

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.ts
@@ -5,7 +5,7 @@ import { nativeOnChain } from '@uniswap/smart-order-router'
 import { useWeb3React } from '@web3-react/core'
 import { SupportedChainId } from 'constants/chains'
 import { TransactionPartsFragment, TransactionStatus } from 'graphql/data/__generated__/types-and-hooks'
-import { ChainToTokenInfoMap } from 'lib/hooks/useTokenList/utils'
+import { ChainTokenInfoMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
 import { useCombinedActiveList } from 'state/lists/hooks'
 import { useMultichainTransactions } from 'state/transactions/hooks'
@@ -27,7 +27,7 @@ import {
 import { getActivityTitle } from '../constants'
 import { Activity, ActivityMap } from './types'
 
-function getCurrency(currencyId: string, chainId: SupportedChainId, tokens: ChainToTokenInfoMap): Currency | undefined {
+function getCurrency(currencyId: string, chainId: SupportedChainId, tokens: ChainTokenInfoMap): Currency | undefined {
   return currencyId === 'ETH' ? nativeOnChain(chainId) : tokens[chainId]?.[currencyId]?.token
 }
 
@@ -48,7 +48,7 @@ function buildCurrencyDescriptor(
 function parseSwap(
   swap: ExactInputSwapTransactionInfo | ExactOutputSwapTransactionInfo,
   chainId: SupportedChainId,
-  tokens: ChainToTokenInfoMap
+  tokens: ChainTokenInfoMap
 ): Partial<Activity> {
   const tokenIn = getCurrency(swap.inputCurrencyId, chainId, tokens)
   const tokenOut = getCurrency(swap.outputCurrencyId, chainId, tokens)
@@ -78,7 +78,7 @@ function parseWrap(wrap: WrapTransactionInfo, chainId: SupportedChainId, status:
 function parseApproval(
   approval: ApproveTransactionInfo,
   chainId: SupportedChainId,
-  tokens: ChainToTokenInfoMap
+  tokens: ChainTokenInfoMap
 ): Partial<Activity> {
   // TODO: Add 'amount' approved to ApproveTransactionInfo so we can distinguish between revoke and approve
   const currency = getCurrency(approval.tokenAddress, chainId, tokens)
@@ -93,7 +93,7 @@ type GenericLPInfo = Omit<
   AddLiquidityV3PoolTransactionInfo | RemoveLiquidityV3TransactionInfo | AddLiquidityV2PoolTransactionInfo,
   'type'
 >
-function parseLP(lp: GenericLPInfo, chainId: SupportedChainId, tokens: ChainToTokenInfoMap): Partial<Activity> {
+function parseLP(lp: GenericLPInfo, chainId: SupportedChainId, tokens: ChainTokenInfoMap): Partial<Activity> {
   const baseCurrency = getCurrency(lp.baseCurrencyId, chainId, tokens)
   const quoteCurrency = getCurrency(lp.quoteCurrencyId, chainId, tokens)
   const [baseRaw, quoteRaw] = [lp.expectedAmountBaseRaw, lp.expectedAmountQuoteRaw]
@@ -105,7 +105,7 @@ function parseLP(lp: GenericLPInfo, chainId: SupportedChainId, tokens: ChainToTo
 function parseCollectFees(
   collect: CollectFeesTransactionInfo,
   chainId: SupportedChainId,
-  tokens: ChainToTokenInfoMap
+  tokens: ChainTokenInfoMap
 ): Partial<Activity> {
   // Adapts CollectFeesTransactionInfo to generic LP type
   const {
@@ -120,7 +120,7 @@ function parseCollectFees(
 function parseMigrateCreateV3(
   lp: MigrateV2LiquidityToV3TransactionInfo | CreateV3PoolTransactionInfo,
   chainId: SupportedChainId,
-  tokens: ChainToTokenInfoMap
+  tokens: ChainTokenInfoMap
 ): Partial<Activity> {
   const baseCurrency = getCurrency(lp.baseCurrencyId, chainId, tokens)
   const baseSymbol = baseCurrency?.symbol ?? t`Unknown`
@@ -134,7 +134,7 @@ function parseMigrateCreateV3(
 export function parseLocalActivity(
   details: TransactionDetails,
   chainId: SupportedChainId,
-  tokens: ChainToTokenInfoMap
+  tokens: ChainTokenInfoMap
 ): Activity | undefined {
   const status = !details.receipt
     ? TransactionStatus.Pending

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/parseLocal.ts
@@ -5,8 +5,9 @@ import { nativeOnChain } from '@uniswap/smart-order-router'
 import { useWeb3React } from '@web3-react/core'
 import { SupportedChainId } from 'constants/chains'
 import { TransactionPartsFragment, TransactionStatus } from 'graphql/data/__generated__/types-and-hooks'
+import { ChainToTokenInfoMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
-import { TokenAddressMap, useCombinedActiveList } from 'state/lists/hooks'
+import { useCombinedActiveList } from 'state/lists/hooks'
 import { useMultichainTransactions } from 'state/transactions/hooks'
 import {
   AddLiquidityV2PoolTransactionInfo,
@@ -26,7 +27,7 @@ import {
 import { getActivityTitle } from '../constants'
 import { Activity, ActivityMap } from './types'
 
-function getCurrency(currencyId: string, chainId: SupportedChainId, tokens: TokenAddressMap): Currency | undefined {
+function getCurrency(currencyId: string, chainId: SupportedChainId, tokens: ChainToTokenInfoMap): Currency | undefined {
   return currencyId === 'ETH' ? nativeOnChain(chainId) : tokens[chainId]?.[currencyId]?.token
 }
 
@@ -47,7 +48,7 @@ function buildCurrencyDescriptor(
 function parseSwap(
   swap: ExactInputSwapTransactionInfo | ExactOutputSwapTransactionInfo,
   chainId: SupportedChainId,
-  tokens: TokenAddressMap
+  tokens: ChainToTokenInfoMap
 ): Partial<Activity> {
   const tokenIn = getCurrency(swap.inputCurrencyId, chainId, tokens)
   const tokenOut = getCurrency(swap.outputCurrencyId, chainId, tokens)
@@ -77,7 +78,7 @@ function parseWrap(wrap: WrapTransactionInfo, chainId: SupportedChainId, status:
 function parseApproval(
   approval: ApproveTransactionInfo,
   chainId: SupportedChainId,
-  tokens: TokenAddressMap
+  tokens: ChainToTokenInfoMap
 ): Partial<Activity> {
   // TODO: Add 'amount' approved to ApproveTransactionInfo so we can distinguish between revoke and approve
   const currency = getCurrency(approval.tokenAddress, chainId, tokens)
@@ -92,7 +93,7 @@ type GenericLPInfo = Omit<
   AddLiquidityV3PoolTransactionInfo | RemoveLiquidityV3TransactionInfo | AddLiquidityV2PoolTransactionInfo,
   'type'
 >
-function parseLP(lp: GenericLPInfo, chainId: SupportedChainId, tokens: TokenAddressMap): Partial<Activity> {
+function parseLP(lp: GenericLPInfo, chainId: SupportedChainId, tokens: ChainToTokenInfoMap): Partial<Activity> {
   const baseCurrency = getCurrency(lp.baseCurrencyId, chainId, tokens)
   const quoteCurrency = getCurrency(lp.quoteCurrencyId, chainId, tokens)
   const [baseRaw, quoteRaw] = [lp.expectedAmountBaseRaw, lp.expectedAmountQuoteRaw]
@@ -104,7 +105,7 @@ function parseLP(lp: GenericLPInfo, chainId: SupportedChainId, tokens: TokenAddr
 function parseCollectFees(
   collect: CollectFeesTransactionInfo,
   chainId: SupportedChainId,
-  tokens: TokenAddressMap
+  tokens: ChainToTokenInfoMap
 ): Partial<Activity> {
   // Adapts CollectFeesTransactionInfo to generic LP type
   const {
@@ -119,7 +120,7 @@ function parseCollectFees(
 function parseMigrateCreateV3(
   lp: MigrateV2LiquidityToV3TransactionInfo | CreateV3PoolTransactionInfo,
   chainId: SupportedChainId,
-  tokens: TokenAddressMap
+  tokens: ChainToTokenInfoMap
 ): Partial<Activity> {
   const baseCurrency = getCurrency(lp.baseCurrencyId, chainId, tokens)
   const baseSymbol = baseCurrency?.symbol ?? t`Unknown`
@@ -133,7 +134,7 @@ function parseMigrateCreateV3(
 export function parseLocalActivity(
   details: TransactionDetails,
   chainId: SupportedChainId,
-  tokens: TokenAddressMap
+  tokens: ChainToTokenInfoMap
 ): Activity | undefined {
   const status = !details.receipt
     ? TransactionStatus.Pending

--- a/src/components/WalletDropdown/MiniPortfolio/Pools/cache.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Pools/cache.ts
@@ -126,7 +126,7 @@ export function useGetCachedTokens(chains: SupportedChainId[]): TokenGetterFn {
       const local: TokenMap = {}
       const missing = new Set<string>()
       addresses.forEach((address) => {
-        const cached = tokenCache.get(chainId, address) ?? allTokens[chainId][address]?.token
+        const cached = tokenCache.get(chainId, address) ?? allTokens[chainId]?.[address]?.token
         cached ? (local[address] = cached) : missing.add(address)
       })
 

--- a/src/components/WalletDropdown/MiniPortfolio/Pools/cache.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Pools/cache.ts
@@ -1,7 +1,7 @@
 import { Token } from '@uniswap/sdk-core'
 import { Pool, Position } from '@uniswap/v3-sdk'
 import { SupportedChainId } from 'constants/chains'
-import { useAllTokensMultichain } from 'hooks/Tokens'
+import { TokenMap, useAllTokensMultichain } from 'hooks/Tokens'
 import { atom, useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import ms from 'ms.macro'
@@ -123,7 +123,7 @@ export function useGetCachedTokens(chains: SupportedChainId[]): TokenGetterFn {
   // Uses tokens from local state if available, otherwise fetches them
   const getTokens: TokenGetterFn = useCallback(
     async (addresses, chainId) => {
-      const local: { [address: string]: Token | undefined } = {}
+      const local: TokenMap = {}
       const missing = new Set<string>()
       addresses.forEach((address) => {
         const cached = tokenCache.get(chainId, address) ?? allTokens[chainId][address]?.token

--- a/src/components/WalletDropdown/MiniPortfolio/Pools/getTokensAsync.ts
+++ b/src/components/WalletDropdown/MiniPortfolio/Pools/getTokensAsync.ts
@@ -5,12 +5,12 @@ import { Erc20Bytes32Interface } from 'abis/types/Erc20Bytes32'
 import { SupportedChainId } from 'constants/chains'
 import { DEFAULT_ERC20_DECIMALS } from 'constants/tokens'
 import { Interface } from 'ethers/lib/utils'
+import { TokenMap } from 'hooks/Tokens'
 import { UniswapInterfaceMulticall } from 'types/v3'
 import { isAddress } from 'utils'
 import { arrayToSlices } from 'utils/arrays'
 import { buildCurrencyKey, CurrencyKey, currencyKey } from 'utils/currencyKey'
 
-type TokenMap = { [address: string]: Token | undefined }
 export type Call = { target: string; callData: string; gasLimit: number }
 type CallResult = { success: boolean; returnData: string }
 export const DEFAULT_GAS_LIMIT = 1_000_000

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -5,7 +5,7 @@ import { SupportedChainId } from 'constants/chains'
 import { DEFAULT_INACTIVE_LIST_URLS, DEFAULT_LIST_OF_LISTS } from 'constants/lists'
 import { useCurrencyFromMap, useTokenFromMapOrNetwork } from 'lib/hooks/useCurrency'
 import { getTokenFilter } from 'lib/hooks/useTokenList/filtering'
-import { ChainToTokenInfoMap } from 'lib/hooks/useTokenList/utils'
+import { ChainTokenInfoMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
 import { isL2ChainId } from 'utils/chains'
 
@@ -15,22 +15,26 @@ import { useUserAddedTokens, useUserAddedTokensOnChain } from '../state/user/hoo
 import { useUnsupportedTokenList } from './../state/lists/hooks'
 
 export type TokenMap = { [address: string]: Token | undefined }
-// reduce token map into standard address <-> Token mapping, optionally include user added tokens
-function useTokensFromMap(tokenMap: ChainToTokenInfoMap): TokenMap {
+export function tokenMapToArray(tokens: TokenMap): Array<Token> {
+  return Object.values(tokens).filter((token): token is Token => token !== undefined)
+}
+
+// reduce ChainTokenInfoMap to standard TokenMap type
+function useTokensFromMap(chainTokenInfoMap: ChainTokenInfoMap): TokenMap {
   const { chainId } = useWeb3React()
   return useMemo(() => {
     if (!chainId) return {}
 
     // reduce to just tokens
-    return Object.keys(tokenMap[chainId] ?? {}).reduce<TokenMap>((newMap, address) => {
-      const entry = tokenMap[chainId][address]
+    return Object.keys(chainTokenInfoMap[chainId] ?? {}).reduce<TokenMap>((newMap, address) => {
+      const entry = chainTokenInfoMap[chainId]?.[address]
       if (entry) newMap[address] = entry.token
       return newMap
     }, {})
-  }, [chainId, tokenMap])
+  }, [chainId, chainTokenInfoMap])
 }
 
-export function useAllTokensMultichain(): ChainToTokenInfoMap {
+export function useAllTokensMultichain(): ChainTokenInfoMap {
   return useCombinedTokenMapFromUrls(DEFAULT_LIST_OF_LISTS)
 }
 

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -14,12 +14,12 @@ import { WrappedTokenInfo } from '../state/lists/wrappedTokenInfo'
 import { useUserAddedTokens, useUserAddedTokensOnChain } from '../state/user/hooks'
 import { useUnsupportedTokenList } from './../state/lists/hooks'
 
-export type TokenMap = { [address: string]: Token | undefined }
+export type TokenMap = { [address in string]?: Token }
 export function tokenMapToArray(tokens: TokenMap): Array<Token> {
-  return Object.values(tokens).filter((token): token is Token => token !== undefined)
+  return Object.values(tokens).filter(Boolean) as Array<Token>
 }
 
-// reduce ChainTokenInfoMap to standard TokenMap type
+/** Reduces ChainTokenInfoMap to the standard TokenMap type. */
 function useTokensFromMap(chainTokenInfoMap: ChainTokenInfoMap): TokenMap {
   const { chainId } = useWeb3React()
   return useMemo(() => {

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -23,7 +23,8 @@ function useTokensFromMap(tokenMap: ChainToTokenInfoMap): TokenMap {
 
     // reduce to just tokens
     return Object.keys(tokenMap[chainId] ?? {}).reduce<TokenMap>((newMap, address) => {
-      newMap[address] = tokenMap[chainId][address].token
+      const entry = tokenMap[chainId][address]
+      if (entry) newMap[address] = entry.token
       return newMap
     }, {})
   }, [chainId, tokenMap])

--- a/src/hooks/useTokenInfoFromActiveList.ts
+++ b/src/hooks/useTokenInfoFromActiveList.ts
@@ -14,10 +14,6 @@ export function useTokenInfoFromActiveList(currency: Currency) {
     if (!chainId) return
     if (currency.isNative) return currency
 
-    try {
-      return activeList[chainId][currency.wrapped.address].token
-    } catch (e) {
-      return currency
-    }
+    return activeList[chainId]?.[currency.wrapped.address]?.token ?? currency
   }, [activeList, chainId, currency])
 }

--- a/src/lib/hooks/useCurrency.ts
+++ b/src/lib/hooks/useCurrency.ts
@@ -3,6 +3,7 @@ import { parseBytes32String } from '@ethersproject/strings'
 import { Currency, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { isSupportedChain } from 'constants/chains'
+import { TokenMap } from 'hooks/Tokens'
 import { useBytes32TokenContract, useTokenContract } from 'hooks/useContract'
 import { NEVER_RELOAD, useSingleCallResult } from 'lib/hooks/multicall'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
@@ -71,8 +72,6 @@ export function useTokenFromActiveNetwork(tokenAddress: string | undefined): Tok
     return new Token(chainId, formattedAddress, parsedDecimals, parsedSymbol, parsedName)
   }, [chainId, tokenAddress, formattedAddress, isLoading, parsedDecimals, parsedSymbol, parsedName])
 }
-
-type TokenMap = { [address: string]: Token }
 
 /**
  * Returns a Token from the tokenAddress.

--- a/src/lib/hooks/useTokenList/utils.ts
+++ b/src/lib/hooks/useTokenList/utils.ts
@@ -1,7 +1,7 @@
 import { TokenInfo, TokenList } from '@uniswap/token-lists'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
-type TokenInfoMap = Readonly<{ [tokenAddress: string]: { token: WrappedTokenInfo; list?: TokenList } }>
+type TokenInfoMap = Readonly<{ [tokenAddress: string]: { token: WrappedTokenInfo; list?: TokenList } | undefined }>
 export type ChainToTokenInfoMap = Readonly<{ [chainId: number]: TokenInfoMap }>
 
 type Mutable<T> = {

--- a/src/lib/hooks/useTokenList/utils.ts
+++ b/src/lib/hooks/useTokenList/utils.ts
@@ -1,36 +1,38 @@
 import { TokenInfo, TokenList } from '@uniswap/token-lists'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
-type TokenInfoMap = Readonly<{ [tokenAddress: string]: { token: WrappedTokenInfo; list?: TokenList } | undefined }>
-export type ChainToTokenInfoMap = Readonly<{ [chainId: number]: TokenInfoMap }>
+type TokenInfoMap = Readonly<{ [tokenAddress in string]?: { token: WrappedTokenInfo; list?: TokenList } }>
+export type ChainTokenInfoMap = Readonly<{ [chainId in number]?: TokenInfoMap }>
 
 type Mutable<T> = {
   -readonly [P in keyof T]: Mutable<T[P]>
 }
 
-const mapCache = typeof WeakMap !== 'undefined' ? new WeakMap<TokenList | TokenInfo[], ChainToTokenInfoMap>() : null
+const mapCache = typeof WeakMap !== 'undefined' ? new WeakMap<TokenList | TokenInfo[], ChainTokenInfoMap>() : null
 
-export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainToTokenInfoMap {
+export function tokensToChainTokenInfoMap(tokens: TokenList | TokenInfo[]): ChainTokenInfoMap {
   const cached = mapCache?.get(tokens)
   if (cached) return cached
 
   const [list, infos] = Array.isArray(tokens) ? [undefined, tokens] : [tokens, tokens.tokens]
-  const map = infos.reduce<Mutable<ChainToTokenInfoMap>>((map, info) => {
+  const map = infos.reduce<Mutable<ChainTokenInfoMap>>((map, info) => {
     try {
       const token = new WrappedTokenInfo(info, list)
       if (map[token.chainId]?.[token.address] !== undefined) {
         console.warn(`Duplicate token skipped: ${token.address}`)
         return map
       }
-      if (!map[token.chainId]) {
-        map[token.chainId] = {}
+      const currentChainMap = map[token.chainId]
+      if (!currentChainMap) {
+        map[token.chainId] = { [token.address]: { token, list } }
+      } else {
+        currentChainMap[token.address] = { token, list }
       }
-      map[token.chainId][token.address] = { token, list }
       return map
     } catch {
       return map
     }
-  }, {}) as ChainToTokenInfoMap
+  }, {}) as ChainTokenInfoMap
   mapCache?.set(tokens, map)
   return map
 }

--- a/src/lib/hooks/useTokenList/utils.ts
+++ b/src/lib/hooks/useTokenList/utils.ts
@@ -1,21 +1,21 @@
 import { TokenInfo, TokenList } from '@uniswap/token-lists'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
-type TokenMap = Readonly<{ [tokenAddress: string]: { token: WrappedTokenInfo; list?: TokenList } }>
-export type ChainTokenMap = Readonly<{ [chainId: number]: TokenMap }>
+type TokenInfoMap = Readonly<{ [tokenAddress: string]: { token: WrappedTokenInfo; list?: TokenList } }>
+export type ChainToTokenInfoMap = Readonly<{ [chainId: number]: TokenInfoMap }>
 
 type Mutable<T> = {
   -readonly [P in keyof T]: Mutable<T[P]>
 }
 
-const mapCache = typeof WeakMap !== 'undefined' ? new WeakMap<TokenList | TokenInfo[], ChainTokenMap>() : null
+const mapCache = typeof WeakMap !== 'undefined' ? new WeakMap<TokenList | TokenInfo[], ChainToTokenInfoMap>() : null
 
-export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainTokenMap {
+export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainToTokenInfoMap {
   const cached = mapCache?.get(tokens)
   if (cached) return cached
 
   const [list, infos] = Array.isArray(tokens) ? [undefined, tokens] : [tokens, tokens.tokens]
-  const map = infos.reduce<Mutable<ChainTokenMap>>((map, info) => {
+  const map = infos.reduce<Mutable<ChainToTokenInfoMap>>((map, info) => {
     try {
       const token = new WrappedTokenInfo(info, list)
       if (map[token.chainId]?.[token.address] !== undefined) {
@@ -30,7 +30,7 @@ export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainTok
     } catch {
       return map
     }
-  }, {}) as ChainTokenMap
+  }, {}) as ChainToTokenInfoMap
   mapCache?.set(tokens, map)
   return map
 }

--- a/src/lib/hooks/useTokenList/utils.ts
+++ b/src/lib/hooks/useTokenList/utils.ts
@@ -22,12 +22,11 @@ export function tokensToChainTokenInfoMap(tokens: TokenList | TokenInfo[]): Chai
         console.warn(`Duplicate token skipped: ${token.address}`)
         return map
       }
-      const currentChainMap = map[token.chainId]
-      if (!currentChainMap) {
-        map[token.chainId] = { [token.address]: { token, list } }
-      } else {
-        currentChainMap[token.address] = { token, list }
-      }
+
+      const tokenInfoMap = map[token.chainId] || {}
+      tokenInfoMap[token.address] = { token, list }
+      map[token.chainId] = tokenInfoMap
+
       return map
     } catch {
       return map

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -1,4 +1,4 @@
-import { ChainToTokenInfoMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/utils'
+import { ChainTokenInfoMap, tokensToChainTokenInfoMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
 import { useAppSelector } from 'state/hooks'
 import sortByListPriority from 'utils/listSort'
@@ -20,7 +20,7 @@ export function useAllLists(): AppState['lists']['byUrl'] {
  * @param map1 the base token map
  * @param map2 the map of additioanl tokens to add to the base map
  */
-function combineMaps(map1: ChainToTokenInfoMap, map2: ChainToTokenInfoMap): ChainToTokenInfoMap {
+function combineMaps(map1: ChainTokenInfoMap, map2: ChainTokenInfoMap): ChainTokenInfoMap {
   const chainIds = Object.keys(
     Object.keys(map1)
       .concat(Object.keys(map2))
@@ -30,18 +30,18 @@ function combineMaps(map1: ChainToTokenInfoMap, map2: ChainToTokenInfoMap): Chai
       }, {})
   ).map((id) => parseInt(id))
 
-  return chainIds.reduce<Mutable<ChainToTokenInfoMap>>((memo, chainId) => {
+  return chainIds.reduce<Mutable<ChainTokenInfoMap>>((memo, chainId) => {
     memo[chainId] = {
       ...map2[chainId],
       // map1 takes precedence
       ...map1[chainId],
     }
     return memo
-  }, {}) as ChainToTokenInfoMap
+  }, {}) as ChainTokenInfoMap
 }
 
 // merge tokens contained within lists from urls
-export function useCombinedTokenMapFromUrls(urls: string[] | undefined): ChainToTokenInfoMap {
+export function useCombinedTokenMapFromUrls(urls: string[] | undefined): ChainTokenInfoMap {
   const lists = useAllLists()
   return useMemo(() => {
     if (!urls) return {}
@@ -54,7 +54,7 @@ export function useCombinedTokenMapFromUrls(urls: string[] | undefined): ChainTo
           const current = lists[currentUrl]?.current
           if (!current) return allTokens
           try {
-            return combineMaps(allTokens, tokensToChainTokenMap(current))
+            return combineMaps(allTokens, tokensToChainTokenInfoMap(current))
           } catch (error) {
             console.error('Could not show token list due to error', error)
             return allTokens
@@ -65,15 +65,15 @@ export function useCombinedTokenMapFromUrls(urls: string[] | undefined): ChainTo
 }
 
 // get all the tokens from active lists, combine with local default tokens
-export function useCombinedActiveList(): ChainToTokenInfoMap {
+export function useCombinedActiveList(): ChainTokenInfoMap {
   const activeTokens = useCombinedTokenMapFromUrls(DEFAULT_ACTIVE_LIST_URLS)
   return activeTokens
 }
 
 // list of tokens not supported on interface for various reasons, used to show warnings and prevent swaps and adds
-export function useUnsupportedTokenList(): ChainToTokenInfoMap {
+export function useUnsupportedTokenList(): ChainTokenInfoMap {
   // get hard-coded broken tokens
-  const brokenListMap = useMemo(() => tokensToChainTokenMap(BROKEN_LIST), [])
+  const brokenListMap = useMemo(() => tokensToChainTokenInfoMap(BROKEN_LIST), [])
 
   // get dynamic list of unsupported tokens
   const loadedUnsupportedListMap = useCombinedTokenMapFromUrls(UNSUPPORTED_LIST_URLS)

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -1,4 +1,4 @@
-import { ChainTokenMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/utils'
+import { ChainToTokenInfoMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
 import { useAppSelector } from 'state/hooks'
 import sortByListPriority from 'utils/listSort'
@@ -6,8 +6,6 @@ import sortByListPriority from 'utils/listSort'
 import BROKEN_LIST from '../../constants/tokenLists/broken.tokenlist.json'
 import { AppState } from '../types'
 import { DEFAULT_ACTIVE_LIST_URLS, UNSUPPORTED_LIST_URLS } from './../../constants/lists'
-
-export type TokenAddressMap = ChainTokenMap
 
 type Mutable<T> = {
   -readonly [P in keyof T]: Mutable<T[P]>
@@ -22,7 +20,7 @@ export function useAllLists(): AppState['lists']['byUrl'] {
  * @param map1 the base token map
  * @param map2 the map of additioanl tokens to add to the base map
  */
-function combineMaps(map1: TokenAddressMap, map2: TokenAddressMap): TokenAddressMap {
+function combineMaps(map1: ChainToTokenInfoMap, map2: ChainToTokenInfoMap): ChainToTokenInfoMap {
   const chainIds = Object.keys(
     Object.keys(map1)
       .concat(Object.keys(map2))
@@ -32,18 +30,18 @@ function combineMaps(map1: TokenAddressMap, map2: TokenAddressMap): TokenAddress
       }, {})
   ).map((id) => parseInt(id))
 
-  return chainIds.reduce<Mutable<TokenAddressMap>>((memo, chainId) => {
+  return chainIds.reduce<Mutable<ChainToTokenInfoMap>>((memo, chainId) => {
     memo[chainId] = {
       ...map2[chainId],
       // map1 takes precedence
       ...map1[chainId],
     }
     return memo
-  }, {}) as TokenAddressMap
+  }, {}) as ChainToTokenInfoMap
 }
 
 // merge tokens contained within lists from urls
-export function useCombinedTokenMapFromUrls(urls: string[] | undefined): TokenAddressMap {
+export function useCombinedTokenMapFromUrls(urls: string[] | undefined): ChainToTokenInfoMap {
   const lists = useAllLists()
   return useMemo(() => {
     if (!urls) return {}
@@ -67,13 +65,13 @@ export function useCombinedTokenMapFromUrls(urls: string[] | undefined): TokenAd
 }
 
 // get all the tokens from active lists, combine with local default tokens
-export function useCombinedActiveList(): TokenAddressMap {
+export function useCombinedActiveList(): ChainToTokenInfoMap {
   const activeTokens = useCombinedTokenMapFromUrls(DEFAULT_ACTIVE_LIST_URLS)
   return activeTokens
 }
 
 // list of tokens not supported on interface for various reasons, used to show warnings and prevent swaps and adds
-export function useUnsupportedTokenList(): TokenAddressMap {
+export function useUnsupportedTokenList(): ChainToTokenInfoMap {
   // get hard-coded broken tokens
   const brokenListMap = useMemo(() => tokensToChainTokenMap(BROKEN_LIST), [])
 

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -275,7 +275,7 @@ export function useTrackedTokenPairs(): [Token, Token][] {
               (BASES_TO_TRACK_LIQUIDITY_FOR[chainId] ?? [])
                 // to construct pairs of the given token with each base
                 .map((base) => {
-                  if (base.address === token.address) {
+                  if (base.address === token?.address) {
                     return null
                   } else {
                     return [base, token]


### PR DESCRIPTION
## Description

The existing type `TokenAddressMap` was misnomered as it actually was a nested map from `chainId` to `tokenAddress` to `{ token: WrappedTokenInfo; list?: TokenList }`

This PR removes the redundant renaming/re-exportation of `ChainTokenMap` to `TokenAddressMap` and renames `ChainTokenMap` to `ChainToTokenInfoMap`. 

Since the confusion of `TokenAddressMap` is now removed, this PR also adds  a simple `TokenMap` type to be used anywhere a map from token address to token is needed. `TokenMap` maps to `Token | undefined` to prevent undefined access errors

`ChainToTokenInfoMap` is also updated to map to `{ token: WrappedTokenInfo; list?: TokenList } | undefined` to prevent similar errors

## Test Plan
#### Manual
This is a refactor PR that should not affect any functionality
