### PR TITLE
fix: Increase MobileBottomBar height to not overlap with iPhone bottom bar

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -85,7 +85,7 @@ function getSettings(darkMode: boolean) {
     deprecated_mediaWidth: deprecated_mediaWidthTemplates,
 
     navHeight: 72,
-    mobileBottomBarHeight: 52,
+    mobileBottomBarHeight: window.matchMedia('(display-mode: standalone)').matches ? 76 : 52,
     maxWidth: MAX_CONTENT_WIDTH,
 
     // deprecated - please use hardcoded exported values instead of


### PR DESCRIPTION
## General Notes
Fixes: #6557 

Increased MobileBottomBar height to 70px

## Screen Shots
| Before  |  After PWA |  After Browser |
|:-------:|:-----------:|:--------------:|
| <img width="400" alt="Screenshot 2023-05-12 at 3 53 56 PM" src="https://github.com/Uniswap/interface/assets/89173284/8dec1494-5328-417f-9e9d-1b448a3fc59b"> | <img width="400" alt="Screenshot 2023-05-12 at 3 53 30 PM" src="https://github.com/Uniswap/interface/assets/89173284/ca91c22c-34f5-4344-b154-8fe4bb4fcd92">  | <img width="400" alt="Screenshot 2023-05-12 at 3 53 30 PM" src="https://github.com/Uniswap/interface/assets/89173284/716752de-2e3d-4d3f-a27b-3c0d0dbff5de"> |


## Testing
1. Go to app.uniseap.org on safari
2. Click on share site
3. Click on "Add to Home Screen
4. Open App

#### Automated testing
- [x] Unit test N/A
- [x] Integration/E2E test N/A