### PR TITLE
fix: match OneKey more generically

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -44,13 +44,13 @@ describe('filterKnownErrors', () => {
     it('filter OneKey errors (macOS users)', () => {
       const originalException = new Error()
       originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
-      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
     it('filter OneKey errors (Windows users)', () => {
       const originalException = new Error()
       originalException.name =
         'yd.<anonymous>(C:\\Users\\xyz\\AppData\\Local\\Programs\\OneKey\\resources\\static\\preload.js)'
-      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+      expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
   })
 

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -46,7 +46,7 @@ describe('filterKnownErrors', () => {
       originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
     })
-    it('filter errors with just OneKey', () => {
+    it('filter OneKey errors (Windows users)', () => {
       const originalException = new Error()
       originalException.name = 'yd.<anonymous>(C:\Users\xyz\AppData\Local\Programs\OneKey\resources\static\preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -48,7 +48,7 @@ describe('filterKnownErrors', () => {
     })
     it('filter errors with just OneKey', () => {
       const originalException = new Error()
-      originalException.name = 'xd.<anonymous>(/Applications/OneKey/Contents/Resources/static/preload.js)'
+      originalException.name = 'yd.<anonymous>(C:\Users\xyz\AppData\Local\Programs\OneKey\resources\static\preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
     })
   })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -43,12 +43,12 @@ describe('filterKnownErrors', () => {
   describe('OneKey', () => {
     it('filter errors with OneKey.app', () => {
       const originalException = new Error()
-      originalException.name = 'xd.<anonymous>(/Applications/OneKey/Contents/Resources/static/preload.js)'
+      originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
     })
     it('filter errors with just OneKey', () => {
       const originalException = new Error()
-      originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
+      originalException.name = 'xd.<anonymous>(/Applications/OneKey/Contents/Resources/static/preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
     })
   })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -41,7 +41,7 @@ describe('filterKnownErrors', () => {
   })
 
   describe('OneKey', () => {
-    it('filter errors with OneKey.app', () => {
+    it('filter OneKey errors (macOS users)', () => {
       const originalException = new Error()
       originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -40,10 +40,17 @@ describe('filterKnownErrors', () => {
     expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 
-  it('filter errors from OneKey app', () => {
-    const originalException = new Error()
-    originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
-    expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+  describe('OneKey', () => {
+    it('filter errors with OneKey.app', () => {
+      const originalException = new Error()
+      originalException.name = 'xd.<anonymous>(/Applications/OneKey/Contents/Resources/static/preload.js)'
+      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    })
+    it('filter errors with just OneKey', () => {
+      const originalException = new Error()
+      originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
+      expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
+    })
   })
 
   describe('chunk errors', () => {

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -48,7 +48,8 @@ describe('filterKnownErrors', () => {
     })
     it('filter OneKey errors (Windows users)', () => {
       const originalException = new Error()
-      originalException.name = 'yd.<anonymous>(C:\Users\xyz\AppData\Local\Programs\OneKey\resources\static\preload.js)'
+      originalException.name =
+        'yd.<anonymous>(C:\\Users\\xyz\\AppData\\Local\\Programs\\OneKey\\resources\\static\\preload.js)'
       expect(filterKnownErrors(ERROR, { originalException })).toBe(null)
     })
   })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -89,7 +89,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * Errors coming from OneKey (a desktop wallet) can be ignored for now.
      * These errors are either application-specific, or they will be thrown separately outside of OneKey.
      */
-    if (error.name.match(/OneKey\.app/i)) return null
+    if (error.name.match(/OneKey/i)) return null
 
     /*
      * Content security policy 'unsafe-eval' errors can be filtered out because there are expected failures.


### PR DESCRIPTION
## Description
Extends the match to handle this error: https://uniswap-labs.sentry.io/issues/4009216608/?project=4504255148851200&referrer=release-issue-stream

It says just OneKey instead of OneKey.app.

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (Na)
