### PR TITLE
fix: Overlapping menu in MetaMask for Chinese language 

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -43,7 +43,11 @@ const MenuItem = ({ href, dataTestId, id, isActive, children }: MenuItemProps) =
       to={href}
       className={isActive ? styles.activeMenuItem : styles.menuItem}
       id={id}
-      style={{ textDecoration: 'none' }}
+      style={{
+        textDecoration: 'none',
+        padding: '5px 15px',
+        width: 'auto',
+      }}
       data-testid={dataTestId}
     >
       {children}
@@ -74,14 +78,10 @@ export const PageTabs = () => {
           <Trans>NFTs</Trans>
         </MenuItem>
       )}
-      <Box display={{ sm: 'flex', lg: 'none', xxl: 'flex' }} width="full">
-        <MenuItem href="/pools" dataTestId="pool-nav-link" isActive={isPoolActive}>
-          <Trans>Pools</Trans>
-        </MenuItem>
-      </Box>
-      <Box marginY={{ sm: '4', md: 'unset' }}>
-        <MenuDropdown />
-      </Box>
+      <MenuItem href="/pools" dataTestId="pool-nav-link" isActive={isPoolActive}>
+        <Trans>Pools</Trans>
+      </MenuItem>
+      <MenuDropdown />
     </>
   )
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -71,7 +71,7 @@ const MobileBottomBar = styled.div`
   left: 0;
   width: 100vw;
   justify-content: space-between;
-  padding: 4px 8px;
+  padding: 4px 5%;
   height: ${({ theme }) => theme.mobileBottomBarHeight}px;
   background: ${({ theme }) => theme.backgroundSurface};
   border-top: 1px solid ${({ theme }) => theme.backgroundOutline};


### PR DESCRIPTION
Fixes: #6265 

## Description
The core reason why this issue is happening is because the Menu Items were set to full width. After fixing this, the items are free to flex in size causing no text wrap.

## Screen capture

| Before  |  After  |
|:-------:|:------:|
| <img width="400" alt="Screenshot" src="https://github.com/Uniswap/interface/assets/89173284/ab128cfb-7975-492b-be78-fe8c1e2e0154"> | <img width="400" alt="Screenshot" src="https://github.com/Uniswap/interface/assets/89173284/0c8284e9-db73-41ea-a1e3-08e77423a0fc"> |

<details>
<summary>Other bugs this fixes</summary>
<br />

As I was testing this, I found some other bugs that were fixed. The menu items styles, when hovering, were funky.

| Before  |  After  |
|:-------:|:------:|
| <img width="400" alt="Screenshot" src="https://github.com/Uniswap/interface/assets/89173284/a644743c-dc43-4082-807c-730d2e5ab8fd"> | <img width="400" alt="Screenshot" src="https://github.com/Uniswap/interface/assets/89173284/61b4a3a2-4550-4049-a008-6db3080eb1b4"> |
</details>


## Test plan

### Reproducing the error

1. Open Metamask App on Phone
2. Open browser to app.uniswap.org
3. Change language to Chinese


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Change language to Chinese
- [ ] Make sure no menu items with text wrap in mobile


### Automated testing
- [x] Unit test N/A
- [x] Integration/E2E test N/A
