### PR TITLE
fix: disables CMC list temporarily

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -3,7 +3,8 @@ export const UNI_EXTENDED_LIST = 'https://gateway.ipfs.io/ipns/extendedtokens.un
 const UNI_UNSUPPORTED_LIST = 'https://gateway.ipfs.io/ipns/unsupportedtokens.uniswap.org'
 const AAVE_LIST = 'tokenlist.aave.eth'
 const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
-const CMC_ALL_LIST = 'https://s3.coinmarketcap.com/generated/dex/tokens/eth-tokens-all.json'
+// TODO(INFRA-179): Re-enable CMC list once we have a better solution for handling large lists.
+// const CMC_ALL_LIST = 'https://s3.coinmarketcap.com/generated/dex/tokens/eth-tokens-all.json'
 const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
 const COINGECKO_BNB_LIST = 'https://tokens.coingecko.com/binance-smart-chain/all.json'
 const COINGECKO_ARBITRUM_LIST = 'https://tokens.coingecko.com/arbitrum-one/all.json'
@@ -29,7 +30,7 @@ export const DEFAULT_INACTIVE_LIST_URLS: string[] = [
   UNI_EXTENDED_LIST,
   COMPOUND_LIST,
   AAVE_LIST,
-  CMC_ALL_LIST,
+  //  CMC_ALL_LIST,
   COINGECKO_LIST,
   COINGECKO_BNB_LIST,
   COINGECKO_ARBITRUM_LIST,


### PR DESCRIPTION
## Description
Temporarily disables the CMC list. It previously was not working for a long time, until this PR fixed the URL to resolve CORS errors: https://github.com/Uniswap/interface/pull/6406

However, this leads to [QuotaExceededErrors](https://uniswap-labs.sentry.io/issues/4169030652/?project=4504255148851200&referrer=release-issue-stream). These are caused when the total size of localStorage is beyond ~5mb, depending on browser.

We will need a better long term solution, as this will continue to happen as token lists will increase in size. We also do want to be able to search the tokens that exist on CMC.

However, for now we should get back to a state where the localStorage updates can work. At the moment, any change to localStorage on our origin will fail, leading to issues like the selected wallet not saving.

Total number of tokens per list:
<img width="937" alt="Screen Shot 2023-05-10 at 2 31 05 PM" src="https://github.com/Uniswap/interface/assets/4899429/41094cd1-1453-4ef4-bb0d-c7be1f1bed9a">

Size per localStorage item:


## Test plan
### Reproducing the error
```js
(function getLocalStorageSize() {
  let totalSize = 0;

  for (let i = 0; i < localStorage.length; i++) {
    const key = localStorage.key(i);
    const value = localStorage.getItem(key);
    const size = key.length + value.length
    console.log(key, size);
    totalSize += size
  }

  console.log('total:', totalSize);
})()
```

```js
console.table(Object.entries(JSON.parse(localStorage.redux_localstorage_simple_lists)['byUrl']).map((value) => {
    const [url, items] = value
    return [url, items.current?.tokens.length]
}))
```

1. Go to a browser which has the errors (you can come to my laptop if you want to see it).
2. Run the scripts above.
3. See that the `redux_localstorage_simple_lists` is very large.

### QA (ie manual testing)
1. On this branch, run the script and see that the total redux store size went down by ~20%.

after (in bytes):
<img width="108" alt="Screen Shot 2023-05-10 at 2 35 20 PM" src="https://github.com/Uniswap/interface/assets/4899429/b65ee326-5bdc-4b42-9e1d-19ee03256ac1">

before:
<img width="103" alt="Screen Shot 2023-05-10 at 2 35 31 PM" src="https://github.com/Uniswap/interface/assets/4899429/cfef0f4d-9689-493e-9c7f-8af6774efb1b">

### Automated testing
- [x] Unit test
- [x] Integration/E2E test

(I basically think as long as existing tests pass this is covered)