### PR TITLE
fix: switch back buttons in mini portfolio 

### DIFF
--- a/src/components/WalletDropdown/AuthenticatedHeader.tsx
+++ b/src/components/WalletDropdown/AuthenticatedHeader.tsx
@@ -287,6 +287,16 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
             <LoadingBubble height="16px" width="100px" margin="4px 0 20px 0" />
           </Column>
         )}
+        {!shouldDisableNFTRoutes && (
+          <HeaderButton
+            data-testid="nft-view-self-nfts"
+            onClick={navigateToProfile}
+            size={ButtonSize.medium}
+            emphasis={ButtonEmphasis.medium}
+          >
+            <Trans>View and sell NFTs</Trans>
+          </HeaderButton>
+        )}
         <HeaderButton
           size={ButtonSize.medium}
           emphasis={ButtonEmphasis.medium}
@@ -306,16 +316,6 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
             </>
           )}
         </HeaderButton>
-        {!shouldDisableNFTRoutes && (
-          <HeaderButton
-            data-testid="nft-view-self-nfts"
-            onClick={navigateToProfile}
-            size={ButtonSize.medium}
-            emphasis={ButtonEmphasis.medium}
-          >
-            <Trans>View and sell NFTs</Trans>
-          </HeaderButton>
-        )}
         {Boolean(!fiatOnrampAvailable && fiatOnrampAvailabilityChecked) && (
           <FiatOnrampNotAvailableText marginTop="8px">
             <Trans>Not available in your region</Trans>


### PR DESCRIPTION
Seems like these buttons were switched around mini portfolio launch. We want them to be switched back so the not available in region message shows right beneath Buy crypto button. 

currently in prod: 
<img width="436" alt="Screen Shot 2023-04-10 at 12 06 25 PM" src="https://user-images.githubusercontent.com/41491154/230942456-625acf90-7607-4f11-84bf-19ede0c05183.png">

what we want in prod: 
<img width="412" alt="Screen Shot 2023-04-10 at 12 05 28 PM" src="https://user-images.githubusercontent.com/41491154/230942457-2acc731d-d0f9-4046-85f7-25413760904a.png">
