### PR TITLE
feat: remove amplitude swap error logging

### DIFF
--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,13 +1,10 @@
 import { Trans } from '@lingui/macro'
 import * as Sentry from '@sentry/react'
-import { sendAnalyticsEvent } from '@uniswap/analytics'
-import { SwapEventName } from '@uniswap/analytics-events'
 import { ButtonLight, SmallButtonPrimary } from 'components/Button'
 import { ChevronUpIcon } from 'nft/components/icons'
 import { useIsMobile } from 'nft/hooks'
 import React, { PropsWithChildren, useState } from 'react'
 import { Copy } from 'react-feather'
-import { useLocation } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { isSentryEnabled } from 'utils/env'
 
@@ -220,18 +217,14 @@ const updateServiceWorkerInBackground = async () => {
 }
 
 export default function ErrorBoundary({ children }: PropsWithChildren): JSX.Element {
-  const { pathname } = useLocation()
   return (
     <Sentry.ErrorBoundary
       fallback={({ error, eventId }) => <Fallback error={error} eventId={eventId} />}
       beforeCapture={(scope) => {
         scope.setLevel('fatal')
       }}
-      onError={(error) => {
+      onError={() => {
         updateServiceWorkerInBackground()
-        if (pathname === '/swap') {
-          sendAnalyticsEvent(SwapEventName.SWAP_ERROR, { error })
-        }
       }}
     >
       {children}


### PR DESCRIPTION
## Description
removes the Amplitude event for "Swap Error" from the main page of the app. this was intended to be used to compare relative error counts between versions of the app with the widget and without. Since we're no longer using the widget on this page, we can remove this logging.

original PR: https://github.com/Uniswap/interface/pull/6008


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] triggered an error by adding a manual throw in the code, and ensured that this callback ran but no amplitude event was logged



### Automated testing

<!-- If N/A, do not check nor delete, but strike through. -->
<!-- eg - [ ] <s>Unit test</s> -->
- [ ] <s>Unit test</s>
- [ ] <s>Integration/E2E test</s>
