### PR TITLE
test(e2e): configure Cypress to post PR status comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,11 +122,6 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
-
-      # Sets ownership, which is misconfigured when checking out a new container.
-      # See https://github.com/actions/runner/issues/2033#issuecomment-1204205989.
-      - run: chown -R $(id -u):$(id -g) $PWD
-
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3
         id: cypress-cache
@@ -154,13 +149,15 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Additional information is required for Cypress to post status updates to the PR:
-          # - if the event is push, the title will be undefined and Cypress will get the commit message from git 
-          # - if the event is pull_request, then we set the commit message to the pull request title
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_INFO_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
+          COMMIT_INFO_EMAIL: ${{ github.event.sender.user.email || github.event.pusher.email }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.sender.user.name || github.event.pusher.name }}
+          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
+          COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
           CYPRESS_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+          DEBUG: commit-info,cypress:server:record
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,11 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
+
+      # Sets ownership, which is misconfigured when checking out a new container.
+      # See https://github.com/actions/runner/issues/2033#issuecomment-1204205989.
+      - run: chown -R $(id -u):$(id -g) $PWD
+
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3
         id: cypress-cache
@@ -145,10 +150,15 @@ jobs:
           start: yarn serve
           wait-on: 'http://localhost:3000'
           browser: chrome
-          group: 4x-chrome
+          group: e2e
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Additional information is required for Cypress to post status updates to the PR:
+          # - if the event is push, the title will be undefined and Cypress will get the commit message from git 
+          # - if the event is pull_request, then we set the commit message to the pull request title
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,13 +151,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-          COMMIT_INFO_EMAIL: ${{ github.event.sender.email || github.event.pusher.email }}
-          COMMIT_INFO_AUTHOR: ${{ github.event.sender.name || github.event.pusher.name }}
+          COMMIT_INFO_EMAIL: ${{ github.event.pull_request.user.email || github.event.pusher.email }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.pull_request.user.name || github.event.pusher.name }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
           COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
           CYPRESS_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
-          DEBUG: commit-info,cypress:server:record
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - run: exit 0
         env:
-          GITHUB_EVENT: ${{ toJSON(github.event }}
+          GITHUB_EVENT: ${{ toJSON(github.event) }}
 
   cypress-test-matrix:
     needs: [build-e2e, cypress-rerun]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: exit 0
+        env:
+          GITHUB_EVENT: ${{ toJSON(github.event }}
 
   cypress-test-matrix:
     needs: [build-e2e, cypress-rerun]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         id: cypress-cache
         with:
           path: /root/.cache/Cypress
-          key: ${{ runner.os }}-cypress
+          key: ${{ runner.os }}-cypress-12-12-0
       - run: |
           yarn cypress install
           yarn cypress info
@@ -159,6 +159,8 @@ jobs:
           # - if the event is pull_request, then we set the commit message to the pull request title
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+          CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+          CYPRESS_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,11 +140,12 @@ jobs:
       - uses: cypress-io/github-action@v4
         with:
           install: false
+          record: true
+          parallel: true
           start: yarn serve
           wait-on: 'http://localhost:3000'
           browser: chrome
-          record: true
-          parallel: true
+          group: 4x-chrome
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         id: cypress-cache
         with:
           path: /root/.cache/Cypress
-          key: ${{ runner.os }}-cypress-12-12-0
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/node_modules/cypress/package.json') }}
       - run: |
           yarn cypress install
           yarn cypress info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-          COMMIT_INFO_AUTHOR: ${{ github.event.sender.login || github.event.head_commit.author.login || github.event.head_commit.author.name }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.sender.login || github.event.head_commit.author.login }}
+          # Cypress requires an email for filtering by author, but GitHub does not expose one.
+          # GitHub's public profile email can be deterministically produced from user id/login.
+          COMMIT_INFO_EMAIL: ${{ github.event.sender.id || github.event.head_commit.author.id }}+${{ github.event.sender.login || github.event.head_commit.author.login }}@users.noreply.github.com
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
           COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,8 +151,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-          COMMIT_INFO_EMAIL: ${{ github.event.sender.user.email || github.event.pusher.email }}
-          COMMIT_INFO_AUTHOR: ${{ github.event.sender.user.name || github.event.pusher.name }}
+          COMMIT_INFO_EMAIL: ${{ github.event.sender.email || github.event.pusher.email }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.sender.name || github.event.pusher.name }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
           COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,8 +151,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-          COMMIT_INFO_EMAIL: ${{ github.event.pull_request.user.email || github.event.pusher.email }}
-          COMMIT_INFO_AUTHOR: ${{ github.event.pull_request.user.name || github.event.pusher.name }}
+          COMMIT_INFO_EMAIL: ${{ github.event.pull_request.head.user.email || github.event.head_commit.author.email }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.pull_request.head.user.name || github.event.head_commit.author.name }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
           COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: exit 0
-        env:
-          GITHUB_EVENT: ${{ toJSON(github.event) }}
 
   cypress-test-matrix:
     needs: [build-e2e, cypress-rerun]
@@ -153,8 +151,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
-          COMMIT_INFO_EMAIL: ${{ github.event.pull_request.head.user.email || github.event.head_commit.author.email }}
-          COMMIT_INFO_AUTHOR: ${{ github.event.pull_request.head.user.name || github.event.head_commit.author.name }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.sender.login || github.event.head_commit.author.login || github.event.head_commit.author.name }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
           COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}

--- a/cypress/e2e/landing.test.ts
+++ b/cypress/e2e/landing.test.ts
@@ -21,6 +21,7 @@ describe('Landing Page', () => {
   })
 
   it('shows landing page when the unicorn icon in nav is selected', () => {
+    cy.visit('/swap')
     cy.get(getTestSelector('uniswap-logo')).click()
     cy.get(getTestSelector('landing-page'))
   })

--- a/cypress/e2e/swap/swap.test.ts
+++ b/cypress/e2e/swap/swap.test.ts
@@ -7,7 +7,7 @@ const UNI_MAINNET = UNI[SupportedChainId.MAINNET]
 
 describe('Swap', () => {
   describe('Swap on main page', () => {
-    before(() => {
+    beforeEach(() => {
       cy.visit('/swap', { ethereum: 'hardhat' })
     })
 
@@ -41,55 +41,53 @@ describe('Swap', () => {
     it('should render an error when a transaction fails due to a passed deadline', () => {
       const DEADLINE_MINUTES = 1
       const TEN_MINUTES_MS = 1000 * 60 * DEADLINE_MINUTES * 10
-      cy.visit('/swap', { ethereum: 'hardhat' })
-        .hardhat({ automine: false })
-        .then((hardhat) => {
-          cy.then(() => hardhat.getBalance(hardhat.wallet.address, USDC_MAINNET))
-            .then((balance) => Number(balance.toFixed(1)))
-            .then((initialBalance) => {
-              // Input swap info.
-              cy.get('#swap-currency-output .open-currency-select-button').click()
-              cy.contains('USDC').click()
-              cy.get('#swap-currency-output .token-amount-input').clear().type('1')
-              cy.get('#swap-currency-input .token-amount-input').should('not.equal', '')
+      cy.hardhat({ automine: false }).then((hardhat) => {
+        cy.then(() => hardhat.getBalance(hardhat.wallet.address, USDC_MAINNET))
+          .then((balance) => Number(balance.toFixed(1)))
+          .then((initialBalance) => {
+            // Input swap info.
+            cy.get('#swap-currency-output .open-currency-select-button').click()
+            cy.contains('USDC').click()
+            cy.get('#swap-currency-output .token-amount-input').clear().type('1')
+            cy.get('#swap-currency-input .token-amount-input').should('not.equal', '')
 
-              // Set deadline to minimum. (1 minute)
-              cy.get(getTestSelector('open-settings-dialog-button')).click()
-              cy.get(getTestSelector('transaction-deadline-settings')).click()
-              cy.get(getTestSelector('deadline-input')).clear().type(DEADLINE_MINUTES.toString())
-              cy.get('body').click('topRight')
-              cy.get(getTestSelector('deadline-input')).should('not.exist')
+            // Set deadline to minimum. (1 minute)
+            cy.get(getTestSelector('open-settings-dialog-button')).click()
+            cy.get(getTestSelector('transaction-deadline-settings')).click()
+            cy.get(getTestSelector('deadline-input')).clear().type(DEADLINE_MINUTES.toString())
+            cy.get('body').click('topRight')
+            cy.get(getTestSelector('deadline-input')).should('not.exist')
 
-              cy.get('#swap-button').click()
-              cy.get('#confirm-swap-or-send').click()
+            cy.get('#swap-button').click()
+            cy.get('#confirm-swap-or-send').click()
 
-              // Dismiss the modal that appears when a transaction is broadcast to the network.
-              cy.get(getTestSelector('dismiss-tx-confirmation')).click()
+            // Dismiss the modal that appears when a transaction is broadcast to the network.
+            cy.get(getTestSelector('dismiss-tx-confirmation')).click()
 
-              // The UI should show the transaction as pending.
-              cy.contains('1 Pending').should('exist')
+            // The UI should show the transaction as pending.
+            cy.contains('1 Pending').should('exist')
 
-              // Mine a block past the deadline.
-              cy.then(() => hardhat.mine(1, TEN_MINUTES_MS)).then(() => {
-                // The UI should no longer show the transaction as pending.
-                cy.contains('1 Pending').should('not.exist')
+            // Mine a block past the deadline.
+            cy.then(() => hardhat.mine(1, TEN_MINUTES_MS)).then(() => {
+              // The UI should no longer show the transaction as pending.
+              cy.contains('1 Pending').should('not.exist')
 
-                // Check that the user is informed of the failure
-                cy.contains('Swap failed').should('exist')
+              // Check that the user is informed of the failure
+              cy.contains('Swap failed').should('exist')
 
-                // Check that the balance is unchanged in the UI
-                cy.get('#swap-currency-output [data-testid="balance-text"]').should(
-                  'have.text',
-                  `Balance: ${initialBalance}`
-                )
+              // Check that the balance is unchanged in the UI
+              cy.get('#swap-currency-output [data-testid="balance-text"]').should(
+                'have.text',
+                `Balance: ${initialBalance}`
+              )
 
-                // Check that the balance is unchanged on chain
-                cy.then(() => hardhat.getBalance(hardhat.wallet.address, USDC_MAINNET))
-                  .then((balance) => Number(balance.toFixed(1)))
-                  .should('eq', initialBalance)
-              })
+              // Check that the balance is unchanged on chain
+              cy.then(() => hardhat.getBalance(hardhat.wallet.address, USDC_MAINNET))
+                .then((balance) => Number(balance.toFixed(1)))
+                .should('eq', initialBalance)
             })
-        })
+          })
+      })
     })
 
     it('should default inputs from URL params ', () => {
@@ -107,7 +105,6 @@ describe('Swap', () => {
     })
 
     it('ETH to wETH is same value (wrapped swaps have no price impact)', () => {
-      cy.visit('/swap')
       cy.get(`#swap-currency-output .open-currency-select-button`).click()
       cy.contains('WETH').click()
       cy.get('#swap-currency-input .token-amount-input').clear().type('0.01')
@@ -115,7 +112,6 @@ describe('Swap', () => {
     })
 
     it('Opens and closes the settings menu', () => {
-      cy.visit('/swap')
       cy.contains('Settings').should('not.exist')
       cy.get(getTestSelector('open-settings-dialog-button')).click()
       cy.contains('Max slippage').should('exist')
@@ -135,7 +131,6 @@ describe('Swap', () => {
     })
 
     it('can swap ETH for USDC', () => {
-      cy.visit('/swap', { ethereum: 'hardhat' })
       const TOKEN_ADDRESS = USDC_MAINNET.address
       const BALANCE_INCREMENT = 1
       cy.hardhat().then((hardhat) => {

--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -52,14 +52,14 @@ describe('Wallet Dropdown', () => {
     itShouldChangeTheLanguage()
   })
 
-  describe('system dark mode', () => {
-    function visitWithSystemDarkMode(darkMode: boolean) {
+  describe('with color theme', () => {
+    function visitSwapWithColorTheme({ dark }: { dark: boolean }) {
       cy.visit('/swap', {
         onBeforeLoad(win) {
           cy.stub(win, 'matchMedia')
             .withArgs('(prefers-color-scheme: dark)')
             .returns({
-              matches: darkMode,
+              matches: dark,
               addEventListener() {
                 /* noop */
               },
@@ -72,7 +72,7 @@ describe('Wallet Dropdown', () => {
     }
 
     it('should properly use dark system theme when auto theme setting is selected', () => {
-      visitWithSystemDarkMode(true)
+      visitSwapWithColorTheme({ dark: true })
       cy.get(getTestSelector('web3-status-connected')).click()
       cy.get(getTestSelector('wallet-settings')).click()
       cy.get(getTestSelector('theme-auto')).click()
@@ -80,7 +80,7 @@ describe('Wallet Dropdown', () => {
     })
 
     it('should properly use light system theme when auto theme setting is selected', () => {
-      visitWithSystemDarkMode(false)
+      visitSwapWithColorTheme({ dark: false })
       cy.get(getTestSelector('web3-status-connected')).click()
       cy.get(getTestSelector('wallet-settings')).click()
       cy.get(getTestSelector('theme-auto')).click()

--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -1,96 +1,108 @@
 import { getTestSelector } from '../utils'
 
-function visit(darkMode: boolean) {
-  cy.visit('/swap', {
-    onBeforeLoad(win) {
-      cy.stub(win, 'matchMedia')
-        .withArgs('(prefers-color-scheme: dark)')
-        .returns({
-          matches: darkMode,
-          addEventListener() {
-            // do nothing
-          },
-        })
-    },
-  })
-}
-
 describe('Wallet Dropdown', () => {
-  before(() => {
-    cy.visit('/pools')
+  function itShouldChangeTheTheme() {
+    it('should change the theme', () => {
+      cy.get(getTestSelector('theme-lightmode')).click()
+
+      cy.get(getTestSelector('theme-lightmode')).should('not.have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+      cy.get(getTestSelector('theme-darkmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+      cy.get(getTestSelector('theme-auto')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+
+      cy.get(getTestSelector('theme-darkmode')).click()
+      cy.get(getTestSelector('theme-lightmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+      cy.get(getTestSelector('theme-darkmode')).should('not.have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+      cy.get(getTestSelector('theme-auto')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+
+      cy.get(getTestSelector('theme-auto')).click()
+      cy.get(getTestSelector('theme-lightmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+      cy.get(getTestSelector('theme-darkmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+      cy.get(getTestSelector('theme-auto')).should('not.have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+    })
+  }
+
+  function itShouldChangeTheLanguage() {
+    it('should select a language', () => {
+      cy.get(getTestSelector('wallet-language-item')).contains('Deutsch').click({ force: true })
+      cy.get(getTestSelector('wallet-header')).should('contain', 'Sprache')
+      cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
+      cy.get(getTestSelector('wallet-header')).should('contain', 'Language')
+      cy.get(getTestSelector('wallet-back')).click()
+    })
+  }
+
+  describe('connected', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.get(getTestSelector('wallet-settings')).click()
+    })
+    itShouldChangeTheTheme()
+    itShouldChangeTheLanguage()
   })
 
-  it('should change the theme', () => {
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.get(getTestSelector('wallet-settings')).click()
-    cy.get(getTestSelector('theme-lightmode')).click()
-
-    cy.get(getTestSelector('theme-lightmode')).should('not.have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-    cy.get(getTestSelector('theme-darkmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-    cy.get(getTestSelector('theme-auto')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-
-    cy.get(getTestSelector('theme-darkmode')).click()
-    cy.get(getTestSelector('theme-lightmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-    cy.get(getTestSelector('theme-darkmode')).should('not.have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-    cy.get(getTestSelector('theme-auto')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-
-    cy.get(getTestSelector('theme-auto')).click()
-    cy.get(getTestSelector('theme-lightmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-    cy.get(getTestSelector('theme-darkmode')).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
-    cy.get(getTestSelector('theme-auto')).should('not.have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+  describe('disconnected', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.get(getTestSelector('wallet-disconnect')).click()
+      cy.get(getTestSelector('wallet-settings')).click()
+    })
+    itShouldChangeTheTheme()
+    itShouldChangeTheLanguage()
   })
 
-  it('should select a language', () => {
-    cy.get(getTestSelector('wallet-language-item')).contains('Deutsch').click({ force: true })
-    cy.get(getTestSelector('wallet-header')).should('contain', 'Sprache')
-    cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
-    cy.get(getTestSelector('wallet-header')).should('contain', 'Language')
-    cy.get(getTestSelector('wallet-back')).click()
+  describe('system dark mode', () => {
+    function visitWithSystemDarkMode(darkMode: boolean) {
+      cy.visit('/swap', {
+        onBeforeLoad(win) {
+          cy.stub(win, 'matchMedia')
+            .withArgs('(prefers-color-scheme: dark)')
+            .returns({
+              matches: darkMode,
+              addEventListener() {
+                /* noop */
+              },
+              removeEventListener() {
+                /* noop */
+              },
+            })
+        },
+      })
+    }
+
+    it('should properly use dark system theme when auto theme setting is selected', () => {
+      visitWithSystemDarkMode(true)
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.get(getTestSelector('wallet-settings')).click()
+      cy.get(getTestSelector('theme-auto')).click()
+      cy.get(getTestSelector('wallet-header')).should('have.css', 'color', 'rgb(152, 161, 192)')
+    })
+
+    it('should properly use light system theme when auto theme setting is selected', () => {
+      visitWithSystemDarkMode(false)
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.get(getTestSelector('wallet-settings')).click()
+      cy.get(getTestSelector('theme-auto')).click()
+      cy.get(getTestSelector('wallet-header')).should('have.css', 'color', 'rgb(119, 128, 160)')
+    })
   })
 
-  it('should change the theme when not connected', () => {
-    cy.get(getTestSelector('wallet-disconnect')).click()
-    cy.get(getTestSelector('wallet-settings')).click()
-    cy.get(getTestSelector('theme-lightmode')).should('exist')
-  })
+  describe('mobile', () => {
+    beforeEach(() => {
+      cy.viewport('iphone-6').visit('/')
+    })
 
-  it('should select a language when not connected', () => {
-    cy.get(getTestSelector('wallet-language-item')).contains('Deutsch').click({ force: true })
-    cy.get(getTestSelector('wallet-header')).should('contain', 'Sprache')
-    cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
-    cy.get(getTestSelector('wallet-header')).should('contain', 'Language')
-    cy.get(getTestSelector('wallet-back')).click()
-  })
+    it('should dismiss the wallet bottom sheet when clicking buy crypto', () => {
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.get(getTestSelector('wallet-buy-crypto')).click()
+      cy.contains('Buy crypto').should('not.be.visible')
+    })
 
-  it('should properly use dark system theme when auto theme setting is selected', () => {
-    visit(true)
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.get(getTestSelector('wallet-settings')).click()
-    cy.get(getTestSelector('theme-auto')).click()
-    cy.get(getTestSelector('wallet-header')).should('have.css', 'color', 'rgb(152, 161, 192)')
-  })
-
-  it('should properly use light system theme when auto theme setting is selected', () => {
-    visit(false)
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.get(getTestSelector('wallet-settings')).click()
-    cy.get(getTestSelector('theme-auto')).click()
-    cy.get(getTestSelector('wallet-header')).should('have.css', 'color', 'rgb(119, 128, 160)')
-  })
-
-  it('should dismiss the wallet bottom sheet when clicking buy crypto', () => {
-    visit(false)
-    cy.viewport('iphone-6')
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.get(getTestSelector('wallet-buy-crypto')).click()
-    cy.contains('Buy crypto').should('not.be.visible')
-  })
-
-  it('should use a bottom sheet and dismiss when on a mobile screen size', () => {
-    visit(true)
-    cy.viewport('iphone-6')
-    cy.get(getTestSelector('web3-status-connected')).click()
-    cy.root().click(15, 40)
-    cy.get(getTestSelector('wallet-settings')).should('not.be.visible')
+    it('should use a bottom sheet and dismiss when on a mobile screen size', () => {
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.root().click(15, 40)
+      cy.get(getTestSelector('wallet-settings')).should('not.be.visible')
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@vanilla-extract/webpack-plugin": "^2.1.11",
     "babel-plugin-istanbul": "^6.1.1",
     "buffer": "^6.0.3",
-    "cypress": "10.3.1",
+    "cypress": "12.12.0",
     "cypress-hardhat": "^2.3.0",
     "env-cmd": "^10.1.0",
     "eslint": "^7.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8165,7 +8165,7 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^6.1.0:
+commander@^6.1.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -8662,10 +8662,10 @@ cypress-hardhat@^2.3.0:
     "@uniswap/sdk-core" "^3.0.1"
     "@uniswap/universal-router-sdk" "^1.3.8"
 
-cypress@*, cypress@10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
-  integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
+cypress@*, cypress@12.12.0:
+  version "12.12.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.12.0.tgz#0da622a34c970d8699ca6562d8e905ed7ce33c77"
+  integrity sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -8681,12 +8681,12 @@ cypress@*, cypress@10.3.1:
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
-    commander "^5.1.0"
+    commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "^4.3.2"
+    debug "^4.3.4"
     enquirer "^2.3.6"
-    eventemitter2 "^6.4.3"
+    eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
@@ -8699,7 +8699,7 @@ cypress@*, cypress@10.3.1:
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
     proxy-from-env "1.0.0"
@@ -10357,10 +10357,10 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter2@^6.4.3:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.4.tgz#aa96e8275c4dbeb017a5d0e03780c65612a1202b"
-  integrity sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==
+eventemitter2@6.4.7, eventemitter2@^6.4.3:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@4.0.7, eventemitter3@^4.0.0, eventemitter3@^4.0.7:
   version "4.0.7"
@@ -13900,10 +13900,10 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Adds `cypress/flake` as a first-class check in GitHub PRs. Once existing flakes are fixed, we can use it to block add'l flakes from merging in.

Configures Cypress to post a comment to PRs with test results and two additional checks: a group check (`cypress:e2e`), and a flakes check (`cypress/flake`). These checks can be used in branch protections to gate merging to `main`, and `cypress:e2e` can replace the more complex `cypress-tests` check currently in use. Also configures Cypress so that structured data (author, PR) are available in the cloud dashboard.

Upgrades Cypress to v12.12.0, which is necessary for the Cypress cloud dashboard to link back to the PR. `CYPRESS_PULL_REQUEST_*` env vars are not available until v12. This makes tests isolated, so each test must now begin with `cy.visit()`. This should have no other effect on our tests. If we're lucky, it'll make them run run faster ⏳ .

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/INFRA-7/configure-github-cypress-integration
_Relevant docs:_ https://docs.cypress.io/guides/continuous-integration/introduction#Git-information

## Test plan

This PR acts as its own test, as it is adding functionality to the PR review process.
The PR checks run, which should generate the two additional checks (`cypress:chrome` and `cypress/flake`) and a PR comment.
Once it is merged to `main`, I'll also need to check that the checks run and are posted to the commit on main. Failure here will not cause breakage, as removing the old `cypress-tests` check is left to a follow-up PR.