### PR TITLE
fix: errors are responsible for their own grammar

### DIFF
--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -69,7 +69,7 @@ export function swapErrorToUserReadableMessage(error: any): string {
         console.error(error, reason)
         return t`An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If that does not work, there may be an incompatibility with the token you are trading. Note: fee on transfer and rebase tokens are incompatible with Uniswap V3.`
       }
-      return t`${reason ? reason : 'Unknown error'}. Try increasing your slippage tolerance.
+      return t`${reason ? reason : 'Unknown error.'} Try increasing your slippage tolerance.
 Note: fee-on-transfer and rebase tokens are incompatible with Uniswap V3.`
   }
 }


### PR DESCRIPTION
The user-readable error formatting util was adding an unnecessary period.

before: 
![image](https://user-images.githubusercontent.com/5773490/236031263-81c32fa6-110d-4f6c-b007-9442847d8282.png)

https://uniswaplabs.atlassian.net/browse/WEB-3287

https://uniswapteam.slack.com/archives/C04D07TQBT4/p1683142590579389