### PR TITLE
fix: only request 1 listing on NFTDetails page

### DIFF
--- a/src/graphql/data/nft/Details.ts
+++ b/src/graphql/data/nft/Details.ts
@@ -49,7 +49,7 @@ gql`
             }
             description
           }
-          listings(first: 25) {
+          listings(first: 1) {
             edges {
               node {
                 address


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- On the NFT Details page v2 we intended on showing multiple listings on the page. This was tested with several assets however an edge case we found was that our BE does not include pooled assets when fetching more than 1 listing. This caused a bug where if a user views a 721 asset listed on an AMM such as [this one](https://app.uniswap.org/#/nfts/asset/0xbd3531da5cf5857e7cfaa92426877b022e612cf8/243) on the collection page it will be purchaseable however on its Detail page it will be viewed as not for sale.
- BE will not be able to support this until after the migration so we will be reverting to only fetching 1 listing until then

<!-- Delete inapplicable lines: -->
_JIRA ticket:_ https://linear.app/uniswap/issue/NFT-1132/revert-to-requesting-1-listing-in-details-page
_Slack thread:_ https://uniswapteam.slack.com/archives/C03MGBD2SNN/p1684435644690259


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

| Before       | After (Desktop) | After (Mobile) |
| ------------ |---------------- | -------------- |
| ![Screen Shot 2023-05-18 at 11 58 55 ](https://github.com/Uniswap/interface/assets/11512321/14b7de4f-b637-424a-bf8e-fffa5ea03956) | ![Screen Shot 2023-05-18 at 11 59 06 ](https://github.com/Uniswap/interface/assets/11512321/c8f9eb87-a6c8-46bd-b00f-f7f965461276)     | paste_after    |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Visit [this NFT](https://app.uniswap.org/#/nfts/asset/0xbd3531da5cf5857e7cfaa92426877b022e612cf8/243) on prod and see it can't be purchased despite being listed on sudo

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Visit [this NFT](https://app.uniswap.org/#/nfts/asset/0xbd3531da5cf5857e7cfaa92426877b022e612cf8/243) on the PR deploy and see it can be purchased
