### PR TITLE
fix: don't console.error for WalletConnect modal close

### DIFF
--- a/src/connection/activate.ts
+++ b/src/connection/activate.ts
@@ -46,15 +46,15 @@ function useTryActivation() {
 
         onSuccess()
       } catch (error) {
-        // TODO(WEB-3162): re-add special treatment for already-pending injected errors & move debug to after didUserReject() check
-        console.debug(`Connection failed: ${connection.getName()}`)
-        console.error(error)
-
         // Gracefully handles errors from the user rejecting a connection attempt
         if (didUserReject(connection, error)) {
           setActivationState(IDLE_ACTIVATION_STATE)
           return
         }
+
+        // TODO(WEB-3162): re-add special treatment for already-pending injected errors & move debug to after didUserReject() check
+        console.debug(`Connection failed: ${connection.getName()}`)
+        console.error(error)
 
         // Failed Connection events are logged here, while successful ones are logged by Web3Provider
         sendAnalyticsEvent(InterfaceEventName.WALLET_CONNECT_TXN_COMPLETED, {


### PR DESCRIPTION
## Description
https://uniswap-labs.sentry.io/issues/3830846117/?end=2023-05-12T19%3A29%3A59&project=4504255148851200&query=release%3A5fe2af4574b0ebc3f2d675c162c2d5b91e3b4158+closed+modal&referrer=issue-stream&sort=freq&start=2023-05-12T17%3A11%3A00&stream_index=0

These were getting sent to sentry because we have the capture console integration on. With that, console.error is logged as an error. However, user rejections are actually handled here already and don't need to be logged. So I moved the early return up before the logging.

## Test plan
- [ ] Unit test
- [ ] Integration/E2E test

I don't think tests are necessary for this but lmk otherwise