### PR TITLE
fix: fix slow yarn start

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+*.config.ts
+*.d.ts
+/src/graphql/data/__generated__/types-and-hooks.ts
+/src/graphql/thegraph/__generated__/types-and-hooks.ts
+/src/schema/schema.graphql


### PR DESCRIPTION
This pr https://github.com/Uniswap/interface/pull/6323 remove eslintignore which slowed down the local build significantly, and introduced a bunch of lint errors when running yarn start. This PR fixes that by adding it back