### PR TITLE
feat: Update Subhead text to match Figma spec

### DIFF
--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -134,7 +134,7 @@ const Fallback = ({ error, eventId }: { error: Error; eventId: string | null }) 
               </Column>
               <CodeBlockWrapper>
                 <CodeTitle>
-                  <ThemedText.SubHeader fontWeight={500}>
+                  <ThemedText.SubHeader>
                     <Trans>Error ID: {eventId}</Trans>
                   </ThemedText.SubHeader>
                   <CopyToClipboard toCopy={eventId}>
@@ -166,7 +166,7 @@ const Fallback = ({ error, eventId }: { error: Error; eventId: string | null }) 
               </Column>
               <CodeBlockWrapper>
                 <CodeTitle>
-                  <ThemedText.SubHeader fontWeight={500}>Error details</ThemedText.SubHeader>
+                  <ThemedText.SubHeader>Error details</ThemedText.SubHeader>
                   <CopyToClipboard toCopy={errorDetails}>
                     <CopyIcon />
                   </CopyToClipboard>

--- a/src/components/Popups/TransactionPopup.tsx
+++ b/src/components/Popups/TransactionPopup.tsx
@@ -43,7 +43,7 @@ function TransactionPopupContent({ tx, chainId }: { tx: TransactionDetails; chai
           <PopupAlertTriangle />
         )
       }
-      title={<ThemedText.SubHeader fontWeight={500}>{activity.title}</ThemedText.SubHeader>}
+      title={<ThemedText.SubHeader>{activity.title}</ThemedText.SubHeader>}
       descriptor={
         <Descriptor color="textSecondary">
           {activity.descriptor}

--- a/src/components/WalletDropdown/AuthenticatedHeader.tsx
+++ b/src/components/WalletDropdown/AuthenticatedHeader.tsx
@@ -239,7 +239,7 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
           <StatusIcon connection={connection} size={40} />
           {account && (
             <AccountNamesWrapper>
-              <ThemedText.SubHeader color="textPrimary" fontWeight={500}>
+              <ThemedText.SubHeader>
                 <CopyText toCopy={ENSName ?? account}>{ENSName ?? shortenAddress(account, 4, 4)}</CopyText>
               </ThemedText.SubHeader>
               {/* Displays smaller view of account if ENS name was rendered above */}

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/ActivityRow.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/ActivityRow.tsx
@@ -48,7 +48,7 @@ export function ActivityRow({
             <PortfolioLogo chainId={chainId} currencies={currencies} images={logos} accountAddress={otherAccount} />
           </Column>
         }
-        title={<ThemedText.SubHeader fontWeight={500}>{title}</ThemedText.SubHeader>}
+        title={<ThemedText.SubHeader>{title}</ThemedText.SubHeader>}
         descriptor={
           <ActivityRowDescriptor color="textSecondary">
             {descriptor}

--- a/src/components/WalletDropdown/MiniPortfolio/Activity/ActivityTab.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/Activity/ActivityTab.tsx
@@ -140,7 +140,7 @@ export function ActivityTab({ account }: { account: string }) {
       <PortfolioTabWrapper>
         {activityGroups.map((activityGroup) => (
           <ActivityGroupWrapper key={activityGroup.title}>
-            <ThemedText.SubHeader color="textSecondary" fontWeight={500} marginLeft="16px">
+            <ThemedText.SubHeader color="textSecondary" marginLeft="16px">
               {activityGroup.title}
             </ThemedText.SubHeader>
             <Column>

--- a/src/components/WalletDropdown/MiniPortfolio/ExpandoRow.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/ExpandoRow.tsx
@@ -36,9 +36,7 @@ export function ExpandoRow({ title = t`Hidden`, numItems, isExpanded, toggle, ch
   return (
     <>
       <Row align="center" justify="space-between" padding="16px">
-        <ThemedText.SubHeader color="textSecondary" variant="subheadSmall">
-          {`${title} (${numItems})`}
-        </ThemedText.SubHeader>
+        <ThemedText.SubHeader variant="subheadSmall">{`${title} (${numItems})`}</ThemedText.SubHeader>
         <ToggleButton align="center" onClick={toggle}>
           <ThemedText.LabelSmall color="textSecondary" variant="buttonLabelSmall">
             {isExpanded ? t`Hide` : t`Show`}

--- a/src/components/WalletDropdown/MiniPortfolio/Pools/index.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/Pools/index.tsx
@@ -129,7 +129,7 @@ function PositionListItem({ positionInfo }: { positionInfo: PositionInfo }) {
         left={<PortfolioLogo chainId={chainId} currencies={[pool.token0, pool.token1]} />}
         title={
           <Row>
-            <ThemedText.SubHeader fontWeight={500}>
+            <ThemedText.SubHeader>
               {pool.token0.symbol} / {pool.token1?.symbol}
             </ThemedText.SubHeader>
           </Row>
@@ -148,7 +148,7 @@ function PositionListItem({ positionInfo }: { positionInfo: PositionInfo }) {
                 </div>
               }
             >
-              <ThemedText.SubHeader fontWeight={500}>
+              <ThemedText.SubHeader>
                 {formatNumber((liquidityValue ?? 0) + (feeValue ?? 0), NumberType.PortfolioBalance)}
               </ThemedText.SubHeader>
             </MouseoverTooltip>

--- a/src/components/WalletDropdown/MiniPortfolio/Tokens.tsx
+++ b/src/components/WalletDropdown/MiniPortfolio/Tokens.tsx
@@ -112,7 +112,7 @@ function TokenRow({ token, quantity, denominatedValue, tokenProjectMarket }: Tok
     >
       <PortfolioRow
         left={<PortfolioLogo chainId={currency.chainId} currencies={[currency]} size="40px" />}
-        title={<ThemedText.SubHeader fontWeight={500}>{token?.name}</ThemedText.SubHeader>}
+        title={<ThemedText.SubHeader>{token?.name}</ThemedText.SubHeader>}
         descriptor={
           <TokenBalanceText>
             {formatNumber(quantity, NumberType.TokenNonTx)} {token?.symbol}
@@ -122,7 +122,7 @@ function TokenRow({ token, quantity, denominatedValue, tokenProjectMarket }: Tok
         right={
           denominatedValue && (
             <>
-              <ThemedText.SubHeader fontWeight={500}>
+              <ThemedText.SubHeader>
                 {formatNumber(denominatedValue?.value, NumberType.PortfolioBalance)}
               </ThemedText.SubHeader>
               <Row justify="flex-end">

--- a/src/components/WalletDropdown/SlideOutMenu.tsx
+++ b/src/components/WalletDropdown/SlideOutMenu.tsx
@@ -49,7 +49,7 @@ export const SlideOutMenu = ({
     <Header>
       <StyledArrow data-testid="wallet-back" onClick={onClose} size={24} />
       <Title>
-        <ThemedText.SubHeader fontWeight={500}>{title}</ThemedText.SubHeader>
+        <ThemedText.SubHeader>{title}</ThemedText.SubHeader>
       </Title>
     </Header>
 

--- a/src/components/WalletDropdown/UniwalletModal.tsx
+++ b/src/components/WalletDropdown/UniwalletModal.tsx
@@ -112,7 +112,7 @@ function InfoSection({ onClose }: { onClose: () => void }) {
   return (
     <InfoSectionWrapper>
       <AutoColumn gap="4px">
-        <ThemedText.SubHeaderSmall color="textPrimary">
+        <ThemedText.SubHeaderSmall>
           <Trans>Don&apos;t have Uniswap Wallet?</Trans>
         </ThemedText.SubHeaderSmall>
         <ThemedText.Caption color="textSecondary">

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -181,7 +181,7 @@ export default function WalletModal({ openSettings }: { openSettings: () => void
   return (
     <Wrapper data-testid="wallet-modal">
       <AutoRow justify="space-between" width="100%" marginBottom="16px">
-        <ThemedText.SubHeader fontWeight={500}>Connect a wallet</ThemedText.SubHeader>
+        <ThemedText.SubHeader>Connect a wallet</ThemedText.SubHeader>
         <IconButton Icon={Settings} onClick={openSettings} data-testid="wallet-settings" />
       </AutoRow>
       {pendingError ? (

--- a/src/nft/components/collection/Sweep.tsx
+++ b/src/nft/components/collection/Sweep.tsx
@@ -366,7 +366,7 @@ export const Sweep = ({ contractAddress, minPrice, maxPrice }: SweepProps) => {
     <SweepContainer data-testid="nft-sweep-slider">
       <SweepLeftmostContainer>
         <SweepHeaderContainer>
-          <ThemedText.SubHeader color="textPrimary" lineHeight="20px" paddingTop="6px" paddingBottom="6px">
+          <ThemedText.SubHeader lineHeight="20px" paddingTop="6px" paddingBottom="6px">
             Sweep
           </ThemedText.SubHeader>
         </SweepHeaderContainer>

--- a/src/nft/components/details/AssetPriceDetails.tsx
+++ b/src/nft/components/details/AssetPriceDetails.tsx
@@ -241,9 +241,7 @@ const OwnerContainer = ({ asset }: { asset: WalletAsset }) => {
   return (
     <BestPriceContainer>
       <HeaderRow>
-        <ThemedText.SubHeader color="accentAction" fontWeight={500} lineHeight="24px">
-          {listing ? 'Your Price' : 'List for Sale'}
-        </ThemedText.SubHeader>
+        <ThemedText.SubHeader color="accentAction">{listing ? 'Your Price' : 'List for Sale'}</ThemedText.SubHeader>
         {listing && (
           <ExternalLink href={listing.marketplaceUrl}>
             <MarketplaceIcon alt={listing.marketplace} src={getMarketplaceIcon(listing.marketplace)} />
@@ -300,9 +298,7 @@ const NotForSale = ({ collectionName, collectionUrl }: { collectionName: string;
     <BestPriceContainer>
       <NotForSaleContainer>
         <CancelListingIcon width="79px" height="79px" color={theme.textTertiary} />
-        <ThemedText.SubHeader fontWeight={500} lineHeight="24px">
-          Not for sale
-        </ThemedText.SubHeader>
+        <ThemedText.SubHeader>Not for sale</ThemedText.SubHeader>
         <DiscoveryContainer>
           <ThemedText.BodySecondary fontSize="14px" lineHeight="20px">
             Discover similar NFTs for sale in
@@ -376,9 +372,7 @@ export const AssetPriceDetails = ({ asset, collection }: AssetPriceDetailsProps)
       ) : isForSale ? (
         <BestPriceContainer>
           <HeaderRow>
-            <ThemedText.SubHeader color="accentAction" fontWeight={500} lineHeight="24px">
-              Best Price
-            </ThemedText.SubHeader>
+            <ThemedText.SubHeader color="accentAction">Best Price</ThemedText.SubHeader>
             <ExternalLink href={cheapestOrder.marketplaceUrl}>
               <MarketplaceIcon alt={cheapestOrder.marketplace} src={getMarketplaceIcon(cheapestOrder.marketplace)} />
             </ExternalLink>

--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -251,7 +251,7 @@ export const ListPage = () => {
   }
 
   const BannerText = isMobile ? (
-    <ThemedText.SubHeader lineHeight="24px">
+    <ThemedText.SubHeader>
       <Trans>Receive</Trans>
     </ThemedText.SubHeader>
   ) : (

--- a/src/theme/components/text.tsx
+++ b/src/theme/components/text.tsx
@@ -53,8 +53,7 @@ export const ThemedText = {
     return <TextWrapper fontWeight={400} fontSize={20} color="textPrimary" {...props} />
   },
   SubHeader(props: TextProps) {
-    // @todo designs use `fontWeight: 500` and we currently have a mix of 600 and 500
-    return <TextWrapper fontWeight={600} fontSize={16} color="textPrimary" {...props} />
+    return <TextWrapper fontWeight={500} fontSize={16} color="textPrimary" lineHeight="24px" {...props} />
   },
   SubHeaderSmall(props: TextProps) {
     return <TextWrapper fontWeight={500} fontSize={14} color="textSecondary" {...props} />


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
This PR updates the `font-weight` and `line-height` for `ThemedText.Subheader` to match the spec in Figma. Here's an [example](https://www.figma.com/file/HOfzU6EFq4H5HNAIiH6Faa/FOR-v1.1?node-id=431-13762&t=tAyxBjGWKG5RgTiv-0) of where it's found in Figma. The previous values were off, so other PRs were using `sprinkles` css instead.

<!-- Delete this section if your change does not affect UI. -->

| Before                  | After (Desktop)        |
| ----------------------- |----------------------- |
| <img width="282" alt="image" src="https://user-images.githubusercontent.com/59578595/230213051-c91b83e7-665a-4dc2-8134-23602ce6cfb2.png"> |<img width="312" alt="image" src="https://user-images.githubusercontent.com/59578595/230213084-b5082473-5d67-4852-afdf-729b1445d21e.png"> |


## Test plan
Go to Vercel preview and look through all areas that use `ThemedText.Subheader` to see if they look ok!

List of places:
- LP ownership warning text
- LP position currency label 
- Error boundary error ID text
- Failed network switch popup text
- Transaction popup title text
- Balance amount text on token details page
+ all places changed in this PR

### Automated testing

- <s>[ ] Unit test</s>
- <s>[ ] Integration/E2E test
</s>