### PR TITLE
feat: special case arb search

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -359,6 +359,14 @@ export const UNI: { [chainId: number]: Token } = {
   [SupportedChainId.GOERLI]: new Token(SupportedChainId.GOERLI, UNI_ADDRESS[5], 18, 'UNI', 'Uniswap'),
 }
 
+export const ARB = new Token(
+  SupportedChainId.ARBITRUM_ONE,
+  '0x912CE59144191C1204E64559FE8253a0e49E6548',
+  18,
+  'ARB',
+  'Arbitrum'
+)
+
 export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } = {
   ...(WETH9 as Record<SupportedChainId, Token>),
   [SupportedChainId.OPTIMISM]: new Token(

--- a/src/graphql/data/SearchTokens.ts
+++ b/src/graphql/data/SearchTokens.ts
@@ -1,6 +1,7 @@
-import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
+import { ARB, WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import gql from 'graphql-tag'
 import { useMemo } from 'react'
+import invariant from 'tiny-invariant'
 
 import { Chain, SearchTokensQuery, useSearchTokensQuery } from './__generated__/types-and-hooks'
 import { chainIdToBackendName } from './util'
@@ -43,17 +44,25 @@ gql`
 
 export type SearchToken = NonNullable<NonNullable<SearchTokensQuery['searchTokens']>[number]>
 
-function isMoreRevelantToken(current: SearchToken, existing: SearchToken | undefined, searchChain: Chain) {
-  if (!existing) return true
+/* Returns the more relevant cross-chain token based on native status and search chain */
+function dedupeCrosschainTokens(current: SearchToken, existing: SearchToken | undefined, searchChain: Chain) {
+  if (!existing) return current
+  invariant(current.project?.id === existing.project?.id, 'Cannot dedupe tokens within different tokenProjects')
 
-  // Always priotize natives, and if both tokens are native, prefer native on current chain (i.e. Matic on Polygon over Matic on Mainnet )
-  if (current.standard === 'NATIVE' && (existing.standard !== 'NATIVE' || current.chain === searchChain)) return true
+  // Special case: always prefer Arbitrum ARB over Mainnet ARB
+  if (current.address === ARB.address) return current
+
+  // Always prioritize natives, and if both tokens are native, prefer native on current chain (i.e. Matic on Polygon over Matic on Mainnet )
+  if (current.standard === 'NATIVE' && (existing.standard !== 'NATIVE' || current.chain === searchChain)) return current
 
   // Prefer tokens on the searched chain, otherwise prefer mainnet tokens
-  return current.chain === searchChain || (existing.chain !== searchChain && current.chain === Chain.Ethereum)
+  if (current.chain === searchChain || (existing.chain !== searchChain && current.chain === Chain.Ethereum))
+    return current
+
+  return existing
 }
 
-// Places natives first, wrapped native on current chain next, then sorts by volume
+/* Places natives first, wrapped native on current chain next, then sorts by volume */
 function searchTokenSortFunction(
   searchChain: Chain,
   wrappedNativeAddress: string | undefined,
@@ -87,7 +96,7 @@ export function useSearchTokens(searchQuery: string, chainId: number) {
     data?.searchTokens?.forEach((token) => {
       if (token.project?.id) {
         const existing = selectionMap[token.project.id]
-        if (isMoreRevelantToken(token, existing, searchChain)) selectionMap[token.project.id] = token
+        selectionMap[token.project.id] = dedupeCrosschainTokens(token, existing, searchChain)
       }
     })
     return Object.values(selectionMap).sort(

--- a/src/graphql/data/SearchTokens.ts
+++ b/src/graphql/data/SearchTokens.ts
@@ -42,6 +42,8 @@ gql`
   }
 `
 
+const ARB_ADDRESS = ARB.address.toLowerCase()
+
 export type SearchToken = NonNullable<NonNullable<SearchTokensQuery['searchTokens']>[number]>
 
 /* Returns the more relevant cross-chain token based on native status and search chain */
@@ -50,7 +52,8 @@ function dedupeCrosschainTokens(current: SearchToken, existing: SearchToken | un
   invariant(current.project?.id === existing.project?.id, 'Cannot dedupe tokens within different tokenProjects')
 
   // Special case: always prefer Arbitrum ARB over Mainnet ARB
-  if (current.address === ARB.address) return current
+  if (current.address?.toLowerCase() === ARB_ADDRESS) return current
+  if (existing.address?.toLowerCase() === ARB_ADDRESS) return existing
 
   // Always prioritize natives, and if both tokens are native, prefer native on current chain (i.e. Matic on Polygon over Matic on Mainnet )
   if (current.standard === 'NATIVE' && (existing.standard !== 'NATIVE' || current.chain === searchChain)) return current


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Special cases the ARB token on Arbitrum to always display over the ARB token on Mainnet in search results when both are returned by the backend, regardless of the user's current chain.

Also cleans up / renames the cross token search code to make functionality more clear.

<!-- Delete inapplicable lines: -->
_[Linear ticket](https://linear.app/uniswap/issue/WEB-1949/special-case-dollararb-in-search-so-the-arbitrum-network-one-shows-up)_



<!-- Delete this section if your change does not affect UI. -->
## Screen capture

| Before       | After (Desktop) |
| ------------ |---------------- |
| <img width="261" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/d0b2044a-2939-4a61-9203-e38f9f31fad6"> |  <img width="301" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/be0fdbaa-8f34-46a1-a412-8ab32c478d3d">      |

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Search for a string that should return ARB as a search result, ensure it has the Arbitrum logo rather than no logo

