### PR TITLE
refactor: filterKnownErrors -> shouldRejectError

### DIFF
--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -69,7 +69,7 @@ function getChunkResponseStatus(asset?: string): number | undefined {
   return resource?.responseStatus
 }
 
-function shouldRejectError(error: unknown) {
+function shouldRejectError(error: EventHint['originalException']) {
   if (error instanceof Error) {
     // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
     // If block number polling, it should not be considered an exception.

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,4 +1,4 @@
-import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
+import { ErrorEvent, EventHint } from '@sentry/types'
 
 // `responseStatus` is only currently supported on certain browsers.
 // see: https://caniuse.com/mdn-api_performanceresourcetiming_responsestatus
@@ -9,9 +9,16 @@ declare global {
 }
 
 export function beforeSend(event: ErrorEvent, hint: EventHint) {
+  // If the error is a known error, it should not be sent to Sentry.
+  // null is returned to indicate that the event should be dropped.
+  if (shouldRejectError(hint.originalException)) {
+    return null
+  }
+
   updateRequestUrl(event)
   addChunkResponseStatusTag(event, hint)
-  return filterKnownErrors(event, hint)
+
+  return event
 }
 
 /** Identifies ethers request errors (as thrown by {@type import(@ethersproject/web).fetchJson}). */
@@ -62,52 +69,47 @@ function getChunkResponseStatus(asset?: string): number | undefined {
   return resource?.responseStatus
 }
 
-/**
- * Filters known (ignorable) errors out before sending them to Sentry.
- * Intended as a {@link ClientOptions.beforeSend} callback. Returning null filters the error from Sentry.
- */
-const filterKnownErrors: Required<ClientOptions>['beforeSend'] = (event: ErrorEvent, hint: EventHint) => {
-  const error = hint.originalException
+function shouldRejectError(error: unknown) {
   if (error instanceof Error) {
     // ethers aggressively polls for block number, and it sometimes fails (whether spuriously or through rate-limiting).
     // If block number polling, it should not be considered an exception.
     if (isEthersRequestError(error)) {
       const method = JSON.parse(error.requestBody).method
-      if (method === 'eth_blockNumber') return null
+      if (method === 'eth_blockNumber') return true
     }
 
     // If the error is a network change, it should not be considered an exception.
-    if (error.message.match(/underlying network changed/)) return null
+    if (error.message.match(/underlying network changed/)) return true
 
     // This is caused by HTML being returned for a chunk from Cloudflare.
     // Usually, it's the result of a 499 exception right before it, which should be handled.
     // Therefore, this can be ignored.
-    if (error.message.match(/Unexpected token '<'/)) return null
+    if (error.message.match(/Unexpected token '<'/)) return true
 
     // Errors coming from a Chrome Extension can be ignored for now. These errors are usually caused by extensions injecting
     // scripts into the page, which we cannot control.
-    if (error.stack?.match(/chrome-extension:\/\//i)) return null
+    if (error.stack?.match(/chrome-extension:\/\//i)) return true
 
     // Errors coming from OneKey (a desktop wallet) can be ignored for now.
     // These errors are either application-specific, or they will be thrown separately outside of OneKey.
-    if (error.stack?.match(/OneKey/i)) return null
+    if (error.stack?.match(/OneKey/i)) return true
 
     // Content security policy 'unsafe-eval' errors can be filtered out because there are expected failures.
     // For example, if a user runs an eval statement in console this error would still get thrown.
     // TODO(INFRA-176): We should extend this to filter out any type of CSP error.
     if (error.message.match(/'unsafe-eval'.*content security policy/i)) {
-      return null
+      return true
     }
 
     // WebAssembly compilation fails because we do not allow 'unsafe-eval' in our CSP.
     // Any thrown errors are due to 3P extensions/applications, so we do not need to handle them.
     if (error.message.match(/WebAssembly.instantiate\(\): Wasm code generation disallowed by embedder/)) {
-      return null
+      return true
     }
 
     // These are caused by user navigation away from the page before a request has finished.
-    if (error instanceof DOMException && error.name === 'AbortError') return null
+    if (error instanceof DOMException && error.name === 'AbortError') return true
   }
 
-  return event
+  return false
 }

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,4 +1,4 @@
-import { ErrorEvent, EventHint } from '@sentry/types'
+import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
 
 // `responseStatus` is only currently supported on certain browsers.
 // see: https://caniuse.com/mdn-api_performanceresourcetiming_responsestatus
@@ -8,9 +8,11 @@ declare global {
   }
 }
 
-export function beforeSend(event: ErrorEvent, hint: EventHint) {
-  // If the error is a known error, it should not be sent to Sentry.
-  // null is returned to indicate that the event should be dropped.
+/**
+ * Filters known (ignorable) errors out before sending them to Sentry. Also, adds tags to the event.
+ * Intended as a {@link ClientOptions.beforeSend} callback. Returning null filters the error from Sentry.
+ */
+export const beforeSend: Required<ClientOptions>['beforeSend'] = (event: ErrorEvent, hint: EventHint) => {
   if (shouldRejectError(hint.originalException)) {
     return null
   }


### PR DESCRIPTION
## Description
Small refactor to return a boolean of whether to reject an error, instead of returning null in the helper function when we want to drop.

Now there is a comment explaining why we use null to drop events in a single location.

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (na)
