### PR TITLE
chore: remove chunkResponseStatus tag

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -45,58 +45,6 @@ describe('beforeSend', () => {
     })
   })
 
-  describe('chunkResponseStatus', () => {
-    afterEach(() => {
-      jest.restoreAllMocks()
-    })
-
-    it('handles when matching JS file not found', () => {
-      jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([])
-      const originalException = new Error(
-        'Loading chunk 20 failed. (error: https://app.uniswap.org/static/js/20.d55382e0.chunk.js)'
-      )
-      expect((beforeSend(ERROR, { originalException }) as Event).tags).toBeUndefined()
-    })
-
-    it('handles when matching CSS file not found', () => {
-      jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([])
-      const originalException = new Error(
-        'Loading chunk 20 failed. (error: https://app.uniswap.org/static/js/20.d55382e0.chunk.js)'
-      )
-      expect((beforeSend(ERROR, { originalException }) as Event).tags).toBeUndefined()
-    })
-
-    it('handles when performance is undefined', () => {
-      window.performance = undefined as any
-      const originalException = new Error('Loading CSS chunk 12 failed. (./static/css/12.d5b3cfe3.chunk.css)')
-      expect((beforeSend(ERROR, { originalException }) as Event).tags).toBeUndefined()
-    })
-
-    it('adds status for a matching JS file', () => {
-      jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([
-        {
-          name: 'https://app.uniswap.org/static/js/20.d55382e0.chunk.js',
-          responseStatus: 499,
-        } as PerformanceEntry,
-      ])
-      const originalException = new Error(
-        'Loading chunk 20 failed. (error: https://app.uniswap.org/static/js/20.d55382e0.chunk.js)'
-      )
-      expect((beforeSend(ERROR, { originalException }) as Event).tags?.chunkResponseStatus).toBe(499)
-    })
-
-    it('adds status for a matching CSS file', () => {
-      jest.spyOn(window.performance, 'getEntriesByType').mockReturnValue([
-        {
-          name: 'https://app.uniswap.org/static/css/12.d5b3cfe3.chunk.css',
-          responseStatus: 200,
-        } as PerformanceEntry,
-      ])
-      const originalException = new Error('Loading CSS chunk 12 failed. (./static/css/12.d5b3cfe3.chunk.css)')
-      expect((beforeSend(ERROR, { originalException }) as Event).tags?.chunkResponseStatus).toBe(200)
-    })
-  })
-
   it('propagates an error', () => {
     expect(beforeSend(ERROR, {})).toBe(ERROR)
   })

--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -1,4 +1,4 @@
-import { ErrorEvent, Event } from '@sentry/types'
+import { ErrorEvent } from '@sentry/types'
 
 import { beforeSend } from './errors'
 

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -18,7 +18,6 @@ export const beforeSend: Required<ClientOptions>['beforeSend'] = (event: ErrorEv
   }
 
   updateRequestUrl(event)
-  addChunkResponseStatusTag(event, hint)
 
   return event
 }
@@ -40,39 +39,6 @@ function updateRequestUrl(event: ErrorEvent) {
       event.request.url = event.request.url.slice(0, -1)
     }
   }
-}
-
-// If a request fails due to a chunk error, this looks for that asset in the performance entries.
-// If found, it adds a tag to the event with the response status of the chunk request.
-function addChunkResponseStatusTag(event: ErrorEvent, hint: EventHint) {
-  const error = hint.originalException
-  if (error instanceof Error) {
-    let asset: string | undefined
-    if (error.message.match(/Loading chunk \d+ failed\. \(([a-zA-Z]+): .+\.chunk\.js\)/)) {
-      asset = error.message.match(/https?:\/\/.+?\.chunk\.js/)?.[0]
-    }
-
-    if (error.message.match(/Loading CSS chunk \d+ failed\. \(.+\.chunk\.css\)/)) {
-      const relativePath = error.message.match(/\/static\/css\/.*\.chunk\.css/)?.[0]
-      asset = `${window.origin}${relativePath}`
-    }
-
-    if (asset) {
-      const status = getChunkResponseStatus(asset)
-      if (status) {
-        if (!event.tags) {
-          event.tags = {}
-        }
-        event.tags.chunkResponseStatus = status
-      }
-    }
-  }
-}
-
-function getChunkResponseStatus(asset?: string): number | undefined {
-  const entries = [...(performance?.getEntriesByType('resource') ?? [])]
-  const resource = entries?.find(({ name }) => name === asset)
-  return resource?.responseStatus
 }
 
 function shouldRejectError(error: EventHint['originalException']) {


### PR DESCRIPTION
## Description
For some reason, this tag wasn't sending properly to Sentry. But now that we're pretty sure the issue is related to network errors, this context is not necessary.

I'll wait to merge after seeing that this PR solves the chunk loading issues: https://github.com/Uniswap/interface/pull/6512

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (NA)