### PR TITLE
fix: update OS listing fee

### DIFF
--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -148,17 +148,13 @@ export const MarketplaceRow = ({
   )
 
   const fees = useMemo(() => {
-    if (selectedMarkets.length === 1) {
-      return getRoyalty(selectedMarkets[0], asset) + selectedMarkets[0].fee
-    } else {
-      let max = 0
-      for (const selectedMarket of selectedMarkets) {
-        const fee = getRoyalty(selectedMarket, asset) + selectedMarket.fee
-        max = Math.max(fee, max)
-      }
-
-      return max
+    let maxFee = 0
+    for (const selectedMarket of selectedMarkets) {
+      const fee = getRoyalty(selectedMarket, asset) + selectedMarket.fee
+      maxFee = Math.max(fee, maxFee)
     }
+
+    return maxFee
   }, [asset, selectedMarkets])
 
   const feeInEth = price && (price * fees) / 100

--- a/src/nft/components/profile/list/MarketplaceRow.tsx
+++ b/src/nft/components/profile/list/MarketplaceRow.tsx
@@ -1,15 +1,9 @@
-// eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
 import Column from 'components/Column'
 import Row from 'components/Row'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { RowsCollpsedIcon, RowsExpandedIcon } from 'nft/components/icons'
-import {
-  getMarketplaceFee,
-  getRoyalty,
-  useHandleGlobalPriceToggle,
-  useSyncPriceWithGlobalMethod,
-} from 'nft/components/profile/list/utils'
+import { getRoyalty, useHandleGlobalPriceToggle, useSyncPriceWithGlobalMethod } from 'nft/components/profile/list/utils'
 import { useSellAsset } from 'nft/hooks'
 import { ListingMarket, WalletAsset } from 'nft/types'
 import { getMarketplaceIcon } from 'nft/utils'
@@ -155,11 +149,11 @@ export const MarketplaceRow = ({
 
   const fees = useMemo(() => {
     if (selectedMarkets.length === 1) {
-      return getRoyalty(selectedMarkets[0], asset) + getMarketplaceFee(selectedMarkets[0], asset)
+      return getRoyalty(selectedMarkets[0], asset) + selectedMarkets[0].fee
     } else {
       let max = 0
       for (const selectedMarket of selectedMarkets) {
-        const fee = getRoyalty(selectedMarket, asset) + getMarketplaceFee(selectedMarket, asset)
+        const fee = getRoyalty(selectedMarket, asset) + selectedMarket.fee
         max = Math.max(fee, max)
       }
 

--- a/src/nft/components/profile/list/RoyaltyTooltip.tsx
+++ b/src/nft/components/profile/list/RoyaltyTooltip.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import Column from 'components/Column'
 import Row from 'components/Row'
-import { getMarketplaceFee, getRoyalty } from 'nft/components/profile/list/utils'
+import { getRoyalty } from 'nft/components/profile/list/utils'
 import { ListingMarket, WalletAsset } from 'nft/types'
 import { formatEth, getMarketplaceIcon } from 'nft/utils'
 import styled, { css } from 'styled-components/macro'
@@ -68,7 +68,7 @@ export const RoyaltyTooltip = ({
               <Trans>fee</Trans>
             </ThemedText.Caption>
           </Row>
-          <FeePercent>{getMarketplaceFee(market, asset)}%</FeePercent>
+          <FeePercent>{market.fee}%</FeePercent>
         </FeeWrap>
       ))}
       <FeeWrap>

--- a/src/nft/components/profile/list/utils.ts
+++ b/src/nft/components/profile/list/utils.ts
@@ -227,11 +227,6 @@ export const getRoyalty = (listingMarket: ListingMarket, asset: WalletAsset) => 
   return baseFee * 0.01
 }
 
-// OpenSea has a 0.5% fee for all assets that do not have a royalty set
-export const getMarketplaceFee = (listingMarket: ListingMarket, asset: WalletAsset) => {
-  return listingMarket.name === 'OpenSea' && !asset.basisPoints ? 0.5 : listingMarket.fee
-}
-
 const BELOW_FLOOR_PRICE_THRESHOLD = 0.8
 
 export const findListingIssues = (sellAssets: WalletAsset[]) => {

--- a/src/nft/utils/listNfts.ts
+++ b/src/nft/utils/listNfts.ts
@@ -38,7 +38,7 @@ export const ListingMarkets: ListingMarket[] = [
   },
   {
     name: 'OpenSea',
-    fee: 0,
+    fee: 2.5,
   },
 ]
 
@@ -59,7 +59,7 @@ const getConsiderationItems = (
   openSeaFee?: ConsiderationInputItem
 } => {
   const creatorFeeBasisPoints = asset?.basisPoints ?? 0
-  const openSeaBasisPoints = !asset?.basisPoints ? 50 : 0
+  const openSeaBasisPoints = (ListingMarkets.find((market) => market.name === 'OpenSea')?.fee ?? 0) * 100
   const sellerBasisPoints = INVERSE_BASIS_POINTS - creatorFeeBasisPoints - openSeaBasisPoints
 
   const creatorFee = price


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Update OS listing fee to be a flat 2.5% for all collections as opposed to 0.5% for collections with no royalties or 0% for collections with royalties as mentioned in their OS Pro announcement
- Use the fee from the ListingMarket object when creating OS's consideration items



<!-- Delete inapplicable lines: -->
_JIRA ticket:_ https://uniswaplabs.atlassian.net/browse/NFT-1193
_Slack thread:_ https://uniswapteam.slack.com/archives/C03MGBD2SNN/p1683553053120529
_Relevant docs:_ https://support.opensea.io/hc/en-us/articles/14068991090067


<!-- Delete this section if your change does not affect UI. -->
## Screen capture
Updated fees
<img width="268" alt="Screen Shot 2023-05-08 at 08 51 30 " src="https://user-images.githubusercontent.com/11512321/236872644-9cb1f422-ed20-456f-b92f-b21ada8610c7.png">
<img width="322" alt="Screen Shot 2023-05-08 at 08 58 52 " src="https://user-images.githubusercontent.com/11512321/236872647-b7f86329-b095-4253-9e86-a5e2e963d2d3.png">
Successfully listing a 721 and an 1155
<img width="1357" alt="Screen Shot 2023-05-08 at 08 50 55 " src="https://user-images.githubusercontent.com/11512321/236872745-28f82f7b-38e7-431c-a8b3-440b0f34f6be.png">
<img width="762" alt="Screen Shot 2023-05-08 at 08 59 06 " src="https://user-images.githubusercontent.com/11512321/236872759-494e4398-d1cf-44b2-9a5b-4f44117561c3.png">

## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Successfully list a 721 and a 1155 nft to OS

