### PR TITLE
feat: use alternate for collection metadata and stats

### DIFF
--- a/src/graphql/data/nft/Collection.ts
+++ b/src/graphql/data/nft/Collection.ts
@@ -6,7 +6,7 @@ import { NftCollection, useCollectionQuery } from '../__generated__/types-and-ho
 
 gql`
   query Collection($addresses: [String!]!) {
-    nftCollections(filter: { addresses: $addresses }) {
+    nftCollections(filter: { addresses: $addresses }, _fs: "DATASOURCE:ALTERNATE") {
       edges {
         cursor
         node {
@@ -33,7 +33,7 @@ gql`
             symbol
             totalSupply
           }
-          traits {
+          traits(_fs: "DATASOURCE:ALTERNATE") {
             name
             values
             stats {
@@ -43,8 +43,8 @@ gql`
               listings
             }
           }
-          markets(currencies: ETH) {
-            floorPrice {
+          markets(currencies: ETH, _fs: "DATASOURCE:ALTERNATE") {
+            floorPrice(_fs: "DATASOURCE:ALTERNATE") {
               currency
               value
             }
@@ -56,19 +56,19 @@ gql`
             listings {
               value
             }
-            volume(duration: DAY) {
+            volume(duration: DAY, _fs: "DATASOURCE:ALTERNATE") {
               value
               currency
             }
-            volumePercentChange(duration: DAY) {
+            volumePercentChange(duration: DAY, _fs: "DATASOURCE:ALTERNATE") {
               value
               currency
             }
-            floorPricePercentChange(duration: DAY) {
+            floorPricePercentChange(duration: DAY, _fs: "DATASOURCE:ALTERNATE") {
               value
               currency
             }
-            marketplaces {
+            marketplaces(_fs: "DATASOURCE:ALTERNATE") {
               marketplace
               listings
               floorPrice

--- a/src/graphql/data/nft/TrendingCollections.ts
+++ b/src/graphql/data/nft/TrendingCollections.ts
@@ -6,7 +6,7 @@ import { HistoryDuration, useTrendingCollectionsQuery } from '../__generated__/t
 
 gql`
   query TrendingCollections($size: Int, $timePeriod: HistoryDuration) {
-    topCollections(first: $size, duration: $timePeriod) {
+    topCollections(first: $size, duration: $timePeriod, _fs: "DATASOURCE:ALTERNATE") {
       edges {
         node {
           name
@@ -21,21 +21,21 @@ gql`
             url
           }
           isVerified
-          markets(currencies: ETH) {
-            floorPrice {
+          markets(currencies: ETH, _fs: "DATASOURCE:ALTERNATE") {
+            floorPrice(_fs: "DATASOURCE:ALTERNATE") {
               value
             }
             owners
             totalVolume {
               value
             }
-            volume(duration: $timePeriod) {
+            volume(duration: $timePeriod, _fs: "DATASOURCE:ALTERNATE") {
               value
             }
-            volumePercentChange(duration: $timePeriod) {
+            volumePercentChange(duration: $timePeriod, _fs: "DATASOURCE:ALTERNATE") {
               value
             }
-            floorPricePercentChange(duration: $timePeriod) {
+            floorPricePercentChange(duration: $timePeriod, _fs: "DATASOURCE:ALTERNATE") {
               value
             }
             sales {


### PR DESCRIPTION
## Description
deploys a preview for alternate datasource for NFT collection metadata and stats

do not merge

### Automated testing

- [x] Unit test N/A
- [x] Integration/E2E test N/A
