### PR TITLE
fix: "Minimum output" should be "Maximum output" when trade is Exact Output

### DIFF
--- a/src/components/swap/AdvancedSwapDetails.test.tsx
+++ b/src/components/swap/AdvancedSwapDetails.test.tsx
@@ -29,7 +29,7 @@ describe('AdvancedSwapDetails.tsx', () => {
   it('renders correct tooltips for test trade with exact output and gas use estimate USD', async () => {
     TEST_TRADE_EXACT_OUTPUT.gasUseEstimateUSD = toCurrencyAmount(TEST_TOKEN_1, 1)
     render(<AdvancedSwapDetails trade={TEST_TRADE_EXACT_OUTPUT} allowedSlippage={TEST_ALLOWED_SLIPPAGE} />)
-    await act(() => userEvent.hover(screen.getByText(/Minimum output/i)))
+    await act(() => userEvent.hover(screen.getByText(/Maximum input/i)))
     expect(await screen.getByText(/The minimum amount you are guaranteed to receive./i)).toBeVisible()
     await act(() => userEvent.hover(screen.getByText('Network fee')))
     expect(await screen.getByText(/The fee paid to miners who process your transaction./i)).toBeVisible()

--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -75,7 +75,7 @@ export function AdvancedSwapDetails({ trade, allowedSlippage, syncing = false }:
             }
           >
             <ThemedText.BodySmall color="textSecondary">
-              <Trans>Minimum output</Trans>
+              {trade.tradeType === TradeType.EXACT_INPUT ? <Trans>Minimum output</Trans> : <Trans>Maximum input</Trans>}
             </ThemedText.BodySmall>
           </MouseoverTooltip>
         </RowFixed>


### PR DESCRIPTION
Fixes: #6563 

## Description
Simple fix, just checking the trade.type same conditions as the value on line 84

## Screen capture

| Before  |  After  |
|:-------:|:------:|
| <img width="400" alt="Screenshot" src="https://github.com/Uniswap/interface/assets/89173284/d493a3b6-2b57-4280-a69d-0f1a5a42a670"> | <img width="400" alt="Screenshot" src="https://github.com/Uniswap/interface/assets/89173284/dcded6c3-1847-4f5f-9a1a-8f6795f30b71"> |


## Test plan

### Reproducing the error

1. Go to app.uniswap.org
2. Make a trade with an exact output
3. "Minimum output" row is showing the maximum input value


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Make sure "Maximum input" when


### Automated testing
- [x] Unit test N/A
- [x] Integration/E2E test N/A