### PR TITLE
ci: CI pipeline fixes for merge issues

### DIFF
--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "@uniswap/web-admins" > CODEOWNERS
           git add CODEOWNERS
-          git commit -m "ci: add CODEOWNERS file"
+          git commit -m "ci: add global CODEOWNERS"
       - name: Git push
         run: |
           git config user.name "UL Service Account"

--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_SERVICE_ACCESS_TOKEN }}
           ref: main
+      - name: Add CODEOWNERS file
+        run: |
+          echo "@uniswap/web-reviewers" > CODEOWNERS
+          git add CODEOWNERS
+          git commit -m "ci: add CODEOWNERS file"
       - name: Git push
         run: |
           git config user.name "UL Service Account"

--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -1,4 +1,4 @@
-name: 1 | Push main to releases/staging
+name: 1 | Push main -> staging
 
 # This CI job is responsible for pushing the current contents of the `main` branch to the
 # `releases/staging` branch, which will in turn kick off a deploy to the staging environment.
@@ -12,7 +12,7 @@ jobs:
     name: 'Push to staging branch'
     runs-on: ubuntu-latest
     environment:
-      name: release
+      name: push/staging
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -20,7 +20,7 @@ jobs:
           ref: main
       - name: Add CODEOWNERS file
         run: |
-          echo "@uniswap/web-reviewers" > CODEOWNERS
+          echo "@uniswap/web-admins" > CODEOWNERS
           git add CODEOWNERS
           git commit -m "ci: add CODEOWNERS file"
       - name: Git push

--- a/.github/workflows/2-deploy-to-staging.yml
+++ b/.github/workflows/2-deploy-to-staging.yml
@@ -1,4 +1,4 @@
-name: 2 | Deploy to staging
+name: 2 | Deploy staging
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ jobs:
   deploy-to-staging:
     runs-on: ubuntu-latest
     environment:
-      name: staging
+      name: deploy/staging
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup

--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "### Description" > /tmp/pr_desc
           echo "" >> /tmp/pr_desc
-          echo "This PR promotes the following commits from `releases/staging` to `releases/prod`." >> /tmp/pr_desc
+          echo "This PR promotes the following commits from **releases/staging** to **releases/prod**." >> /tmp/pr_desc
           echo "" >> /tmp/pr_desc
           gh pr view ${{ steps.create-pull-request.outputs.pull-request-number }} --json commits | jq '.commits[] | [.oid, .messageHeadline] | @tsv' | sed 's/"//g' | sed 's/\\t/ - /g' >> /tmp/pr_desc
           echo "" >> /tmp/pr_desc

--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -1,4 +1,4 @@
-name: 3 | Generate PR for releases/staging to releases/prod
+name: 3 | Push releases/staging to releases/prod
 
 # This CI job is responsible for force pushing the content of releases/staging to releases/prod. It
 # is restricted to web-reviewers through virtue of the GitHub environment protection rules for the

--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -1,54 +1,25 @@
 name: 3 | Generate PR for releases/staging to releases/prod
 
-# This CI job is responsible for generating PRs that bring the HEAD of `releases/staging` into `releases/prod`.
-# These PRs are meant to be the only (standard) way that code is merged into the `releases/prod` branch.
+# This CI job is responsible for force pushing the content of releases/staging to releases/prod. It
+# is restricted to web-reviewers through virtue of the GitHub environment protection rules for the
+# prod environment.
 
 on:
   workflow_dispatch:
 
-# https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-branch-up-to-date-with-another
 jobs:
-  prod-gen-pr:
-    name: 'Generate PR for merging to releases/prod branch'
+  push-prod:
+    name: 'Push to prod branch'
     runs-on: ubuntu-latest
     environment:
-      name: release
+      name: prod
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           token: ${{ secrets.RELEASE_SERVICE_ACCESS_TOKEN }}
-          ref: main
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-        with:
-          token: ${{ secrets.RELEASE_SERVICE_ACCESS_TOKEN }}
-          ref: releases/prod
-      - name: Reset promotion branch
+          ref: releases/staging
+      - name: Git push
         run: |
-          git fetch origin releases/staging:releases/staging
-          git reset --hard releases/staging
-      - name: Setup git
-        run: |
-          git config user.name "UL Mobile Service Account"
+          git config user.name "UL Service Account"
           git config user.email "hello-happy-puppy@users.noreply.github.com"
-      - uses: peter-evans/create-pull-request@ea54357f43e3d1cf1125471d0814f4d02cc0d364
-        id: create-pull-request
-        with:
-          token: ${{ secrets.RELEASE_SERVICE_ACCESS_TOKEN }}
-          base: 'releases/prod'
-          title: 'ci: promotes staging to prod'
-          delete-branch: 'true'
-          committer: 'UL Service Account <hello-happy-puppy@users.noreply.github.com>'
-          author: 'UL Service Account <hello-happy-puppy@users.noreply.github.com>'
-          branch: 'approvals/staging-to-prod'
-      - name: Update PR body
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "### Description" > /tmp/pr_desc
-          echo "" >> /tmp/pr_desc
-          echo "This PR promotes the following commits from **releases/staging** to **releases/prod**." >> /tmp/pr_desc
-          echo "" >> /tmp/pr_desc
-          gh pr view ${{ steps.create-pull-request.outputs.pull-request-number }} --json commits | jq '.commits[] | [.oid, .messageHeadline] | @tsv' | sed 's/"//g' | sed 's/\\t/ - /g' >> /tmp/pr_desc
-          echo "" >> /tmp/pr_desc
-          echo "**Once approved this PR will be automatically merged via a merge commit.**" >> /tmp/pr_desc
-          gh pr edit ${{ steps.create-pull-request.outputs.pull-request-number }} -b "$(cat /tmp/pr_desc)"
+          git push origin releases/staging:releases/prod --force

--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -30,11 +30,6 @@ jobs:
         run: |
           git config user.name "UL Mobile Service Account"
           git config user.email "hello-happy-puppy@users.noreply.github.com"
-      - name: Add CODEOWNERS file
-        run: |
-          echo "@uniswap/web-reviewers" > CODEOWNERS
-          git add CODEOWNERS
-          git commit -m "ci: add CODEOWNERS file"
       - uses: peter-evans/create-pull-request@ea54357f43e3d1cf1125471d0814f4d02cc0d364
         id: create-pull-request
         with:
@@ -57,7 +52,3 @@ jobs:
           echo "" >> /tmp/pr_desc
           echo "**Once approved this PR will be automatically merged via a merge commit.**" >> /tmp/pr_desc
           gh pr edit ${{ steps.create-pull-request.outputs.pull-request-number }} -b "$(cat /tmp/pr_desc)"
-      - name: Enable PR automerge
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_SERVICE_ACCESS_TOKEN }}
-        run: gh pr merge --delete-branch --merge --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"

--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -1,4 +1,4 @@
-name: 3 | Push releases/staging to releases/prod
+name: 3 | Push staging -> prod
 
 # This CI job is responsible for force pushing the content of releases/staging to releases/prod. It
 # is restricted to web-reviewers through virtue of the GitHub environment protection rules for the
@@ -12,7 +12,7 @@ jobs:
     name: 'Push to prod branch'
     runs-on: ubuntu-latest
     environment:
-      name: prod
+      name: push/prod
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/.github/workflows/4-deploy-to-prod.yml
+++ b/.github/workflows/4-deploy-to-prod.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy-to-prod:
+    runs-on: ubuntu-latest
     environment:
       name: release
     steps:

--- a/.github/workflows/4-deploy-to-prod.yml
+++ b/.github/workflows/4-deploy-to-prod.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy-to-prod:
     environment:
-      name: prod
+      name: release
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup

--- a/.github/workflows/4-deploy-to-prod.yml
+++ b/.github/workflows/4-deploy-to-prod.yml
@@ -1,4 +1,4 @@
-name: 4 | Deploy to prod
+name: 4 | Deploy prod
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ jobs:
   deploy-to-prod:
     runs-on: ubuntu-latest
     environment:
-      name: release
+      name: deploy/prod
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -89,4 +89,3 @@ jobs:
           environment: production
           sourcemaps: './build/static/js'
           url_prefix: '~/static/js'
-


### PR DESCRIPTION
## Description

This PR contains the following fixes for the prod CI pipeline:

- Add `CODEOWNERS` into staging (this enables us to require `CODEOWNERS` correctly for staging -> prod)
- Remove automerge configuration for prod PR
- Force push from `releases/staging` -> `releases/prod` rather than cut a PR
