### PR TITLE
fix: update nonce deduplication logic

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/index.tsx
@@ -82,7 +82,23 @@ const ActivityGroupWrapper = styled(Column)`
   gap: 8px;
 `
 
-function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = {}): Array<Activity> {
+/* Detects transactions from same account with the same nonce and different hash */
+function wasTxCancelled(localActivity: Activity, remoteMap: ActivityMap, account: string): boolean {
+  if (!localActivity.nonce) return false // handles locally cached tx's that were stored before we started tracking nonces
+  
+  return Object.values(remoteMap).some((remoteTx) => {
+    if (!remoteTx) return false
+  
+    // Cancellations are only possible when both nonce and tx.from are the same
+    if (remoteTx.nonce === localActivity.nonce && remoteTx.receipt?.from === account) {
+      // If the remote tx has a different hash than the local tx, the local tx was cancelled
+      return remoteTx.hash.toLowerCase() !== localActivity.hash.toLowerCase()
+    }
+    return false
+  })
+}
+
+function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = {}, account: string): Array<Activity> {
   const txHashes = [...new Set([...Object.keys(localMap), ...Object.keys(remoteMap)])]
 
   // Merges local and remote activities w/ same hash, preferring remote data
@@ -90,16 +106,12 @@ function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = 
     const localActivity = (localMap?.[hash] ?? {}) as Activity
     const remoteActivity = (remoteMap?.[hash] ?? {}) as Activity
 
-    // Check for nonce collision
-    const isNonceCollision =
-      localActivity.nonce !== undefined &&
-      Object.keys(remoteMap).some((remoteHash) => remoteMap[remoteHash]?.nonce === localActivity.nonce)
+    // TODO(WEB-2064): Display cancelled status in UI rather than completely hiding cancelled TXs
+    if (localActivity.status === TransactionStatus.Pending && wasTxCancelled(localActivity, remoteMap, account)) return acc
 
-    if (!isNonceCollision) {
-      // TODO(cartcrom): determine best logic for which fields to prefer from which sources
-      // i.e.prefer remote exact swap output instead of local estimated output
-      acc.push({ ...localActivity, ...remoteActivity } as Activity)
-    }
+    // TODO(cartcrom): determine best logic for which fields to prefer from which sources
+    // i.e.prefer remote exact swap output instead of local estimated output
+    acc.push({ ...localActivity, ...remoteActivity } as Activity)
 
     return acc
   }, [])

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/index.tsx
@@ -84,13 +84,14 @@ const ActivityGroupWrapper = styled(Column)`
 
 /* Detects transactions from same account with the same nonce and different hash */
 function wasTxCancelled(localActivity: Activity, remoteMap: ActivityMap, account: string): boolean {
-  if (!localActivity.nonce) return false // handles locally cached tx's that were stored before we started tracking nonces
-  
+  // handles locally cached tx's that were stored before we started tracking nonces
+  if (!localActivity.nonce || localActivity.status !== TransactionStatus.Pending) return false
+
   return Object.values(remoteMap).some((remoteTx) => {
     if (!remoteTx) return false
-  
+
     // Cancellations are only possible when both nonce and tx.from are the same
-    if (remoteTx.nonce === localActivity.nonce && remoteTx.receipt?.from === account) {
+    if (remoteTx.nonce === localActivity.nonce && remoteTx.receipt?.from.toLowerCase() === account.toLowerCase()) {
       // If the remote tx has a different hash than the local tx, the local tx was cancelled
       return remoteTx.hash.toLowerCase() !== localActivity.hash.toLowerCase()
     }
@@ -107,7 +108,7 @@ function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = 
     const remoteActivity = (remoteMap?.[hash] ?? {}) as Activity
 
     // TODO(WEB-2064): Display cancelled status in UI rather than completely hiding cancelled TXs
-    if (localActivity.status === TransactionStatus.Pending && wasTxCancelled(localActivity, remoteMap, account)) return acc
+    if (wasTxCancelled(localActivity, remoteMap, account)) return acc
 
     // TODO(cartcrom): determine best logic for which fields to prefer from which sources
     // i.e.prefer remote exact swap output instead of local estimated output
@@ -144,9 +145,9 @@ export function ActivityTab({ account }: { account: string }) {
 
   const activityGroups = useMemo(() => {
     const remoteMap = parseRemoteActivities(data?.portfolios?.[0].assetActivities)
-    const allActivities = combineActivities(localMap, remoteMap)
+    const allActivities = combineActivities(localMap, remoteMap, account)
     return createGroups(allActivities)
-  }, [data?.portfolios, localMap])
+  }, [data?.portfolios, localMap, account])
 
   if (!data && loading)
     return (


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Updates nonce deduplication logic to not hide all transactions that are present on both backend and frontend cache. These transactions were previously hidden by recent changes meant to handle cancelled tx's.

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

| Before       | After (Desktop) | 
| ------------ |---------------- | 
| <img width="336" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/e8809293-21b7-4545-966f-4aa5ee8ef29a"> | <img width="392" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/de7a9ac4-6d0a-4c38-98d1-cc9901fe392d"> | 


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Make a swap on mainnet, wait for it to confirm, and view the tx in your mini portfolio
2. Refresh the page (to fetch remote tx's) and the tx should no longer be in your mini portfolio