### PR TITLE
fix: update service worker to precache css/js files

### DIFF
--- a/cypress/e2e/service-worker.test.ts
+++ b/cypress/e2e/service-worker.test.ts
@@ -53,7 +53,8 @@ describe('Service Worker', () => {
   it('installs a ServiceWorker', () => {
     cy.visit('/', { serviceWorker: true })
       .get('#swap-page')
-      .wait('@NotInstalled', { timeout: 20000 })
+      // This is emitted after caching the entry file, which takes some time to load.
+      .wait('@NotInstalled', { timeout: 60000 })
       .window({ timeout: 20000 })
       .and((win) => {
         expect(win.navigator.serviceWorker.controller?.state).to.equal('activated')

--- a/cypress/e2e/service-worker.test.ts
+++ b/cypress/e2e/service-worker.test.ts
@@ -55,7 +55,7 @@ describe('Service Worker', () => {
       .get('#swap-page')
       // This is emitted after caching the entry file, which takes some time to load.
       .wait('@NotInstalled', { timeout: 60000 })
-      .window({ timeout: 20000 })
+      .window()
       .and((win) => {
         expect(win.navigator.serviceWorker.controller?.state).to.equal('activated')
       })

--- a/cypress/e2e/service-worker.test.ts
+++ b/cypress/e2e/service-worker.test.ts
@@ -8,8 +8,8 @@ describe('Service Worker', () => {
       if (!isValid) {
         throw new Error(
           '\n' +
-          'Service Worker tests must be run on a production-like build\n' +
-          'To test, build with `yarn build:e2e` and serve with `yarn serve`'
+            'Service Worker tests must be run on a production-like build\n' +
+            'To test, build with `yarn build:e2e` and serve with `yarn serve`'
         )
       }
     })

--- a/cypress/e2e/service-worker.test.ts
+++ b/cypress/e2e/service-worker.test.ts
@@ -8,8 +8,8 @@ describe('Service Worker', () => {
       if (!isValid) {
         throw new Error(
           '\n' +
-            'Service Worker tests must be run on a production-like build\n' +
-            'To test, build with `yarn build:e2e` and serve with `yarn serve`'
+          'Service Worker tests must be run on a production-like build\n' +
+          'To test, build with `yarn build:e2e` and serve with `yarn serve`'
         )
       }
     })

--- a/src/serviceWorker/index.test.ts
+++ b/src/serviceWorker/index.test.ts
@@ -1,0 +1,68 @@
+import { PrecacheEntry } from 'workbox-precaching/_types'
+
+import { splitAssetsAndEntries } from './index'
+
+describe('splitAssetsAndEntries', () => {
+  test('splits resources into assets and entries', () => {
+    const resources = [
+      'index.html',
+      { url: '/main.js', revision: 'abc123' },
+      { url: '/styles.css', revision: 'def456' },
+      { url: '/media/image.jpg', revision: 'ghi789' },
+      { url: '/other-page.html', revision: 'jkl012' },
+    ]
+
+    const result = splitAssetsAndEntries(resources)
+
+    expect(result).toEqual({
+      assets: ['/media/image.jpg', '/main.js', '/styles.css'],
+      entries: [
+        { url: '/main.js', revision: 'abc123' },
+        { url: '/styles.css', revision: 'def456' },
+        { url: '/other-page.html', revision: 'jkl012' },
+      ],
+    })
+  })
+
+  test('handles empty input', () => {
+    const resources: (string | PrecacheEntry)[] = []
+
+    const result = splitAssetsAndEntries(resources)
+
+    expect(result).toEqual({ assets: [], entries: [] })
+  })
+
+  test('handles input with only index.html', () => {
+    const resources = ['index.html']
+
+    const result = splitAssetsAndEntries(resources)
+
+    expect(result).toEqual({ assets: ['index.html'], entries: [] })
+  })
+
+  test('handles input with only assets', () => {
+    const resources = [
+      { url: '/media/image.jpg', revision: 'abc123' },
+      { url: '/main.js', revision: 'def456' },
+      { url: '/styles.css', revision: 'ghi789' },
+    ]
+
+    const result = splitAssetsAndEntries(resources)
+
+    expect(result).toEqual({
+      assets: ['/media/image.jpg', '/main.js', '/styles.css'],
+      entries: [],
+    })
+  })
+
+  test('handles input with only entries', () => {
+    const resources = [
+      { url: '/other-page.html', revision: 'abc123' },
+      { url: '/about.html', revision: 'def456' },
+    ]
+
+    const result = splitAssetsAndEntries(resources)
+
+    expect(result).toEqual({ assets: [], entries: resources })
+  })
+})

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -20,15 +20,18 @@ self.skipWaiting()
 registerRoute(new DocumentRoute())
 
 // Splits entries into assets, which are loaded on-demand; and entries, which are precached.
-// Effectively, this precaches the document, and caches all other assets on-demand.
+// Effectively, this caches all media assets on-demand and pre-caches everything else.
 const { assets, entries } = self.__WB_MANIFEST.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
   ({ assets, entries }, entry) => {
     if (typeof entry === 'string') {
+      // If the entry is a string, it's the index.html file.
       return { entries, assets: [...assets, entry] }
-    } else if (entry.revision) {
-      return { entries: [...entries, entry], assets }
-    } else {
+    } else if (entry.url.includes('/media/')) {
+      // If the entry is a media file, it's an asset.
       return { entries, assets: [...assets, toURL(entry)] }
+    } else {
+      // Otherwise, it's an entry.
+      return { entries: [...entries, entry], assets }
     }
   },
   { assets: [], entries: [] }

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -7,7 +7,7 @@ import { registerRoute, Route } from 'workbox-routing'
 import { CacheFirst } from 'workbox-strategies'
 
 import { DocumentRoute } from './document'
-import { groupEntries } from './utils'
+import { groupEntries, toURL } from './utils'
 
 declare const self: ServiceWorkerGlobalScope
 
@@ -23,9 +23,10 @@ registerRoute(new DocumentRoute())
 const { onDemandCacheEntries, precacheEntries } = groupEntries(self.__WB_MANIFEST)
 
 // Registers the onDemandCacheEntries' routes for on-demand caching.
+const onDemandCacheURLs = onDemandCacheEntries.map(toURL)
 registerRoute(
   new Route(
-    ({ url }) => onDemandCacheEntries.includes('.' + url.pathname),
+    ({ url }) => onDemandCacheURLs.includes('.' + url.pathname),
     new CacheFirst({
       cacheName: 'assets',
       plugins: [new ExpirationPlugin({ maxEntries: 16 })],

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -7,7 +7,7 @@ import { registerRoute, Route } from 'workbox-routing'
 import { CacheFirst } from 'workbox-strategies'
 
 import { DocumentRoute } from './document'
-import { splitAssetsAndEntries } from './utils'
+import { groupEntries } from './utils'
 
 declare const self: ServiceWorkerGlobalScope
 
@@ -20,12 +20,12 @@ registerRoute(new DocumentRoute())
 
 // Splits entries into assets, which are loaded on-demand; and entries, which are precached.
 // Effectively, this caches all media assets on-demand and pre-caches everything else.
-const { assets, entries } = splitAssetsAndEntries(self.__WB_MANIFEST)
+const { onDemandCacheEntries, precacheEntries } = groupEntries(self.__WB_MANIFEST)
 
-// Registers the assets' routes for on-demand caching.
+// Registers the onDemandCacheEntries' routes for on-demand caching.
 registerRoute(
   new Route(
-    ({ url }) => assets.includes('.' + url.pathname),
+    ({ url }) => onDemandCacheEntries.includes('.' + url.pathname),
     new CacheFirst({
       cacheName: 'assets',
       plugins: [new ExpirationPlugin({ maxEntries: 16 })],
@@ -34,4 +34,4 @@ registerRoute(
 )
 
 // Precaches entries and registers a default route to serve them.
-precacheAndRoute(entries)
+precacheAndRoute(precacheEntries)

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -18,11 +18,11 @@ self.skipWaiting()
 // This must be done before setting up workbox-precaching, so that it takes precedence.
 registerRoute(new DocumentRoute())
 
-// Splits entries into assets, which are loaded on-demand; and entries, which are precached.
-// Effectively, this caches all media assets on-demand and pre-caches everything else.
+// Splits entries into:
+// - mediaURLs: loaded on-demand
+// - precacheEntries
 const { mediaURLs, precacheEntries } = groupEntries(self.__WB_MANIFEST)
 
-// Registers the mediaURLs' routes for on-demand caching.
 registerRoute(
   new Route(
     ({ url }) => mediaURLs.includes('.' + url.pathname),

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -27,7 +27,7 @@ registerRoute(
   new Route(
     ({ url }) => mediaURLs.includes('.' + url.pathname),
     new CacheFirst({
-      cacheName: 'assets',
+      cacheName: 'media',
       plugins: [new ExpirationPlugin({ maxEntries: 16 })],
     })
   )

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -3,12 +3,11 @@ import 'workbox-precaching' // defines __WB_MANIFEST
 import { clientsClaim } from 'workbox-core'
 import { ExpirationPlugin } from 'workbox-expiration'
 import { precacheAndRoute } from 'workbox-precaching'
-import { PrecacheEntry } from 'workbox-precaching/_types'
 import { registerRoute, Route } from 'workbox-routing'
 import { CacheFirst } from 'workbox-strategies'
 
 import { DocumentRoute } from './document'
-import { toURL } from './utils'
+import { splitAssetsAndEntries } from './utils'
 
 declare const self: ServiceWorkerGlobalScope
 
@@ -21,26 +20,6 @@ registerRoute(new DocumentRoute())
 
 // Splits entries into assets, which are loaded on-demand; and entries, which are precached.
 // Effectively, this caches all media assets on-demand and pre-caches everything else.
-export const splitAssetsAndEntries = (
-  resources: (string | PrecacheEntry)[]
-): { assets: string[]; entries: PrecacheEntry[] } => {
-  return resources.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
-    ({ assets, entries }, entry) => {
-      if (typeof entry === 'string') {
-        // If the entry is a string, it's the index.html file.
-        return { entries, assets: [...assets, entry] }
-      } else if (entry.url.includes('/media/')) {
-        // If the entry is a media file, it's an asset.
-        return { entries, assets: [...assets, toURL(entry)] }
-      } else {
-        // Otherwise, it's an entry.
-        return { entries: [...entries, entry], assets }
-      }
-    },
-    { assets: [], entries: [] }
-  )
-}
-
 const { assets, entries } = splitAssetsAndEntries(self.__WB_MANIFEST)
 
 // Registers the assets' routes for on-demand caching.

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -7,7 +7,7 @@ import { registerRoute, Route } from 'workbox-routing'
 import { CacheFirst } from 'workbox-strategies'
 
 import { DocumentRoute } from './document'
-import { groupEntries, toURL } from './utils'
+import { groupEntries } from './utils'
 
 declare const self: ServiceWorkerGlobalScope
 
@@ -20,13 +20,12 @@ registerRoute(new DocumentRoute())
 
 // Splits entries into assets, which are loaded on-demand; and entries, which are precached.
 // Effectively, this caches all media assets on-demand and pre-caches everything else.
-const { onDemandCacheEntries, precacheEntries } = groupEntries(self.__WB_MANIFEST)
+const { mediaURLs, precacheEntries } = groupEntries(self.__WB_MANIFEST)
 
-// Registers the onDemandCacheEntries' routes for on-demand caching.
-const onDemandCacheURLs = onDemandCacheEntries.map(toURL)
+// Registers the mediaURLs' routes for on-demand caching.
 registerRoute(
   new Route(
-    ({ url }) => onDemandCacheURLs.includes('.' + url.pathname),
+    ({ url }) => mediaURLs.includes('.' + url.pathname),
     new CacheFirst({
       cacheName: 'assets',
       plugins: [new ExpirationPlugin({ maxEntries: 16 })],

--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -21,21 +21,27 @@ registerRoute(new DocumentRoute())
 
 // Splits entries into assets, which are loaded on-demand; and entries, which are precached.
 // Effectively, this caches all media assets on-demand and pre-caches everything else.
-const { assets, entries } = self.__WB_MANIFEST.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
-  ({ assets, entries }, entry) => {
-    if (typeof entry === 'string') {
-      // If the entry is a string, it's the index.html file.
-      return { entries, assets: [...assets, entry] }
-    } else if (entry.url.includes('/media/')) {
-      // If the entry is a media file, it's an asset.
-      return { entries, assets: [...assets, toURL(entry)] }
-    } else {
-      // Otherwise, it's an entry.
-      return { entries: [...entries, entry], assets }
-    }
-  },
-  { assets: [], entries: [] }
-)
+export const splitAssetsAndEntries = (
+  resources: (string | PrecacheEntry)[]
+): { assets: string[]; entries: PrecacheEntry[] } => {
+  return resources.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
+    ({ assets, entries }, entry) => {
+      if (typeof entry === 'string') {
+        // If the entry is a string, it's the index.html file.
+        return { entries, assets: [...assets, entry] }
+      } else if (entry.url.includes('/media/')) {
+        // If the entry is a media file, it's an asset.
+        return { entries, assets: [...assets, toURL(entry)] }
+      } else {
+        // Otherwise, it's an entry.
+        return { entries: [...entries, entry], assets }
+      }
+    },
+    { assets: [], entries: [] }
+  )
+}
+
+const { assets, entries } = splitAssetsAndEntries(self.__WB_MANIFEST)
 
 // Registers the assets' routes for on-demand caching.
 registerRoute(

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -3,7 +3,6 @@ import { groupEntries } from './utils'
 describe('groupEntries', () => {
   test('splits resources into mediaURLs and precacheEntries', () => {
     const resources = [
-      './static/whitepaper.pdf',
       { url: './static/js/main.js', revision: 'abc123' },
       { url: './static/css/styles.css', revision: 'def456' },
       { url: './static/media/image.jpg', revision: 'ghi789' },
@@ -12,7 +11,7 @@ describe('groupEntries', () => {
     const result = groupEntries(resources)
 
     expect(result).toEqual({
-      mediaURLs: ['./static/whitepaper.pdf', './static/media/image.jpg'],
+      mediaURLs: ['./static/media/image.jpg'],
       precacheEntries: [
         { url: './static/js/main.js', revision: 'abc123' },
         { url: './static/css/styles.css', revision: 'def456' },

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -1,5 +1,3 @@
-import { PrecacheEntry } from 'workbox-precaching/_types'
-
 import { groupEntries } from './utils'
 
 describe('groupEntries', () => {

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -1,6 +1,6 @@
 import { PrecacheEntry } from 'workbox-precaching/_types'
 
-import { splitAssetsAndEntries } from './index'
+import { splitAssetsAndEntries } from './utils'
 
 describe('splitAssetsAndEntries', () => {
   test('splits resources into assets and entries', () => {

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -5,20 +5,20 @@ import { splitAssetsAndEntries } from './utils'
 describe('splitAssetsAndEntries', () => {
   test('splits resources into assets and entries', () => {
     const resources = [
-      'index.html',
-      { url: '/main.js', revision: 'abc123' },
-      { url: '/styles.css', revision: 'def456' },
-      { url: '/media/image.jpg', revision: 'ghi789' },
+      './static/whitepaper.pdf',
+      { url: './static/js/main.js', revision: 'abc123' },
+      { url: './static/css/styles.css', revision: 'def456' },
+      { url: './static/media/image.jpg', revision: 'ghi789' },
       { url: '/other-page.html', revision: 'jkl012' },
     ]
 
     const result = splitAssetsAndEntries(resources)
 
     expect(result).toEqual({
-      assets: ['index.html', '/media/image.jpg'],
+      assets: ['./static/whitepaper.pdf', './static/media/image.jpg'],
       entries: [
-        { url: '/main.js', revision: 'abc123' },
-        { url: '/styles.css', revision: 'def456' },
+        { url: './static/js/main.js', revision: 'abc123' },
+        { url: './static/css/styles.css', revision: 'def456' },
         { url: '/other-page.html', revision: 'jkl012' },
       ],
     })
@@ -32,24 +32,24 @@ describe('splitAssetsAndEntries', () => {
     expect(result).toEqual({ assets: [], entries: [] })
   })
 
-  test('handles input with only index.html', () => {
-    const resources = ['index.html']
+  test('handles input with only ./static/whitepaper.pdf', () => {
+    const resources = ['./static/whitepaper.pdf']
 
     const result = splitAssetsAndEntries(resources)
 
-    expect(result).toEqual({ assets: ['index.html'], entries: [] })
+    expect(result).toEqual({ assets: ['./static/whitepaper.pdf'], entries: [] })
   })
 
   test('handles input with only assets', () => {
     const resources = [
-      { url: '/media/image.jpg', revision: 'abc123' },
-      { url: '/media/image2.jpg', revision: 'abc123' },
+      { url: './static/media/image.jpg', revision: 'abc123' },
+      { url: './static/media/image2.jpg', revision: 'abc123' },
     ]
 
     const result = splitAssetsAndEntries(resources)
 
     expect(result).toEqual({
-      assets: ['/media/image.jpg', '/media/image2.jpg'],
+      assets: ['./static/media/image.jpg', './static/media/image2.jpg'],
       entries: [],
     })
   })

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -15,7 +15,7 @@ describe('splitAssetsAndEntries', () => {
     const result = splitAssetsAndEntries(resources)
 
     expect(result).toEqual({
-      assets: ['/media/image.jpg', '/main.js', '/styles.css'],
+      assets: ['index.html', '/media/image.jpg'],
       entries: [
         { url: '/main.js', revision: 'abc123' },
         { url: '/styles.css', revision: 'def456' },
@@ -43,14 +43,13 @@ describe('splitAssetsAndEntries', () => {
   test('handles input with only assets', () => {
     const resources = [
       { url: '/media/image.jpg', revision: 'abc123' },
-      { url: '/main.js', revision: 'def456' },
-      { url: '/styles.css', revision: 'ghi789' },
+      { url: '/media/image2.jpg', revision: 'abc123' },
     ]
 
     const result = splitAssetsAndEntries(resources)
 
     expect(result).toEqual({
-      assets: ['/media/image.jpg', '/main.js', '/styles.css'],
+      assets: ['/media/image.jpg', '/media/image2.jpg'],
       entries: [],
     })
   })

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -1,9 +1,9 @@
 import { PrecacheEntry } from 'workbox-precaching/_types'
 
-import { splitAssetsAndEntries } from './utils'
+import { groupEntries } from './utils'
 
-describe('splitAssetsAndEntries', () => {
-  test('splits resources into assets and entries', () => {
+describe('groupEntries', () => {
+  test('splits resources into onDemandCacheEntries and precacheEntries', () => {
     const resources = [
       './static/whitepaper.pdf',
       { url: './static/js/main.js', revision: 'abc123' },
@@ -12,11 +12,11 @@ describe('splitAssetsAndEntries', () => {
       { url: '/other-page.html', revision: 'jkl012' },
     ]
 
-    const result = splitAssetsAndEntries(resources)
+    const result = groupEntries(resources)
 
     expect(result).toEqual({
-      assets: ['./static/whitepaper.pdf', './static/media/image.jpg'],
-      entries: [
+      onDemandCacheEntries: ['./static/whitepaper.pdf', './static/media/image.jpg'],
+      precacheEntries: [
         { url: './static/js/main.js', revision: 'abc123' },
         { url: './static/css/styles.css', revision: 'def456' },
         { url: '/other-page.html', revision: 'jkl012' },
@@ -27,41 +27,41 @@ describe('splitAssetsAndEntries', () => {
   test('handles empty input', () => {
     const resources: (string | PrecacheEntry)[] = []
 
-    const result = splitAssetsAndEntries(resources)
+    const result = groupEntries(resources)
 
-    expect(result).toEqual({ assets: [], entries: [] })
+    expect(result).toEqual({ onDemandCacheEntries: [], precacheEntries: [] })
   })
 
   test('handles input with only ./static/whitepaper.pdf', () => {
     const resources = ['./static/whitepaper.pdf']
 
-    const result = splitAssetsAndEntries(resources)
+    const result = groupEntries(resources)
 
-    expect(result).toEqual({ assets: ['./static/whitepaper.pdf'], entries: [] })
+    expect(result).toEqual({ onDemandCacheEntries: ['./static/whitepaper.pdf'], precacheEntries: [] })
   })
 
-  test('handles input with only assets', () => {
+  test('handles input with only onDemandCacheEntries', () => {
     const resources = [
       { url: './static/media/image.jpg', revision: 'abc123' },
       { url: './static/media/image2.jpg', revision: 'abc123' },
     ]
 
-    const result = splitAssetsAndEntries(resources)
+    const result = groupEntries(resources)
 
     expect(result).toEqual({
-      assets: ['./static/media/image.jpg', './static/media/image2.jpg'],
-      entries: [],
+      onDemandCacheEntries: ['./static/media/image.jpg', './static/media/image2.jpg'],
+      precacheEntries: [],
     })
   })
 
-  test('handles input with only entries', () => {
+  test('handles input with only precacheEntries', () => {
     const resources = [
       { url: '/other-page.html', revision: 'abc123' },
       { url: '/about.html', revision: 'def456' },
     ]
 
-    const result = splitAssetsAndEntries(resources)
+    const result = groupEntries(resources)
 
-    expect(result).toEqual({ assets: [], entries: resources })
+    expect(result).toEqual({ onDemandCacheEntries: [], precacheEntries: resources })
   })
 })

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -3,65 +3,22 @@ import { PrecacheEntry } from 'workbox-precaching/_types'
 import { groupEntries } from './utils'
 
 describe('groupEntries', () => {
-  test('splits resources into onDemandCacheEntries and precacheEntries', () => {
+  test('splits resources into mediaURLs and precacheEntries', () => {
     const resources = [
       './static/whitepaper.pdf',
       { url: './static/js/main.js', revision: 'abc123' },
       { url: './static/css/styles.css', revision: 'def456' },
       { url: './static/media/image.jpg', revision: 'ghi789' },
-      { url: '/other-page.html', revision: 'jkl012' },
     ]
 
     const result = groupEntries(resources)
 
     expect(result).toEqual({
-      onDemandCacheEntries: ['./static/whitepaper.pdf', { url: './static/media/image.jpg', revision: 'ghi789' }],
+      mediaURLs: ['./static/whitepaper.pdf', './static/media/image.jpg'],
       precacheEntries: [
         { url: './static/js/main.js', revision: 'abc123' },
         { url: './static/css/styles.css', revision: 'def456' },
-        { url: '/other-page.html', revision: 'jkl012' },
       ],
     })
-  })
-
-  test('handles empty input', () => {
-    const resources: (string | PrecacheEntry)[] = []
-
-    const result = groupEntries(resources)
-
-    expect(result).toEqual({ onDemandCacheEntries: [], precacheEntries: [] })
-  })
-
-  test('handles input with only ./static/whitepaper.pdf', () => {
-    const resources = ['./static/whitepaper.pdf']
-
-    const result = groupEntries(resources)
-
-    expect(result).toEqual({ onDemandCacheEntries: ['./static/whitepaper.pdf'], precacheEntries: [] })
-  })
-
-  test('handles input with only onDemandCacheEntries', () => {
-    const resources = [
-      { url: './static/media/image.jpg', revision: 'abc123' },
-      { url: './static/media/image2.jpg', revision: 'abc123' },
-    ]
-
-    const result = groupEntries(resources)
-
-    expect(result).toEqual({
-      onDemandCacheEntries: resources,
-      precacheEntries: [],
-    })
-  })
-
-  test('handles input with only precacheEntries', () => {
-    const resources = [
-      { url: '/other-page.html', revision: 'abc123' },
-      { url: '/about.html', revision: 'def456' },
-    ]
-
-    const result = groupEntries(resources)
-
-    expect(result).toEqual({ onDemandCacheEntries: [], precacheEntries: resources })
   })
 })

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -3,6 +3,7 @@ import { groupEntries } from './utils'
 describe('groupEntries', () => {
   test('splits resources into mediaURLs and precacheEntries', () => {
     const resources = [
+      './static/whitepaper.pdf',
       { url: './static/js/main.js', revision: 'abc123' },
       { url: './static/css/styles.css', revision: 'def456' },
       { url: './static/media/image.jpg', revision: 'ghi789' },
@@ -11,7 +12,7 @@ describe('groupEntries', () => {
     const result = groupEntries(resources)
 
     expect(result).toEqual({
-      mediaURLs: ['./static/media/image.jpg'],
+      mediaURLs: ['./static/whitepaper.pdf', './static/media/image.jpg'],
       precacheEntries: [
         { url: './static/js/main.js', revision: 'abc123' },
         { url: './static/css/styles.css', revision: 'def456' },

--- a/src/serviceWorker/utils.test.ts
+++ b/src/serviceWorker/utils.test.ts
@@ -15,7 +15,7 @@ describe('groupEntries', () => {
     const result = groupEntries(resources)
 
     expect(result).toEqual({
-      onDemandCacheEntries: ['./static/whitepaper.pdf', './static/media/image.jpg'],
+      onDemandCacheEntries: ['./static/whitepaper.pdf', { url: './static/media/image.jpg', revision: 'ghi789' }],
       precacheEntries: [
         { url: './static/js/main.js', revision: 'abc123' },
         { url: './static/css/styles.css', revision: 'def456' },
@@ -49,7 +49,7 @@ describe('groupEntries', () => {
     const result = groupEntries(resources)
 
     expect(result).toEqual({
-      onDemandCacheEntries: ['./static/media/image.jpg', './static/media/image2.jpg'],
+      onDemandCacheEntries: resources,
       precacheEntries: [],
     })
   })

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -17,7 +17,7 @@ export function isDevelopment() {
 }
 
 type GroupedEntries = { mediaURLs: string[]; precacheEntries: PrecacheEntry[] }
-export const groupEntries = (entries: (string | PrecacheEntry)[]): GroupedEntries => {
+export function groupEntries(entries: (string | PrecacheEntry)[]): GroupedEntries {
   return entries.reduce<GroupedEntries>(
     ({ mediaURLs, precacheEntries }, entry) => {
       if (typeof entry === 'string') {

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -16,18 +16,16 @@ export function isDevelopment() {
   )
 }
 
-function toURL(entry: string | PrecacheEntry): string {
+export function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
 
-type GroupedEntries = { onDemandCacheEntries: string[]; precacheEntries: PrecacheEntry[] }
+type GroupedEntries = { onDemandCacheEntries: (string | PrecacheEntry)[]; precacheEntries: PrecacheEntry[] }
 export const groupEntries = (resources: (string | PrecacheEntry)[]): GroupedEntries => {
   return resources.reduce<GroupedEntries>(
     ({ onDemandCacheEntries, precacheEntries }, entry) => {
-      if (typeof entry === 'string') {
+      if (typeof entry === 'string' || entry.url.includes('/media/')) {
         return { precacheEntries, onDemandCacheEntries: [...onDemandCacheEntries, entry] }
-      } else if (entry.url.includes('/media/')) {
-        return { precacheEntries, onDemandCacheEntries: [...onDemandCacheEntries, toURL(entry)] }
       } else {
         return { precacheEntries: [...precacheEntries, entry], onDemandCacheEntries }
       }

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -7,16 +7,16 @@ declare const self: ServiceWorkerGlobalScope
 export function isDevelopment() {
   return Boolean(
     self.location.hostname === 'localhost' ||
-      // [::1] is the IPv6 localhost address
-      self.location.hostname === '[::1]' ||
-      // 127.0.0.0/8 are considered localhost for IPv4
-      self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
-      // vercel previews
-      self.location.hostname.endsWith('.vercel.app')
+    // [::1] is the IPv6 localhost address
+    self.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4
+    self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
+    // vercel previews
+    self.location.hostname.endsWith('.vercel.app')
   )
 }
 
-export function toURL(entry: string | PrecacheEntry): string {
+function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
 

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -26,13 +26,10 @@ export const splitAssetsAndEntries = (
   return resources.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
     ({ assets, entries }, entry) => {
       if (typeof entry === 'string') {
-        // If the entry is a string, it's the index.html file.
         return { entries, assets: [...assets, entry] }
       } else if (entry.url.includes('/media/')) {
-        // If the entry is a media file, it's an asset.
         return { entries, assets: [...assets, toURL(entry)] }
       } else {
-        // Otherwise, it's an entry.
         return { entries: [...entries, entry], assets }
       }
     },

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -7,12 +7,12 @@ declare const self: ServiceWorkerGlobalScope
 export function isDevelopment() {
   return Boolean(
     self.location.hostname === 'localhost' ||
-      // [::1] is the IPv6 localhost address
-      self.location.hostname === '[::1]' ||
-      // 127.0.0.0/8 are considered localhost for IPv4
-      self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
-      // vercel previews
-      self.location.hostname.endsWith('.vercel.app')
+    // [::1] is the IPv6 localhost address
+    self.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4
+    self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
+    // vercel previews
+    self.location.hostname.endsWith('.vercel.app')
   )
 }
 
@@ -20,19 +20,18 @@ function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
 
-export const splitAssetsAndEntries = (
-  resources: (string | PrecacheEntry)[]
-): { assets: string[]; entries: PrecacheEntry[] } => {
-  return resources.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
-    ({ assets, entries }, entry) => {
+type GroupedEntries = { onDemandCacheEntries: string[]; precacheEntries: PrecacheEntry[] }
+export const groupEntries = (resources: (string | PrecacheEntry)[]): GroupedEntries => {
+  return resources.reduce<GroupedEntries>(
+    ({ onDemandCacheEntries, precacheEntries }, entry) => {
       if (typeof entry === 'string') {
-        return { entries, assets: [...assets, entry] }
+        return { precacheEntries, onDemandCacheEntries: [...onDemandCacheEntries, entry] }
       } else if (entry.url.includes('/media/')) {
-        return { entries, assets: [...assets, toURL(entry)] }
+        return { precacheEntries, onDemandCacheEntries: [...onDemandCacheEntries, toURL(entry)] }
       } else {
-        return { entries: [...entries, entry], assets }
+        return { precacheEntries: [...precacheEntries, entry], onDemandCacheEntries }
       }
     },
-    { assets: [], entries: [] }
+    { onDemandCacheEntries: [], precacheEntries: [] }
   )
 }

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -7,12 +7,12 @@ declare const self: ServiceWorkerGlobalScope
 export function isDevelopment() {
   return Boolean(
     self.location.hostname === 'localhost' ||
-    // [::1] is the IPv6 localhost address
-    self.location.hostname === '[::1]' ||
-    // 127.0.0.0/8 are considered localhost for IPv4
-    self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
-    // vercel previews
-    self.location.hostname.endsWith('.vercel.app')
+      // [::1] is the IPv6 localhost address
+      self.location.hostname === '[::1]' ||
+      // 127.0.0.0/8 are considered localhost for IPv4
+      self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
+      // vercel previews
+      self.location.hostname.endsWith('.vercel.app')
   )
 }
 

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -20,16 +20,16 @@ export function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
 
-type GroupedEntries = { onDemandCacheEntries: (string | PrecacheEntry)[]; precacheEntries: PrecacheEntry[] }
-export const groupEntries = (resources: (string | PrecacheEntry)[]): GroupedEntries => {
-  return resources.reduce<GroupedEntries>(
-    ({ onDemandCacheEntries, precacheEntries }, entry) => {
+type GroupedEntries = { mediaURLs: string[]; precacheEntries: PrecacheEntry[] }
+export const groupEntries = (entries: (string | PrecacheEntry)[]): GroupedEntries => {
+  return entries.reduce<GroupedEntries>(
+    ({ mediaURLs, precacheEntries }, entry) => {
       if (typeof entry === 'string' || entry.url.includes('/media/')) {
-        return { precacheEntries, onDemandCacheEntries: [...onDemandCacheEntries, entry] }
+        return { precacheEntries, mediaURLs: [...mediaURLs, toURL(entry)] }
       } else {
-        return { precacheEntries: [...precacheEntries, entry], onDemandCacheEntries }
+        return { precacheEntries: [...precacheEntries, entry], mediaURLs }
       }
     },
-    { onDemandCacheEntries: [], precacheEntries: [] }
+    { mediaURLs: [], precacheEntries: [] }
   )
 }

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -17,10 +17,12 @@ export function isDevelopment() {
 }
 
 type GroupedEntries = { mediaURLs: string[]; precacheEntries: PrecacheEntry[] }
-export const groupEntries = (entries: PrecacheEntry[]): GroupedEntries => {
+export const groupEntries = (entries: (string | PrecacheEntry)[]): GroupedEntries => {
   return entries.reduce<GroupedEntries>(
     ({ mediaURLs, precacheEntries }, entry) => {
-      if (entry.url.includes('/media/')) {
+      if (typeof entry === 'string') {
+        return { precacheEntries, mediaURLs: [...mediaURLs, entry] }
+      } else if (entry.url.includes('/media/')) {
         return { precacheEntries, mediaURLs: [...mediaURLs, entry.url] }
       } else {
         return { precacheEntries: [...precacheEntries, entry], mediaURLs }

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -20,7 +20,6 @@ export function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
 
-
 export const splitAssetsAndEntries = (
   resources: (string | PrecacheEntry)[]
 ): { assets: string[]; entries: PrecacheEntry[] } => {
@@ -39,4 +38,4 @@ export const splitAssetsAndEntries = (
     },
     { assets: [], entries: [] }
   )
-}mport { toURL } from './utils'
+}

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -7,15 +7,36 @@ declare const self: ServiceWorkerGlobalScope
 export function isDevelopment() {
   return Boolean(
     self.location.hostname === 'localhost' ||
-      // [::1] is the IPv6 localhost address
-      self.location.hostname === '[::1]' ||
-      // 127.0.0.0/8 are considered localhost for IPv4
-      self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
-      // vercel previews
-      self.location.hostname.endsWith('.vercel.app')
+    // [::1] is the IPv6 localhost address
+    self.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4
+    self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
+    // vercel previews
+    self.location.hostname.endsWith('.vercel.app')
   )
 }
 
 export function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
+
+
+export const splitAssetsAndEntries = (
+  resources: (string | PrecacheEntry)[]
+): { assets: string[]; entries: PrecacheEntry[] } => {
+  return resources.reduce<{ assets: string[]; entries: PrecacheEntry[] }>(
+    ({ assets, entries }, entry) => {
+      if (typeof entry === 'string') {
+        // If the entry is a string, it's the index.html file.
+        return { entries, assets: [...assets, entry] }
+      } else if (entry.url.includes('/media/')) {
+        // If the entry is a media file, it's an asset.
+        return { entries, assets: [...assets, toURL(entry)] }
+      } else {
+        // Otherwise, it's an entry.
+        return { entries: [...entries, entry], assets }
+      }
+    },
+    { assets: [], entries: [] }
+  )
+}mport { toURL } from './utils'

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -16,16 +16,12 @@ export function isDevelopment() {
   )
 }
 
-function toURL(entry: string | PrecacheEntry): string {
-  return typeof entry === 'string' ? entry : entry.url
-}
-
 type GroupedEntries = { mediaURLs: string[]; precacheEntries: PrecacheEntry[] }
-export const groupEntries = (entries: (string | PrecacheEntry)[]): GroupedEntries => {
+export const groupEntries = (entries: PrecacheEntry[]): GroupedEntries => {
   return entries.reduce<GroupedEntries>(
     ({ mediaURLs, precacheEntries }, entry) => {
-      if (typeof entry === 'string' || entry.url.includes('/media/')) {
-        return { precacheEntries, mediaURLs: [...mediaURLs, toURL(entry)] }
+      if (entry.url.includes('/media/')) {
+        return { precacheEntries, mediaURLs: [...mediaURLs, entry.url] }
       } else {
         return { precacheEntries: [...precacheEntries, entry], mediaURLs }
       }

--- a/src/serviceWorker/utils.ts
+++ b/src/serviceWorker/utils.ts
@@ -7,16 +7,16 @@ declare const self: ServiceWorkerGlobalScope
 export function isDevelopment() {
   return Boolean(
     self.location.hostname === 'localhost' ||
-    // [::1] is the IPv6 localhost address
-    self.location.hostname === '[::1]' ||
-    // 127.0.0.0/8 are considered localhost for IPv4
-    self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
-    // vercel previews
-    self.location.hostname.endsWith('.vercel.app')
+      // [::1] is the IPv6 localhost address
+      self.location.hostname === '[::1]' ||
+      // 127.0.0.0/8 are considered localhost for IPv4
+      self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
+      // vercel previews
+      self.location.hostname.endsWith('.vercel.app')
   )
 }
 
-export function toURL(entry: string | PrecacheEntry): string {
+function toURL(entry: string | PrecacheEntry): string {
   return typeof entry === 'string' ? entry : entry.url
 }
 


### PR DESCRIPTION
## Description
We are getting a significant number of errors where chunks are not being found:
https://uniswap-labs.sentry.io/issues/4009148084/?project=4504255148851200&referrer=release-issue-stream
https://uniswap-labs.sentry.io/issues/4131879787/?project=4504255148851200&referrer=release-issue-stream

We think this is caused by cache misses from the service worker. After some investigation, it seems like the logic for separating the pre-cached and on-demand cached content could be leading to the issue. Previously, we only pre-cached the document, but now we want to pre-cache all JS/CSS files, while all media assets can be on-demand cached.

The downside here is many files that may not be needed will get stored to disk, but this is a compromise we are willing to make for now. Over time we could make smarter decisions like not precaching locales, but we'd need to make improvements to the build system to make that happen.

I needed to make a change to the service worker e2e test because it was being flakey. This is unrelated to this code change but needed to make sure the tests passed before merging.

## Test plan
### Reproducing the error
1. add console.logs for `self.__WB_MANIFEST`, `assets` and `entries` in `src/serviceWorker/index.ts` to see what the values look like.
2. run `yarn build` and `yarn serve`
3. Check console to see that entries only has one element in it.

After changes:
<img width="714" alt="Screen Shot 2023-05-03 at 12 07 02 PM" src="https://user-images.githubusercontent.com/4899429/235974852-cc92031a-1a24-4267-8b85-bb77666e33a6.png">
<img width="710" alt="Screen Shot 2023-05-03 at 12 07 07 PM" src="https://user-images.githubusercontent.com/4899429/235974854-9018b481-bff5-4bc4-b35b-4012c10fc3b7.png">



### Automated testing
- [x] Unit test
- [x] Integration/E2E test (N/A)
