### PR TITLE
fix: handle switchChain failure in swap

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -712,6 +712,8 @@ export function Swap({
                   await switchChain(connector, chainId)
                 } catch (error) {
                   // Ignore error, which keeps the user on the previous chain.
+                  // TODO(WEB-3306): This UX could be improved to handle user rejected errors
+                  // differently compared to other failures.
                 }
               }}
             >

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -707,8 +707,12 @@ export function Swap({
             </TraceEvent>
           ) : chainId && chainId !== connectedChainId ? (
             <ButtonPrimary
-              onClick={() => {
-                switchChain(connector, chainId)
+              onClick={async () => {
+                try {
+                  await switchChain(connector, chainId)
+                } catch (error) {
+                  // Ignore error, which keeps the user on the previous chain.
+                }
               }}
             >
               Connect to {getChainInfo(chainId)?.label}

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -39,6 +39,7 @@ import { TradeState } from 'state/routing/types'
 import styled, { useTheme } from 'styled-components/macro'
 import invariant from 'tiny-invariant'
 import { currencyAmountToPreciseFloat, formatTransactionAmount } from 'utils/formatNumbers'
+import { didUserReject } from 'utils/swapErrorToUserReadableMessage'
 import { switchChain } from 'utils/switchChain'
 
 import AddressInputPanel from '../../components/AddressInputPanel'
@@ -711,9 +712,12 @@ export function Swap({
                 try {
                   await switchChain(connector, chainId)
                 } catch (error) {
-                  // Ignore error, which keeps the user on the previous chain.
-                  // TODO(WEB-3306): This UX could be improved to handle user rejected errors
-                  // differently compared to other failures.
+                  if (didUserReject(error)) {
+                    // Ignore error, which keeps the user on the previous chain.
+                  } else {
+                    // TODO(WEB-3306): This UX could be improved to show an error state.
+                    throw error
+                  }
                 }
               }}
             >


### PR DESCRIPTION
## Description
https://uniswap-labs.sentry.io/issues/3788318733/events/6d4f1062f25a40db900229797c48e1fe/?project=4504255148851200&referrer=next-event

`message: User rejected the request.` means the user rejected in their wallet when we prompt to switch chains. This is an example where that rejection is not caught.

Right now this ignores user rejected errors (meaning the user stays on the same chain) and continues to throw for other errors. This adds a note to a JIRA ticket to improve the failure case UX.

## Test plan
### Reproducing the error
1. Connect to mainnet
2. Go to an arbitrum token details page
3. Click "connect to ethereum"
4. Cancel the request in wallet
5. See the error in console

### QA (ie manual testing)
- [x] Run through the same steps and see no error

### Automated testing
- [ ] Unit test
- [ ] Integration/E2E test

I didn't add these because we can't switch chain via tests easily yet.