### PR TITLE
fix: disable bnb network option on uniwallet

### DIFF
--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -76,7 +76,7 @@ export const ChainSelector = ({ leftAlign }: ChainSelectorProps) => {
       <Column paddingX="8">
         {NETWORK_SELECTOR_CHAINS.map((chainId: SupportedChainId) => (
           <ChainSelectorRow
-            disabled={isUniWallet && chainId === SupportedChainId.CELO}
+            disabled={isUniWallet && [SupportedChainId.CELO, SupportedChainId.BNB].includes(chainId)}
             onSelectChain={onSelectChain}
             targetChain={chainId}
             key={chainId}

--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -4,7 +4,7 @@ import { MouseoverTooltip } from 'components/Tooltip'
 import { ConnectionType } from 'connection'
 import { useGetConnection } from 'connection'
 import { getChainInfo } from 'constants/chainInfo'
-import { SupportedChainId } from 'constants/chains'
+import { SupportedChainId, UniWalletSupportedChains } from 'constants/chains'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import useSelectChain from 'hooks/useSelectChain'
 import useSyncChainQuery from 'hooks/useSyncChainQuery'
@@ -76,7 +76,7 @@ export const ChainSelector = ({ leftAlign }: ChainSelectorProps) => {
       <Column paddingX="8">
         {NETWORK_SELECTOR_CHAINS.map((chainId: SupportedChainId) => (
           <ChainSelectorRow
-            disabled={isUniWallet && [SupportedChainId.CELO, SupportedChainId.BNB].includes(chainId)}
+            disabled={isUniWallet && !UniWalletSupportedChains.includes(chainId)}
             onSelectChain={onSelectChain}
             targetChain={chainId}
             key={chainId}

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -25,6 +25,13 @@ export enum SupportedChainId {
   BNB = 56,
 }
 
+export const UniWalletSupportedChains = [
+  SupportedChainId.MAINNET,
+  SupportedChainId.ARBITRUM_ONE,
+  SupportedChainId.OPTIMISM,
+  SupportedChainId.POLYGON,
+]
+
 export const CHAIN_IDS_TO_NAMES = {
   [SupportedChainId.MAINNET]: 'mainnet',
   [SupportedChainId.GOERLI]: 'goerli',


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->


_Slack thread:_ https://uniswapteam.slack.com/archives/C04D07TQBT4/p1682535435459049

<!-- Delete this section if your change does not affect UI. -->
## Screen capture


| Before       | After (Desktop) |
| ------------ |---------------- |
| ![image](https://user-images.githubusercontent.com/5773490/234677262-d84f2c84-71b0-4789-8962-4c682a55938e.png) | <img width="466" alt="image" src="https://user-images.githubusercontent.com/5773490/234678357-135a6781-83fd-4f5e-8e96-b711a7e299d8.png">        |


## Test plan
connect to the app with the uniswap wallet and confirm both options are disabled

connect to the app with anything else and confirm all options are enabled
