### PR TITLE
fix: do not attempt to cache i18n:extract

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -53,16 +53,6 @@ runs:
       shell: bash
 
     # Messages are extracted from source.
-    # A record of source file content hashes is maintained in node_modules/.cache/lingui by a custom extractor.
-    # Messages are always extracted, but extraction may rely on the custom extractor's loaded cache.
-    - uses: actions/cache@v3
-      id: i18n-extract-cache
-      with:
-        path: |
-          src/locales/en-US.po
-          node_modules/.cache
-        key: ${{ runner.os }}-i18n-extract-${{ github.run_id }}
-        restore-keys: ${{ runner.os }}-i18n-extract-
     - run: yarn i18n:extract
       shell: bash
 

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -1,51 +1,3 @@
-import { default as babelExtractor } from '@lingui/cli/api/extractors/babel'
-import { createHash } from 'crypto'
-import { mkdirSync, readFileSync, writeFileSync } from 'fs'
-import * as path from 'path'
-import * as pkgUp from 'pkg-up' // pkg-up is used by lingui, and is used here to match lingui's own extractors
-
-/**
- * A custom caching extractor for CI.
- * Falls back to the babelExtractor in a non-CI (ie local) environment.
- * Caches a file's latest extracted content's hash, and skips re-extracting if it is already present in the cache.
- * In CI, re-extracting files takes over one minute, so this is a significant savings.
- */
-const cachingExtractor: typeof babelExtractor = {
-  match(filename: string) {
-    return babelExtractor.match(filename)
-  },
-  extract(filename: string, code: string, ...options: unknown[]) {
-    if (!process.env.CI) return babelExtractor.extract(filename, code, ...options)
-
-    // This runs from node_modules/@lingui/conf, so we need to back out to the root.
-    const pkg = pkgUp.sync()
-    if (!pkg) throw new Error('No root found')
-    const root = path.dirname(pkg)
-
-    const filePath = path.join(root, filename)
-    const file = readFileSync(filePath)
-    const hash = createHash('sha256').update(file).digest('hex')
-
-    const cacheRoot = path.join(root, 'node_modules/.cache/lingui')
-    mkdirSync(cacheRoot, { recursive: true })
-    const cachePath = path.join(cacheRoot, filename.replace(/\//g, '-'))
-
-    // Only read from the cache if we're not performing a "clean" run, as a clean run must re-extract from all
-    // files to ensure that obsolete messages are removed.
-    if (!process.argv.includes('--clean')) {
-      try {
-        const cache = readFileSync(cachePath, 'utf8')
-        if (cache === hash) return
-      } catch (e) {
-        // It should not be considered an error if there is no cache file.
-      }
-    }
-    writeFileSync(cachePath, hash)
-
-    return babelExtractor.extract(filename, code, ...options)
-  },
-}
-
 const linguiConfig = {
   catalogs: [
     {
@@ -108,7 +60,6 @@ const linguiConfig = {
   runtimeConfigModule: ['@lingui/core', 'i18n'],
   sourceLocale: 'en-US',
   pseudoLocale: 'pseudo',
-  extractors: [cachingExtractor],
 }
 
 export default linguiConfig


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Removes the buggy caching layer for i18n:extract, to allow translation messages to be correctly extracted.

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C02T729PMQE/p1684776627955079?thread_ts=1684775215.278659&cid=C02T729PMQE


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Run the caching extractor locally, verify that it incorrectly strips message headers
2. Run the new non-caching extractor, verify that message headers are still there