### PR TITLE
fix: ignore error caused by Cloudflare HTML response

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -24,4 +24,9 @@ describe('filterKnownErrors', () => {
     const originalException = new Error('user rejected transaction')
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
+
+  it('filters invalid HTML response errors', () => {
+    const originalException = new Error("Unexpected token '<'")
+    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+  })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -26,7 +26,7 @@ describe('filterKnownErrors', () => {
   })
 
   it('filters invalid HTML response errors', () => {
-    const originalException = new Error("Unexpected token '<'")
+    const originalException = new SyntaxError("Unexpected token '<'")
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -28,7 +28,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
 
     // Cloudflare may serve HTML error pages (eg from a 499), which are already raised as ChunkLoadError.
     // Parsing the HTML results in a second SyntaxError. This not the root error (it is already reported as ChunkLoadError), so it should not be reported.
-    if (error.message.match(/Unexpected token '<'/)) return null
+    if (error instanceof SyntaxError && error.message.match(/Unexpected token '<'/)) return null
   }
 
   return event

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -26,9 +26,12 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     // If the error is based on a user rejecting, it should not be considered an exception.
     if (didUserReject(error)) return null
 
-    // Cloudflare may serve HTML error pages (eg from a 499), which are already raised as ChunkLoadError.
-    // Parsing the HTML results in a second SyntaxError. This not the root error (it is already reported as ChunkLoadError), so it should not be reported.
-    if (error instanceof SyntaxError && error.message.match(/Unexpected token '<'/)) return null
+    /*
+     * This is caused by HTML being returned for a chunk from Cloudflare.
+     * Usually, it's the result of a 499 exception right before it, which should be handled.
+     * Therefore, this can be ignored.
+     */
+    if (error.message.match(/Unexpected token '<'/)) return null
   }
 
   return event

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -25,6 +25,11 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
 
     // If the error is based on a user rejecting, it should not be considered an exception.
     if (didUserReject(error)) return null
+
+    // This is caused by HTML being returned for a chunk from Cloudflare.
+    // Usually, it's the result of a 499 exception right before it, which should be handled.
+    // Therefore, this can be ignored.
+    if (error.message.match(/Unexpected token '<'/)) return null
   }
 
   return event

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -26,9 +26,8 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     // If the error is based on a user rejecting, it should not be considered an exception.
     if (didUserReject(error)) return null
 
-    // This is caused by HTML being returned for a chunk from Cloudflare.
-    // Usually, it's the result of a 499 exception right before it, which should be handled.
-    // Therefore, this can be ignored.
+    // Cloudflare may serve HTML error pages (eg from a 499), which are already raised as ChunkLoadError.
+    // Parsing the HTML results in a second SyntaxError. This not the root error (it is already reported as ChunkLoadError), so it should not be reported.
     if (error.message.match(/Unexpected token '<'/)) return null
   }
 


### PR DESCRIPTION
## Description
This is caused by HTML being returned for a chunk from Cloudflare. Usually, it's the result of a 499 exception right before it, which should be handled. Therefore, this can be ignored.

In the future, there will be a PR that handles the 499 exceptions via Cloudflare to ignore those exceptions in logging as well.

_JIRA ticket:_ https://uniswaplabs.atlassian.net/browse/INFRA-172
_Slack thread:_ https://uniswapteam.slack.com/archives/C050USFTS5B/p1681335647517689

## Test plan
### QA (ie manual testing)
This is not easily testable locally, so instead we can see if these errors are not showing up tomorrow in Setry.

### Automated testing
- [x] Unit test (added)
- [x] Integration/E2E test (n/a)