### PR TITLE
fix: use backend to resolve NFT image for ENS avatar

### DIFF
--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -77,4 +77,11 @@ describe('Wallet Dropdown', () => {
     cy.get(getTestSelector('theme-auto')).click()
     cy.get(getTestSelector('wallet-header')).should('have.css', 'color', 'rgb(119, 128, 160)')
   })
+
+  it('should render the ENS name and avatar', () => {
+    visit(true)
+    cy.get(getTestSelector('web3-status-connected')).click()
+    cy.contains('averylongtestaddress.eth').should('exist')
+    cy.get(getTestSelector('identicon-styled-avatar')).should('be.visible')
+  })
 })

--- a/cypress/support/ethereum.ts
+++ b/cypress/support/ethereum.ts
@@ -11,7 +11,7 @@ import { SupportedChainId } from '../../src/constants/chains'
 
 // todo: figure out how env vars actually work in CI
 // const TEST_PRIVATE_KEY = Cypress.env('INTEGRATION_TEST_PRIVATE_KEY')
-const TEST_PRIVATE_KEY = '0xe580410d7c37d26c6ad1a837bbae46bc27f9066a466fb3a66e770523b4666d19'
+const TEST_PRIVATE_KEY = 'c19d41225c87bf8c7d82264f1559555f8f46a1e22584a269fb905f63ef2bec3a'
 
 // address of the above key
 const TEST_ADDRESS_NEVER_USE = new Wallet(TEST_PRIVATE_KEY).address

--- a/src/components/Identicon/index.tsx
+++ b/src/components/Identicon/index.tsx
@@ -46,7 +46,12 @@ export default function Identicon({ size }: { size?: number }) {
   return (
     <StyledIdenticon iconSize={iconSize}>
       {avatar && fetchable ? (
-        <StyledAvatar alt="avatar" src={avatar} onError={handleError}></StyledAvatar>
+        <StyledAvatar
+          data-testid="identicon-styled-avatar"
+          alt="avatar"
+          src={avatar}
+          onError={handleError}
+        ></StyledAvatar>
       ) : (
         <span ref={iconRef} />
       )}

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -14,9 +14,7 @@ import ENS_PUBLIC_RESOLVER_ABI from 'abis/ens-public-resolver.json'
 import ENS_ABI from 'abis/ens-registrar.json'
 import ERC20_ABI from 'abis/erc20.json'
 import ERC20_BYTES32_ABI from 'abis/erc20_bytes32.json'
-import ERC721_ABI from 'abis/erc721.json'
-import ERC1155_ABI from 'abis/erc1155.json'
-import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Erc721, Erc1155, Weth } from 'abis/types'
+import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Weth } from 'abis/types'
 import WETH_ABI from 'abis/weth.json'
 import {
   ARGENT_WALLET_DETECTOR_ADDRESS,
@@ -82,14 +80,6 @@ export function useWETHContract(withSignerIfPossible?: boolean) {
     WETH_ABI,
     withSignerIfPossible
   )
-}
-
-export function useERC721Contract(nftAddress?: string) {
-  return useContract<Erc721>(nftAddress, ERC721_ABI, false)
-}
-
-export function useERC1155Contract(nftAddress?: string) {
-  return useContract<Erc1155>(nftAddress, ERC1155_ABI, false)
 }
 
 export function useArgentWalletDetectorContract() {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -14,7 +14,9 @@ import ENS_PUBLIC_RESOLVER_ABI from 'abis/ens-public-resolver.json'
 import ENS_ABI from 'abis/ens-registrar.json'
 import ERC20_ABI from 'abis/erc20.json'
 import ERC20_BYTES32_ABI from 'abis/erc20_bytes32.json'
-import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Weth } from 'abis/types'
+import ERC721_ABI from 'abis/erc721.json'
+import ERC1155_ABI from 'abis/erc1155.json'
+import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Erc721, Erc1155, Weth } from 'abis/types'
 import WETH_ABI from 'abis/weth.json'
 import {
   ARGENT_WALLET_DETECTOR_ADDRESS,
@@ -80,6 +82,14 @@ export function useWETHContract(withSignerIfPossible?: boolean) {
     WETH_ABI,
     withSignerIfPossible
   )
+}
+
+export function useERC721Contract(nftAddress?: string) {
+  return useContract<Erc721>(nftAddress, ERC721_ABI, false)
+}
+
+export function useERC1155Contract(nftAddress?: string) {
+  return useContract<Erc1155>(nftAddress, ERC1155_ABI, false)
 }
 
 export function useArgentWalletDetectorContract() {

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -69,17 +69,22 @@ function useAvatarFromNode(node?: string): { avatar?: string; loading: boolean }
 function useAvatarFromNFT(nftUri = '', enforceOwnership: boolean): { avatar?: string; loading: boolean } {
   const { account } = useWeb3React()
   const parts = nftUri.toLowerCase().split(':')
+  // TODO: when backend supports other chain's NFTs, use the EIP155 chain ID here.
   const [contractAddress, id] = parts[2]?.split('/') ?? []
-  const { data, loading } = useNftAssetDetails(contractAddress, id)
-  const { owner } = useERC721Owner(contractAddress, id)
-  const { balance: erc1155Balance } = useERC1155BalanceForOwner(contractAddress, id, account)
+  const { data, loading: assetLoading } = useNftAssetDetails(contractAddress, id)
+  const { owner, loading: erc721OwnerLoading } = useERC721Owner(contractAddress, id)
+  const { balance: erc1155Balance, loading: erc1155BalanceLoading } = useERC1155BalanceForOwner(
+    contractAddress,
+    id,
+    account
+  )
   const isOwner = owner?.toLowerCase() === account?.toLowerCase() || erc1155Balance > 0
   return useMemo(() => {
     return {
       avatar: isOwner || !enforceOwnership ? data?.[0]?.imageUrl : undefined,
-      loading,
+      loading: assetLoading || erc721OwnerLoading || erc1155BalanceLoading,
     }
-  }, [data, enforceOwnership, isOwner, loading])
+  }, [assetLoading, data, enforceOwnership, erc1155BalanceLoading, erc721OwnerLoading, isOwner])
 }
 
 function useERC721Owner(


### PR DESCRIPTION
## Description

Use our GraphQL API for fetching the NFT image URL for an ENS Avatar

https://uniswaplabs.atlassian.net/browse/WEB-3104?atlOrigin=eyJpIjoiZGZmZmIwMDQ4ZTdiNDJiYjgyYjBjZWZlODFjYjc5NGMiLCJwIjoiaiJ9


## Screen Capture

NFT metadata working fine:

| Before  | After        |
| ---------------- |-----------------|
|  <img width="346" alt="image" src="https://user-images.githubusercontent.com/66155195/229938664-1ffd0c2d-fd61-46fb-bae0-be5b8d388566.png"> |  <img width="346" alt="image" src="https://user-images.githubusercontent.com/66155195/229939068-69b1c180-bf6b-453f-90a0-c76613469275.png"> |


NFT metadata wasn't working:
| Before  | After   (when comparing owner to onchain owner     |
| ---------------- |-----------------|
| [bug report](https://uniswaplabs.atlassian.net/browse/WEB-3104?atlOrigin=eyJpIjoiZTRjNzE2YzM2NTZmNDAxZDliMGRmNTJjZTUyMjRmODIiLCJwIjoiaiJ9)   |  <img width="346" alt="image" src="https://user-images.githubusercontent.com/66155195/229942414-8ef65e09-e4e9-4872-88b2-104aed356ed5.png"> |


## Test Plan
#### Manual

tested manually with an address that has an ENS avatar set to an owned NFT - it works the same for avatars that worked before, and it now works for avatars which were hitting cors issues on the previous implementation

#### Automated
- [ ] Unit test
- [x] Integration/E2E test
