### PR TITLE
fix: handle other types of chunk error codes

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -58,6 +58,32 @@ describe('filterKnownErrors', () => {
       expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
 
+    it('filters 499 error coded chunk timeout', () => {
+      jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([
+        {
+          name: 'https://app.uniswap.org/static/js/20.d55382e0.chunk.js',
+          responseStatus: 499,
+        } as PerformanceEntry,
+      ])
+      const originalException = new Error(
+        'Loading chunk 20 failed. (timeout: https://app.uniswap.org/static/js/20.d55382e0.chunk.js)'
+      )
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
+    })
+
+    it('filters 499 error coded chunk missing', () => {
+      jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([
+        {
+          name: 'https://app.uniswap.org/static/js/20.d55382e0.chunk.js',
+          responseStatus: 499,
+        } as PerformanceEntry,
+      ])
+      const originalException = new Error(
+        'Loading chunk 20 failed. (missing: https://app.uniswap.org/static/js/20.d55382e0.chunk.js)'
+      )
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
+    })
+
     it('filters 499 error coded CSS chunk error', () => {
       jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([
         {

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -67,7 +67,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * CF claims that some number of these is expected, and that they should be ignored.
      * See https://groups.google.com/a/uniswap.org/g/cloudflare-eng/c/t3xvAiJFujY.
      */
-    if (error.message.match(/Loading chunk \d+ failed\. \(([^:]+):[^:]+\.chunk\.js\)/)) {
+    if (error.message.match(/Loading chunk \d+ failed\. \(([^:]+): .+\.chunk\.js\)/)) {
       const asset = error.message.match(/https?:\/\/.+?\.chunk\.js/)?.[0]
       if (shouldFilterChunkError(asset)) return null
     }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -67,8 +67,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * CF claims that some number of these is expected, and that they should be ignored.
      * See https://groups.google.com/a/uniswap.org/g/cloudflare-eng/c/t3xvAiJFujY.
      */
-    if (error.message.match(/Loading chunk \d+ failed\. \(([^:]+):[^:]+\.chunk\.js\)/
-    )) {
+    if (error.message.match(/Loading chunk \d+ failed\. \(([^:]+):[^:]+\.chunk\.js\)/)) {
       const asset = error.message.match(/https?:\/\/.+?\.chunk\.js/)?.[0]
       if (shouldFilterChunkError(asset)) return null
     }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -67,7 +67,8 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * CF claims that some number of these is expected, and that they should be ignored.
      * See https://groups.google.com/a/uniswap.org/g/cloudflare-eng/c/t3xvAiJFujY.
      */
-    if (error.message.match(/Loading chunk \d+ failed\. \(error: .+\.chunk\.js\)/)) {
+    if (error.message.match(/Loading chunk \d+ failed\. \(([^:]+):[^:]+\.chunk\.js\)/
+    )) {
       const asset = error.message.match(/https?:\/\/.+?\.chunk\.js/)?.[0]
       if (shouldFilterChunkError(asset)) return null
     }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -67,7 +67,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * CF claims that some number of these is expected, and that they should be ignored.
      * See https://groups.google.com/a/uniswap.org/g/cloudflare-eng/c/t3xvAiJFujY.
      */
-    if (error.message.match(/Loading chunk \d+ failed\. \(([^:]+): .+\.chunk\.js\)/)) {
+    if (error.message.match(/Loading chunk \d+ failed\. \(([a-zA-Z]+): .+\.chunk\.js\)/)) {
       const asset = error.message.match(/https?:\/\/.+?\.chunk\.js/)?.[0]
       if (shouldFilterChunkError(asset)) return null
     }


### PR DESCRIPTION
## Description
This makes the regex matching more generic. This is because the text can say `error:`, but also things like `timeout:` or `missing:`. These should all be checked for 499s.

See: https://uniswap-labs.sentry.io/issues/4009148084/events/5e960da931d44c19bb54e977f8d651a4/?project=4504255148851200&query=is%3Aunresolved+release%3A95b9624bca2325ffc28bb513426120c9e4a1c8bb+%22timeout%3A%22&referrer=previous-event&sort=freq&statsPeriod=14d&stream_index=0

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (n/a)
