### PR TITLE
feat: update useAllTokensMultichain usage

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseLocal.test.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseLocal.test.ts
@@ -2,7 +2,7 @@ import { SupportedChainId, Token, TradeType as MockTradeType } from '@uniswap/sd
 import { PERMIT2_ADDRESS } from '@uniswap/universal-router-sdk'
 import { DAI as MockDAI, nativeOnChain, USDC_MAINNET as MockUSDC_MAINNET } from 'constants/tokens'
 import { TransactionStatus as MockTxStatus } from 'graphql/data/__generated__/types-and-hooks'
-import { TokenAddressMap } from 'state/lists/hooks'
+import { ChainTokenMap } from 'hooks/Tokens'
 import {
   ExactInputSwapTransactionInfo,
   ExactOutputSwapTransactionInfo,
@@ -89,15 +89,15 @@ function mockMultiStatus(info: TransactionInfo, id: string): [TransactionDetails
   ]
 }
 
-const mockTokenAddressMap: TokenAddressMap = {
+const mockTokenAddressMap: ChainTokenMap = {
   [mockChainId]: {
-    [MockDAI.address]: { token: MockDAI },
-    [MockUSDC_MAINNET.address]: { token: MockUSDC_MAINNET },
-  } as TokenAddressMap[number],
+    [MockDAI.address]: MockDAI,
+    [MockUSDC_MAINNET.address]: MockUSDC_MAINNET,
+  },
 }
 
-jest.mock('../../../../state/lists/hooks', () => ({
-  useCombinedActiveList: () => mockTokenAddressMap,
+jest.mock('../../../../hooks/Tokens', () => ({
+  useAllTokensMultichain: () => mockTokenAddressMap,
 }))
 
 jest.mock('../../../../state/transactions/hooks', () => {
@@ -300,7 +300,7 @@ describe('parseLocalActivity', () => {
       },
     } as TransactionDetails
     const chainId = SupportedChainId.MAINNET
-    const tokens = {} as TokenAddressMap
+    const tokens = {} as ChainTokenMap
     expect(parseLocalActivity(details, chainId, tokens)).toMatchObject({
       chainId: 1,
       currencies: [undefined, undefined],

--- a/src/components/AccountDrawer/MiniPortfolio/Pools/cache.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Pools/cache.ts
@@ -126,7 +126,7 @@ export function useGetCachedTokens(chains: SupportedChainId[]): TokenGetterFn {
       const local: { [address: string]: Token | undefined } = {}
       const missing = new Set<string>()
       addresses.forEach((address) => {
-        const cached = tokenCache.get(chainId, address) ?? allTokens[chainId][address]?.token
+        const cached = tokenCache.get(chainId, address) ?? allTokens[chainId]?.[address]
         cached ? (local[address] = cached) : missing.add(address)
       })
 

--- a/src/components/Popups/TransactionPopup.tsx
+++ b/src/components/Popups/TransactionPopup.tsx
@@ -3,8 +3,8 @@ import { parseLocalActivity } from 'components/AccountDrawer/MiniPortfolio/Activ
 import { PortfolioLogo } from 'components/AccountDrawer/MiniPortfolio/PortfolioLogo'
 import PortfolioRow from 'components/AccountDrawer/MiniPortfolio/PortfolioRow'
 import Column from 'components/Column'
+import { useAllTokensMultichain } from 'hooks/Tokens'
 import useENSName from 'hooks/useENSName'
-import { useCombinedActiveList } from 'state/lists/hooks'
 import { useTransaction } from 'state/transactions/hooks'
 import { TransactionDetails } from 'state/transactions/types'
 import styled from 'styled-components/macro'
@@ -19,7 +19,7 @@ const Descriptor = styled(ThemedText.BodySmall)`
 
 function TransactionPopupContent({ tx, chainId }: { tx: TransactionDetails; chainId: number }) {
   const success = tx.receipt?.status === 1
-  const tokens = useCombinedActiveList()
+  const tokens = useAllTokensMultichain()
   const activity = parseLocalActivity(tx, chainId, tokens)
   const { ENSName } = useENSName(activity?.otherAccount)
 

--- a/src/hooks/Tokens.test.ts
+++ b/src/hooks/Tokens.test.ts
@@ -1,0 +1,59 @@
+import { SupportedChainId as MockSupportedChainId } from 'constants/chains'
+import {
+  DAI as MockDAI,
+  USDC_MAINNET as MockUSDC_MAINNET,
+  USDC_OPTIMISM as MockUSDC_OPTIMISM,
+  USDT as MockUSDT,
+  WETH_POLYGON as MockWETH_POLYGON,
+} from 'constants/tokens'
+import { renderHook } from 'test-utils/render'
+
+import { useAllTokensMultichain } from './Tokens'
+
+jest.mock('../state/lists/hooks.ts', () => {
+  return {
+    useCombinedTokenMapFromUrls: () => ({
+      [MockSupportedChainId.MAINNET]: {
+        [MockDAI.address]: { token: MockDAI },
+        [MockUSDC_MAINNET.address]: { token: MockUSDC_MAINNET },
+      },
+      [MockSupportedChainId.POLYGON]: {
+        [MockWETH_POLYGON.address]: { token: MockWETH_POLYGON },
+      },
+    }),
+  }
+})
+
+jest.mock('../state/hooks.ts', () => {
+  return {
+    useAppSelector: () => ({
+      [MockSupportedChainId.MAINNET]: {
+        [MockDAI.address]: MockDAI,
+        [MockUSDT.address]: MockUSDT,
+      },
+      [MockSupportedChainId.OPTIMISM]: {
+        [MockUSDC_OPTIMISM.address]: MockUSDC_OPTIMISM,
+      },
+    }),
+  }
+})
+
+describe('useAllTokensMultichain', () => {
+  it('should return multi-chain tokens from lists and userAddedTokens', () => {
+    const { result } = renderHook(() => useAllTokensMultichain())
+
+    expect(result.current).toStrictEqual({
+      [MockSupportedChainId.MAINNET]: {
+        [MockDAI.address]: MockDAI,
+        [MockUSDC_MAINNET.address]: MockUSDC_MAINNET,
+        [MockUSDT.address]: MockUSDT,
+      },
+      [MockSupportedChainId.POLYGON]: {
+        [MockWETH_POLYGON.address]: MockWETH_POLYGON,
+      },
+      [MockSupportedChainId.OPTIMISM]: {
+        [MockUSDC_OPTIMISM.address]: MockUSDC_OPTIMISM,
+      },
+    })
+  })
+})

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -5,6 +5,7 @@ import { SupportedChainId } from 'constants/chains'
 import { DEFAULT_INACTIVE_LIST_URLS, DEFAULT_LIST_OF_LISTS } from 'constants/lists'
 import { useCurrencyFromMap, useTokenFromMapOrNetwork } from 'lib/hooks/useCurrency'
 import { getTokenFilter } from 'lib/hooks/useTokenList/filtering'
+import { TokenAddressMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
 import { useAppSelector } from 'state/hooks'
 import { isL2ChainId } from 'utils/chains'
@@ -12,7 +13,7 @@ import { isL2ChainId } from 'utils/chains'
 import { useAllLists, useCombinedActiveList, useCombinedTokenMapFromUrls } from '../state/lists/hooks'
 import { WrappedTokenInfo } from '../state/lists/wrappedTokenInfo'
 import { deserializeToken, useUserAddedTokens, useUserAddedTokensOnChain } from '../state/user/hooks'
-import { TokenAddressMap, useUnsupportedTokenList } from './../state/lists/hooks'
+import { useUnsupportedTokenList } from './../state/lists/hooks'
 
 type Maybe<T> = T | null | undefined
 
@@ -29,6 +30,7 @@ function useTokensFromMap(tokenMap: TokenAddressMap, chainId: Maybe<SupportedCha
   }, [chainId, tokenMap])
 }
 
+// TODO(INFRA-164): after disallowing unchecked index access, refactor ChainTokenMap to not use ?'s
 export type ChainTokenMap = { [chainId in number]?: { [address in string]?: Token } }
 export function useAllTokensMultichain(): ChainTokenMap {
   const allTokensFromLists = useCombinedTokenMapFromUrls(DEFAULT_LIST_OF_LISTS)

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -32,6 +32,7 @@ function useTokensFromMap(tokenMap: TokenAddressMap, chainId: Maybe<SupportedCha
 
 // TODO(INFRA-164): after disallowing unchecked index access, refactor ChainTokenMap to not use ?'s
 export type ChainTokenMap = { [chainId in number]?: { [address in string]?: Token } }
+/** Returns tokens from all token lists on all chains, combined with user added tokens */
 export function useAllTokensMultichain(): ChainTokenMap {
   const allTokensFromLists = useCombinedTokenMapFromUrls(DEFAULT_LIST_OF_LISTS)
   const userAddedTokensMap = useAppSelector(({ user: { tokens } }) => tokens)
@@ -63,7 +64,7 @@ export function useAllTokensMultichain(): ChainTokenMap {
   }, [allTokensFromLists, userAddedTokensMap])
 }
 
-// Returns all tokens from the default list + user added tokens
+/** Returns all tokens from the default list + user added tokens */
 export function useDefaultActiveTokens(chainId: Maybe<SupportedChainId>): { [address: string]: Token } {
   const defaultListTokens = useCombinedActiveList()
   const tokensFromMap = useTokensFromMap(defaultListTokens, chainId)

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -40,14 +40,16 @@ export function useAllTokensMultichain(): ChainTokenMap {
   return useMemo(() => {
     const chainTokenMap: ChainTokenMap = {}
 
-    Object.keys(userAddedTokensMap).forEach((key) => {
-      const chainId = Number(key)
-      const tokenMap = {} as { [address in string]?: Token }
-      Object.values(userAddedTokensMap[chainId]).forEach((serializedToken) => {
-        tokenMap[serializedToken.address] = deserializeToken(serializedToken)
+    if (userAddedTokensMap) {
+      Object.keys(userAddedTokensMap).forEach((key) => {
+        const chainId = Number(key)
+        const tokenMap = {} as { [address in string]?: Token }
+        Object.values(userAddedTokensMap[chainId]).forEach((serializedToken) => {
+          tokenMap[serializedToken.address] = deserializeToken(serializedToken)
+        })
+        chainTokenMap[chainId] = tokenMap
       })
-      chainTokenMap[chainId] = tokenMap
-    })
+    }
 
     Object.keys(allTokensFromLists).forEach((key) => {
       const chainId = Number(key)

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -40,25 +40,23 @@ export function useAllTokensMultichain(): ChainTokenMap {
   return useMemo(() => {
     const chainTokenMap: ChainTokenMap = {}
 
-    Object.keys(userAddedTokensMap)
-      .map(Number)
-      .forEach((chainId) => {
-        const tokenMap = {} as { [address in string]?: Token }
-        Object.values(userAddedTokensMap[chainId]).forEach((serializedToken) => {
-          tokenMap[serializedToken.address] = deserializeToken(serializedToken)
-        })
-        chainTokenMap[chainId] = tokenMap
+    Object.keys(userAddedTokensMap).forEach((key) => {
+      const chainId = Number(key)
+      const tokenMap = {} as { [address in string]?: Token }
+      Object.values(userAddedTokensMap[chainId]).forEach((serializedToken) => {
+        tokenMap[serializedToken.address] = deserializeToken(serializedToken)
       })
+      chainTokenMap[chainId] = tokenMap
+    })
 
-    Object.keys(allTokensFromLists)
-      .map(Number)
-      .forEach((chainId) => {
-        const tokenMap = chainTokenMap[chainId] ?? {}
-        Object.values(allTokensFromLists[chainId]).forEach(({ token }) => {
-          tokenMap[token.address] = token
-        })
-        chainTokenMap[chainId] = tokenMap
+    Object.keys(allTokensFromLists).forEach((key) => {
+      const chainId = Number(key)
+      const tokenMap = chainTokenMap[chainId] ?? {}
+      Object.values(allTokensFromLists[chainId]).forEach(({ token }) => {
+        tokenMap[token.address] = token
       })
+      chainTokenMap[chainId] = tokenMap
+    })
 
     return chainTokenMap
   }, [allTokensFromLists, userAddedTokensMap])

--- a/src/lib/hooks/useTokenList/utils.ts
+++ b/src/lib/hooks/useTokenList/utils.ts
@@ -2,20 +2,21 @@ import { TokenInfo, TokenList } from '@uniswap/token-lists'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 type TokenMap = Readonly<{ [tokenAddress: string]: { token: WrappedTokenInfo; list?: TokenList } }>
-export type ChainTokenMap = Readonly<{ [chainId: number]: TokenMap }>
+// TODO(INFRA-164): replace usage of the misnomered TokenAddressMap w/ ChainTokenMap from src/hooks/Tokens.ts
+export type TokenAddressMap = Readonly<{ [chainId: number]: TokenMap }>
 
 type Mutable<T> = {
   -readonly [P in keyof T]: Mutable<T[P]>
 }
 
-const mapCache = typeof WeakMap !== 'undefined' ? new WeakMap<TokenList | TokenInfo[], ChainTokenMap>() : null
+const mapCache = typeof WeakMap !== 'undefined' ? new WeakMap<TokenList | TokenInfo[], TokenAddressMap>() : null
 
-export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainTokenMap {
+export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): TokenAddressMap {
   const cached = mapCache?.get(tokens)
   if (cached) return cached
 
   const [list, infos] = Array.isArray(tokens) ? [undefined, tokens] : [tokens, tokens.tokens]
-  const map = infos.reduce<Mutable<ChainTokenMap>>((map, info) => {
+  const map = infos.reduce<Mutable<TokenAddressMap>>((map, info) => {
     try {
       const token = new WrappedTokenInfo(info, list)
       if (map[token.chainId]?.[token.address] !== undefined) {
@@ -30,7 +31,7 @@ export function tokensToChainTokenMap(tokens: TokenList | TokenInfo[]): ChainTok
     } catch {
       return map
     }
-  }, {}) as ChainTokenMap
+  }, {}) as TokenAddressMap
   mapCache?.set(tokens, map)
   return map
 }

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -1,4 +1,4 @@
-import { ChainTokenMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/utils'
+import { TokenAddressMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/utils'
 import { useMemo } from 'react'
 import { useAppSelector } from 'state/hooks'
 import sortByListPriority from 'utils/listSort'
@@ -6,8 +6,6 @@ import sortByListPriority from 'utils/listSort'
 import BROKEN_LIST from '../../constants/tokenLists/broken.tokenlist.json'
 import { AppState } from '../types'
 import { DEFAULT_ACTIVE_LIST_URLS, UNSUPPORTED_LIST_URLS } from './../../constants/lists'
-
-export type TokenAddressMap = ChainTokenMap
 
 type Mutable<T> = {
   -readonly [P in keyof T]: Mutable<T[P]>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Updates local tx parser to use useAllTokensMultichain, and updates useAllTokensMultichain to merge tokens from all lists w/ userAdded tokens.

This fixes an existing problem where Mini Portfolio and & the TX Notification toast would only render tokens from the default list.

<!-- Delete inapplicable lines: -->
[Slack thread](https://uniswapteam.slack.com/archives/C04QKTF9T35/p1683220935782969)


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

| Before       | After (Desktop) |
| ----------- |---------------- |
| <img width="393" alt="Screen Shot 2023-05-04 at 4 52 03 PM" src="https://user-images.githubusercontent.com/39385577/236327117-b6c87eb6-b019-4fa7-be1d-13723df91c4f.png"> | <img width="389" alt="image" src="https://user-images.githubusercontent.com/39385577/236327279-96cb4e97-47e9-416d-8cab-0e1abdc7801f.png">      |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Swap a token that is not included on the default list & view the tx notification or Activity tab
