### PR TITLE
fix: add price impact back

### DIFF
--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -7,6 +7,7 @@ import { LoadingRows } from 'components/Loader/styled'
 import { SUPPORTED_GAS_ESTIMATE_CHAIN_IDS } from 'constants/chains'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 import { InterfaceTrade } from 'state/routing/types'
+import formatPriceImpact from 'utils/formatPriceImpact'
 
 import { Separator, ThemedText } from '../../theme'
 import Column from '../Column'
@@ -64,6 +65,16 @@ export function AdvancedSwapDetails({ trade, allowedSlippage, syncing = false }:
           </TextWithLoadingPlaceholder>
         </RowBetween>
       )}
+      <RowBetween>
+        <MouseoverTooltip text={<Trans>The impact your trade has on the market price of this pool.</Trans>}>
+          <ThemedText.BodySmall color="textSecondary">
+            <Trans>Price Impact</Trans>
+          </ThemedText.BodySmall>
+        </MouseoverTooltip>
+        <TextWithLoadingPlaceholder syncing={syncing} width={50}>
+          <ThemedText.BodySmall>{formatPriceImpact(trade.priceImpact)}</ThemedText.BodySmall>
+        </TextWithLoadingPlaceholder>
+      </RowBetween>
       <RowBetween>
         <RowFixed>
           <MouseoverTooltip

--- a/src/components/swap/PriceImpactWarning.tsx
+++ b/src/components/swap/PriceImpactWarning.tsx
@@ -3,6 +3,7 @@ import { Percent } from '@uniswap/sdk-core'
 import { OutlineCard } from 'components/Card'
 import styled, { useTheme } from 'styled-components/macro'
 import { opacify } from 'theme/utils'
+import formatPriceImpact from 'utils/formatPriceImpact'
 
 import { ThemedText } from '../../theme'
 import { AutoColumn } from '../Column'
@@ -17,8 +18,6 @@ const StyledCard = styled(OutlineCard)`
 interface PriceImpactWarningProps {
   priceImpact: Percent
 }
-
-const formatPriceImpact = (priceImpact: Percent) => `${priceImpact.multiply(-1).toFixed(2)}%`
 
 export default function PriceImpactWarning({ priceImpact }: PriceImpactWarningProps) {
   const theme = useTheme()

--- a/src/components/swap/__snapshots__/AdvancedSwapDetails.test.tsx.snap
+++ b/src/components/swap/__snapshots__/AdvancedSwapDetails.test.tsx.snap
@@ -88,6 +88,26 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
           <div
             class="c6 css-zhpkf8"
           >
+            Network fee
+          </div>
+        </div>
+      </div>
+      <div
+        class="c7 css-zhpkf8"
+      >
+        ~$1.00
+      </div>
+    </div>
+    <div
+      class="c2 c3 c4"
+    >
+      <div
+        class="c5"
+      >
+        <div>
+          <div
+            class="c6 css-zhpkf8"
+          >
             Price Impact
           </div>
         </div>

--- a/src/components/swap/__snapshots__/AdvancedSwapDetails.test.tsx.snap
+++ b/src/components/swap/__snapshots__/AdvancedSwapDetails.test.tsx.snap
@@ -32,17 +32,17 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c5 {
+.c8 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-.c7 {
+.c6 {
   color: #7780A0;
 }
 
-.c8 {
+.c7 {
   color: #0D111C;
 }
 
@@ -67,7 +67,7 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
   gap: 12px;
 }
 
-.c6 {
+.c5 {
   display: inline-block;
   height: inherit;
 }
@@ -82,14 +82,34 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
       class="c2 c3 c4"
     >
       <div
-        class="c2 c3 c5"
+        class="c5"
+      >
+        <div>
+          <div
+            class="c6 css-zhpkf8"
+          >
+            Price Impact
+          </div>
+        </div>
+      </div>
+      <div
+        class="c7 css-zhpkf8"
+      >
+        105566.37%
+      </div>
+    </div>
+    <div
+      class="c2 c3 c4"
+    >
+      <div
+        class="c2 c3 c8"
       >
         <div
-          class="c6"
+          class="c5"
         >
           <div>
             <div
-              class="c7 css-zhpkf8"
+              class="c6 css-zhpkf8"
             >
               Minimum output
             </div>
@@ -97,7 +117,7 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c8 css-zhpkf8"
+        class="c7 css-zhpkf8"
       >
         0.00000000000000098 DEF
       </div>
@@ -106,14 +126,14 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
       class="c2 c3 c4"
     >
       <div
-        class="c2 c3 c5"
+        class="c2 c3 c8"
       >
         <div
-          class="c6"
+          class="c5"
         >
           <div>
             <div
-              class="c7 css-zhpkf8"
+              class="c6 css-zhpkf8"
             >
               Expected output
             </div>
@@ -121,7 +141,7 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c8 css-zhpkf8"
+        class="c7 css-zhpkf8"
       >
         0.000000000000001 DEF
       </div>
@@ -133,16 +153,16 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
       class="c2 c3 c4"
     >
       <div
-        class="c7 css-zhpkf8"
+        class="c6 css-zhpkf8"
       >
         Order routing
       </div>
       <div
-        class="c6"
+        class="c5"
       >
         <div>
           <div
-            class="c8 css-zhpkf8"
+            class="c7 css-zhpkf8"
           >
             Uniswap API
           </div>

--- a/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
@@ -273,6 +273,26 @@ exports[`SwapDetailsDropdown.tsx renders a trade 1`] = `
               class="c2 c3 c4"
             >
               <div
+                class="c10"
+              >
+                <div>
+                  <div
+                    class="c12 css-zhpkf8"
+                  >
+                    Price Impact
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c9 css-zhpkf8"
+              >
+                105566.37%
+              </div>
+            </div>
+            <div
+              class="c2 c3 c4"
+            >
+              <div
                 class="c2 c3 c6"
               >
                 <div

--- a/src/utils/formatPriceImpact.test.ts
+++ b/src/utils/formatPriceImpact.test.ts
@@ -1,5 +1,5 @@
-import { Percent } from "@uniswap/sdk-core"
-import formatPriceImpact from "./formatPriceImpact"
+import { Percent } from '@uniswap/sdk-core'
+import formatPriceImpact from './formatPriceImpact'
 
 describe('formatPriceImpact', () => {
   it('formats price impact', () => {

--- a/src/utils/formatPriceImpact.test.ts
+++ b/src/utils/formatPriceImpact.test.ts
@@ -1,0 +1,11 @@
+import { Percent } from "@uniswap/sdk-core"
+import formatPriceImpact from "./formatPriceImpact"
+
+describe('formatPriceImpact', () => {
+  it('formats positive price impact', () => {
+    expect(formatPriceImpact(new Percent(5, 10_000))).toEqual('-0.05%')
+  })
+  it('formats negative price impact', () => {
+    expect(formatPriceImpact(new Percent(-5, 10_000))).toEqual('0.05%')
+  })
+})

--- a/src/utils/formatPriceImpact.test.ts
+++ b/src/utils/formatPriceImpact.test.ts
@@ -2,10 +2,12 @@ import { Percent } from "@uniswap/sdk-core"
 import formatPriceImpact from "./formatPriceImpact"
 
 describe('formatPriceImpact', () => {
-  it('formats positive price impact', () => {
+  it('formats price impact', () => {
     expect(formatPriceImpact(new Percent(5, 10_000))).toEqual('-0.05%')
   })
-  it('formats negative price impact', () => {
+  // While there's theoretically no such thing as "positive price impact", this can show up 
+  // due to a bug in routing-api, so it's still tested for
+  it('formats price impact when given a negative value', () => {
     expect(formatPriceImpact(new Percent(-5, 10_000))).toEqual('0.05%')
   })
 })

--- a/src/utils/formatPriceImpact.test.ts
+++ b/src/utils/formatPriceImpact.test.ts
@@ -1,11 +1,12 @@
 import { Percent } from '@uniswap/sdk-core'
+
 import formatPriceImpact from './formatPriceImpact'
 
 describe('formatPriceImpact', () => {
   it('formats price impact', () => {
     expect(formatPriceImpact(new Percent(5, 10_000))).toEqual('-0.05%')
   })
-  // While there's theoretically no such thing as "positive price impact", this can show up 
+  // While there's theoretically no such thing as "positive price impact", this can show up
   // due to a bug in routing-api, so it's still tested for
   it('formats price impact when given a negative value', () => {
     expect(formatPriceImpact(new Percent(-5, 10_000))).toEqual('0.05%')

--- a/src/utils/formatPriceImpact.ts
+++ b/src/utils/formatPriceImpact.ts
@@ -1,0 +1,5 @@
+import { Percent } from '@uniswap/sdk-core'
+
+export default function formatPriceImpact(priceImpact: Percent) {
+  return `${priceImpact.multiply(-1).toFixed(2)}%`
+}


### PR DESCRIPTION
It was accidentally removed from previous PR due to various designs in our Figma. Fixes WEB-2034

<img width="464" alt="Screenshot 2023-05-16 at 11 55 48" src="https://github.com/Uniswap/interface/assets/2464966/e3f30ffe-00f0-422e-8e46-aaa18c9e6f3e">
