### PR TITLE
feat: refactor Swap Button and  state management

### DIFF
--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -22,7 +22,7 @@ export enum WrapType {
 
 const NOT_APPLICABLE = { wrapType: WrapType.NOT_APPLICABLE }
 
-enum WrapInputError {
+export enum WrapInputError {
   NO_ERROR, // must be equal to 0 so all other errors are truthy
   ENTER_NATIVE_AMOUNT,
   ENTER_WRAPPED_AMOUNT,

--- a/src/lib/utils/parseENSAddress.ts
+++ b/src/lib/utils/parseENSAddress.ts
@@ -1,4 +1,4 @@
-const ENS_NAME_REGEX = /^(([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+)eth(\/.*)?$/
+export const ENS_NAME_REGEX = /^(([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+)eth(\/.*)?$/
 
 export default function parseENSAddress(
   ensAddress: string

--- a/src/lib/utils/parseENSAddress.ts
+++ b/src/lib/utils/parseENSAddress.ts
@@ -1,4 +1,4 @@
-export const ENS_NAME_REGEX = /^(([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+)eth(\/.*)?$/
+const ENS_NAME_REGEX = /^(([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+)eth(\/.*)?$/
 
 export default function parseENSAddress(
   ensAddress: string

--- a/src/pages/Swap/SwapButton.test.tsx
+++ b/src/pages/Swap/SwapButton.test.tsx
@@ -1,0 +1,212 @@
+import { CurrencyAmount, TradeType, WETH9 } from '@uniswap/sdk-core'
+import { DAI_MAINNET, nativeOnChain, V3Route } from '@uniswap/smart-order-router'
+import { FeeAmount, Pool } from '@uniswap/v3-sdk'
+import { useWeb3React } from '@web3-react/core'
+import { SupportedChainId } from 'constants/chains'
+import { USDC_MAINNET, WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
+import { useBestTrade } from 'hooks/useBestTrade'
+import usePermit2Allowance, { AllowanceState } from 'hooks/usePermit2Allowance'
+import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
+import JSBI from 'jsbi'
+import { useCurrencyBalances } from 'lib/hooks/useCurrencyBalance'
+import { InterfaceTrade, TradeState } from 'state/routing/types'
+import { Field } from 'state/swap/actions'
+import { DerivedSwapInfoContextProvider } from 'state/swap/hooks'
+import { SwapState } from 'state/swap/reducer'
+import { toCurrencyAmount } from 'test-utils/constants'
+import { mocked } from 'test-utils/mocked'
+import { act, render, screen } from 'test-utils/render'
+import { warningSeverity } from 'utils/prices'
+import { switchChain } from 'utils/switchChain'
+
+import { SwapButton } from './SwapButton'
+
+function getSwapState(input: string, output: string): SwapState {
+  return {
+    independentField: Field.INPUT,
+    typedValue: '1',
+    [Field.INPUT]: {
+      currencyId: input,
+    },
+    [Field.OUTPUT]: {
+      currencyId: output,
+    },
+    recipient: null,
+  }
+}
+
+const TEST_TRADE_USDC_DAI = new InterfaceTrade({
+  v3Routes: [
+    {
+      routev3: new V3Route(
+        [
+          new Pool(
+            USDC_MAINNET,
+            DAI_MAINNET,
+            FeeAmount.HIGH,
+            '2437312313659959819381354528',
+            '10272714736694327408',
+            -69633
+          ),
+        ],
+        USDC_MAINNET,
+        DAI_MAINNET
+      ),
+      inputAmount: toCurrencyAmount(USDC_MAINNET, 1),
+      outputAmount: toCurrencyAmount(DAI_MAINNET, 1),
+    },
+  ],
+  v2Routes: [],
+  tradeType: TradeType.EXACT_INPUT,
+})
+
+jest.mock('utils/switchChain')
+const mockToggleAccountDrawer = jest.fn()
+jest.mock('components/AccountDrawer', () => ({
+  useToggleAccountDrawer: () => mockToggleAccountDrawer,
+}))
+jest.mock('hooks/useWrapCallback')
+const mockUseWrapCallback = mocked(useWrapCallback) as jest.MockedFunction<typeof useWrapCallback>
+jest.mock('lib/hooks/useCurrencyBalance')
+const mockUseCurrencyBalances = mocked(useCurrencyBalances) as jest.MockedFunction<typeof useCurrencyBalances>
+jest.mock('hooks/useBestTrade')
+const mockUseBestTrade = mocked(useBestTrade) as jest.MockedFunction<typeof useBestTrade>
+jest.mock('hooks/usePermit2Allowance')
+const mockUsePermit2Allowance = mocked(usePermit2Allowance) as jest.MockedFunction<typeof usePermit2Allowance>
+jest.mock('utils/prices')
+const mockWarningSeverity = mocked(warningSeverity) as jest.MockedFunction<typeof warningSeverity>
+
+describe('Swap Button', () => {
+  beforeEach(() => {
+    mockUseWrapCallback.mockClear()
+    mockUseWrapCallback.mockReturnValue({
+      wrapType: WrapType.NOT_APPLICABLE,
+      inputError: undefined,
+      execute: jest.fn(),
+    })
+    mockUseCurrencyBalances.mockClear()
+    mockUseCurrencyBalances.mockReturnValue([
+      CurrencyAmount.fromRawAmount(USDC_MAINNET, JSBI.BigInt('1000000000000000000')),
+      CurrencyAmount.fromRawAmount(DAI_MAINNET, JSBI.BigInt('1000000000000000000')),
+    ])
+    mocked(useWeb3React).mockReturnValue({
+      account: '0x8097eF8A44005Fb3e4F7251845Ad59542f8Bec7C',
+      chainId: SupportedChainId.MAINNET,
+    } as ReturnType<typeof useWeb3React>)
+    mockUseBestTrade.mockClear()
+    mockUseBestTrade.mockReturnValue({
+      state: TradeState.VALID,
+      trade: TEST_TRADE_USDC_DAI,
+    })
+    mockUsePermit2Allowance.mockClear()
+    mockUsePermit2Allowance.mockReturnValue({
+      state: AllowanceState.ALLOWED,
+    })
+    mockWarningSeverity.mockClear()
+    mockWarningSeverity.mockReturnValue(0)
+  })
+
+  it('should render unsupported asset disabled button', () => {
+    render(
+      <DerivedSwapInfoContextProvider
+        state={getSwapState(USDC_MAINNET.address, '0x4bf5dc91E2555449293D7824028Eb8Fe5879B689')} // on the "broken" list
+        chainId={SupportedChainId.MAINNET}
+      >
+        <SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />
+      </DerivedSwapInfoContextProvider>
+    )
+    expect(screen.getByText('Unsupported Asset')).toBeInTheDocument()
+    expect(screen.getByTestId('swap-button')).toBeDisabled()
+  })
+
+  it('should render Connect wallet button when not connected', () => {
+    mocked(useWeb3React).mockReturnValue({ account: undefined } as ReturnType<typeof useWeb3React>)
+    render(<SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />)
+    expect(screen.getByText('Connect Wallet')).toBeInTheDocument()
+    expect(screen.getByTestId('swap-button')).toBeEnabled()
+    act(() => {
+      screen.getByText('Connect Wallet').click()
+    })
+    expect(mockToggleAccountDrawer).toHaveBeenCalled()
+  })
+
+  it('should render switch chain button', () => {
+    render(<SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.OPTIMISM} />)
+    expect(screen.getByText('Connect to Optimism')).toBeInTheDocument()
+    expect(screen.getByTestId('swap-button')).toBeEnabled()
+    act(() => {
+      screen.getByText('Connect to Optimism').click()
+    })
+    expect(switchChain).toHaveBeenCalled()
+  })
+
+  it('should render wrap button', () => {
+    mockUseWrapCallback.mockReturnValue({
+      wrapType: WrapType.WRAP,
+      inputError: undefined,
+      execute: jest.fn(),
+    })
+    mockUseCurrencyBalances.mockReturnValue([
+      CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.MAINNET), JSBI.BigInt('1000000000000000000')),
+      CurrencyAmount.fromRawAmount(WETH9[SupportedChainId.MAINNET], JSBI.BigInt('1000000000000000000')),
+    ])
+    render(
+      <DerivedSwapInfoContextProvider
+        state={getSwapState('ETH', WRAPPED_NATIVE_CURRENCY?.[SupportedChainId.MAINNET]?.address ?? '')}
+        chainId={SupportedChainId.MAINNET}
+      >
+        <SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />
+      </DerivedSwapInfoContextProvider>
+    )
+    expect(screen.getByText('Wrap')).toBeInTheDocument()
+    expect(screen.getByTestId('wrap-button')).toBeEnabled()
+  })
+
+  it('should render insufficient liquidity error button', () => {
+    mockUseBestTrade.mockReturnValue({
+      state: TradeState.VALID,
+      trade: undefined, // no route
+    })
+    render(
+      <DerivedSwapInfoContextProvider
+        state={getSwapState(USDC_MAINNET.address, DAI_MAINNET.address)}
+        chainId={SupportedChainId.MAINNET}
+      >
+        <SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />
+      </DerivedSwapInfoContextProvider>
+    )
+    expect(screen.getByText('Insufficient liquidity for this trade.')).toBeInTheDocument()
+  })
+
+  it('should render approval button', () => {
+    const mockApprove = jest.fn()
+    mockUsePermit2Allowance.mockReturnValue({
+      state: AllowanceState.REQUIRED,
+      token: USDC_MAINNET,
+      isApprovalLoading: false,
+      approveAndPermit: mockApprove,
+    })
+    render(
+      <DerivedSwapInfoContextProvider
+        state={getSwapState(USDC_MAINNET.address, DAI_MAINNET.address)}
+        chainId={SupportedChainId.MAINNET}
+      >
+        <SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />
+      </DerivedSwapInfoContextProvider>
+    )
+    expect(screen.getByTestId('swap-approve-button')).toBeEnabled()
+  })
+
+  it('should render swap button', () => {
+    render(
+      <DerivedSwapInfoContextProvider
+        state={getSwapState(USDC_MAINNET.address, DAI_MAINNET.address)}
+        chainId={SupportedChainId.MAINNET}
+      >
+        <SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />
+      </DerivedSwapInfoContextProvider>
+    )
+    expect(screen.getByTestId('swap-button')).toBeEnabled()
+    expect(screen.getByText('Review Swap')).toBeInTheDocument()
+  })
+})

--- a/src/pages/Swap/SwapButton.test.tsx
+++ b/src/pages/Swap/SwapButton.test.tsx
@@ -119,22 +119,22 @@ describe('Swap Button', () => {
     expect(screen.getByTestId('swap-button')).toBeDisabled()
   })
 
-  it('should render Connect wallet button when not connected', () => {
+  it('should render Connect wallet button when not connected', async () => {
     mocked(useWeb3React).mockReturnValue({ account: undefined } as ReturnType<typeof useWeb3React>)
     render(<SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.MAINNET} />)
     expect(screen.getByText('Connect Wallet')).toBeInTheDocument()
     expect(screen.getByTestId('swap-button')).toBeEnabled()
-    act(() => {
+    await act(async () => {
       screen.getByText('Connect Wallet').click()
     })
     expect(mockToggleAccountDrawer).toHaveBeenCalled()
   })
 
-  it('should render switch chain button', () => {
+  it('should render switch chain button', async () => {
     render(<SwapButton onSwapClick={jest.fn()} chainId={SupportedChainId.OPTIMISM} />)
     expect(screen.getByText('Connect to Optimism')).toBeInTheDocument()
     expect(screen.getByTestId('swap-button')).toBeEnabled()
-    act(() => {
+    await act(async () => {
       screen.getByText('Connect to Optimism').click()
     })
     expect(switchChain).toHaveBeenCalled()
@@ -178,7 +178,7 @@ describe('Swap Button', () => {
     expect(screen.getByText('Insufficient liquidity for this trade.')).toBeInTheDocument()
   })
 
-  it('should render approval button', () => {
+  it('should render approval button', async () => {
     const mockApprove = jest.fn()
     mockUsePermit2Allowance.mockReturnValue({
       state: AllowanceState.REQUIRED,
@@ -195,6 +195,10 @@ describe('Swap Button', () => {
       </DerivedSwapInfoContextProvider>
     )
     expect(screen.getByTestId('swap-approve-button')).toBeEnabled()
+    await act(async () => {
+      screen.getByTestId('swap-approve-button').click()
+    })
+    expect(mockApprove).toHaveBeenCalled()
   })
 
   it('should render swap button', () => {

--- a/src/pages/Swap/SwapButton.tsx
+++ b/src/pages/Swap/SwapButton.tsx
@@ -112,7 +112,7 @@ export function SwapButton({ chainId, onSwapClick }: SwapButtonProps) {
 
   if (swapIsUnsupported) {
     return (
-      <ButtonPrimary disabled={true}>
+      <ButtonPrimary disabled={true} data-testid="swap-button">
         <ThemedText.DeprecatedMain mb="4px">
           <Trans>Unsupported Asset</Trans>
         </ThemedText.DeprecatedMain>
@@ -128,7 +128,7 @@ export function SwapButton({ chainId, onSwapClick }: SwapButtonProps) {
         properties={{ received_swap_quote: getIsValidSwapQuote(trade, tradeState, swapInputError) }}
         element={InterfaceElementName.CONNECT_WALLET_BUTTON}
       >
-        <ButtonLight onClick={toggleWalletDrawer} fontWeight={600}>
+        <ButtonLight data-testid="swap-button" onClick={toggleWalletDrawer} fontWeight={600}>
           <Trans>Connect Wallet</Trans>
         </ButtonLight>
       </TraceEvent>
@@ -138,6 +138,7 @@ export function SwapButton({ chainId, onSwapClick }: SwapButtonProps) {
   if (chainId && chainId !== connectedChainId) {
     return (
       <ButtonPrimary
+        data-testid="swap-button"
         onClick={() => {
           switchChain(connector, chainId)
         }}
@@ -153,7 +154,7 @@ export function SwapButton({ chainId, onSwapClick }: SwapButtonProps) {
 
   if (routeNotFound && userHasSpecifiedInputOutput && !routeIsLoading && !routeIsSyncing) {
     return (
-      <GrayCard style={{ textAlign: 'center' }}>
+      <GrayCard style={{ textAlign: 'center' }} data-testid="swap-button">
         <ThemedText.DeprecatedMain mb="4px">
           <Trans>Insufficient liquidity for this trade.</Trans>
         </ThemedText.DeprecatedMain>
@@ -204,6 +205,7 @@ export function SwapButton({ chainId, onSwapClick }: SwapButtonProps) {
     <ButtonError
       onClick={onSwapClick}
       id="swap-button"
+      data-testid="swap-button"
       disabled={Boolean(
         swapInputError ||
           routeIsSyncing ||

--- a/src/pages/Swap/SwapButton.tsx
+++ b/src/pages/Swap/SwapButton.tsx
@@ -1,0 +1,227 @@
+import { Trans } from '@lingui/macro'
+import { sendAnalyticsEvent, TraceEvent, useTrace } from '@uniswap/analytics'
+import { BrowserEvent, InterfaceElementName, InterfaceEventName } from '@uniswap/analytics-events'
+import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
+import { useWeb3React } from '@web3-react/core'
+import { useToggleAccountDrawer } from 'components/AccountDrawer'
+import { ButtonError, ButtonLight, ButtonPrimary } from 'components/Button'
+import { GrayCard } from 'components/Card'
+import { MouseoverTooltip } from 'components/Tooltip'
+import { getChainInfo } from 'constants/chainInfo'
+import { isSupportedChain, SupportedChainId } from 'constants/chains'
+import usePermit2Allowance, { AllowanceState } from 'hooks/usePermit2Allowance'
+import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
+import JSBI from 'jsbi'
+import { useCallback, useMemo, useState } from 'react'
+import { Info, Loader } from 'react-feather'
+import { TradeState } from 'state/routing/types'
+import { useDerivedSwapInfo } from 'state/swap/hooks'
+import { SwapState } from 'state/swap/reducer'
+import { ThemedText } from 'theme'
+import invariant from 'tiny-invariant'
+import { getIsValidSwapQuote } from 'utils/getIsValidSwapQuote'
+import { switchChain } from 'utils/switchChain'
+
+import { Field } from '../../state/swap/actions'
+import { WrapButton } from './WrapButton'
+
+interface SwapButtonProps {
+  state: SwapState
+  chainId: SupportedChainId | undefined
+  onSwapClick: () => void
+}
+
+export function SwapButton({ state, chainId, onSwapClick }: SwapButtonProps) {
+  const trace = useTrace()
+  const { account, chainId: connectedChainId, connector } = useWeb3React()
+  const toggleWalletDrawer = useToggleAccountDrawer()
+
+  const {
+    trade: { state: tradeState, trade },
+    currencies,
+    allowedSlippage,
+    parsedAmount,
+    inputError: swapInputError,
+    swapIsUnsupported,
+    priceImpactTooHigh,
+    priceImpactSeverity,
+  } = useDerivedSwapInfo(state, chainId)
+
+  const {
+    wrapType,
+    inputError: wrapInputError,
+    execute: onWrap,
+  } = useWrapCallback(currencies[Field.INPUT], currencies[Field.OUTPUT], state.typedValue)
+
+  const showWrap: boolean = wrapType !== WrapType.NOT_APPLICABLE
+  const parsedAmounts = useMemo(
+    () =>
+      showWrap
+        ? {
+            [Field.INPUT]: parsedAmount,
+            [Field.OUTPUT]: parsedAmount,
+          }
+        : {
+            [Field.INPUT]: state.independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
+            [Field.OUTPUT]: state.independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount,
+          },
+    [state.independentField, parsedAmount, showWrap, trade]
+  )
+
+  const maximumAmountIn = useMemo(() => {
+    const maximumAmountIn = trade?.maximumAmountIn(allowedSlippage)
+    return maximumAmountIn?.currency.isToken ? (maximumAmountIn as CurrencyAmount<Token>) : undefined
+  }, [allowedSlippage, trade])
+  const allowance = usePermit2Allowance(
+    maximumAmountIn ??
+      (parsedAmounts[Field.INPUT]?.currency.isToken
+        ? (parsedAmounts[Field.INPUT] as CurrencyAmount<Token>)
+        : undefined),
+    isSupportedChain(chainId) ? UNIVERSAL_ROUTER_ADDRESS(chainId) : undefined
+  )
+
+  const isApprovalLoading = allowance.state === AllowanceState.REQUIRED && allowance.isApprovalLoading
+  const [isAllowancePending, setIsAllowancePending] = useState(false)
+  const updateAllowance = useCallback(async () => {
+    invariant(allowance.state === AllowanceState.REQUIRED)
+    setIsAllowancePending(true)
+    try {
+      await allowance.approveAndPermit()
+      sendAnalyticsEvent(InterfaceEventName.APPROVE_TOKEN_TXN_SUBMITTED, {
+        chain_id: chainId,
+        token_symbol: maximumAmountIn?.currency.symbol,
+        token_address: maximumAmountIn?.currency.address,
+        ...trace,
+      })
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setIsAllowancePending(false)
+    }
+  }, [allowance, chainId, maximumAmountIn?.currency.address, maximumAmountIn?.currency.symbol, trace])
+
+  const isValid = !swapInputError
+  const routeNotFound = !trade?.swaps
+  const routeIsLoading = TradeState.LOADING === tradeState
+  const routeIsSyncing = TradeState.SYNCING === tradeState
+  const userHasSpecifiedInputOutput = Boolean(
+    currencies[Field.INPUT] &&
+      currencies[Field.OUTPUT] &&
+      parsedAmounts[state.independentField]?.greaterThan(JSBI.BigInt(0))
+  )
+
+  if (swapIsUnsupported) {
+    return (
+      <ButtonPrimary disabled={true}>
+        <ThemedText.DeprecatedMain mb="4px">
+          <Trans>Unsupported Asset</Trans>
+        </ThemedText.DeprecatedMain>
+      </ButtonPrimary>
+    )
+  }
+
+  if (!account) {
+    return (
+      <TraceEvent
+        events={[BrowserEvent.onClick]}
+        name={InterfaceEventName.CONNECT_WALLET_BUTTON_CLICKED}
+        properties={{ received_swap_quote: getIsValidSwapQuote(trade, tradeState, swapInputError) }}
+        element={InterfaceElementName.CONNECT_WALLET_BUTTON}
+      >
+        <ButtonLight onClick={toggleWalletDrawer} fontWeight={600}>
+          <Trans>Connect Wallet</Trans>
+        </ButtonLight>
+      </TraceEvent>
+    )
+  }
+
+  if (chainId && chainId !== connectedChainId) {
+    return (
+      <ButtonPrimary
+        onClick={() => {
+          switchChain(connector, chainId)
+        }}
+      >
+        Connect to {getChainInfo(chainId)?.label}
+      </ButtonPrimary>
+    )
+  }
+
+  if (showWrap) {
+    return <WrapButton onClick={onWrap} error={wrapInputError} type={wrapType} />
+  }
+
+  if (routeNotFound && userHasSpecifiedInputOutput && !routeIsLoading && !routeIsSyncing) {
+    return (
+      <GrayCard style={{ textAlign: 'center' }}>
+        <ThemedText.DeprecatedMain mb="4px">
+          <Trans>Insufficient liquidity for this trade.</Trans>
+        </ThemedText.DeprecatedMain>
+      </GrayCard>
+    )
+  }
+
+  if (isValid && allowance.state === AllowanceState.REQUIRED) {
+    return (
+      <ButtonPrimary onClick={updateAllowance} disabled={isAllowancePending || isApprovalLoading} style={{ gap: 14 }}>
+        {isAllowancePending ? (
+          <>
+            <Loader size="20px" />
+            <Trans>Approve in your wallet</Trans>
+          </>
+        ) : isApprovalLoading ? (
+          <>
+            <Loader size="20px" />
+            <Trans>Approval pending</Trans>
+          </>
+        ) : (
+          <>
+            <div style={{ height: 20 }}>
+              <MouseoverTooltip
+                text={
+                  <Trans>
+                    Permission is required for Uniswap to swap each token. This will expire after one month for your
+                    security.
+                  </Trans>
+                }
+              >
+                <Info size={20} />
+              </MouseoverTooltip>
+            </div>
+            <Trans>Approve use of {currencies[Field.INPUT]?.symbol}</Trans>
+          </>
+        )}
+      </ButtonPrimary>
+    )
+  }
+
+  return (
+    <ButtonError
+      onClick={onSwapClick}
+      id="swap-button"
+      disabled={Boolean(
+        swapInputError ||
+          routeIsSyncing ||
+          routeIsLoading ||
+          priceImpactTooHigh ||
+          allowance.state !== AllowanceState.ALLOWED
+      )}
+      error={!swapInputError && (priceImpactSeverity ?? 0) > 2 && allowance.state === AllowanceState.ALLOWED}
+    >
+      <ThemedText.HeadlineSmall fontSize={20} fontWeight={600}>
+        {swapInputError ? (
+          swapInputError
+        ) : routeIsSyncing || routeIsLoading ? (
+          <Trans>Review Swap</Trans>
+        ) : priceImpactTooHigh ? (
+          <Trans>Price Impact Too High</Trans>
+        ) : (priceImpactSeverity ?? 0) > 2 ? (
+          <Trans>Swap Anyway</Trans>
+        ) : (
+          <Trans>Review Swap</Trans>
+        )}
+      </ThemedText.HeadlineSmall>
+    </ButtonError>
+  )
+}

--- a/src/pages/Swap/WrapButton.test.tsx
+++ b/src/pages/Swap/WrapButton.test.tsx
@@ -1,0 +1,43 @@
+import { WrapInputError, WrapType } from 'hooks/useWrapCallback'
+import { render, screen } from 'test-utils/render'
+
+import { WrapButton } from './WrapButton'
+
+describe('WrapButton', () => {
+  it('should render an error and be disabled, wrap type', () => {
+    render(<WrapButton onClick={jest.fn()} error={WrapInputError.INSUFFICIENT_NATIVE_BALANCE} type={WrapType.WRAP} />)
+    expect(screen.getByText('Insufficient ETH balance')).toBeInTheDocument()
+    expect(screen.getByTestId('wrap-button')).toBeDisabled()
+  })
+
+  it('should render an error and be disabled, unwrap type', () => {
+    render(
+      <WrapButton onClick={jest.fn()} error={WrapInputError.INSUFFICIENT_WRAPPED_BALANCE} type={WrapType.UNWRAP} />
+    )
+    expect(screen.getByText('Insufficient WETH balance')).toBeInTheDocument()
+    expect(screen.getByTestId('wrap-button')).toBeDisabled()
+  })
+
+  it('should render a wrap button', () => {
+    const clickCallback = jest.fn()
+    render(<WrapButton onClick={clickCallback} type={WrapType.WRAP} />)
+    expect(screen.getByText('Wrap')).toBeInTheDocument()
+    expect(screen.getByTestId('wrap-button')).not.toBeDisabled()
+    screen.getByTestId('wrap-button').click()
+    expect(clickCallback).toHaveBeenCalled()
+  })
+
+  it('should render an unwrap button', () => {
+    const clickCallback = jest.fn()
+    render(<WrapButton onClick={clickCallback} type={WrapType.UNWRAP} />)
+    expect(screen.getByText('Unwrap')).toBeInTheDocument()
+    expect(screen.getByTestId('wrap-button')).not.toBeDisabled()
+    screen.getByTestId('wrap-button').click()
+    expect(clickCallback).toHaveBeenCalled()
+  })
+
+  it('should render null', () => {
+    render(<WrapButton onClick={jest.fn()} type={WrapType.NOT_APPLICABLE} />)
+    expect(screen.queryByTestId('wrap-button')).not.toContainHTML('*')
+  })
+})

--- a/src/pages/Swap/WrapButton.tsx
+++ b/src/pages/Swap/WrapButton.tsx
@@ -4,7 +4,7 @@ import { WrapErrorText, WrapInputError, WrapType } from 'hooks/useWrapCallback'
 
 interface WrapButtonProps {
   onClick: (() => Promise<void>) | undefined
-  error: WrapInputError | undefined
+  error?: WrapInputError
   type: WrapType
 }
 

--- a/src/pages/Swap/WrapButton.tsx
+++ b/src/pages/Swap/WrapButton.tsx
@@ -1,0 +1,23 @@
+import { Trans } from '@lingui/macro'
+import { ButtonPrimary } from 'components/Button'
+import { WrapErrorText, WrapInputError, WrapType } from 'hooks/useWrapCallback'
+
+interface WrapButtonProps {
+  onClick: (() => Promise<void>) | undefined
+  error: WrapInputError | undefined
+  type: WrapType
+}
+
+export function WrapButton({ onClick, error, type }: WrapButtonProps) {
+  return (
+    <ButtonPrimary disabled={Boolean(error)} onClick={onClick} fontWeight={600} data-testid="wrap-button">
+      {error ? (
+        <WrapErrorText wrapInputError={error} />
+      ) : type === WrapType.WRAP ? (
+        <Trans>Wrap</Trans>
+      ) : type === WrapType.UNWRAP ? (
+        <Trans>Unwrap</Trans>
+      ) : null}
+    </ButtonPrimary>
+  )
+}

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -797,13 +797,13 @@ export function Swap({
                 {swapInputError ? (
                   swapInputError
                 ) : routeIsSyncing || routeIsLoading ? (
-                  <Trans>Swap</Trans>
+                  <Trans>Review Swap</Trans>
                 ) : priceImpactTooHigh ? (
                   <Trans>Price Impact Too High</Trans>
                 ) : priceImpactSeverity > 2 ? (
                   <Trans>Swap Anyway</Trans>
                 ) : (
-                  <Trans>Swap</Trans>
+                  <Trans>Review Swap</Trans>
                 )}
               </Text>
             </ButtonError>

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -6,7 +6,6 @@ import useAutoSlippageTolerance from 'hooks/useAutoSlippageTolerance'
 import { useBestTrade } from 'hooks/useBestTrade'
 import { useIsSwapUnsupported } from 'hooks/useIsSwapUnsupported'
 import { useUSDPrice } from 'hooks/useUSDPrice'
-import { ENS_NAME_REGEX } from 'lib/utils/parseENSAddress'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ParsedQs } from 'qs'
 import { createContext, PropsWithChildren, ReactNode, useCallback, useEffect, useMemo } from 'react'
@@ -342,6 +341,7 @@ function parseIndependentFieldURLParameter(urlParam: any): Field {
   return typeof urlParam === 'string' && urlParam.toLowerCase() === 'output' ? Field.OUTPUT : Field.INPUT
 }
 
+const ENS_NAME_REGEX = /^[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)?$/
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/
 function validatedRecipient(recipient: any): string | null {
   if (typeof recipient !== 'string') return null

--- a/src/utils/getIsValidSwapQuote.test.ts
+++ b/src/utils/getIsValidSwapQuote.test.ts
@@ -1,0 +1,36 @@
+import { TradeState } from 'state/routing/types'
+import { TEST_TRADE_EXACT_INPUT } from 'test-utils/constants'
+
+import { getIsValidSwapQuote } from './getIsValidSwapQuote'
+
+describe('getIsValidSwapQuote', () => {
+  it('should return true when swapInputError is truthy and trade and tradeState are truthy', () => {
+    const swapInputError = 'swapInputError'
+    expect(getIsValidSwapQuote(TEST_TRADE_EXACT_INPUT, TradeState.VALID, swapInputError)).toBe(true)
+    expect(getIsValidSwapQuote(TEST_TRADE_EXACT_INPUT, TradeState.SYNCING, swapInputError)).toBe(true)
+  })
+
+  it('should return false when swapInputError is falsy and trade and tradeState are truthy', () => {
+    const swapInputError = ''
+    expect(getIsValidSwapQuote(TEST_TRADE_EXACT_INPUT, TradeState.VALID, swapInputError)).toBe(false)
+  })
+
+  it('should return false when swapInputError is truthy and trade/tradeState are falsy', () => {
+    const swapInputError = 'swapInputError'
+    // tradeState falsy
+    expect(getIsValidSwapQuote(TEST_TRADE_EXACT_INPUT, TradeState.INVALID, swapInputError)).toBe(false)
+    expect(getIsValidSwapQuote(TEST_TRADE_EXACT_INPUT, TradeState.NO_ROUTE_FOUND, swapInputError)).toBe(false)
+    expect(getIsValidSwapQuote(TEST_TRADE_EXACT_INPUT, TradeState.LOADING, swapInputError)).toBe(false)
+    // trade falsy
+    expect(getIsValidSwapQuote(undefined, TradeState.VALID, swapInputError)).toBe(false)
+    expect(getIsValidSwapQuote(undefined, TradeState.SYNCING, swapInputError)).toBe(false)
+    // both falsey
+    expect(getIsValidSwapQuote(undefined, TradeState.INVALID, swapInputError)).toBe(false)
+    expect(getIsValidSwapQuote(undefined, TradeState.NO_ROUTE_FOUND, swapInputError)).toBe(false)
+  })
+
+  it('should return false when swapInputError is falsy and trade and tradeState are falsy', () => {
+    const swapInputError = ''
+    expect(getIsValidSwapQuote(undefined, TradeState.INVALID, swapInputError)).toBe(false)
+  })
+})

--- a/src/utils/getIsValidSwapQuote.ts
+++ b/src/utils/getIsValidSwapQuote.ts
@@ -1,0 +1,11 @@
+import { Currency, TradeType } from '@uniswap/sdk-core'
+import { ReactNode } from 'react'
+import { InterfaceTrade, TradeState } from 'state/routing/types'
+
+export function getIsValidSwapQuote(
+  trade: InterfaceTrade<Currency, Currency, TradeType> | undefined,
+  tradeState: TradeState,
+  swapInputError?: ReactNode
+): boolean {
+  return !!swapInputError && !!trade && (tradeState === TradeState.VALID || tradeState === TradeState.SYNCING)
+}

--- a/src/utils/prices.test.ts
+++ b/src/utils/prices.test.ts
@@ -12,7 +12,7 @@ import {
   toCurrencyAmount,
 } from 'test-utils/constants'
 
-import { computeRealizedLPFeeAmount, warningSeverity } from './prices'
+import { computeRealizedLPFeeAmount, largerPercentValue, warningSeverity } from './prices'
 
 const pair12 = new Pair(
   CurrencyAmount.fromRawAmount(TEST_TOKEN_1, JSBI.BigInt(10000)),
@@ -128,6 +128,19 @@ describe('prices', () => {
     })
     it('correct for 50', () => {
       expect(warningSeverity(new Percent(5, 10))).toEqual(4)
+    })
+  })
+
+  describe('largerPercentValue', () => {
+    it('returns the larger of two percent values', () => {
+      const one = new Percent(1, 100)
+      const ten = new Percent(10, 100)
+      expect(largerPercentValue(one, ten)).toEqual(ten)
+      expect(largerPercentValue(ten, one)).toEqual(ten)
+      expect(largerPercentValue(one, one)).toEqual(one)
+      expect(largerPercentValue(undefined, one)).toEqual(one)
+      expect(largerPercentValue(one, undefined)).toEqual(one)
+      expect(largerPercentValue(undefined, undefined)).toEqual(undefined)
     })
   })
 })

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -82,7 +82,7 @@ const IMPACT_TIERS = [
   ALLOWED_PRICE_IMPACT_LOW,
 ]
 
-type WarningSeverity = 0 | 1 | 2 | 3 | 4
+export type WarningSeverity = 0 | 1 | 2 | 3 | 4
 export function warningSeverity(priceImpact: Percent | undefined): WarningSeverity {
   if (!priceImpact) return 0
   // This function is used to calculate the Severity level for % changes in USD value and Price Impact.
@@ -103,4 +103,15 @@ export function getPriceImpactWarning(priceImpact: Percent): 'warning' | 'error'
   if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_HIGH)) return 'error'
   if (priceImpact.greaterThan(ALLOWED_PRICE_IMPACT_MEDIUM)) return 'warning'
   return
+}
+
+export function largerPercentValue(a?: Percent, b?: Percent) {
+  if (a && b) {
+    return a.greaterThan(b) ? a : b
+  } else if (a) {
+    return a
+  } else if (b) {
+    return b
+  }
+  return undefined
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Refactor the Swap Button into separate components, and move more state into `DerivedSwapInfo`, and make all the `DerivedSwapInfo` state available to the component and children via a Context. 

Motivation:
All of this state was just living in the body of the Swap Component, which makes the file long and difficult to parse. Since it's state, it was already causing the entire Swap Component to re-render, so this is more of a re-organization of code than a functional change.
Also, a refactor like this is needed if we're going to start modularizing different parts of the UI - e.g. separating the Button/Footer, inputs, header instead of keeping them in this monolithic component. The Context allows children at any level below the Swap Component to access swap state without passing tons of props (for an example, see `ConfirmSwapModal`)

As you can see by the added tests, modularizing like this makes unit testing easier too.

Next Steps:
This was just a first step in this direction, only focused on the SwapButton and state that it needs. We can continue to modularize pieces of the Swap Component and add more shared state to the `DerivedSwapInfoContext`. 


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually swap and verify that the Swap Component behaves the same

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test (added several new test suites)
- [x] Integration/E2E test (automated test runs)
