### PR TITLE
build: caching i18n extractor

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -53,16 +53,6 @@ runs:
       shell: bash
 
     # Messages are extracted from source.
-    # A record of source file content hashes is maintained in node_modules/.cache/lingui by a custom extractor.
-    # Messages are always extracted, but extraction may rely on the custom extractor's loaded cache.
-    - uses: actions/cache@v3
-      id: i18n-extract-cache
-      with:
-        path: |
-          src/locales/en-US.po
-          node_modules/.cache
-        key: ${{ runner.os }}-i18n-extract-${{ github.run_id }}
-        restore-keys: ${{ runner.os }}-i18n-extract-
     - run: yarn i18n:extract
       shell: bash
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -53,6 +53,14 @@ runs:
       shell: bash
 
     # Messages are extracted from source.
+    # A record of source file content hashes and catalogs is maintained in node_modules/.cache/lingui.
+    # Messages are always extracted, but extraction may short-circuit from the custom extractor's cache.
+    - uses: actions/cache@v3
+      id: i18n-extract-cache
+      with:
+        path: node_modules/.cache
+        key: ${{ runner.os }}-i18n-extract-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-i18n-extract-
     - run: yarn i18n:extract
       shell: bash
 

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -1,51 +1,3 @@
-import { default as babelExtractor } from '@lingui/cli/api/extractors/babel'
-import { createHash } from 'crypto'
-import { mkdirSync, readFileSync, writeFileSync } from 'fs'
-import * as path from 'path'
-import * as pkgUp from 'pkg-up' // pkg-up is used by lingui, and is used here to match lingui's own extractors
-
-/**
- * A custom caching extractor for CI.
- * Falls back to the babelExtractor in a non-CI (ie local) environment.
- * Caches a file's latest extracted content's hash, and skips re-extracting if it is already present in the cache.
- * In CI, re-extracting files takes over one minute, so this is a significant savings.
- */
-const cachingExtractor: typeof babelExtractor = {
-  match(filename: string) {
-    return babelExtractor.match(filename)
-  },
-  extract(filename: string, code: string, ...options: unknown[]) {
-    if (!process.env.CI) return babelExtractor.extract(filename, code, ...options)
-
-    // This runs from node_modules/@lingui/conf, so we need to back out to the root.
-    const pkg = pkgUp.sync()
-    if (!pkg) throw new Error('No root found')
-    const root = path.dirname(pkg)
-
-    const filePath = path.join(root, filename)
-    const file = readFileSync(filePath)
-    const hash = createHash('sha256').update(file).digest('hex')
-
-    const cacheRoot = path.join(root, 'node_modules/.cache/lingui')
-    mkdirSync(cacheRoot, { recursive: true })
-    const cachePath = path.join(cacheRoot, filename.replace(/\//g, '-'))
-
-    // Only read from the cache if we're not performing a "clean" run, as a clean run must re-extract from all
-    // files to ensure that obsolete messages are removed.
-    if (!process.argv.includes('--clean')) {
-      try {
-        const cache = readFileSync(cachePath, 'utf8')
-        if (cache === hash) return
-      } catch (e) {
-        // It should not be considered an error if there is no cache file.
-      }
-    }
-    writeFileSync(cachePath, hash)
-
-    return babelExtractor.extract(filename, code, ...options)
-  },
-}
-
 const linguiConfig = {
   catalogs: [
     {
@@ -108,7 +60,6 @@ const linguiConfig = {
   runtimeConfigModule: ['@lingui/core', 'i18n'],
   sourceLocale: 'en-US',
   pseudoLocale: 'pseudo',
-  extractors: [cachingExtractor],
 }
 
 export default linguiConfig

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -1,3 +1,57 @@
+/* eslint-env node */
+import { default as babelExtractor } from '@lingui/cli/api/extractors/babel'
+import { createHash } from 'crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync } from 'fs'
+import * as path from 'path'
+
+/** A custom caching extractor. */
+const cachingExtractor: typeof babelExtractor = {
+  match(filename: string) {
+    return babelExtractor.match(filename)
+  },
+  /**
+   * Stores a hash of a file and its corresponding catalog, to be re-used if the hash is unchanged.
+   * @lingui/babel-plugin-extract-messages extracts to localeDir, so if the messages are unchanged for filename, it is
+   * valid to copy over the last-generated file.
+   */
+  extract(filename: string, localeDir: string, ...options: unknown[]) {
+    // This runs from node_modules/@lingui/conf, so we need to back out to the root.
+    const root = __dirname.split('/node_modules')[0]
+
+    // localePath is copied catalogFilename from @lingui/babel-plugin-extract-messages.
+    const localePath = path.join(localeDir, '_build', filename + '.json')
+
+    const cacheRoot = path.join(root, 'node_modules/.cache/lingui')
+    const cachePath = path.join(cacheRoot, filename + '.json')
+
+    const filePath = path.join(root, filename)
+    const fileHash = createHash('sha256').update(readFileSync(filePath)).digest('hex')
+
+    // If we have a matching cached copy of the catalog, we can copy it over and return early.
+    if (existsSync(cachePath)) {
+      const { hash, catalog } = JSON.parse(readFileSync(cachePath, 'utf8'))
+      if (hash === fileHash) {
+        if (catalog) {
+          mkdirSync(path.dirname(localePath), { recursive: true })
+          writeFileSync(localePath, JSON.stringify(catalog, null, 2))
+        }
+        return
+      }
+    }
+
+    babelExtractor.extract(filename, localeDir, ...options)
+
+    mkdirSync(path.dirname(cachePath), { recursive: true })
+    if (existsSync(localePath)) {
+      const catalog = JSON.parse(readFileSync(localePath, 'utf8'))
+      writeFileSync(cachePath, JSON.stringify({ hash: fileHash, catalog }))
+    } else {
+      writeFileSync(cachePath, JSON.stringify({ hash: fileHash }))
+    }
+  },
+}
+
 const linguiConfig = {
   catalogs: [
     {
@@ -60,6 +114,7 @@ const linguiConfig = {
   runtimeConfigModule: ['@lingui/core', 'i18n'],
   sourceLocale: 'en-US',
   pseudoLocale: 'pseudo',
+  extractors: [cachingExtractor],
 }
 
 export default linguiConfig

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -5,30 +5,37 @@ import { mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { existsSync } from 'fs'
 import * as path from 'path'
 
-/** A custom caching extractor. */
+/** A custom caching extractor built on top of babelExtractor. */
 const cachingExtractor: typeof babelExtractor = {
+  /** Delegates to babelExtractor.match. */
   match(filename: string) {
     return babelExtractor.match(filename)
   },
   /**
-   * Stores a hash of a file and its corresponding catalog, to be re-used if the hash is unchanged.
-   * @lingui/babel-plugin-extract-messages extracts to localeDir, so if the messages are unchanged for filename, it is
-   * valid to copy over the last-generated file.
+   * Checks a cache before extraction, only delegating to babelExtractor.extract if the file has changed.
+   *
+   * The lingui extractor works by extracting JSON (the catalog) from `filename` to `buildDir/filename.json`.
+   * Caching works by man-in-the-middling this:
+   * - File freshness is computed as a hash of `filename` contents.
+   * - Before extracting, we check the cache to see if we already have a fresh catalog for the file.
+   *   If we do, we copy it to `localeDir/filename.json`. Copying is significantly faster than extracting.
+   * - After extracting, we copy the catalog to the cache.
    */
   extract(filename: string, localeDir: string, ...options: unknown[]) {
     // This runs from node_modules/@lingui/conf, so we need to back out to the root.
     const root = __dirname.split('/node_modules')[0]
 
-    // localePath is copied catalogFilename from @lingui/babel-plugin-extract-messages.
-    const localePath = path.join(localeDir, '_build', filename + '.json')
-
-    const cacheRoot = path.join(root, 'node_modules/.cache/lingui')
-    const cachePath = path.join(cacheRoot, filename + '.json')
+    // This logic mimics catalogFilename in @lingui/babel-plugin-extract-messages.
+    const buildDir = path.join(localeDir, '_build')
+    const localePath = path.join(buildDir, filename + '.json')
 
     const filePath = path.join(root, filename)
     const fileHash = createHash('sha256').update(readFileSync(filePath)).digest('hex')
 
-    // If we have a matching cached copy of the catalog, we can copy it over and return early.
+    const cacheRoot = path.join(root, 'node_modules/.cache/lingui')
+    const cachePath = path.join(cacheRoot, filename + '.json')
+
+    // If we have a matching cached copy of the catalog, we can copy it to localePath and return early.
     if (existsSync(cachePath)) {
       const { hash, catalog } = JSON.parse(readFileSync(cachePath, 'utf8'))
       if (hash === fileHash) {
@@ -42,6 +49,7 @@ const cachingExtractor: typeof babelExtractor = {
 
     babelExtractor.extract(filename, localeDir, ...options)
 
+    // Cache the extracted catalog.
     mkdirSync(path.dirname(cachePath), { recursive: true })
     if (existsSync(localePath)) {
       const catalog = JSON.parse(readFileSync(localePath, 'utf8'))


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Implements a caching i18n extractor to speed up lingui extraction. This saves minutes from build times, so it's a non-trivial change.

This builds on the old (broken) extractor: https://github.com/Uniswap/interface/blob/f3a80c62722b09ea82d4747b0ef93774fbfc9f05/lingui.config.ts#L13.

The old extractor was broken in that it assumed lingui extracted using the existing catalog as a basis, and only added to it. In fact, lingui extracts from every file every time, and fully reconstructs the catalog.

This new extractor works by man-in-the-middling lingui extraction. Lingui passes extractors a temporary `localeDir` to extract to. The extractor is expected to populate a new file, `${localeDir}/_build/${filename}.json`, with the extracted JSON. The caching extractor adds a few steps:
- Before extracting `filename`, check the cache for an already-extracted JSON matching the file contents.
  If found, copy it to `${localeDir}/${filename}.json` and return. Copying the JSON over is significantly faster than re-extracting.
- After extracting, store the hash and extracted JSON in the cache, `${cacheRoot}/${filename}.json`, for use in future extractions.

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C02T729PMQE/p1684776627955079?thread_ts=1684775215.278659&cid=C02T729PMQE

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Using the preview link, ensure other languages show up.
2. Locally, run `yarn i18n:extract`, and ensure `src/locales/en-US.po` is valid across multiple runs.