### PR TITLE
build: set version on sentry release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,4 +123,5 @@ jobs:
         with:
           environment: production
           sourcemaps: './build/static/js'
+          version: ${{ github.sha }}
           url_prefix: '~/static/js'


### PR DESCRIPTION
## Description
Right now we have cases where this error shows up.
<img width="906" alt="Screen Shot 2023-04-24 at 6 05 45 PM" src="https://user-images.githubusercontent.com/4899429/234126837-4178b1e6-222d-4331-a428-31c7d5fd4121.png">

I believe it's because we're not adding the release version into the github action which actually uploads the sourcemaps.
https://github.com/getsentry/action-release#parameters

The version is set here to the current commit hash. https://github.com/Uniswap/interface/blob/main/src/tracing/index.ts#L23

## Test plan
I believe we have to merge this to see what happens on deploy tomorrow honestly.