### PR TITLE
chore: removing unnecessary data in assets query

### DIFF
--- a/src/components/WalletDropdown/MiniPortfolio/NFTs.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/NFTs.tsx
@@ -5,13 +5,22 @@ import { useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import styled from 'styled-components/macro'
 
-import { useToggleWalletDrawer } from '..'
+import { useWalletDrawer } from '..'
 import { DEFAULT_NFT_QUERY_AMOUNT } from './constants'
 import { NFT } from './NFT'
 
 export default function NFTs({ account }: { account: string }) {
-  const { walletAssets, loading, hasNext, loadMore } = useNftBalance(account, [], [], DEFAULT_NFT_QUERY_AMOUNT)
-  const toggleWalletDrawer = useToggleWalletDrawer()
+  const [walletDrawerOpen, toggleWalletDrawer] = useWalletDrawer()
+  const { walletAssets, loading, hasNext, loadMore } = useNftBalance(
+    account,
+    [],
+    [],
+    DEFAULT_NFT_QUERY_AMOUNT,
+    undefined,
+    undefined,
+    undefined,
+    !walletDrawerOpen
+  )
 
   const [currentTokenPlayingMedia, setCurrentTokenPlayingMedia] = useState<string | undefined>()
 

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -39,36 +39,18 @@ gql`
         node {
           id
           name
-          ownerAddress
           image {
             url
           }
           smallImage {
             url
           }
-          originalImage {
-            url
-          }
           tokenId
-          description
           animationUrl
           suspiciousFlag
           collection {
-            name
-            isVerified
-            image {
-              url
-            }
-            creator {
-              address
-              profileImage {
-                url
-              }
-              isVerified
-            }
             nftContracts {
               address
-              standard
             }
           }
           listings(first: 1) {
@@ -99,10 +81,7 @@ gql`
           }
           rarities {
             provider
-            rank
-            score
           }
-          metadataUrl
         }
         cursor
       }

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -83,7 +83,7 @@ gql`
             }
           }
           rarities {
-            provider
+            rank
           }
         }
         cursor

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -42,12 +42,18 @@ gql`
           image {
             url
           }
+          smallImage {
+            url
+          }
           tokenId
           animationUrl
           suspiciousFlag
           collection {
+            name
+            isVerified
             nftContracts {
               address
+              standard
             }
           }
           listings(first: 1) {

--- a/src/graphql/data/nft/Asset.ts
+++ b/src/graphql/data/nft/Asset.ts
@@ -42,9 +42,6 @@ gql`
           image {
             url
           }
-          smallImage {
-            url
-          }
           tokenId
           animationUrl
           suspiciousFlag

--- a/src/graphql/data/nft/NftBalance.ts
+++ b/src/graphql/data/nft/NftBalance.ts
@@ -122,7 +122,8 @@ export function useNftBalance(
   first?: number,
   after?: string,
   last?: number,
-  before?: string
+  before?: string,
+  disabled = false
 ) {
   const { data, loading, fetchMore } = useNftBalanceQuery({
     variables: {
@@ -140,6 +141,7 @@ export function useNftBalance(
       last,
       before,
     },
+    skip: disabled,
   })
 
   const hasNext = data?.nftBalances?.pageInfo?.hasNextPage

--- a/src/graphql/data/nft/NftBalance.ts
+++ b/src/graphql/data/nft/NftBalance.ts
@@ -123,7 +123,7 @@ export function useNftBalance(
   after?: string,
   last?: number,
   before?: string,
-  disabled = false
+  skip = false
 ) {
   const { data, loading, fetchMore } = useNftBalanceQuery({
     variables: {
@@ -141,7 +141,7 @@ export function useNftBalance(
       last,
       before,
     },
-    skip: disabled,
+    skip,
   })
 
   const hasNext = data?.nftBalances?.pageInfo?.hasNextPage


### PR DESCRIPTION
Reducing initial response size by reducing the requested amount of data for the assets query + making mini portfolio only load nft balance when opened
