### PR TITLE
build: change automated release to 16:00 UTC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 on:
   schedule:
-    - cron: '0 12 * * 1-4' # every day 12:00 UTC Monday-Thursday
+    - cron: '0 16 * * 1-4' # every day 16:00 UTC Monday-Thursday
   # manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
## Description
As part of an incident review, we decided to change the release time from 12:00 UTC (8:00AM EST) to 16:00 UTC (12:00PM EST).

This won't properly handle daylight savings, but given we're about to shift to a different deploy system I don't think it's worth it to worry about.

## Test plan
There's no way to test a GitHub action other than merging this.

### Automated testing
N/A