### PR TITLE
build: notify from notify/test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == 'main' && 'notify/test' }}
+      name: ${{ github.ref_name == 'merge/6597' && 'notify/test' }}
     steps:
+      - run: echo ${{ github.ref_name }}
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == 'merge/6597' && 'notify/test' }}
+      name: ${{ github.ref_name == '6597/merge' && 'notify/test' }}
     steps:
       - run: echo ${{ github.ref_name }}
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == '6597/merge' && 'notify/test' }}
+      name: ${{ github.ref_name == 'main' && 'notify/test' }}
     steps:
-      - run: echo ${{ github.ref_name }}
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'main' && 'notify/test' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -30,10 +32,12 @@ jobs:
         uses: ./.github/actions/report
         with:
           name: Lint
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_REPORTER_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   
   typecheck:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'main' && 'notify/test' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -48,10 +52,12 @@ jobs:
         uses: ./.github/actions/report
         with:
           name: Typecheck
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_REPORTER_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deps-tests:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'main' && 'notify/test' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -60,10 +66,12 @@ jobs:
         uses: ./.github/actions/report
         with:
           name: Dependency checks
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_REPORTER_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   unit-tests:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'main' && 'notify/test' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -84,7 +92,7 @@ jobs:
         uses: ./.github/actions/report
         with:
           name: Unit tests
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_REPORTER_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-e2e:
     runs-on: ubuntu-latest
@@ -115,6 +123,8 @@ jobs:
   cypress-test-matrix:
     needs: [build-e2e, cypress-rerun]
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'main' && 'notify/test' }}
     container: cypress/browsers:node-18.14.1-chrome-111.0.5563.64-1-ff-111.0-edge-111.0.1661.43-1
     strategy:
       fail-fast: false
@@ -156,17 +166,17 @@ jobs:
           verbose: true
           flags: e2e-tests
 
+      - if: failure() && github.ref_name == 'main'
+        uses: ./.github/actions/report
+        with:
+          name: Cypress tests
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   # Included as a single job to check for cypress-test-matrix success, as a matrix cannot be checked.
   cypress-tests:
     if: always()
     needs: [cypress-test-matrix]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - if: needs.cypress-test-matrix.result != 'success'
         run: exit 1
-      - if: failure() && github.ref_name == 'main'
-        uses: ./.github/actions/report
-        with:
-          name: Cypress tests
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_REPORTER_WEBHOOK }}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Runs test workflow from a protected environment if on `main`.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/INFRA-12/isolate-the-slack-webhook-url-to-an-environment

### Test Plan

The logic (`${{ github.ref_name == 'main' && 'notify/test' }}`) was tested by modifying it to read `${{ github.ref_name == '6597/merge' && 'notify/test' }}` and observing the correct environment selection: https://github.com/Uniswap/interface/actions/runs/5019599122.