### PR TITLE
fix: remove "Received Swap Quote" field from Connect Wallet event

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -9,12 +9,10 @@ import PrefetchBalancesWrapper from 'components/WalletDropdown/PrefetchBalancesW
 import { useGetConnection } from 'connection'
 import { Portal } from 'nft/components/common/Portal'
 import { useIsNftClaimAvailable } from 'nft/hooks/useIsNftClaimAvailable'
-import { getIsValidSwapQuote } from 'pages/Swap'
 import { darken } from 'polished'
 import { useCallback, useMemo } from 'react'
 import { AlertTriangle } from 'react-feather'
 import { useAppSelector } from 'state/hooks'
-import { useDerivedSwapInfo } from 'state/swap/hooks'
 import styled from 'styled-components/macro'
 import { colors } from 'theme/colors'
 import { flexRowNoWrap } from 'theme/styles'
@@ -153,11 +151,6 @@ function Web3StatusInner() {
   const { account, connector, chainId, ENSName } = useWeb3React()
   const getConnection = useGetConnection()
   const connection = getConnection(connector)
-  const {
-    trade: { state: tradeState, trade },
-    inputError: swapInputError,
-  } = useDerivedSwapInfo()
-  const validSwapQuote = getIsValidSwapQuote(trade, tradeState, swapInputError)
   const [, toggleWalletDrawer] = useWalletDrawer()
   const handleWalletDropdownClick = useCallback(() => {
     sendAnalyticsEvent(InterfaceEventName.ACCOUNT_DROPDOWN_BUTTON_CLICKED)
@@ -223,7 +216,6 @@ function Web3StatusInner() {
       <TraceEvent
         events={[BrowserEvent.onClick]}
         name={InterfaceEventName.CONNECT_WALLET_BUTTON_CLICKED}
-        properties={{ received_swap_quote: validSwapQuote }}
         element={InterfaceElementName.CONNECT_WALLET_BUTTON}
       >
         <Web3StatusConnectWrapper

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -127,7 +127,7 @@ const DetailsSwapSection = styled(SwapSection)`
   border-top-right-radius: 0;
 `
 
-export function getIsValidSwapQuote(
+function getIsValidSwapQuote(
   trade: InterfaceTrade<Currency, Currency, TradeType> | undefined,
   tradeState: TradeState,
   swapInputError?: ReactNode


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
Removes the `received_swap_quote` field from the `CONNECT_WALLET_BUTTON_CLICKED` event.

This field is one of two places in the app where the global Swap State is actually accessed "globally" or not in the swap component. Since we are trying to make the swap state local to the swap component, we wanted to remove this.

It's ok to remove this field because we already log an event for this information, `SWAP_QUOTE_RECEIVED`, and it's possible to link the two events by user/session id on amplitude. Further, accessing the swap state at this point (connecting wallet) doesn't even give the most accurate representation of whether the user *has* received a quote, because it's actually checking the user currently has a quote loaded for the swap inputs at that moment.
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->

https://uniswapteam.slack.com/archives/C03JAKVATU6/p1680823555408989

https://www.notion.so/uniswaplabs/Swap-widget-replacement-work-bd91b44494d547259b4f29f4c36b3dfc


## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->

first, verify "swap quote received" is logged when wallet is not connected

<img width="753" alt="image" src="https://user-images.githubusercontent.com/66155195/230650655-7df81195-c8c0-477d-9fdd-bb1884461417.png">

then, click the  connect wallet button and verify the changed event:

<img width="753" alt="image" src="https://user-images.githubusercontent.com/66155195/230650755-6c36d878-ea1a-46e8-bc97-170ad84c54bb.png">


### Automated testing

<!-- If N/A, do not check nor delete, but strike through. -->
<!-- eg - [ ] <s>Unit test</s> -->
- <s>[ ] Unit test</s>
- <s>[ ] Integration/E2E test</s>
