### PR TITLE
fix: prevent race condition for swap state

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -417,10 +417,20 @@ export function Swap({
     if (stablecoinPriceImpact && !confirmPriceImpactWithoutFee(stablecoinPriceImpact)) {
       return
     }
-    setSwapState({ attemptingTxn: true, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: undefined })
+    setSwapState((currentState) => ({
+      ...currentState,
+      attemptingTxn: true,
+      swapErrorMessage: undefined,
+      txHash: undefined,
+    }))
     swapCallback()
       .then((hash) => {
-        setSwapState({ attemptingTxn: false, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: hash })
+        setSwapState((currentState) => ({
+          ...currentState,
+          attemptingTxn: false,
+          swapErrorMessage: undefined,
+          txHash: hash,
+        }))
         sendEvent({
           category: 'Swap',
           action: 'transaction hash',
@@ -440,19 +450,16 @@ export function Swap({
         })
       })
       .catch((error) => {
-        setSwapState({
+        setSwapState((currentState) => ({
+          ...currentState,
           attemptingTxn: false,
-          tradeToConfirm,
-          showConfirm,
           swapErrorMessage: error.message,
           txHash: undefined,
-        })
+        }))
       })
   }, [
     swapCallback,
     stablecoinPriceImpact,
-    tradeToConfirm,
-    showConfirm,
     recipient,
     recipientAddress,
     account,
@@ -471,16 +478,16 @@ export function Swap({
   }, [stablecoinPriceImpact, trade])
 
   const handleConfirmDismiss = useCallback(() => {
-    setSwapState({ showConfirm: false, tradeToConfirm, attemptingTxn, swapErrorMessage, txHash })
+    setSwapState((currentState) => ({ ...currentState, showConfirm: false }))
     // if there was a tx hash, we want to clear the input
     if (txHash) {
       onUserInput(Field.INPUT, '')
     }
-  }, [attemptingTxn, onUserInput, swapErrorMessage, tradeToConfirm, txHash])
+  }, [onUserInput, txHash])
 
   const handleAcceptChanges = useCallback(() => {
-    setSwapState({ tradeToConfirm: trade, swapErrorMessage, txHash, attemptingTxn, showConfirm })
-  }, [attemptingTxn, showConfirm, swapErrorMessage, trade, txHash])
+    setSwapState((currentState) => ({ ...currentState, tradeToConfirm: trade }))
+  }, [trade])
 
   const handleInputSelect = useCallback(
     (inputCurrency: Currency) => {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

This bug happens when the `ConfirmSwapModal` is dismissed before  the `swapCallback`  promise resolves.

When the bug happens, the state is set like this:
1. user proceeds normally and opens the `ConfirmSwapModal` -> `showConfirm` is true (set on L783)
2. `handleSwap` is called and triggers the `swapCallback` (L426). `showConfirm` is still true at this point
3. `handleConfirmDismiss` is called and `showConfirm` is set to `false`
4. `swapCallback` resolves and sets `showConfirm` to an outdated value (L428) which re-opens the modal


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. see the [test results](https://github.com/Uniswap/interface/pull/6541) for the `swap/errors.test.ts` test suite - it's flaky because this race condition causes the modal to stay visible when it shouldn't


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] this change totally fixes flakiness in certain swap e2e tests (tested in other branches)
- [x] manually verified that the ConfirmSwapModal still works in the new permit2 flow with these changes

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
- [x] Integration/E2E test (existing test flakiness in other PRs is fixed by this change)
