### PR TITLE
build: analyzes only mapped

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "craco start",
     "build": "craco build",
     "build:e2e": "REACT_APP_CSP_ALLOW_UNSAFE_EVAL=true REACT_APP_ADD_COVERAGE_INSTRUMENTATION=true craco build",
-    "analyze": "source-map-explorer 'build/static/js/*.js'",
+    "analyze": "source-map-explorer 'build/static/js/*.js' --only-mapped",
     "serve": "serve build -l 3000",
     "lint": "yarn eslint --ignore-path .gitignore --cache --cache-location node_modules/.cache/eslint/ .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Description
Previous we'd get errors like this:
![image](https://user-images.githubusercontent.com/4899429/234108487-6ad67f12-bd61-46b1-a77e-05294e12c7a7.png)

Instead, now we use `--only-mapped`:
> -m, --only-mapped: exclude "unmapped" bytes from the output. This will result in total counts less than the file size.

Some number of unmapped bytes is expected from modules that don't provide mappings or have code requires to build their module that don't have mappings.