### PR TITLE
test(e2e): configure cypress test retries for CI

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   videoUploadOnPasses: false,
   defaultCommandTimeout: 24000, // 2x average block time
   chromeWebSecurity: false,
+  retries: { runMode: 2 },
   e2e: {
     setupNodeEvents(on, config) {
       codeCoverageTask(on, config)


### PR DESCRIPTION
## Description

Configures retries for Cypress CI, as documented in https://docs.cypress.io/guides/guides/test-retries.
This run actually had a flake, and can be observed retrying: https://cloud.cypress.io/projects/yp82ef/runs/9498/test-results/37de495e-3340-4443-b76d-0b3a0f89e67f.

_Jira ticket:_ https://uniswaplabs.atlassian.net/browse/INFRA-165


## Test Plan
#### Automated
- [ ] <s>Unit test</s>
- [X] Integration/E2E test
