### PR TITLE
fix: add a catch on collect static call

### DIFF
--- a/src/hooks/useV3PositionFees.ts
+++ b/src/hooks/useV3PositionFees.ts
@@ -27,21 +27,25 @@ export function useV3PositionFees(
   // latestBlockNumber is included to ensure data stays up-to-date every block
   const [amounts, setAmounts] = useState<[BigNumber, BigNumber] | undefined>()
   useEffect(() => {
-    if (positionManager && tokenIdHexString && owner) {
-      positionManager.callStatic
-        .collect(
-          {
-            tokenId: tokenIdHexString,
-            recipient: owner, // some tokens might fail if transferred to address(0)
-            amount0Max: MAX_UINT128,
-            amount1Max: MAX_UINT128,
-          },
-          { from: owner } // need to simulate the call as the owner
-        )
-        .then((results) => {
+    ;(async function getFees() {
+      if (positionManager && tokenIdHexString && owner) {
+        try {
+          const results = await positionManager.callStatic.collect(
+            {
+              tokenId: tokenIdHexString,
+              recipient: owner, // some tokens might fail if transferred to address(0)
+              amount0Max: MAX_UINT128,
+              amount1Max: MAX_UINT128,
+            },
+            { from: owner } // need to simulate the call as the owner
+          )
           setAmounts([results.amount0, results.amount1])
-        })
-    }
+        } catch {
+          // If the static call fails, the default state will remain for `amounts`.
+          // This case is handled by returning unclaimed fees as empty.
+        }
+      }
+    })()
   }, [positionManager, tokenIdHexString, owner, latestBlockNumber])
 
   if (pool && amounts) {

--- a/src/hooks/useV3PositionFees.ts
+++ b/src/hooks/useV3PositionFees.ts
@@ -43,6 +43,7 @@ export function useV3PositionFees(
         } catch {
           // If the static call fails, the default state will remain for `amounts`.
           // This case is handled by returning unclaimed fees as empty.
+          // TODO(INFRA-178): Look into why we have failures with call data being 0x.
         }
       }
     })()


### PR DESCRIPTION
## Description
https://uniswap-labs.sentry.io/issues/4086521318/?project=4504255148851200&query=call+revert+exception&referrer=issue-stream&sort=freq&statsPeriod=90d&stream_index=0

This error is happening when users go to the position page. We show the amount of uncollected fees they have in the UI before they actually send the collect transaction. However, that call isn't caught right now leading to errors being thrown.

This is noticed by seeing that this is a "dry-run" since it's a call revert, rather than a sendTransaction failure.

What's odd is that the call data is "0x", while it should have some hashed data. We don't know if this is an issue with the ethers logging, or due to an issue on our end. But it would be better to confirm that this fix is right before diving more into that.

With this, in the error state we will show that the fees are undefined instead.

## Test plan
### Reproducing the error
1. Change code locally to always throw an error in the static call.
2. Check what position page looks like when connected and disconnected to a wallet.

### Automated testing
- [] Unit test
- [] Integration/E2E test

We decided that this is fine to manual test vs creating automated tests.