### PR TITLE
fix: remove top-level Fragment

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -140,20 +140,18 @@ export default function SwapPage({ className }: { className?: string }) {
   const loadedUrlParams = useDefaultsFromURLSearch()
   return (
     <Trace page={InterfacePageName.SWAP_PAGE} shouldLogImpression>
-      <>
-        <PageWrapper>
-          <Swap
-            className={className}
-            chainId={connectedChainId}
-            prefilledState={{
-              [Field.INPUT]: { currencyId: loadedUrlParams?.[Field.INPUT]?.currencyId },
-              [Field.OUTPUT]: { currencyId: loadedUrlParams?.[Field.OUTPUT]?.currencyId },
-            }}
-          />
-          <NetworkAlert />
-        </PageWrapper>
-        <SwitchLocaleLink />
-      </>
+      <PageWrapper>
+        <Swap
+          className={className}
+          chainId={connectedChainId}
+          prefilledState={{
+            [Field.INPUT]: { currencyId: loadedUrlParams?.[Field.INPUT]?.currencyId },
+            [Field.OUTPUT]: { currencyId: loadedUrlParams?.[Field.OUTPUT]?.currencyId },
+          }}
+        />
+        <NetworkAlert />
+      </PageWrapper>
+      <SwitchLocaleLink />
     </Trace>
   )
 }


### PR DESCRIPTION
## Description
This should resolve these errors: https://uniswap-labs.sentry.io/issues/4174993328/?project=4504255148851200&query=release%3A59b757dda03c2772c73b710fe4690208a5c7b001&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=19

I found the solution here: https://github.com/remix-run/react-router/issues/8834#issuecomment-1118083034

The claim is that a top-level fragment will have issues when the DOM node is attempted to be removed. In this case, the Fragment isn't even necessary.

### Reproducing the error
I haven't actually been able to reproduce this locally.

### QA (ie manual testing)
I tested making sure the Swap page loads and works when I navigate away.

### Automated testing
- [ ] Unit test
- [ ] Integration/E2E test

I don't think any new tests are necessary here beyond making sure existing tests pass.