### PR TITLE
build: remove unnecessary webpack plugins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,11 @@ module.exports = {
           {
             paths: [
               {
+                name: 'moment',
+                // tree-shaking for moment is not configured to improve performance - see craco.config.cjs.
+                message: 'moment is not configured for tree-shaking. Is it necessary?',
+              },
+              {
                 name: 'zustand',
                 importNames: ['default'],
                 message: 'Default import from zustand is deprecated. Import `{ create }` instead.',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,8 +22,8 @@ module.exports = {
             paths: [
               {
                 name: 'moment',
-                // tree-shaking for moment is not configured to improve performance - see craco.config.cjs.
-                message: 'moment is not configured for tree-shaking. Is it necessary?',
+                // tree-shaking for moment is not configured because it degrades performance - see craco.config.cjs.
+                message: 'moment is not configured for tree-shaking. If you use it, update the Webpack configuration.',
               },
               {
                 name: 'zustand',

--- a/craco.config.cjs
+++ b/craco.config.cjs
@@ -3,7 +3,7 @@ const { VanillaExtractPlugin } = require('@vanilla-extract/webpack-plugin')
 const { execSync } = require('child_process')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
-const { DefinePlugin } = require('webpack')
+const { DefinePlugin, IgnorePlugin } = require('webpack')
 
 const commitHash = execSync('git rev-parse HEAD').toString().trim()
 const isProduction = process.env.NODE_ENV === 'production'
@@ -73,6 +73,9 @@ module.exports = {
           // Case sensitive paths are enforced by typescript.
           // See https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames.
           if (plugin instanceof CaseSensitivePathsPlugin) return false
+
+          // IgnorePlugin is used to tree-shake moment locales, but we do not use moment in this project.
+          if (plugin instanceof IgnorePlugin) return false
 
           return true
         })

--- a/craco.config.cjs
+++ b/craco.config.cjs
@@ -70,7 +70,7 @@ module.exports = {
           return plugin
         })
         .filter((plugin) => {
-          // Case sensitive paths are enforced by typescript.
+          // Case sensitive paths are enforced by TypeScript.
           // See https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames.
           if (plugin instanceof CaseSensitivePathsPlugin) return false
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Removes filename case sensitivity checks from the webpack pipeline.
  These are already checked for by typescript, via `forceConsistentCasingInFileNames`
- Removes moment tree-shaking from the webpack piepline, as moment is unused.
  Guards against future moment usage via eslint.

This does not have any noticeable improvement on CI tests.

<!-- Delete inapplicable lines: -->
_Relevant docs:_ https://www.notion.so/uniswaplabs/Optimizing-interface-build-performance-29adef9205ae44928bac0e04ed50e382?pvs=4

## Test plan
- [x] N/A