### PR TITLE
fix: handle fee collect error

### DIFF
--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -514,6 +514,10 @@ export function PositionPage() {
               expectedCurrencyOwed1: CurrencyAmount.fromRawAmount(currency1ForFeeCollectionPurposes, 0).toExact(),
             })
           })
+          .catch((error) => {
+            setCollecting(false)
+            console.error(error)
+          })
       })
       .catch((error) => {
         setCollecting(false)


### PR DESCRIPTION
## Description
This change solves a bug where a provider call fails and causes the error boundary to be reached. You will see the error reported here: https://uniswap-labs.sentry.io/issues/4079703285/?project=4504255148851200&query=is%3Aunresolved+call+revert+exception&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=1

## Test plan
### Reproducing the error
1. Change the `.then` in related promise to throw an Error.
2. Confirm that it is caught and the collecting state goes back to false.

#### Devices
I only tested on Desktop Chrome for this.

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test (WIP)
- [x ] Integration/E2E test (N/A)
