### PR TITLE
fix: App crashing when changing sorting or toggling usd price on trneding NFTs table

### DIFF
--- a/src/nft/components/explore/Cells/Cells.tsx
+++ b/src/nft/components/explore/Cells/Cells.tsx
@@ -114,8 +114,8 @@ export const EthCell = ({
   denomination: Denomination
   usdPrice?: number
 }) => {
-  const denominatedValue = getDenominatedValue(denomination, true, value, usdPrice)
   const isNftGraphqlEnabled = useNftGraphqlEnabled()
+  const denominatedValue = getDenominatedValue(denomination, !isNftGraphqlEnabled, value, usdPrice)
   const formattedValue = denominatedValue
     ? denomination === Denomination.ETH
       ? isNftGraphqlEnabled

--- a/src/nft/components/explore/CollectionTable.tsx
+++ b/src/nft/components/explore/CollectionTable.tsx
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { useNftGraphqlEnabled } from 'featureFlags/flags/nftlGraphql'
 import { CollectionTableColumn, TimePeriod } from 'nft/types'
 import { useMemo } from 'react'
 import { CellProps, Column, Row } from 'react-table'
@@ -26,18 +27,23 @@ const compareFloats = (a?: number, b?: number): 1 | -1 => {
 }
 
 const CollectionTable = ({ data, timePeriod }: { data: CollectionTableColumn[]; timePeriod: TimePeriod }) => {
+  const isNftGraphqlEnabled = useNftGraphqlEnabled()
   const floorSort = useMemo(() => {
     return (rowA: Row<CollectionTableColumn>, rowB: Row<CollectionTableColumn>) => {
-      const aFloor = BigNumber.from(rowA.original.floor.value ?? 0)
-      const bFloor = BigNumber.from(rowB.original.floor.value ?? 0)
+      if (isNftGraphqlEnabled) {
+        return compareFloats(rowA.original.floor.value, rowB.original.floor.value)
+      } else {
+        const aFloor = BigNumber.from(rowA.original.floor.value ?? 0)
+        const bFloor = BigNumber.from(rowB.original.floor.value ?? 0)
 
-      return aFloor.gte(bFloor) ? 1 : -1
+        return aFloor.gte(bFloor) ? 1 : -1
+      }
     }
-  }, [])
+  }, [isNftGraphqlEnabled])
 
   const floorChangeSort = useMemo(() => {
     return (rowA: Row<CollectionTableColumn>, rowB: Row<CollectionTableColumn>) => {
-      return compareFloats(rowA.original.floor.change, rowB.original.floor.change)
+      return compareFloats(rowA.original.floor.value, rowB.original.floor.change)
     }
   }, [])
 

--- a/src/nft/components/explore/CollectionTable.tsx
+++ b/src/nft/components/explore/CollectionTable.tsx
@@ -43,7 +43,7 @@ const CollectionTable = ({ data, timePeriod }: { data: CollectionTableColumn[]; 
 
   const floorChangeSort = useMemo(() => {
     return (rowA: Row<CollectionTableColumn>, rowB: Row<CollectionTableColumn>) => {
-      return compareFloats(rowA.original.floor.value, rowB.original.floor.change)
+      return compareFloats(rowA.original.floor.change, rowB.original.floor.change)
     }
   }, [])
 


### PR DESCRIPTION
## Description
We recently swapped out endpoint for trending collections from heroku to graphql. Floor prices previously given in wei are now given in eth. We checked for this in several locations but missed when a user toggles to see USD prices instead of eth and when a user sorts by floor price. This PR adds those checks.

As a not we generally remove the flag after a week of being live. This feature was launched Monday so sometime next week we will be removing the nftGraphQl flag and defaulting to the true case.


<!-- Delete inapplicable lines: -->
_JIRA ticket:_ https://uniswaplabs.atlassian.net/browse/NFT-1180?atlOrigin=eyJpIjoiMWI3NzAwYzI0NzhkNGY2NGI4ODQ2OTgxYzQxOWNhZDAiLCJwIjoiamlyYS1zbGFjay1pbnQifQ
_Slack thread:_ https://uniswapteam.slack.com/archives/C04BVC4J5HU/p1681327827268469
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

Testing all variations on table
![workingSorting](https://user-images.githubusercontent.com/11512321/231569926-a8c70de4-be35-44ea-a556-9c06405804e0.gif)


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Toggle price from eth to usd on Trending NFTs table
2. Sort by floor price on trending NFTs table

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] I tested all variations of sorting for both eth and usd, all work as expected. Shown via screen capture
