### PR TITLE
feat: [DetailsV2] more shared component content

### DIFF
--- a/src/nft/components/details/detailsV2/ActivityTableContent.tsx
+++ b/src/nft/components/details/detailsV2/ActivityTableContent.tsx
@@ -1,3 +1,5 @@
+import { TableContentHeight } from './DataPageTable'
+
 export const ActivityTableContent = () => {
-  return <div>Activity Content</div>
+  return <div style={{ height: `${TableContentHeight}px` }}>Activity Content</div>
 }

--- a/src/nft/components/details/detailsV2/DataPage.tsx
+++ b/src/nft/components/details/detailsV2/DataPage.tsx
@@ -38,6 +38,7 @@ const ContentContainer = styled(Row)`
 const LeftColumn = styled(Column)`
   gap: 24px;
   width: 100%;
+  align-self: flex-start;
 `
 
 export const DataPage = ({ asset }: { asset: GenieAsset }) => {

--- a/src/nft/components/details/detailsV2/DataPage.tsx
+++ b/src/nft/components/details/detailsV2/DataPage.tsx
@@ -1,5 +1,6 @@
 import Column from 'components/Column'
 import Row from 'components/Row'
+import { GenieAsset } from 'nft/types'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS } from 'theme'
 
@@ -39,13 +40,13 @@ const LeftColumn = styled(Column)`
   width: 100%;
 `
 
-export const DataPage = () => {
+export const DataPage = ({ asset }: { asset: GenieAsset }) => {
   return (
     <DataPageContainer>
       <DataPageHeader />
       <ContentContainer>
         <LeftColumn>
-          <DataPageTraits />
+          <DataPageTraits asset={asset} />
           <DataPageDescription />
         </LeftColumn>
         <DataPageTable />

--- a/src/nft/components/details/detailsV2/DataPageDescription.tsx
+++ b/src/nft/components/details/detailsV2/DataPageDescription.tsx
@@ -2,12 +2,14 @@ import { Trans } from '@lingui/macro'
 
 import { Tab, TabbedComponent } from './TabbedComponent'
 
+const DescriptionContentHeight = 252
+
 const DescriptionContent = () => {
-  return <div>Description Content</div>
+  return <div style={{ height: `${DescriptionContentHeight}px` }}>Description Content</div>
 }
 
 const DetailsContent = () => {
-  return <div>Details Content</div>
+  return <div style={{ height: `${DescriptionContentHeight}px` }}>Details Content</div>
 }
 
 const DescriptionTabs: Array<Tab> = [
@@ -24,5 +26,5 @@ const DescriptionTabs: Array<Tab> = [
 ]
 
 export const DataPageDescription = () => {
-  return <TabbedComponent tabs={DescriptionTabs} style={{ height: '288px' }} />
+  return <TabbedComponent tabs={DescriptionTabs} />
 }

--- a/src/nft/components/details/detailsV2/DataPageTable.tsx
+++ b/src/nft/components/details/detailsV2/DataPageTable.tsx
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro'
 import { ActivityTableContent } from './ActivityTableContent'
 import { ListingsTableContent } from './ListingsTableContent'
 import { OffersTableContent } from './OffersTableContent'
-import { Tab, TabbedComponent } from './TabbedComponent'
+import { Tab, TabbedComponent, TabTitleWithBubble } from './TabbedComponent'
 
 export const TableContentHeight = 568
 
@@ -14,12 +14,12 @@ const TableTabs: Array<Tab> = [
     content: <ActivityTableContent />,
   },
   {
-    title: <Trans>Offers</Trans>,
+    title: <TabTitleWithBubble title={<Trans>Offers</Trans>} bubbleNumber={/* placeholder */ 11} />,
     key: 'offers',
     content: <OffersTableContent />,
   },
   {
-    title: <Trans>Listings</Trans>,
+    title: <TabTitleWithBubble title={<Trans>Listings</Trans>} bubbleNumber={/* placeholder */ 11} />,
     key: 'listings',
     content: <ListingsTableContent />,
   },

--- a/src/nft/components/details/detailsV2/DataPageTable.tsx
+++ b/src/nft/components/details/detailsV2/DataPageTable.tsx
@@ -5,6 +5,8 @@ import { ListingsTableContent } from './ListingsTableContent'
 import { OffersTableContent } from './OffersTableContent'
 import { Tab, TabbedComponent } from './TabbedComponent'
 
+export const TableContentHeight = 568
+
 const TableTabs: Array<Tab> = [
   {
     title: <Trans>Activity</Trans>,
@@ -24,5 +26,5 @@ const TableTabs: Array<Tab> = [
 ]
 
 export const DataPageTable = () => {
-  return <TabbedComponent tabs={TableTabs} style={{ height: '604px' }} />
+  return <TabbedComponent tabs={TableTabs} />
 }

--- a/src/nft/components/details/detailsV2/DataPageTraits.tsx
+++ b/src/nft/components/details/detailsV2/DataPageTraits.tsx
@@ -1,9 +1,7 @@
 import { Trans } from '@lingui/macro'
-import Row from 'components/Row'
 import { GenieAsset } from 'nft/types'
 
-import { getBubbleText, TabNumBubble } from './shared'
-import { Tab, TabbedComponent } from './TabbedComponent'
+import { Tab, TabbedComponent, TabTitleWithBubble } from './TabbedComponent'
 
 const TraitsContent = () => {
   return <div style={{ height: '492px' }}>Traits Content</div>
@@ -12,12 +10,7 @@ const TraitsContent = () => {
 export const DataPageTraits = ({ asset }: { asset: GenieAsset }) => {
   const TraitTabs: Array<Tab> = [
     {
-      title: (
-        <Row gap="8px">
-          <Trans>Traits</Trans>
-          {asset.traits && <TabNumBubble>{getBubbleText(asset.traits.length)}</TabNumBubble>}
-        </Row>
-      ),
+      title: <TabTitleWithBubble title={<Trans>Traits</Trans>} bubbleNumber={asset.traits?.length} />,
       key: 'traits',
       content: <TraitsContent />,
     },

--- a/src/nft/components/details/detailsV2/DataPageTraits.tsx
+++ b/src/nft/components/details/detailsV2/DataPageTraits.tsx
@@ -2,11 +2,11 @@ import { Trans } from '@lingui/macro'
 import Row from 'components/Row'
 import { GenieAsset } from 'nft/types'
 
-import { TabNumBubble } from './shared'
+import { getBubbleText, TabNumBubble } from './shared'
 import { Tab, TabbedComponent } from './TabbedComponent'
 
 const TraitsContent = () => {
-  return <div>Traits Content</div>
+  return <div style={{ height: '492px' }}>Traits Content</div>
 }
 
 export const DataPageTraits = ({ asset }: { asset: GenieAsset }) => {
@@ -15,12 +15,12 @@ export const DataPageTraits = ({ asset }: { asset: GenieAsset }) => {
       title: (
         <Row gap="8px">
           <Trans>Traits</Trans>
-          {asset.traits && <TabNumBubble>{asset.traits.length > 10 ? '10+' : asset.traits?.length}</TabNumBubble>}
+          {asset.traits && <TabNumBubble>{getBubbleText(asset.traits.length)}</TabNumBubble>}
         </Row>
       ),
       key: 'traits',
       content: <TraitsContent />,
     },
   ]
-  return <TabbedComponent tabs={TraitTabs} style={{ height: '528px' }} />
+  return <TabbedComponent tabs={TraitTabs} />
 }

--- a/src/nft/components/details/detailsV2/DataPageTraits.tsx
+++ b/src/nft/components/details/detailsV2/DataPageTraits.tsx
@@ -1,19 +1,26 @@
 import { Trans } from '@lingui/macro'
+import Row from 'components/Row'
+import { GenieAsset } from 'nft/types'
 
+import { TabNumBubble } from './shared'
 import { Tab, TabbedComponent } from './TabbedComponent'
 
 const TraitsContent = () => {
   return <div>Traits Content</div>
 }
 
-const TraitTabs: Array<Tab> = [
-  {
-    title: <Trans>Traits</Trans>,
-    key: 'traits',
-    content: <TraitsContent />,
-  },
-]
-
-export const DataPageTraits = () => {
+export const DataPageTraits = ({ asset }: { asset: GenieAsset }) => {
+  const TraitTabs: Array<Tab> = [
+    {
+      title: (
+        <Row gap="8px">
+          <Trans>Traits</Trans>
+          {asset.traits && <TabNumBubble>{asset.traits.length > 10 ? '10+' : asset.traits?.length}</TabNumBubble>}
+        </Row>
+      ),
+      key: 'traits',
+      content: <TraitsContent />,
+    },
+  ]
   return <TabbedComponent tabs={TraitTabs} style={{ height: '528px' }} />
 }

--- a/src/nft/components/details/detailsV2/ListingsTableContent.tsx
+++ b/src/nft/components/details/detailsV2/ListingsTableContent.tsx
@@ -1,3 +1,5 @@
+import { TableContentHeight } from './DataPageTable'
+
 export const ListingsTableContent = () => {
-  return <div>Listings Content</div>
+  return <div style={{ height: `${TableContentHeight}px` }}>Listings Content</div>
 }

--- a/src/nft/components/details/detailsV2/NftDetails.tsx
+++ b/src/nft/components/details/detailsV2/NftDetails.tsx
@@ -18,7 +18,7 @@ export const NftDetails = ({ asset, collection }: NftDetailsProps) => {
       <LandingPage>
         Details page for {asset.name} from {collection.collectionName}
       </LandingPage>
-      <DataPage />
+      <DataPage asset={asset} />
     </>
   )
 }

--- a/src/nft/components/details/detailsV2/OffersTableContent.tsx
+++ b/src/nft/components/details/detailsV2/OffersTableContent.tsx
@@ -1,3 +1,5 @@
+import { TableContentHeight } from './DataPageTable'
+
 export const OffersTableContent = () => {
-  return <div>Offers Content</div>
+  return <div style={{ height: `${TableContentHeight}px` }}>Offers Content</div>
 }

--- a/src/nft/components/details/detailsV2/TabbedComponent.tsx
+++ b/src/nft/components/details/detailsV2/TabbedComponent.tsx
@@ -1,6 +1,5 @@
 import Row from 'components/Row'
-import { ChevronUpIcon } from 'nft/components/icons'
-import { useReducer, useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
@@ -24,21 +23,6 @@ const Tab = styled(ThemedText.SubHeader)<{ isActive: boolean; numTabs: number }>
   &:hover {
     opacity: ${({ numTabs, theme }) => numTabs > 1 && theme.opacity.hover}};
   }
-`
-
-const Chevron = styled(ChevronUpIcon)<{ isOpen: boolean }>`
-  height: 24px;
-  width: 24px;
-  fill: ${({ theme }) => theme.textSecondary};
-  transition: ${({
-    theme: {
-      transition: { duration },
-    },
-  }) => `${duration.fast} transform`};
-  transform: ${({ isOpen }) => `rotate(${isOpen ? 0 : 180}deg)`};
-  cursor: pointer;
-  margin-left: auto;
-  margin-right: 0;
 `
 
 const TabNumBubble = styled(ThemedText.UtilityBadge)`
@@ -71,7 +55,6 @@ interface TabbedComponentProps {
 
 export const TabbedComponent = ({ tabs, defaultTabIndex = 0 }: TabbedComponentProps) => {
   const [activeTab, setActiveTab] = useState(tabs[defaultTabIndex].key)
-  const [isOpen, toggleIsOpen] = useReducer((s) => !s, true)
   const activeContent = tabs.find((tab) => tab.key === activeTab)?.content
   return (
     <TabbedComponentContainer>
@@ -86,9 +69,8 @@ export const TabbedComponent = ({ tabs, defaultTabIndex = 0 }: TabbedComponentPr
             {tab.title}
           </Tab>
         ))}
-        <Chevron isOpen={isOpen} onClick={toggleIsOpen} />
       </TabsRow>
-      {isOpen && activeContent}
+      {activeContent}
     </TabbedComponentContainer>
   )
 }

--- a/src/nft/components/details/detailsV2/TabbedComponent.tsx
+++ b/src/nft/components/details/detailsV2/TabbedComponent.tsx
@@ -4,7 +4,7 @@ import { useReducer, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
-import { containerStyles } from './shared'
+import { containerStyles, getBubbleText } from './shared'
 
 const TabbedComponentContainer = styled.div`
   ${containerStyles}
@@ -40,6 +40,23 @@ const Chevron = styled(ChevronUpIcon)<{ isOpen: boolean }>`
   margin-left: auto;
   margin-right: 0;
 `
+
+const TabNumBubble = styled(ThemedText.UtilityBadge)`
+  background: ${({ theme }) => theme.backgroundOutline};
+  border-radius: 4px;
+  padding: 2px 4px;
+  color: ${({ theme }) => theme.textSecondary};
+  line-height: 12px;
+`
+
+export const TabTitleWithBubble = ({ title, bubbleNumber }: { title: React.ReactNode; bubbleNumber?: number }) => {
+  return (
+    <Row gap="8px">
+      {title}
+      {bubbleNumber && <TabNumBubble>{getBubbleText(bubbleNumber)}</TabNumBubble>}
+    </Row>
+  )
+}
 
 export interface Tab {
   title: React.ReactNode

--- a/src/nft/components/details/detailsV2/TabbedComponent.tsx
+++ b/src/nft/components/details/detailsV2/TabbedComponent.tsx
@@ -67,15 +67,14 @@ export interface Tab {
 interface TabbedComponentProps {
   tabs: Tab[]
   defaultTabIndex?: number
-  style?: React.CSSProperties
 }
 
-export const TabbedComponent = ({ tabs, defaultTabIndex = 0, style }: TabbedComponentProps) => {
+export const TabbedComponent = ({ tabs, defaultTabIndex = 0 }: TabbedComponentProps) => {
   const [activeTab, setActiveTab] = useState(tabs[defaultTabIndex].key)
   const [isOpen, toggleIsOpen] = useReducer((s) => !s, true)
   const activeContent = tabs.find((tab) => tab.key === activeTab)?.content
   return (
-    <TabbedComponentContainer style={style}>
+    <TabbedComponentContainer>
       <TabsRow>
         {tabs.map((tab) => (
           <Tab

--- a/src/nft/components/details/detailsV2/TabbedComponent.tsx
+++ b/src/nft/components/details/detailsV2/TabbedComponent.tsx
@@ -1,13 +1,12 @@
 import Row from 'components/Row'
-import { useState } from 'react'
+import { ChevronUpIcon } from 'nft/components/icons'
+import { useReducer, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
 import { containerStyles } from './shared'
 
 const TabbedComponentContainer = styled.div`
-  height: 288px;
-
   ${containerStyles}
 `
 
@@ -27,6 +26,21 @@ const Tab = styled(ThemedText.SubHeader)<{ isActive: boolean; numTabs: number }>
   }
 `
 
+const Chevron = styled(ChevronUpIcon)<{ isOpen: boolean }>`
+  height: 24px;
+  width: 24px;
+  fill: ${({ theme }) => theme.textSecondary};
+  transition: ${({
+    theme: {
+      transition: { duration },
+    },
+  }) => `${duration.fast} transform`};
+  transform: ${({ isOpen }) => `rotate(${isOpen ? 0 : 180}deg)`};
+  cursor: pointer;
+  margin-left: auto;
+  margin-right: 0;
+`
+
 export interface Tab {
   title: React.ReactNode
   key: string
@@ -41,6 +55,7 @@ interface TabbedComponentProps {
 
 export const TabbedComponent = ({ tabs, defaultTabIndex = 0, style }: TabbedComponentProps) => {
   const [activeTab, setActiveTab] = useState(tabs[defaultTabIndex].key)
+  const [isOpen, toggleIsOpen] = useReducer((s) => !s, true)
   const activeContent = tabs.find((tab) => tab.key === activeTab)?.content
   return (
     <TabbedComponentContainer style={style}>
@@ -55,8 +70,9 @@ export const TabbedComponent = ({ tabs, defaultTabIndex = 0, style }: TabbedComp
             {tab.title}
           </Tab>
         ))}
+        <Chevron isOpen={isOpen} onClick={toggleIsOpen} />
       </TabsRow>
-      {activeContent}
+      {isOpen && activeContent}
     </TabbedComponentContainer>
   )
 }

--- a/src/nft/components/details/detailsV2/shared.ts
+++ b/src/nft/components/details/detailsV2/shared.ts
@@ -1,5 +1,4 @@
-import styled, { css } from 'styled-components/macro'
-import { ThemedText } from 'theme'
+import { css } from 'styled-components/macro'
 
 export const containerStyles = css`
   background: ${({ theme }) => theme.backgroundSurface};
@@ -7,14 +6,6 @@ export const containerStyles = css`
   padding: 16px 20px;
   width: 100%;
   align-self: flex-start;
-`
-
-export const TabNumBubble = styled(ThemedText.UtilityBadge)`
-  background: ${({ theme }) => theme.backgroundOutline};
-  border-radius: 4px;
-  padding: 2px 4px;
-  color: ${({ theme }) => theme.textSecondary};
-  line-height: 12px;
 `
 
 export function getBubbleText(num: number) {

--- a/src/nft/components/details/detailsV2/shared.ts
+++ b/src/nft/components/details/detailsV2/shared.ts
@@ -1,4 +1,5 @@
-import { css } from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
+import { ThemedText } from 'theme'
 
 export const containerStyles = css`
   background: ${({ theme }) => theme.backgroundSurface};
@@ -6,4 +7,12 @@ export const containerStyles = css`
   padding: 16px 20px;
   width: 100%;
   align-self: flex-start;
+`
+
+export const TabNumBubble = styled(ThemedText.UtilityBadge)`
+  background: ${({ theme }) => theme.backgroundOutline};
+  border-radius: 4px;
+  padding: 2px 4px;
+  color: ${({ theme }) => theme.textSecondary};
+  line-height: 12px;
 `

--- a/src/nft/components/details/detailsV2/shared.ts
+++ b/src/nft/components/details/detailsV2/shared.ts
@@ -16,3 +16,8 @@ export const TabNumBubble = styled(ThemedText.UtilityBadge)`
   color: ${({ theme }) => theme.textSecondary};
   line-height: 12px;
 `
+
+export function getBubbleText(num: number) {
+  if (num <= 10) return num
+  return '10+'
+}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Iteratively adding more shared styles, components, and functions to be used across the Data page components. These are:
- Some tabs have bubbles corresponding to a number related to the content
- Removed the `styles` param and instead added placeholder height to the content themselves which can be replaced as those components are worked on.

Dependent on #6399 

<!-- Delete this section if your change does not affect UI. -->
## Screen capture
<img width="1122" alt="Screen Shot 2023-04-21 at 10 53 05 " src="https://user-images.githubusercontent.com/11512321/233702809-36184e69-cce8-4005-9d96-066fde013369.png">


## Test plan

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Updated snapshot
