### PR TITLE
ci: Emit to slack on merge to releases/* branch

### DIFF
--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -1,0 +1,41 @@
+name: Slack notifications for releases/* merges
+
+# This CI job will push notifications to Slack whenever code is merged into any of the
+# release branches.
+
+on:
+  push:
+    branches:
+      - 'releases/*'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  notify-slack:
+    name: 'Emit Slack notification(s)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send custom JSON data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        with:
+          payload: |
+            {
+              "text": "This is a really cool test!",
+              "blocks": [
+                {
+                    "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Cool tests can be cool"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -12,7 +12,7 @@ jobs:
     name: 'Emit Slack notification(s)'
     runs-on: ubuntu-latest
     steps:
-      - name: Parse event to Slack messages
+      - name: Parse event to slug
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         # This is a bit of shell kung fu that formats the contents of the GitHub event into a multi-line Slack message

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -20,9 +20,6 @@ on:
   push:
     branches:
       - 'releases/*'
-  pull_request:
-    branches:
-      - '**'
 
 jobs:
   notify-slack:

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -20,9 +20,6 @@ on:
   push:
     branches:
       - 'releases/*'
-  pull_request:
-    branches:
-      - '**'
 
 jobs:
   notify-slack:
@@ -30,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Parse event to slug
-        id: parse-slug
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         # Formats the contents of the GitHub event into slugs: one line per commit, formatted for Slack.
@@ -42,7 +38,7 @@ jobs:
           | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
           | sed 's/$/\\n/g' | tr -d '\n' \
           > /tmp/parsed_github_context
-          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_OUTPUT
+          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
@@ -75,7 +71,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.parse-slug.outputs.SLACK_COMMITS | 'New branch created' }}"
+                    "text": "${{ env.SLACK_COMMITS || 'New branch created' }}"
                   }
                 },
                 {

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Parse event to slug
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        # This is a bit of shell kung fu that formats the contents of the GitHub event into a multi-line Slack message
+        # Formats the contents of the GitHub event into slugs: one line per commit, formatted for Slack.
         # The steps are as follows:
         # 1. Pull commit data from the Github context and format it as a TSV with jq
         # 2. Clean up the TSV output so that it's more easily parsed by awk

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -43,7 +43,7 @@ jobs:
           | sed 's/$/\\n/g' | tr -d '\n' \
           > /tmp/parsed_github_context
           echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
-          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_CONTEXT
+          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $env:GITHUB_OUTPUT
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -7,22 +7,25 @@ on:
   push:
     branches:
       - 'releases/*'
-  pull_request:
-    branches:
-      - '**'
 
 jobs:
   notify-slack:
     name: 'Emit Slack notification(s)'
     runs-on: ubuntu-latest
     steps:
+      - name: Parse event to Slack messages
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo $GITHUB_CONTEXT | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' | sed 's/$/\\n/g' | tr -d '\n' > /tmp/foo
+          echo "SLACK_COMMITS=$(cat /tmp/foo)" >> $GITHUB_ENV
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
         with:
           payload: |
             {
-              "text": "This is a really cool test!",
+              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
               "blocks": [
                 {
                     "type": "divider"
@@ -31,7 +34,31 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Cool tests can be cool"
+                    "text": "*Code merged to <https://github.com/Uniswap/interface/tree/${{ github.ref }}|${{ github.ref_name }}> branch:*\n"
+                  }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Actor*: <https://github.com/${{ github.triggering_actor }}/|${{ github.triggering_actor }}>\n*Force pushed*: ${{ github.event.forced || false }}\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.SLACK_COMMITS || 'New branch created' }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.event.compare}}|View Diff>"
                   }
                 }
               ]

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -1,7 +1,6 @@
 name: Slack notifications for releases/* merges
 
-# This CI job will push notifications to Slack whenever code is merged into any of the
-# release branches.
+# This CI job will push notifications to Slack whenever code is merged into any releases/* branch
 
 on:
   push:
@@ -16,9 +15,17 @@ jobs:
       - name: Parse event to Slack messages
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+        # This is a bit of shell kung fu that formats the contents of the GitHub event into a multi-line Slack message
+        # The steps are as follows:
+        # 1. Pull commit data from the Github context and format it as a TSV with jq
+        # 2. Clean up the TSV output so that it's more easily parsed by awk
+        # 3. Use awk to format the TSV into a Slack message
+        # 4. Use sed and tr to deal with new-line escaping issues
+        # 5. Write the output to a file
+        # 6. Use Github action syntax to load the contents of the file into an environment variable
         run: |
-          echo $GITHUB_CONTEXT | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' | sed 's/$/\\n/g' | tr -d '\n' > /tmp/foo
-          echo "SLACK_COMMITS=$(cat /tmp/foo)" >> $GITHUB_ENV
+          echo $GITHUB_CONTEXT | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' | sed 's/$/\\n/g' | tr -d '\n' > /tmp/parsed_github_context
+          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -20,6 +20,9 @@ on:
   push:
     branches:
       - 'releases/*'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   notify-slack:

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -24,7 +24,12 @@ jobs:
         # 5. Write the output to a file
         # 6. Use Github action syntax to load the contents of the file into an environment variable
         run: |
-          echo $GITHUB_CONTEXT | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' | sed 's/$/\\n/g' | tr -d '\n' > /tmp/parsed_github_context
+          echo $GITHUB_CONTEXT \
+          | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' \
+          | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' \
+          | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
+          | sed 's/$/\\n/g' | tr -d '\n' \
+          > /tmp/parsed_github_context
           echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
       - name: Send custom JSON data to Slack workflow
         id: slack

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -30,17 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Parse event to slug
+        id: parse-slug
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         # Formats the contents of the GitHub event into slugs: one line per commit, formatted for Slack.
         # Explanation for each line is in the comments above.
         run: |
-          echo $GITHUB_CONTEXT \
-          | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' \
-          | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' \
-          | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
-          | sed 's/$/\\n/g' | tr -d '\n' \
-          > /tmp/parsed_github_context
+          echo $GITHUB_CONTEXT | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' | sed 's/$/\\n/g' | tr -d '\n' > /tmp/parsed_github_context
           echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
       - name: Send custom JSON data to Slack workflow
         id: slack

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -76,7 +76,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.SLACK_COMMITS || 'New branch created' }}"
+                    "text": "${{ steps.parse-slug.outputs.SLACK_COMMITS || 'New branch created' }}"
                   }
                 },
                 {

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -1,11 +1,28 @@
 name: Slack notifications for releases/* merges
 
 # This CI job will push notifications to Slack whenever code is merged into any releases/* branch
+#
+# The steps of the command line kung-fu shown below are as follows:
+# First we take the JSON-formatted Github context
+#  echo $GITHUB_CONTEXT \
+# Then we parse out the specific fields we want for our messages using jq and format it into tab-separated values
+#  | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' \
+# We need to do some cleaning on this output - specifically removing quotes and replacing newlines with something easier to split
+#  | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' \
+# We then use awk to format the TSV into a Slack message
+#  | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
+# Finally, we need to deal with some escaping issues with newlines so that we don't break the Slack message format
+#  | sed 's/$/\\n/g' | tr -d '\n' \
+# Then shove the bytes into a file to store them in their exact format
+#  > /tmp/parsed_github_context
 
 on:
   push:
     branches:
       - 'releases/*'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   notify-slack:
@@ -13,16 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Parse event to slug
+        id: parse-slug
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         # Formats the contents of the GitHub event into slugs: one line per commit, formatted for Slack.
-        # The steps are as follows:
-        # 1. Pull commit data from the Github context and format it as a TSV with jq
-        # 2. Clean up the TSV output so that it's more easily parsed by awk
-        # 3. Use awk to format the TSV into a Slack message
-        # 4. Use sed and tr to deal with new-line escaping issues
-        # 5. Write the output to a file
-        # 6. Use Github action syntax to load the contents of the file into an environment variable
+        # Explanation for each line is in the comments above.
         run: |
           echo $GITHUB_CONTEXT \
           | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' \
@@ -30,7 +42,7 @@ jobs:
           | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
           | sed 's/$/\\n/g' | tr -d '\n' \
           > /tmp/parsed_github_context
-          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
+          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_OUTPUT
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
@@ -63,7 +75,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.SLACK_COMMITS || 'New branch created' }}"
+                    "text": "${{ steps.parse-slug.outputs.SLACK_COMMITS | 'New branch created' }}"
                   }
                 },
                 {

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -42,7 +42,6 @@ jobs:
           | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
           | sed 's/$/\\n/g' | tr -d '\n' \
           > /tmp/parsed_github_context
-          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
           echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> "$GITHUB_OUTPUT"
       - name: Send custom JSON data to Slack workflow
         id: slack

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -36,8 +36,14 @@ jobs:
         # Formats the contents of the GitHub event into slugs: one line per commit, formatted for Slack.
         # Explanation for each line is in the comments above.
         run: |
-          echo $GITHUB_CONTEXT | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' | sed 's/$/\\n/g' | tr -d '\n' > /tmp/parsed_github_context
+          echo $GITHUB_CONTEXT \
+          | jq '.event.commits[] | [.url, .id[0:7], .author.username, .timestamp, .message] | @tsv' \
+          | sed 's/"//g' | sed 's/\\t/;/g' | sed 's/\\n/;/g' | sed 's/\\//g' \
+          | awk -F';' '{print "• <"$1"|"$2"> (<https://github.com/"$3"|"$3">, "$4") - "$5}' \
+          | sed 's/$/\\n/g' | tr -d '\n' \
+          > /tmp/parsed_github_context
           echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
+          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_CONTEXT
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844

--- a/.github/workflows/notify-slack-on-release-merge.yml
+++ b/.github/workflows/notify-slack-on-release-merge.yml
@@ -43,7 +43,7 @@ jobs:
           | sed 's/$/\\n/g' | tr -d '\n' \
           > /tmp/parsed_github_context
           echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $GITHUB_ENV
-          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> $env:GITHUB_OUTPUT
+          echo "SLACK_COMMITS=$(cat /tmp/parsed_github_context)" >> "$GITHUB_OUTPUT"
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844


### PR DESCRIPTION
## Description

This PR introduces a CI action that triggers on merge to any of the `releases/*` branches. When code is merged to any of the branches in question a message will be sent to Slack containing relevant information as to...

- Who merged the code?
- What was in the code?
- Was the merge a force push?

This in turn provides the UL engineering team with visibility into code changes for their CI pipeline.

## Test plan

### QA (ie manual testing)

This GH action definition was first committed to the PR with a `pull_request` target definition, meaning that it runs every time new code is committed to this PR.

I then confirmed that a test message was correctly sent to the expected Slack channel:

<img width="319" alt="image" src="https://user-images.githubusercontent.com/1545295/230655541-1e6f4dda-d370-4e66-a67f-d88a93049f5d.png">

The PR was then updated to have the correct information in the Slack message (which cannot be fully tested as the contents of the GH action context change depending on what the target type is).

Note that this updated Slack message content was copied from another UL repository where the formatting has already been tested and confirmed to work (please see #mobile-build-alerts channel for reference).