### PR TITLE
feat: Bump universal-router-sdk for new router address

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "@uniswap/sdk-core": "^3.2.2",
     "@uniswap/smart-order-router": "^3.6.1",
     "@uniswap/token-lists": "^1.0.0-beta.30",
-    "@uniswap/universal-router-sdk": "^1.3.8",
+    "@uniswap/universal-router-sdk": "1.5.0-beta.2",
     "@uniswap/v2-core": "1.0.0",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v2-sdk": "^3.0.1",

--- a/src/nft/components/bag/BagFooter.tsx
+++ b/src/nft/components/bag/BagFooter.tsx
@@ -334,8 +334,7 @@ export const BagFooter = ({ setModalIsOpen, eventProperties }: BagFooterProps) =
   const { allowance, isAllowancePending, isApprovalLoading, updateAllowance } = usePermit2Approval(
     trade?.inputAmount.currency.isToken ? (trade?.inputAmount as CurrencyAmount<Token>) : undefined,
     maximumAmountIn,
-    shouldUsePayWithAnyToken,
-    true
+    shouldUsePayWithAnyToken
   )
   usePayWithAnyTokenSwap(trade, allowance, allowedSlippage)
   const priceImpact = usePriceImpact(trade)

--- a/src/nft/hooks/usePermit2Approval.test.ts
+++ b/src/nft/hooks/usePermit2Approval.test.ts
@@ -15,7 +15,7 @@ const mockUsePermit2Allowance = usePermit2Allowance as jest.MockedFunction<typeo
 describe('usePermit2Approval', () => {
   it('sets spender of the correct UR contract from NFT side', async () => {
     mockUsePermit2Allowance.mockReturnValue({ state: AllowanceState.LOADING })
-    renderHook(() => usePermit2Approval(USDCAmount, undefined, true, true))
+    renderHook(() => usePermit2Approval(USDCAmount, undefined, true))
     expect(mockUsePermit2Allowance).toHaveBeenCalledWith(USDCAmount, NFT_UNIVERSAL_ROUTER_MAINNET_ADDRESS)
   })
 })

--- a/src/nft/hooks/usePermit2Approval.test.ts
+++ b/src/nft/hooks/usePermit2Approval.test.ts
@@ -1,13 +1,13 @@
 import { CurrencyAmount } from '@uniswap/sdk-core'
 import { USDC_MAINNET } from '@uniswap/smart-order-router'
+import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
+import { SupportedChainId } from 'constants/chains'
 import usePermit2Allowance, { AllowanceState } from 'hooks/usePermit2Allowance'
 import { renderHook } from 'test-utils/render'
 
 import usePermit2Approval from './usePermit2Approval'
 
 const USDCAmount = CurrencyAmount.fromRawAmount(USDC_MAINNET, '10000')
-const NFT_UNIVERSAL_ROUTER_MAINNET_ADDRESS = '0x4c60051384bd2d3c01bfc845cf5f4b44bcbe9de5'
-
 jest.mock('hooks/usePermit2Allowance')
 
 const mockUsePermit2Allowance = usePermit2Allowance as jest.MockedFunction<typeof usePermit2Allowance>
@@ -16,6 +16,6 @@ describe('usePermit2Approval', () => {
   it('sets spender of the correct UR contract from NFT side', async () => {
     mockUsePermit2Allowance.mockReturnValue({ state: AllowanceState.LOADING })
     renderHook(() => usePermit2Approval(USDCAmount, undefined, true))
-    expect(mockUsePermit2Allowance).toHaveBeenCalledWith(USDCAmount, NFT_UNIVERSAL_ROUTER_MAINNET_ADDRESS)
+    expect(mockUsePermit2Allowance).toHaveBeenCalledWith(USDCAmount, UNIVERSAL_ROUTER_ADDRESS(SupportedChainId.MAINNET))
   })
 })

--- a/src/nft/hooks/usePermit2Approval.ts
+++ b/src/nft/hooks/usePermit2Approval.ts
@@ -7,24 +7,17 @@ import usePermit2Allowance, { AllowanceState } from 'hooks/usePermit2Allowance'
 import { useCallback, useMemo, useState } from 'react'
 import invariant from 'tiny-invariant'
 
-// TODO: This should be removed when the sdk is updated to include the new UR address
-const NFT_UNIVERSAL_ROUTER_MAINNET_ADDRESS = '0x4c60051384bd2d3c01bfc845cf5f4b44bcbe9de5'
-
 export default function usePermit2Approval(
   amount?: CurrencyAmount<Token>,
   maximumAmount?: CurrencyAmount<Token>,
-  enabled?: boolean,
-  shouldUseNftRouter?: boolean
+  enabled?: boolean
 ) {
   const { chainId } = useWeb3React()
 
+  const allowanceAmount = maximumAmount ?? (amount?.currency.isToken ? (amount as CurrencyAmount<Token>) : undefined)
   const allowance = usePermit2Allowance(
-    enabled ? maximumAmount ?? (amount?.currency.isToken ? (amount as CurrencyAmount<Token>) : undefined) : undefined,
-    enabled && chainId
-      ? shouldUseNftRouter && chainId === 1
-        ? NFT_UNIVERSAL_ROUTER_MAINNET_ADDRESS
-        : UNIVERSAL_ROUTER_ADDRESS(chainId)
-      : undefined
+    enabled ? allowanceAmount : undefined,
+    enabled && chainId ? UNIVERSAL_ROUTER_ADDRESS(chainId) : undefined
   )
   const isApprovalLoading = allowance.state === AllowanceState.REQUIRED && allowance.isApprovalLoading
   const [isAllowancePending, setIsAllowancePending] = useState(false)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5305,6 +5305,20 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.30.tgz#2103ca23b8007c59ec71718d34cdc97861c409e5"
   integrity sha512-HwY2VvkQ8lNR6ks5NqQfAtg+4IZqz3KV1T8d2DlI8emIn9uMmaoFbIOg0nzjqAVKKnZSbMTRRtUoAh6mmjRvog==
 
+"@uniswap/universal-router-sdk@1.5.0-beta.2":
+  version "1.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.0-beta.2.tgz#1ccbcb71baf4a772c028d30a0f8e7d56c38864d5"
+  integrity sha512-YADNVUhAeTTZiHvKaHhuViLpf+DYl4tF/Lqqg8hR1ypaRzmICR1kdwuQk1De0+gHu3D2HWsUgh+Ra8cmPPCzgg==
+  dependencies:
+    "@uniswap/permit2-sdk" "^1.2.0"
+    "@uniswap/router-sdk" "^1.4.0"
+    "@uniswap/sdk-core" "^3.1.0"
+    "@uniswap/universal-router" "1.4.1-beta.0"
+    "@uniswap/v2-sdk" "^3.0.1"
+    "@uniswap/v3-sdk" "^3.9.0"
+    bignumber.js "^9.0.2"
+    ethers "^5.3.1"
+
 "@uniswap/universal-router-sdk@^1.3.8", "@uniswap/universal-router-sdk@^1.3.9":
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.3.9.tgz#75a1b354457b85e1e0271ecd5956ea3323a40eca"
@@ -5323,6 +5337,15 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.2.1.tgz#5fe4aa21d6bc89314d99f26407f28154f8e16f42"
   integrity sha512-F3S1wKylncuvIG2qwC1ciXXc1z1QmKsalo4p6H2A90LSRylEEhNp7ITxs7qCcnfRh+ZNkGJ0yQ0zmuVJSBezOQ==
+  dependencies:
+    "@openzeppelin/contracts" "4.7.0"
+    "@uniswap/v2-core" "1.0.1"
+    "@uniswap/v3-core" "1.0.0"
+
+"@uniswap/universal-router@1.4.1-beta.0":
+  version "1.4.1-beta.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.4.1-beta.0.tgz#ec8dfa8df72ecd008540c69a984b50fbaccbddd4"
+  integrity sha512-lgMj2eRCJEnuNRb811oFzZsZc7PAvpOtVuApH60aHJjLvU5zn+KemHRMDQqeQ34f4CIdnH4ZcCmaFen5N+bzVw==
   dependencies:
     "@openzeppelin/contracts" "4.7.0"
     "@uniswap/v2-core" "1.0.1"


### PR DESCRIPTION
## Description
This PR bumps the version of universal-router-sdk to use the new contract address `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD` for mainnet. Other chains coming soon.

This also removes the conditional flow for PWAT on NFTs because it uses the same router address for both Swap and NFTs.

## Test plan
Test swaps and NFT buys~

### QA (ie manual testing)
- [ ] Test erc20 swaps
- [ ] Test native swaps
- [ ] Test erc20 swaps with no permit allowance
- [ ] Test erc20 swaps with no token allowance and no permit allowance
- [ ] Test pwat NFT flow (@JackShort will let you fill this in more)


