### PR TITLE
build: send url without hash to sentry

### DIFF
--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -6,6 +6,20 @@ function isEthersRequestError(error: Error): error is Error & { requestBody: str
   return 'requestBody' in error && typeof (error as unknown as Record<'requestBody', unknown>).requestBody === 'string'
 }
 
+export function beforeSend(event: ErrorEvent, hint: EventHint) {
+  /*
+   * Since the interface currently uses HashRouter, URLs will have a # before the path.
+   * This leads to issues when we send the URL into Sentry, as the path gets parsed as a "fragment".
+   * Instead, this logic removes the # part of the URL.
+   * See https://romain-clement.net/articles/sentry-url-fragments/#url-fragments
+   **/
+  if (event.request?.url) {
+    event.request.url = event.request.url.replace('/#', '')
+  }
+
+  return filterKnownErrors(event, hint)
+}
+
 /**
  * Filters known (ignorable) errors out before sending them to Sentry.
  * Intended as a {@link ClientOptions.beforeSend} callback. Returning null filters the error from Sentry.

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -2,13 +2,12 @@ import 'components/analytics'
 
 import * as Sentry from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'
-import { ErrorEvent, EventHint } from '@sentry/types'
 import { initializeAnalytics, OriginApplication } from '@uniswap/analytics'
 import { SharedEventName } from '@uniswap/analytics-events'
 import { isSentryEnabled } from 'utils/env'
 import { getEnvName, isProductionEnv } from 'utils/env'
 
-import { filterKnownErrors } from './errors'
+import { beforeSend } from './errors'
 
 export { trace } from './trace'
 
@@ -18,20 +17,6 @@ window.GIT_COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
 // Actual KEYs are set by proxy servers.
 const AMPLITUDE_DUMMY_KEY = '00000000000000000000000000000000'
 export const STATSIG_DUMMY_KEY = 'client-0000000000000000000000000000000000000000000'
-
-export function beforeSend(event: ErrorEvent, hint: EventHint) {
-  /*
-   * Since the interface currently uses HashRouter, URLs will have a # before the path.
-   * This leads to issues when we send the URL into Sentry, as the path gets parsed as a "fragment".
-   * Instead, this logic removes the # part of the URL.
-   * See https://romain-clement.net/articles/sentry-url-fragments/#url-fragments
-   **/
-  if (event.request?.url) {
-    event.request.url = event.request.url.replace('/#', '')
-  }
-
-  return filterKnownErrors(event, hint)
-}
 
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -32,7 +32,7 @@ Sentry.init({
     }),
   ],
   beforeSend(event: ErrorEvent, hint: EventHint) {
-    /**
+    /*
      * Since the interface currently uses HashRouter, URLs will have a # before the path.
      * This leads to issues when we send the URL into Sentry, as the path gets parsed as a "fragment".
      * Instead, this logic removes the # part of the URL.

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -36,7 +36,7 @@ Sentry.init({
      * Since the interface currently uses HashRouter, URLs will have a # before the path.
      * This leads to issues when we send the URL into Sentry, as the path gets parsed as a "fragment".
      * Instead, this logic removes the # part of the URL.
-     * More context here: https://romain-clement.net/articles/sentry-url-fragments/#url-fragments
+     * See https://romain-clement.net/articles/sentry-url-fragments/#url-fragments
      **/
     if (event.request?.url) {
       event.request.url = event.request.url.replace('/#', '')

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -2,7 +2,9 @@ import '@sentry/tracing' // required to populate Sentry.startTransaction, which 
 
 import * as Sentry from '@sentry/react'
 import { Transaction } from '@sentry/tracing'
+import { ErrorEvent, EventHint } from '@sentry/types'
 import assert from 'assert'
+import { beforeSend } from 'tracing'
 
 import { trace } from './trace'
 
@@ -81,6 +83,41 @@ describe('trace', () => {
       })
       const transaction = getTransaction()
       expect(transaction.tags).toEqual({ is_widget: true })
+    })
+  })
+
+  describe('beforeSend', () => {
+    it('handles no path', async () => {
+      const errorEvent: ErrorEvent = {
+        type: undefined,
+        request: {
+          url: 'https://app.uniswap.org',
+        },
+      }
+      const eventHint: EventHint = {}
+      expect((beforeSend(errorEvent, eventHint) as ErrorEvent)?.request?.url).toEqual('https://app.uniswap.org')
+    })
+
+    it('handles hash with path', async () => {
+      const errorEvent: ErrorEvent = {
+        type: undefined,
+        request: {
+          url: 'https://app.uniswap.org/#/pools',
+        },
+      }
+      const eventHint: EventHint = {}
+      expect((beforeSend(errorEvent, eventHint) as ErrorEvent)?.request?.url).toEqual('https://app.uniswap.org/pools')
+    })
+
+    it('handles just hash', async () => {
+      const errorEvent: ErrorEvent = {
+        type: undefined,
+        request: {
+          url: 'https://app.uniswap.org/#',
+        },
+      }
+      const eventHint: EventHint = {}
+      expect((beforeSend(errorEvent, eventHint) as ErrorEvent)?.request?.url).toEqual('https://app.uniswap.org')
     })
   })
 

--- a/src/tracing/trace.test.ts
+++ b/src/tracing/trace.test.ts
@@ -4,8 +4,8 @@ import * as Sentry from '@sentry/react'
 import { Transaction } from '@sentry/tracing'
 import { ErrorEvent, EventHint } from '@sentry/types'
 import assert from 'assert'
-import { beforeSend } from 'tracing'
 
+import { beforeSend } from './errors'
 import { trace } from './trace'
 
 jest.mock('@sentry/react', () => {


### PR DESCRIPTION
## Description
Re-writes the URL sent to Sentry logs to not have a hash in it. We use HashRouter from react-router to support IPFS, but this leads to issues in Sentry where the hash is picked up as a fragment (see https://romain-clement.net/articles/sentry-url-fragments/#url-fragments).

Instead, we use the method shown in that post to remove the hash in the url.
app.uniswap.org -> app.uniswap.org
app.uniswap.org/# -> app.uniswap.org
app.uniswap.org/#/pools -> app.uniswap.org/pools

_Slack thread:_ https://uniswapteam.slack.com/archives/C050USFTS5B/p1681312677826209

### QA (ie manual testing)
![image](https://user-images.githubusercontent.com/4899429/231563094-ae7cea10-6291-4bb3-bab8-bb51130d8c33.png)
![image](https://user-images.githubusercontent.com/4899429/231563110-86960bf3-4ef0-4d31-894d-751194483509.png)

### Automated testing
- [x] Unit test
- [x] Integration/E2E test (N/A)
