### PR TITLE
fix: Use client side router only for price fetching

### DIFF
--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -126,11 +126,7 @@ export const routingApi = createApi({
         )
       },
       async queryFn(args, _api, _extraOptions, fetch) {
-        if (
-          args.routerPreference === RouterPreference.API ||
-          args.routerPreference === RouterPreference.AUTO ||
-          args.routerPreference === INTERNAL_ROUTER_PREFERENCE_PRICE
-        ) {
+        if (args.routerPreference === RouterPreference.API || args.routerPreference === RouterPreference.AUTO) {
           try {
             const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, tradeType } = args
             const type = isExactInput(tradeType) ? 'exactIn' : 'exactOut'


### PR DESCRIPTION
## Description
We were previously using client-side-only routing for price fetching, and switched to API, and the increase in pricing requests for illiquid tokens spiked our 4xx errors, so revert back to client-side routing for now
