### PR TITLE
chore: increase cypress timeout to reduce flake in long-running tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,7 @@ import { setupHardhatEvents } from 'cypress-hardhat'
 export default defineConfig({
   projectId: 'yp82ef',
   videoUploadOnPasses: false,
-  defaultCommandTimeout: 24000, // 2x average block time
+  defaultCommandTimeout: 48000, // 4x average block time
   chromeWebSecurity: false,
   retries: { runMode: 2 },
   e2e: {


### PR DESCRIPTION
Now that we've got more chain interaction-heavy tests that run for a longer period of time it makes sense to bump this so we reduce flake. Some tests are failing simply because they don't have enough time to complete the required steps on the slower CI instances. 

thread: https://uniswapteam.slack.com/archives/C055M7VAUGY/p1683911992673969
linear: https://linear.app/uniswap/issue/WEB-2047/increase-cypress-default-timeout