### PR TITLE
fix: filter WebAssembly compile errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -22,22 +22,22 @@ describe('filterKnownErrors', () => {
     const originalException = new (class extends Error {
       requestBody = JSON.stringify({ method: 'eth_blockNumber' })
     })()
-    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 
   it('filters network change errors', () => {
     const originalException = new Error('underlying network changed')
-    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 
   it('filters user rejected request errors', () => {
     const originalException = new Error('user rejected transaction')
-    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 
   it('filters invalid HTML response errors', () => {
     const originalException = new SyntaxError("Unexpected token '<'")
-    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 
   describe('chunk errors', () => {
@@ -152,14 +152,21 @@ describe('filterKnownErrors', () => {
       const originalException = new Error(
         "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inlin..."
       )
-      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
 
     it('filters CSP unsafe-eval compile/instatiate errors', () => {
       const originalException = new Error(
         "Refused to compile or instantiate WebAssembly module because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-a..."
       )
-      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
+    })
+
+    it('filters WebAssembly compilation errors', () => {
+      const originalException = new Error(
+        'Aborted(CompileError: WebAssembly.instantiate(): Wasm code generation disallowed by embedder). Build with -sASSERTIONS for more info.'
+      )
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
   })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -93,6 +93,11 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     if (error.message.match(/'unsafe-eval'.*content security policy/i)) {
       return null
     }
+
+    // WebAssembly compication requires 'unsafe-eval' in CSP, meaning these errors can be filtered out.
+    if (error.message.match(/WebAssembly.instantiate\(\): Wasm code generation disallowed by embedder/)) {
+      return null
+    }
   }
 
   return event

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -94,7 +94,8 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
       return null
     }
 
-    // WebAssembly compication requires 'unsafe-eval' in CSP, meaning these errors can be filtered out.
+    // WebAssembly compilation fails because we do not allow 'unsafe-eval' in our CSP.
+    // Any thrown errors are due to 3P extensions/applications, so we do not need to handle them.
     if (error.message.match(/WebAssembly.instantiate\(\): Wasm code generation disallowed by embedder/)) {
       return null
     }


### PR DESCRIPTION
## Description
These are also a form of CSP errors, which prevent unsafe evaluation on the interface. https://uniswap-labs.sentry.io/issues/4009129049/?end=2023-04-25T15%3A57%3A59&project=4504255148851200&query=release%3A963121f19b0ea66590d648f83f940c9b9928f75b&referrer=issue-stream&sort=freq&start=2023-04-25T12%3A11%3A00&stream_index=16

We should eventually find a better way to catch all different strings for CSP errors, but for now we can just filter the ones that are showing up in sentry often enough to worry about.

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (n/a)
