### PR TITLE
fix: filter CSP unsafe-eval errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -29,4 +29,11 @@ describe('filterKnownErrors', () => {
     const originalException = new SyntaxError("Unexpected token '<'")
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
+
+  it('filters CSP errors', () => {
+    const originalException = new SyntaxError(
+      "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inlin..."
+    )
+    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+  })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -31,7 +31,7 @@ describe('filterKnownErrors', () => {
   })
 
   it('filters CSP errors', () => {
-    const originalException = new SyntaxError(
+    const originalException = new Error(
       "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inlin..."
     )
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -30,7 +30,7 @@ describe('filterKnownErrors', () => {
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
 
-  it('filters CSP errors', () => {
+  it('filters CSP unsafe-eval errors', () => {
     const originalException = new Error(
       "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inlin..."
     )

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -48,8 +48,9 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     if (error.message.match(/Unexpected token '<'/)) return null
 
     /*
-     * Content security policy errors can be filtered out because there are expected failures.
+     * Content security policy 'unsafe-eval' errors can be filtered out because there are expected failures.
      * For example, if a user runs an eval statement in console this error would still get thrown.
+     * TODO(INFRA-176): We should extend this to filter out any type of CSP error.
      */
     if (
       error.message.match(

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -46,6 +46,18 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * Therefore, this can be ignored.
      */
     if (error.message.match(/Unexpected token '<'/)) return null
+
+    /*
+     * Content security policy errors can be filtered out because there are expected failures.
+     * For example, if a user runs an eval statement in console this error would still get thrown.
+     */
+    if (
+      error.message.match(
+        /Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive/
+      )
+    ) {
+      return null
+    }
   }
 
   return event


### PR DESCRIPTION
## Description
Filters out unsafe-eval errors caused by our content-security policy. This is what prevents unsafe javascript evaluation on our site which can be an attack vector. Since these are expected errors, we don't need to send them to Sentry.

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (N/A)
