### PR TITLE
build: restrict promotions to their branches

### DIFF
--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -5,6 +5,8 @@ name: 1 | Push main -> staging
 
 on:
   workflow_dispatch:
+    branches:
+      - main
 
 # https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action
 jobs:

--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -6,6 +6,8 @@ name: 3 | Push staging -> prod
 
 on:
   workflow_dispatch:
+    branches:
+      - releases/staging
 
 jobs:
   push-prod:


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Restricts promotion workflows to their branches. These flows will fail if not run from the correct branch, due to environment configurations.

This uses an undocumented setting, and needs to be tried (in a test repo) first.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/INFRA-20/3-should-be-auto-run-from-releasesstaging