### PR TITLE
fix: filter out all `unsafe-eval` csp errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -30,10 +30,20 @@ describe('filterKnownErrors', () => {
     expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
   })
 
-  it('filters CSP unsafe-eval errors', () => {
-    const originalException = new Error(
-      "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inlin..."
-    )
-    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+  describe('Content Security Policy', () => {
+    it('filters unsafe-eval evaluate errors', () => {
+      const originalException = new Error(
+        "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inlin..."
+      )
+      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    })
+
+    it('filters CSP unsafe-eval compile/instatiate errors', () => {
+      const originalException = new Error(
+        "Refused to compile or instantiate WebAssembly module because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-a..."
+      )
+      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    })
   })
+
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -45,5 +45,4 @@ describe('filterKnownErrors', () => {
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
     })
   })
-
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -8,6 +8,11 @@ describe('filterKnownErrors', () => {
     expect(filterKnownErrors(ERROR, {})).toBe(ERROR)
   })
 
+  it('propagates an error with generic text', () => {
+    const originalException = new Error('generic error copy')
+    expect(filterKnownErrors(ERROR, { originalException })).toBe(ERROR)
+  })
+
   it('filters block number polling errors', () => {
     const originalException = new (class extends Error {
       requestBody = JSON.stringify({ method: 'eth_blockNumber' })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -52,11 +52,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * For example, if a user runs an eval statement in console this error would still get thrown.
      * TODO(INFRA-176): We should extend this to filter out any type of CSP error.
      */
-    if (
-      error.message.match(
-        /Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive/
-      )
-    ) {
+    if (error.message.match(/(?=.*(?:content\s*security\s*policy))(?=.*(?:'unsafe-eval')).*/i)) {
       return null
     }
   }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -52,7 +52,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * For example, if a user runs an eval statement in console this error would still get thrown.
      * TODO(INFRA-176): We should extend this to filter out any type of CSP error.
      */
-    if (error.message.match(/(?=.*(?:content\s*security\s*policy))(?=.*(?:'unsafe-eval')).*/i)) {
+    if (error.message.match(/'unsafe-eval'.*content security policy/i)) {
       return null
     }
   }


### PR DESCRIPTION
## Description
This more generically checks for `unsafe-eval` errors that are related to content security policy. This is to make sure that this error is caught: https://uniswap-labs.sentry.io/issues/4008805391/?project=4504255148851200&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=13

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (N/A)
