### PR TITLE
refactor: imports shared polyfills in setupTests

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom' // jest custom assertions
 import 'jest-styled-components' // adds style diffs to snapshot tests
+import 'polyfills'
 
-import { ResizeObserver } from '@juggle/resize-observer'
 import type { createPopper } from '@popperjs/core'
 import { useWeb3React } from '@web3-react/core'
 import failOnConsole from 'jest-fail-on-console'
@@ -31,8 +31,6 @@ global.matchMedia =
       removeEventListener: jest.fn(),
     }
   })
-
-global.ResizeObserver = ResizeObserver
 
 jest.mock('@popperjs/core', () => {
   const core = jest.requireActual('@popperjs/core')


### PR DESCRIPTION
## Description
Instead of polyfilling manually in two places, this makes sure all polyfills in `polyfills.ts` are used in `setupTests.ts`.

## Test plan
- [x] Unit test
- [x] Integration/E2E test
