### PR TITLE
fix: propagates user rejection errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -74,6 +74,11 @@ describe('filterKnownErrors', () => {
     expect(filterKnownErrors(ERROR, { originalException })).toBe(ERROR)
   })
 
+  it('propagates user rejected request errors', () => {
+    const originalException = new Error('user rejected transaction')
+    expect(filterKnownErrors(ERROR, { originalException })).toBe(ERROR)
+  })
+
   it('filters block number polling errors', () => {
     const originalException = new (class extends Error {
       requestBody = JSON.stringify({ method: 'eth_blockNumber' })
@@ -83,11 +88,6 @@ describe('filterKnownErrors', () => {
 
   it('filters network change errors', () => {
     const originalException = new Error('underlying network changed')
-    expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
-  })
-
-  it('filters user rejected request errors', () => {
-    const originalException = new Error('user rejected transaction')
     expect(filterKnownErrors(ERROR, { originalException })).toBeNull()
   })
 

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,5 +1,4 @@
 import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
-import { didUserReject } from 'utils/swapErrorToUserReadableMessage'
 
 // `responseStatus` is only currently supported on certain browsers.
 // see: https://caniuse.com/mdn-api_performanceresourcetiming_responsestatus
@@ -79,9 +78,6 @@ export const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: 
 
     // If the error is a network change, it should not be considered an exception.
     if (error.message.match(/underlying network changed/)) return null
-
-    // If the error is based on a user rejecting, it should not be considered an exception.
-    if (didUserReject(error)) return null
 
     // This is caused by HTML being returned for a chunk from Cloudflare.
     // Usually, it's the result of a 499 exception right before it, which should be handled.


### PR DESCRIPTION
## Description
This reverts this PR: https://github.com/Uniswap/interface/pull/6330

I've changed my mind here, and think with the added context in Sentry these errors are worth monitoring again. We should know where we're not catching these errors, and address them.

## Test plan
- [x] Unit test
- [x] Integration/E2E test (N/A)
