### PR TITLE
fix: eslintrc breakage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,11 @@ module.exports = {
           {
             zones: [
               {
-                target: ['src/**/*[!.test].ts', 'src/**/*[!.test].tsx'],
+                target: 'src/**/*[!.test].ts',
+                from: 'src/test-utils',
+              },
+              {
+                target: 'src/**/*[!.test].tsx',
                 from: 'src/test-utils',
               },
             ],


### PR DESCRIPTION
`yarn eslint --fix` was breaking, resulting in the error: 

Error: .eslintrc.js#overrides[1]:
	Configuration for rule "import/no-restricted-paths" is invalid:
	Value ["src/**/*[!.test].ts","src/**/*[!.test].tsx"] should be string.

This PR fixes it. 