### PR TITLE
test(e2e): mock uniswap token lists from ipfs

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -117,15 +117,9 @@ beforeEach(() => {
       )
     })
     // Mock our own token list responses to avoid the latency of IPFS.
-    .intercept('https://gateway.ipfs.io/ipns/tokens.uniswap.org', (req) => {
-      req.reply(TokenListJSON)
-    })
-    .intercept('https://gateway.ipfs.io/ipns/extendedtokens.uniswap.org', (req) => {
-      req.reply(200)
-    })
-    .intercept('https://gateway.ipfs.io/ipns/unsupportedtokens.uniswap.org', (req) => {
-      req.reply(200)
-    })
+    .intercept('https://gateway.ipfs.io/ipns/tokens.uniswap.org', TokenListJSON)
+    .intercept('https://gateway.ipfs.io/ipns/extendedtokens.uniswap.org', { statusCode: 201, body: { tokens: [] } })
+    .intercept('https://gateway.ipfs.io/ipns/unsupportedtokens.uniswap.org', { statusCode: 201, body: { tokens: [] } })
     // Reset hardhat between tests to ensure isolation.
     // This resets the fork, as well as options like automine.
     .hardhat()

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -9,6 +9,7 @@ import '@cypress/code-coverage/support'
 import 'cypress-hardhat/lib/browser'
 
 import { Eip1193Bridge } from '@ethersproject/experimental/lib/eip1193-bridge'
+import TokenListJSON from '@uniswap/default-token-list'
 import assert from 'assert'
 
 import { FeatureFlag } from '../../src/featureFlags/flags/featureFlags'
@@ -114,6 +115,16 @@ beforeEach(() => {
           events_ingested: req.body.events.length,
         })
       )
+    })
+    // Mock our own token list responses to avoid the latency of IPFS.
+    .intercept('https://gateway.ipfs.io/ipns/tokens.uniswap.org', (req) => {
+      req.reply(TokenListJSON)
+    })
+    .intercept('https://gateway.ipfs.io/ipns/extendedtokens.uniswap.org', (req) => {
+      req.reply(200)
+    })
+    .intercept('https://gateway.ipfs.io/ipns/unsupportedtokens.uniswap.org', (req) => {
+      req.reply(200)
     })
     // Reset hardhat between tests to ensure isolation.
     // This resets the fork, as well as options like automine.

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@types/ua-parser-js": "^0.7.35",
     "@types/uuid": "^8.3.4",
     "@types/wcag-contrast": "^3.0.0",
+    "@uniswap/default-token-list": "^9.4.0",
     "@uniswap/eslint-config": "^1.1.1",
     "@vanilla-extract/babel-plugin": "^1.1.7",
     "@vanilla-extract/jest-transform": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5167,6 +5167,11 @@
   resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-2.2.0.tgz#d85a5c2520f57f4920bd989dfc9f01e1b701a567"
   integrity sha512-vFPWoGzDjHP4i2l7yLaober/lZMmzOZXXirVF8XNyfNzRxgmYCWKO6SzKtfEUwxpd3/KUebgdK55II4Mnak62A==
 
+"@uniswap/default-token-list@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-9.4.0.tgz#60c4d249b3be5d0123480e5a4fd092a1fd10ef0c"
+  integrity sha512-PsYsEPpFs0CIjWHel2FDPo6T/EkZ+RuH9NfX55FbMbZMTuw9TSQEfl8p1fYt6KAMWi0Zy/Mfqp16y+OiYJyoBA==
+
 "@uniswap/eslint-config@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@uniswap/eslint-config/-/eslint-config-1.1.1.tgz#83d2633dad6507ca58bc11c8892035812059488e"


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes flakiness in tests caused by slow loading of token lists over IPFS, by serving the default token list through an HTTP interceptor in cypress E2E tests.

### Automated testing
- [x] Integration/E2E test
