### PR TITLE
chore: removing token type check from routing

### DIFF
--- a/src/nft/utils/buildSellObject.ts
+++ b/src/nft/utils/buildSellObject.ts
@@ -27,7 +27,7 @@ const buildNftTradeInput = (assets: UpdatedGenieAsset[]): NftTradeInput[] => {
   return assets.flatMap((asset) => {
     const { id, address, marketplace, priceInfo, tokenId, tokenType } = asset
 
-    if (!id || !marketplace || !tokenType) return []
+    if (!id || !marketplace) return []
 
     const ethAmountInput: TokenAmountInput = {
       amount: priceInfo.ETHPrice,


### PR DESCRIPTION
** Backend removed the check for tokenType for routing and some endpoints don't pass the tokenType from nxyz so we have to remove the check on the frontend