### PR TITLE
revert(e2e): waitForAnimations

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,6 @@ import { setupHardhatEvents } from 'cypress-hardhat'
 export default defineConfig({
   projectId: 'yp82ef',
   videoUploadOnPasses: false,
-  waitForAnimations: false,
   defaultCommandTimeout: 24000, // 2x average block time
   chromeWebSecurity: false,
   retries: { runMode: 2 },


### PR DESCRIPTION
## Description
Reverts a flakey e2e test so that we unblock deploys. I cherry-picked this from https://github.com/Uniswap/interface/pull/6524

## Test plan
### Automated testing
- [x] Unit test (N/A)
- [x] Integration/E2E test
