### PR TITLE
fix: filter errors with OneKey in stack

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -48,8 +48,11 @@ describe('filterKnownErrors', () => {
     })
     it('filter OneKey errors (Windows users)', () => {
       const originalException = new Error()
-      originalException.name =
-        'yd.<anonymous>(C:\\Users\\xyz\\AppData\\Local\\Programs\\OneKey\\resources\\static\\preload.js)'
+      originalException.stack = `
+        SyntaxError: Unexpected token u in JSON at position 0
+  at JSON.parse(<anonymous>)
+  at _d._handleAccountChange(/Applications/OneKey.app/Contents/Resources/static/preload.js:2:1634067)
+  `
       expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
   })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -43,16 +43,20 @@ describe('filterKnownErrors', () => {
   describe('OneKey', () => {
     it('filter OneKey errors (macOS users)', () => {
       const originalException = new Error()
-      originalException.name = 'xd.<anonymous>(/Applications/OneKey.app/Contents/Resources/static/preload.js)'
+      originalException.stack = `
+        SyntaxError: Unexpected token u in JSON at position 0
+          at JSON.parse(<anonymous>)
+          at _d._handleAccountChange(/Applications/OneKey.app/Contents/Resources/static/preload.js:2:1634067)
+      `
       expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
     it('filter OneKey errors (Windows users)', () => {
       const originalException = new Error()
       originalException.stack = `
         SyntaxError: Unexpected token u in JSON at position 0
-  at JSON.parse(<anonymous>)
-  at _d._handleAccountChange(/Applications/OneKey.app/Contents/Resources/static/preload.js:2:1634067)
-  `
+          at JSON.parse(<anonymous>)
+          vd._handleAccountChange(C:\\Users\\example\\AppData\\Local\\Programs\\OneKey\\resources\\static\\preload.js:2:1626130
+      `
       expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
   })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -89,7 +89,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
      * Errors coming from OneKey (a desktop wallet) can be ignored for now.
      * These errors are either application-specific, or they will be thrown separately outside of OneKey.
      */
-    if (error.name.match(/OneKey/i)) return null
+    if (error.stack?.match(/OneKey/i)) return null
 
     /*
      * Content security policy 'unsafe-eval' errors can be filtered out because there are expected failures.


### PR DESCRIPTION
## Description
https://uniswap-labs.sentry.io/issues/4009216613/events/df10a0f032eb4e80979d2947c46dbbce/?end=2023-05-01T16%3A10%3A59&project=4504255148851200&query=+browser.name%3AElectron&referrer=previous-event&sort=freq&start=2023-05-01T12%3A09%3A00&stream_index=1

This is an example of an error which is sourced from OneKey, but OneKey is not in the name or message. However, it is in the stack so we can filter by checking that instead.

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (n/a)
