### PR TITLE
fix: flaky retry test

### DIFF
--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -57,7 +57,9 @@ describe('retry', () => {
         checkTime(
           () => expect(retry(makeFn(4, 'abc'), { n: 3, maxWait: 100, minWait: 50 }).promise).rejects.toThrow('failure'),
           150,
-          400
+          // It may wait up to 400ms, but we add 50ms because the event loop may be busy.
+          // This has been observed over 400ms; assuming the event loop is instant will cause flaky tests.
+          450
         )
       )
     }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes a flaky retry test by bumping the time by 50ms, to account for the event loop.
This test can take up to 400ms of setTimeout time, but waiting a maximum of 400ms will cause flakiness; I've observed it at 424ms locally.


## Test plan

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
