### PR TITLE
fix: handle addEventListener being unsupported on Safari <14

### DIFF
--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -29,10 +29,16 @@ const themeModeAtom = atomWithStorage<ThemeMode>('interface_color_theme', ThemeM
 export function SystemThemeUpdater() {
   const setSystemTheme = useUpdateAtom(systemThemeAtom)
 
+  const listener = (event: MediaQueryListEvent) => {
+    setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
+  }
+
   useEffect(() => {
-    DARKMODE_MEDIA_QUERY.addEventListener?.('change', (event: MediaQueryListEvent) => {
-      setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
-    })
+    try {
+      DARKMODE_MEDIA_QUERY.addEventListener('change', listener)
+    } catch (e) {
+      DARKMODE_MEDIA_QUERY.addListener(listener)
+    }
   }, [setSystemTheme])
 
   return null

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -29,10 +29,16 @@ const themeModeAtom = atomWithStorage<ThemeMode>('interface_color_theme', ThemeM
 export function SystemThemeUpdater() {
   const setSystemTheme = useUpdateAtom(systemThemeAtom)
 
+  const listener = (event: MediaQueryListEvent) => {
+    setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
+  }
+
   useEffect(() => {
-    DARKMODE_MEDIA_QUERY.addEventListener('change', (event) => {
-      setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
-    })
+    try {
+      DARKMODE_MEDIA_QUERY.addEventListener('change', listener)
+    } catch (e) {
+      DARKMODE_MEDIA_QUERY.addListener(listener)
+    }
   }, [setSystemTheme])
 
   return null

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -29,16 +29,10 @@ const themeModeAtom = atomWithStorage<ThemeMode>('interface_color_theme', ThemeM
 export function SystemThemeUpdater() {
   const setSystemTheme = useUpdateAtom(systemThemeAtom)
 
-  const listener = (event: MediaQueryListEvent) => {
-    setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
-  }
-
   useEffect(() => {
-    try {
-      DARKMODE_MEDIA_QUERY.addEventListener('change', listener)
-    } catch (e) {
-      DARKMODE_MEDIA_QUERY.addListener(listener)
-    }
+    DARKMODE_MEDIA_QUERY.addEventListener?.('change', (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
+    })
   }, [setSystemTheme])
 
   return null

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -29,9 +29,12 @@ const themeModeAtom = atomWithStorage<ThemeMode>('interface_color_theme', ThemeM
 export function SystemThemeUpdater() {
   const setSystemTheme = useUpdateAtom(systemThemeAtom)
 
-  const listener = (event: MediaQueryListEvent) => {
-    setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
-  }
+  const listener = useCallback(
+    (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? ThemeMode.DARK : ThemeMode.LIGHT)
+    },
+    [setSystemTheme]
+  )
 
   useEffect(() => {
     /*

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -43,7 +43,7 @@ export function SystemThemeUpdater() {
     } catch (e) {
       DARKMODE_MEDIA_QUERY.addListener(listener)
     }
-  }, [setSystemTheme])
+  }, [setSystemTheme, listener])
 
   return null
 }

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -34,6 +34,10 @@ export function SystemThemeUpdater() {
   }
 
   useEffect(() => {
+    /*
+     * Need to fallback to support older browsers (mainly, Safari < 14).
+     * See: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
+     */
     try {
       DARKMODE_MEDIA_QUERY.addEventListener('change', listener)
     } catch (e) {

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -5,7 +5,7 @@ import { atomWithStorage, useAtomValue, useUpdateAtom } from 'jotai/utils'
 import ms from 'ms.macro'
 import { useCallback, useEffect, useMemo } from 'react'
 import { Moon, Sun } from 'react-feather'
-import { addListener, removeListener } from 'utils/matchMedia'
+import { addMediaQueryListener, removeMediaQueryListener } from 'utils/matchMedia'
 
 import { Segment, SegmentedControl } from './SegmentedControl'
 import { ThemedText } from './text'
@@ -38,8 +38,8 @@ export function SystemThemeUpdater() {
   )
 
   useEffect(() => {
-    addListener(DARKMODE_MEDIA_QUERY, listener)
-    return () => removeListener(DARKMODE_MEDIA_QUERY, listener)
+    addMediaQueryListener(DARKMODE_MEDIA_QUERY, listener)
+    return () => removeMediaQueryListener(DARKMODE_MEDIA_QUERY, listener)
   }, [setSystemTheme, listener])
 
   return null

--- a/src/theme/components/ThemeToggle.tsx
+++ b/src/theme/components/ThemeToggle.tsx
@@ -5,6 +5,7 @@ import { atomWithStorage, useAtomValue, useUpdateAtom } from 'jotai/utils'
 import ms from 'ms.macro'
 import { useCallback, useEffect, useMemo } from 'react'
 import { Moon, Sun } from 'react-feather'
+import { addListener, removeListener } from 'utils/matchMedia'
 
 import { Segment, SegmentedControl } from './SegmentedControl'
 import { ThemedText } from './text'
@@ -37,15 +38,8 @@ export function SystemThemeUpdater() {
   )
 
   useEffect(() => {
-    /*
-     * Need to fallback to support older browsers (mainly, Safari < 14).
-     * See: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
-     */
-    try {
-      DARKMODE_MEDIA_QUERY.addEventListener('change', listener)
-    } catch (e) {
-      DARKMODE_MEDIA_QUERY.addListener(listener)
-    }
+    addListener(DARKMODE_MEDIA_QUERY, listener)
+    return () => removeListener(DARKMODE_MEDIA_QUERY, listener)
   }, [setSystemTheme, listener])
 
   return null

--- a/src/utils/matchMedia.test.ts
+++ b/src/utils/matchMedia.test.ts
@@ -1,61 +1,53 @@
-import { addListener, removeListener } from './matchMedia'
+import { addMediaQueryListener, removeMediaQueryListener } from './matchMedia'
 
-describe('addListener', () => {
+describe('addMediaQueryListener', () => {
   test('adds event listener to media query', () => {
     const mediaQuery = {
       addEventListener: jest.fn(),
       addListener: jest.fn(),
-    }
+    } as unknown as MediaQueryList
 
     const listener = jest.fn()
-    addListener(mediaQuery as unknown as MediaQueryList, listener)
+    addMediaQueryListener(mediaQuery, listener)
 
     expect(mediaQuery.addEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.addListener).not.toHaveBeenCalled()
   })
 
-  test('falls back to addListener for older browsers', () => {
+  test('falls back to addMediaQueryListener for older browsers', () => {
     const mediaQuery = {
-      addEventListener: jest.fn(() => {
-        throw new Error('not supported')
-      }),
       addListener: jest.fn(),
-    }
+    } as unknown as MediaQueryList
 
     const listener = jest.fn()
-    addListener(mediaQuery as unknown as MediaQueryList, listener)
+    addMediaQueryListener(mediaQuery, listener)
 
-    expect(mediaQuery.addEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.addListener).toHaveBeenCalledWith(listener)
   })
 })
 
-describe('removeListener', () => {
+describe('removeMediaQueryListener', () => {
   test('removes event listener from media query', () => {
     const mediaQuery = {
       removeEventListener: jest.fn(),
       removeListener: jest.fn(),
-    }
+    } as unknown as MediaQueryList
 
     const listener = jest.fn()
-    removeListener(mediaQuery as unknown as MediaQueryList, listener)
+    removeMediaQueryListener(mediaQuery, listener)
 
     expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.removeListener).not.toHaveBeenCalled()
   })
 
-  test('falls back to removeListener for older browsers', () => {
+  test('falls back to removeMediaQueryListener for older browsers', () => {
     const mediaQuery = {
-      removeEventListener: jest.fn(() => {
-        throw new Error('not supported')
-      }),
       removeListener: jest.fn(),
-    }
+    } as unknown as MediaQueryList
 
     const listener = jest.fn()
-    removeListener(mediaQuery as unknown as MediaQueryList, listener)
+    removeMediaQueryListener(mediaQuery, listener)
 
-    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.removeListener).toHaveBeenCalledWith(listener)
   })
 })

--- a/src/utils/matchMedia.test.ts
+++ b/src/utils/matchMedia.test.ts
@@ -1,0 +1,73 @@
+import { addListener, removeListener } from './matchMedia'
+
+describe('addListener', () => {
+  test('adds event listener to media query', () => {
+    const mediaQuery = {
+      matches: true,
+      addEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      removeListener: jest.fn(),
+    }
+
+    const listener = jest.fn()
+    addListener(mediaQuery as MediaQueryList, listener)
+
+    expect(mediaQuery.addEventListener).toHaveBeenCalledWith('change', listener)
+    expect(mediaQuery.addListener).not.toHaveBeenCalled()
+  })
+
+  test('falls back to addListener for older browsers', () => {
+    const mediaQuery = {
+      matches: true,
+      addEventListener: jest.fn(() => {
+        throw new Error('not supported')
+      }),
+      addListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      removeListener: jest.fn(),
+    }
+
+    const listener = jest.fn()
+    addListener(mediaQuery as MediaQueryList, listener)
+
+    expect(mediaQuery.addEventListener).toHaveBeenCalledWith('change', listener)
+    expect(mediaQuery.addListener).toHaveBeenCalledWith(listener)
+  })
+})
+
+describe('removeListener', () => {
+  test('removes event listener from media query', () => {
+    const mediaQuery = {
+      matches: true,
+      addEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      removeListener: jest.fn(),
+    }
+
+    const listener = jest.fn()
+    removeListener(mediaQuery as MediaQueryList, listener)
+
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener)
+    expect(mediaQuery.removeListener).not.toHaveBeenCalled()
+  })
+
+  test('falls back to removeListener for older browsers', () => {
+    const mediaQuery = {
+      matches: true,
+      addEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeEventListener: jest.fn(() => {
+        throw new Error('not supported')
+      }),
+      removeListener: jest.fn(),
+    }
+
+    const listener = jest.fn()
+    removeListener(mediaQuery as MediaQueryList, listener)
+
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener)
+    expect(mediaQuery.removeListener).toHaveBeenCalledWith(listener)
+  })
+})

--- a/src/utils/matchMedia.test.ts
+++ b/src/utils/matchMedia.test.ts
@@ -3,15 +3,12 @@ import { addListener, removeListener } from './matchMedia'
 describe('addListener', () => {
   test('adds event listener to media query', () => {
     const mediaQuery = {
-      matches: true,
       addEventListener: jest.fn(),
       addListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      removeListener: jest.fn(),
     }
 
     const listener = jest.fn()
-    addListener(mediaQuery as MediaQueryList, listener)
+    addListener(mediaQuery as unknown as MediaQueryList, listener)
 
     expect(mediaQuery.addEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.addListener).not.toHaveBeenCalled()
@@ -19,17 +16,14 @@ describe('addListener', () => {
 
   test('falls back to addListener for older browsers', () => {
     const mediaQuery = {
-      matches: true,
       addEventListener: jest.fn(() => {
         throw new Error('not supported')
       }),
       addListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      removeListener: jest.fn(),
     }
 
     const listener = jest.fn()
-    addListener(mediaQuery as MediaQueryList, listener)
+    addListener(mediaQuery as unknown as MediaQueryList, listener)
 
     expect(mediaQuery.addEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.addListener).toHaveBeenCalledWith(listener)
@@ -39,15 +33,12 @@ describe('addListener', () => {
 describe('removeListener', () => {
   test('removes event listener from media query', () => {
     const mediaQuery = {
-      matches: true,
-      addEventListener: jest.fn(),
-      addListener: jest.fn(),
       removeEventListener: jest.fn(),
       removeListener: jest.fn(),
     }
 
     const listener = jest.fn()
-    removeListener(mediaQuery as MediaQueryList, listener)
+    removeListener(mediaQuery as unknown as MediaQueryList, listener)
 
     expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.removeListener).not.toHaveBeenCalled()
@@ -55,9 +46,6 @@ describe('removeListener', () => {
 
   test('falls back to removeListener for older browsers', () => {
     const mediaQuery = {
-      matches: true,
-      addEventListener: jest.fn(),
-      addListener: jest.fn(),
       removeEventListener: jest.fn(() => {
         throw new Error('not supported')
       }),
@@ -65,7 +53,7 @@ describe('removeListener', () => {
     }
 
     const listener = jest.fn()
-    removeListener(mediaQuery as MediaQueryList, listener)
+    removeListener(mediaQuery as unknown as MediaQueryList, listener)
 
     expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener)
     expect(mediaQuery.removeListener).toHaveBeenCalledWith(listener)

--- a/src/utils/matchMedia.ts
+++ b/src/utils/matchMedia.ts
@@ -1,7 +1,6 @@
-/*
- * Need to fallback to support older browsers (mainly, Safari < 14).
- * See: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
- */
+// Need to fallback to support older browsers (mainly, Safari < 14).
+// See: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
+
 export function addListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
   try {
     mediaQuery.addEventListener('change', listener)

--- a/src/utils/matchMedia.ts
+++ b/src/utils/matchMedia.ts
@@ -1,7 +1,7 @@
 // Need to fallback to support older browsers (mainly, Safari < 14).
 // See: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
 
-export function addListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
+export function addMediaQueryListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
   try {
     mediaQuery.addEventListener('change', listener)
   } catch (e) {
@@ -9,7 +9,7 @@ export function addListener(mediaQuery: MediaQueryList, listener: (event: MediaQ
   }
 }
 
-export function removeListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
+export function removeMediaQueryListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
   try {
     mediaQuery.removeEventListener('change', listener)
   } catch (e) {

--- a/src/utils/matchMedia.ts
+++ b/src/utils/matchMedia.ts
@@ -1,0 +1,19 @@
+/*
+ * Need to fallback to support older browsers (mainly, Safari < 14).
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
+ */
+export function addListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
+  try {
+    mediaQuery.addEventListener('change', listener)
+  } catch (e) {
+    mediaQuery.addListener(listener)
+  }
+}
+
+export function removeListener(mediaQuery: MediaQueryList, listener: (event: MediaQueryListEvent) => void) {
+  try {
+    mediaQuery.removeEventListener('change', listener)
+  } catch (e) {
+    mediaQuery.removeListener(listener)
+  }
+}


### PR DESCRIPTION
## Description
`addEventListener` is not defined on Safari versions below 14. This adds code to fallback to `addListener`.
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener

https://uniswap-labs.sentry.io/issues/4044597264/?end=2023-04-25T15%3A57%3A59&project=4504255148851200&query=release%3A963121f19b0ea66590d648f83f940c9b9928f75b&referrer=issue-stream&sort=freq&start=2023-04-25T12%3A11%3A00&stream_index=19

## Test plan
### Reproducing the error
Use Safari 13 (I haven't actually tried this) and try changing the dark mode preference on the system.

### Automated testing
- [x] Unit test
- [x] Integration/E2E test (na)