### PR TITLE
fix: filter AbortError from Sentry

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -201,4 +201,9 @@ describe('filterKnownErrors', () => {
       expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
     })
   })
+
+  it('filters AbortErrors', () => {
+    const originalException = new Error('AbortError: The user aborted a request.')
+    expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
+  })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -96,6 +96,9 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     if (error.message.match(/WebAssembly.instantiate\(\): Wasm code generation disallowed by embedder/)) {
       return null
     }
+
+    // These are caused by user navigation away from the page before a request has finished.
+    if (error.message.startsWith('AbortError')) return null
   }
 
   return event


### PR DESCRIPTION
## Description
It is possible for an AbortError to be sent to Sentry even if it's caused by the user navigating away from the page, because Sentry captures errors and exceptions occurring in your application, including those caused by user actions.

In the case of an AbortError, it typically occurs when a fetch request is aborted, often due to the user navigating away from the page or closing the browser tab. When this happens, the browser cancels the ongoing fetch request, and the JavaScript Promise associated with the request rejects with an AbortError.

![image](https://user-images.githubusercontent.com/4899429/236558991-f590aa0f-8205-4b21-abb2-384a627f6361.png)


## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (n/a)
