### PR TITLE
test: add test for position page states

### DIFF
--- a/cypress/e2e/position.test.ts
+++ b/cypress/e2e/position.test.ts
@@ -1,0 +1,11 @@
+describe('Position', () => {
+  it('shows an valid state on a supported network', () => {
+    cy.visit('/pools/1')
+    cy.contains('UNI / ETH')
+  })
+
+  it('shows an invalid state on a supported network', () => {
+    cy.visit('/pools/788893')
+    cy.contains('To view a position, you must be connected to the network it belongs to.')
+  })
+})


### PR DESCRIPTION
## Description
Adds tests for the position pages, both invalid and valid pools. This sets us up for the next PR, which will make sure that unsupported chains also show the invalid state vs crashing.

#### Devices
The test works on Chrome only right now, since it's through Cypress.

### Automated testing
- [x] Unit test (n/a)
- [x] Integration/E2E test