### PR TITLE
fix: ignore ethers call revert exceptions

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -21,9 +21,9 @@ describe('filterKnownErrors', () => {
   })
 
   it('filters call revert errors', () => {
-    const originalException = new Error(
-      'call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ]'
-    )
+    const originalException = new (class extends Error {
+      requestBody = JSON.stringify({ method: 'collect((uint256,address,uint128,uint128))' })
+    })()
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -19,4 +19,11 @@ describe('filterKnownErrors', () => {
     const originalException = new Error('underlying network changed')
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
+
+  it('filters call revert errors', () => {
+    const originalException = new Error(
+      'call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ]'
+    )
+    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+  })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -22,7 +22,7 @@ describe('filterKnownErrors', () => {
 
   it('filters call revert errors', () => {
     const originalException = new (class extends Error {
-      requestBody = JSON.stringify({ method: 'collect((uint256,address,uint128,uint128))' })
+      requestBody = JSON.stringify({ code: 'CALL_EXCEPTION' })
     })()
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -17,9 +17,10 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
       // If block number polling fails, it should not be considered an exception.
       if (method === 'eth_blockNumber') return null
 
+      const code = JSON.parse(error.requestBody).code
       // For now, these errors are not actionable so we should not report them.
       // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
-      if (method.startsWith('collect(')) return null
+      if (code.startsWith('CALL_EXCEPTION')) return null
     }
 
     // If the error is a network change, it should not be considered an exception.

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -5,7 +5,6 @@ function isEthersRequestError(error: Error): error is Error & { requestBody: str
   return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }
 /**
-
  * Filters known (ignorable) errors out before sending them to Sentry.
  * Intended as a {@link ClientOptions.beforeSend} callback. Returning null filters the error from Sentry.
  */
@@ -17,11 +16,11 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
       // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
       // If block number polling fails, it should not be considered an exception.
       if (method === 'eth_blockNumber') return null
-    }
 
-    // For now, these errors are not actionable so we should not report them.
-    // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
-    if (error.message.match(/call revert exception/)) return null
+      // For now, these errors are not actionable so we should not report them.
+      // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
+      if (method.startsWith('collect(')) return null
+    }
 
     // If the error is a network change, it should not be considered an exception.
     if (error.message.match(/underlying network changed/)) return null

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -2,6 +2,7 @@ import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
 
 /** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
 function isEthersRequestError(error: Error): error is Error & { requestBody: string } {
+  if (error.message.match(/call revert exception/)) return true
   return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }
 

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -15,7 +15,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     if (isEthersRequestError(error)) {
       const method = JSON.parse(error.requestBody).method
       // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
-      // If block number polling, it should not be considered an exception.
+      // If block number polling fails, it should not be considered an exception.
       if (method === 'eth_blockNumber') return null
     }
 

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -19,7 +19,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
       if (method === 'eth_blockNumber') return null
     }
 
-    // for now, these errors are not actionable so we should not report them.
+    // For now, these errors are not actionable so we should not report them.
     // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
     if (error.message.match(/call revert exception/)) return null
 

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -17,10 +17,11 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
       // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
       // If block number polling, it should not be considered an exception.
       if (method === 'eth_blockNumber') return null
-      // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
-      // for now, these errors are not actionable so we should not report them.
-      if (error.message.match(/call revert exception/)) return null
     }
+
+    // for now, these errors are not actionable so we should not report them.
+    // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
+    if (error.message.match(/call revert exception/)) return null
 
     // If the error is a network change, it should not be considered an exception.
     if (error.message.match(/underlying network changed/)) return null

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -2,22 +2,24 @@ import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
 
 /** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
 function isEthersRequestError(error: Error): error is Error & { requestBody: string } {
-  if (error.message.match(/call revert exception/)) return true
   return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }
-
 /**
+
  * Filters known (ignorable) errors out before sending them to Sentry.
  * Intended as a {@link ClientOptions.beforeSend} callback. Returning null filters the error from Sentry.
  */
 export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: ErrorEvent, hint: EventHint) => {
   const error = hint.originalException
   if (error instanceof Error) {
-    // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
-    // If block number polling, it should not be considered an exception.
     if (isEthersRequestError(error)) {
       const method = JSON.parse(error.requestBody).method
+      // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
+      // If block number polling, it should not be considered an exception.
       if (method === 'eth_blockNumber') return null
+      // ethers exceptions are currently not caught in the codebase because we don't try/catch all provider calls.
+      // for now, these errors are not actionable so we should not report them.
+      if (error.message.match(/call revert exception/)) return null
     }
 
     // If the error is a network change, it should not be considered an exception.


### PR DESCRIPTION
As part of a plan to reduce the number of Sentry errors, we are going through the most common issues and either fixing or catching errors.

This one is here: https://uniswap-labs.sentry.io/issues/4076446793/?project=4504255148851200&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=1

In this case, it's not caught by the error boundary (as seen because it says handled: no).

This is caused when there is an error thrown by an ethers call. The issue is we do not wrap all provider calls in try/catch, even though any of them are capable of failing. Over time we should start doing this but for now these errors are not actionable.

JIRA ticket: https://uniswaplabs.atlassian.net/browse/WEB-3187

Test plan
I added a test here to show that user rejected error matching strings should get filtered out.

Automated testing
 Unit test (need to fix this)
 Integration/E2E test ✅  (N/A)