### PR TITLE
build: add chainId as tag in sentry ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import * as Sentry from '@sentry/react'
+import { useWeb3React } from '@web3-react/core'
 import { ButtonLight, SmallButtonPrimary } from 'components/Button'
 import { ChevronUpIcon } from 'nft/components/icons'
 import { useIsMobile } from 'nft/hooks'
@@ -217,11 +218,13 @@ const updateServiceWorkerInBackground = async () => {
 }
 
 export default function ErrorBoundary({ children }: PropsWithChildren): JSX.Element {
+  const { chainId } = useWeb3React()
   return (
     <Sentry.ErrorBoundary
       fallback={({ error, eventId }) => <Fallback error={error} eventId={eventId} />}
       beforeCapture={(scope) => {
         scope.setLevel('fatal')
+        scope.setTag('chain_id', chainId)
       }}
       onError={() => {
         updateServiceWorkerInBackground()

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,6 +1,5 @@
 import { Trans } from '@lingui/macro'
 import * as Sentry from '@sentry/react'
-import { useWeb3React } from '@web3-react/core'
 import { ButtonLight, SmallButtonPrimary } from 'components/Button'
 import { ChevronUpIcon } from 'nft/components/icons'
 import { useIsMobile } from 'nft/hooks'
@@ -218,13 +217,11 @@ const updateServiceWorkerInBackground = async () => {
 }
 
 export default function ErrorBoundary({ children }: PropsWithChildren): JSX.Element {
-  const { chainId } = useWeb3React()
   return (
     <Sentry.ErrorBoundary
       fallback={({ error, eventId }) => <Fallback error={error} eventId={eventId} />}
       beforeCapture={(scope) => {
         scope.setLevel('fatal')
-        scope.setTag('chainId', chainId)
       }}
       onError={() => {
         updateServiceWorkerInBackground()

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import * as Sentry from '@sentry/react'
+import { useWeb3React } from '@web3-react/core'
 import { ButtonLight, SmallButtonPrimary } from 'components/Button'
 import { ChevronUpIcon } from 'nft/components/icons'
 import { useIsMobile } from 'nft/hooks'
@@ -217,11 +218,13 @@ const updateServiceWorkerInBackground = async () => {
 }
 
 export default function ErrorBoundary({ children }: PropsWithChildren): JSX.Element {
+  const { chainId } = useWeb3React()
   return (
     <Sentry.ErrorBoundary
       fallback={({ error, eventId }) => <Fallback error={error} eventId={eventId} />}
       beforeCapture={(scope) => {
         scope.setLevel('fatal')
+        scope.setTag('chainId', chainId)
       }}
       onError={() => {
         updateServiceWorkerInBackground()

--- a/src/components/Web3Provider/index.tsx
+++ b/src/components/Web3Provider/index.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react'
 import { useWeb3React, Web3ReactHooks, Web3ReactProvider } from '@web3-react/core'
 import { Connector } from '@web3-react/types'
 import { isSupportedChain } from 'constants/chains'
@@ -26,6 +27,10 @@ function Tracer() {
   const { chainId, provider } = useWeb3React()
   const networkProvider = isSupportedChain(chainId) ? RPC_PROVIDERS[chainId] : undefined
   const shouldTrace = useTraceJsonRpcFlag() === TraceJsonRpcVariant.Enabled
+
+  useEffect(() => {
+    Sentry.setTag('chain_id', chainId)
+  }, [chainId])
 
   useEffect(() => {
     if (shouldTrace) {

--- a/src/components/Web3Provider/index.tsx
+++ b/src/components/Web3Provider/index.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react'
 import { useWeb3React, Web3ReactHooks, Web3ReactProvider } from '@web3-react/core'
 import { Connector } from '@web3-react/types'
 import { isSupportedChain } from 'constants/chains'
@@ -27,10 +26,6 @@ function Tracer() {
   const { chainId, provider } = useWeb3React()
   const networkProvider = isSupportedChain(chainId) ? RPC_PROVIDERS[chainId] : undefined
   const shouldTrace = useTraceJsonRpcFlag() === TraceJsonRpcVariant.Enabled
-
-  useEffect(() => {
-    Sentry.setTag('chain_id', chainId)
-  }, [chainId])
 
   useEffect(() => {
     if (shouldTrace) {


### PR DESCRIPTION
## Description
Adds `chain_id` as a tag in sentry logs from the ErrorBoundary. This means "handled" events will have the tag, and async events will not yet. Will add that support in a separate PR so that we can start instrumenting this sooner to debug some issues. This will allow us to filter by chain_id for events, and also see which chains are causing errors most often for different errors.

https://uniswapteam.slack.com/archives/C050USFTS5B/p1681254541015739

## Test plan
### QA (ie manual testing)
Manually create an error, and verify that it is sent to Sentry with a chainId as a tag.
<img width="641" alt="Screen Shot 2023-04-12 at 2 27 04 PM" src="https://user-images.githubusercontent.com/4899429/231551034-7694c607-70b1-40a3-a0e8-fff2c80a14d4.png">


### Automated testing
- [x] Unit test (N/A)
- [x] Integration/E2E test (N/A)
