### PR TITLE
fix: ignores "user rejected transaction" errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -19,4 +19,9 @@ describe('filterKnownErrors', () => {
     const originalException = new Error('underlying network changed')
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
+
+  it('filters user rejected request errors', () => {
+    const originalException = new Error('user rejected request')
+    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+  })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -21,7 +21,7 @@ describe('filterKnownErrors', () => {
   })
 
   it('filters user rejected request errors', () => {
-    const originalException = new Error('user rejected request')
+    const originalException = new Error('user rejected transaction')
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -21,6 +21,9 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
 
     // If the error is a network change, it should not be considered an exception.
     if (error.message.match(/underlying network changed/)) return null
+
+    // If the error is based on a user rejecting, it should not be considered an exception.
+    if (error.message.match(/user rejected transaction/)) return null
   }
 
   return event

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,4 +1,5 @@
 import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
+import { didUserReject } from 'utils/swapErrorToUserReadableMessage'
 
 /** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
 function isEthersRequestError(error: Error): error is Error & { requestBody: string } {
@@ -23,7 +24,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     if (error.message.match(/underlying network changed/)) return null
 
     // If the error is based on a user rejecting, it should not be considered an exception.
-    if (error.message.match(/user rejected transaction/)) return null
+    if (didUserReject(error)) return null
   }
 
   return event


### PR DESCRIPTION
## Description
As part of a plan to reduce the number of Sentry errors, we are going through the most common issues and either fixing or catching errors.

This one is here: https://uniswap-labs.sentry.io/issues/4066659882/?project=4504255148851200&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=17

In this case, it's not caught by the error boundary (as seen because it says `handled: no`). We don't need to log this error because user rejections are considered valid, and are not actually an error in our product.

JIRA ticket: https://uniswaplabs.atlassian.net/browse/WEB-3187

## Test plan
I added a test here to show that user rejected error matching strings should get filtered out.

### Automated testing
- [x] Unit test
- [x] Integration/E2E test (N/A)
