### PR TITLE
feat: hide looksrare until we can support their sdk

### DIFF
--- a/src/nft/utils/listNfts.ts
+++ b/src/nft/utils/listNfts.ts
@@ -37,11 +37,12 @@ export const ListingMarkets: ListingMarket[] = [
     fee: 0.5,
     icon: '/nft/svgs/marketplaces/x2y2.svg',
   },
-  {
-    name: 'LooksRare',
-    fee: 1.5,
-    icon: '/nft/svgs/marketplaces/looksrare.svg',
-  },
+  // Hiding LooksRare until we can support their v2 SDK
+  // {
+  //   name: 'LooksRare',
+  //   fee: 1.5,
+  //   icon: '/nft/svgs/marketplaces/looksrare.svg',
+  // },
   {
     name: 'OpenSea',
     fee: 0,

--- a/src/nft/utils/listNfts.ts
+++ b/src/nft/utils/listNfts.ts
@@ -37,12 +37,6 @@ export const ListingMarkets: ListingMarket[] = [
     fee: 0.5,
     icon: '/nft/svgs/marketplaces/x2y2.svg',
   },
-  // Hiding LooksRare until we can support their v2 SDK
-  // {
-  //   name: 'LooksRare',
-  //   fee: 1.5,
-  //   icon: '/nft/svgs/marketplaces/looksrare.svg',
-  // },
   {
     name: 'OpenSea',
     fee: 0,


### PR DESCRIPTION
## Description
LR will no longer support orders to their v1 endpoint starting tomorrow 04/12. To upgrade to their v2 sdk will require updating our node version from 14 to 16 or getting LR to support 14, both solutions likely requiring more time than we have. In the interim this PR hides LR as a listing marketplace.

**Out of scope:**
Adding any logic to support listing to LR v2. All of that logic will be kept to its own PR(s). This PR is strictly to hide our current feature which will no longer work as of 04/12.


_Slack thread:_ [endpoint deprecation announcement](https://uniswapteam.slack.com/archives/C03RB5AEHDK/p1680808568805939)


## Screen capture

With hidden LR marketplace
<img width="1262" alt="Screen Shot 2023-04-11 at 10 20 10 " src="https://user-images.githubusercontent.com/11512321/231241332-ec015ed1-5695-4695-a2a0-f927b2b032ed.png">

