### PR TITLE
fix: remove trailing slash from request url

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -16,10 +16,10 @@ describe('beforeSend', () => {
         request: {
           url: 'https://app.uniswap.org/#/example',
         },
-      }
+      } as ErrorEvent
 
-      beforeSend(event as ErrorEvent, null as any)
-      expect(event.request.url).toBe('https://app.uniswap.org/example')
+      beforeSend(event, null as any)
+      expect(event.request?.url).toBe('https://app.uniswap.org/example')
     })
 
     test('should remove trailing slash from the request URL', () => {
@@ -27,10 +27,10 @@ describe('beforeSend', () => {
         request: {
           url: 'https://app.uniswap.org/example/',
         },
-      }
+      } as ErrorEvent
 
-      beforeSend(event as ErrorEvent, null as any)
-      expect(event.request.url).toBe('https://app.uniswap.org/example')
+      beforeSend(event, null as any)
+      expect(event.request?.url).toBe('https://app.uniswap.org/example')
     })
 
     test('should not modify the request URL if no changes are required', () => {
@@ -38,10 +38,10 @@ describe('beforeSend', () => {
         request: {
           url: 'https://app.uniswap.org/example',
         },
-      }
+      } as ErrorEvent
 
-      beforeSend(event as ErrorEvent, null as any)
-      expect(event.request.url).toBe('https://app.uniswap.org/example')
+      beforeSend(event, null as any)
+      expect(event.request?.url).toBe('https://app.uniswap.org/example')
     })
   })
 

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -18,7 +18,7 @@ describe('beforeSend', () => {
         },
       } as ErrorEvent
 
-      beforeSend(event, null as any)
+      beforeSend(event, {})
       expect(event.request?.url).toBe('https://app.uniswap.org/example')
     })
 
@@ -29,7 +29,7 @@ describe('beforeSend', () => {
         },
       } as ErrorEvent
 
-      beforeSend(event, null as any)
+      beforeSend(event, {})
       expect(event.request?.url).toBe('https://app.uniswap.org/example')
     })
 
@@ -40,7 +40,7 @@ describe('beforeSend', () => {
         },
       } as ErrorEvent
 
-      beforeSend(event, null as any)
+      beforeSend(event, {})
       expect(event.request?.url).toBe('https://app.uniswap.org/example')
     })
   })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -10,6 +10,41 @@ Object.defineProperty(window.performance, 'getEntriesByType', {
 describe('beforeSend', () => {
   const ERROR = {} as ErrorEvent
 
+  describe('updateRequestUrl', () => {
+    test('should remove "/#" from the request URL', () => {
+      const event = {
+        request: {
+          url: 'https://app.uniswap.org/#/example',
+        },
+      }
+
+      beforeSend(event as ErrorEvent, null as any)
+      expect(event.request.url).toBe('https://app.uniswap.org/example')
+    })
+
+    test('should remove trailing slash from the request URL', () => {
+      const event = {
+        request: {
+          url: 'https://app.uniswap.org/example/',
+        },
+      }
+
+      beforeSend(event as ErrorEvent, null as any)
+      expect(event.request.url).toBe('https://app.uniswap.org/example')
+    })
+
+    test('should not modify the request URL if no changes are required', () => {
+      const event = {
+        request: {
+          url: 'https://app.uniswap.org/example',
+        },
+      }
+
+      beforeSend(event as ErrorEvent, null as any)
+      expect(event.request.url).toBe('https://app.uniswap.org/example')
+    })
+  })
+
   describe('chunkResponseStatus', () => {
     afterEach(() => {
       jest.restoreAllMocks()

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -23,10 +23,14 @@ function isEthersRequestError(error: Error): error is Error & { requestBody: str
 // Since the interface currently uses HashRouter, URLs will have a # before the path.
 // This leads to issues when we send the URL into Sentry, as the path gets parsed as a "fragment".
 // Instead, this logic removes the # part of the URL.
+// It also removes trailing slashes, as they are not needed.
 // See https://romain-clement.net/articles/sentry-url-fragments/#url-fragments
 function updateRequestUrl(event: ErrorEvent) {
   if (event.request?.url) {
     event.request.url = event.request.url.replace('/#', '')
+    if (event.request.url.endsWith('/')) {
+      event.request.url = event.request.url.slice(0, -1)
+    }
   }
 }
 


### PR DESCRIPTION
## Description
<img width="318" alt="Screen Shot 2023-05-11 at 3 45 30 PM" src="https://github.com/Uniswap/interface/assets/4899429/44e238c5-6c8f-4057-b100-38c2f20ff3e0">

Removes this behavior in Sentry, since these should be grouped together. Also adds more tests.


## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (n/a)
