### PR TITLE
fix: properly filter AbortErrors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -203,7 +203,8 @@ describe('filterKnownErrors', () => {
   })
 
   it('filters AbortErrors', () => {
-    const originalException = new Error('AbortError: The user aborted a request.')
+    const originalException = new DOMException('The user aborted a request.') as any
+    originalException.name = 'AbortError'
     expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -203,8 +203,7 @@ describe('filterKnownErrors', () => {
   })
 
   it('filters AbortErrors', () => {
-    const originalException = new DOMException('The user aborted a request.') as any
-    originalException.name = 'AbortError'
+    const originalException = new DOMException('The user aborted a request.', 'AbortError')
     expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -98,7 +98,7 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
     }
 
     // These are caused by user navigation away from the page before a request has finished.
-    if (error.message.startsWith('AbortError')) return null
+    if (error instanceof DOMException && error.name === 'AbortError') return null
   }
 
   return event


### PR DESCRIPTION
## Description
According to MDN:
```
Note: When abort() is called, the fetch() promise rejects with an Error of type DOMException, with name AbortError.
```

https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort

Therefore, my previous filtering was failing because I checked for AbortError: to be the start of the error message. Really, that only happens when toString is called later on.

## Test plan
- [x] Unit test
- [x] Integration/E2E test (N/A)
