### PR TITLE
fix: catch RouterPreference.AUTO case for routing-api usage

### DIFF
--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -123,7 +123,7 @@ export const routingApi = createApi({
           args
 
         try {
-          if (routerPreference === RouterPreference.API) {
+          if (routerPreference === RouterPreference.API || routerPreference === RouterPreference.AUTO) {
             const query = qs.stringify({
               ...API_QUERY_PARAMS,
               tokenInAddress,


### PR DESCRIPTION
## Description
This PR fixes the case where a user preference setting is on AUTO but it was falling back to client-side routing


## Test plan
Verified through network tab 
