### PR TITLE
feat: [DetailsV2] Add left padding to trait rows and headers

### DIFF
--- a/src/nft/components/details/detailsV2/DataPageTraits.tsx
+++ b/src/nft/components/details/detailsV2/DataPageTraits.tsx
@@ -13,7 +13,7 @@ import { Tab, TabbedComponent } from './TabbedComponent'
 import { TraitRow } from './TraitRow'
 
 const TraitsHeaderContainer = styled(Row)`
-  padding-right: 12px;
+  padding: 0px 12px;
 `
 
 const TraitsHeader = styled(ThemedText.SubHeaderSmall)<{ $flex?: number; $justifyContent?: string }>`

--- a/src/nft/components/details/detailsV2/TraitRow.tsx
+++ b/src/nft/components/details/detailsV2/TraitRow.tsx
@@ -25,7 +25,7 @@ const SubheaderTinyHidden = styled(SubheaderTiny)`
 `
 
 const TraitRowContainer = styled(Row)`
-  padding: 12px 18px 12px 0px;
+  padding: 12px 18px 12px 12px;
   border-radius: 12px;
   cursor: pointer;
   text-decoration: none;

--- a/src/nft/components/details/detailsV2/__snapshots__/DataPageTraits.test.tsx.snap
+++ b/src/nft/components/details/detailsV2/__snapshots__/DataPageTraits.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`data page trait component does not load with asset with no traits 1`] =
 }
 
 .c8 {
-  padding-right: 12px;
+  padding: 0px 12px;
 }
 
 .c10 {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Design requested to add 12px of left padding to the header and trait rows for a better hover effect

<!-- Delete inapplicable lines: -->
_JIRA ticket:_ https://linear.app/uniswap/issue/NFT-1116/update-trait-row-left-padding


<!-- Delete this section if your change does not affect UI. -->
## Screen capture
<img width="569" alt="Screen Shot 2023-05-10 at 12 38 28 " src="https://github.com/Uniswap/interface/assets/11512321/df79cf06-0f15-4287-a987-70c7e8022795">


## Test plan
- updated snapshot
