### PR TITLE
refactor: rename confirmation state vars

### DIFF
--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -325,17 +325,17 @@ interface ConfirmationModalProps {
   isOpen: boolean
   onDismiss: () => void
   hash: string | undefined
-  content: () => ReactNode
-  attemptingTxn: boolean
+  pending: boolean
   pendingText: ReactNode
   currencyToAdd?: Currency | undefined
+  content: () => ReactNode
 }
 
 export default function TransactionConfirmationModal({
   isOpen,
   onDismiss,
-  attemptingTxn,
   hash,
+  pending,
   pendingText,
   content,
   currencyToAdd,
@@ -347,9 +347,9 @@ export default function TransactionConfirmationModal({
   // confirmation screen
   return (
     <Modal isOpen={isOpen} $scrollOverlay={true} onDismiss={onDismiss} maxHeight={90}>
-      {isL2ChainId(chainId) && (hash || attemptingTxn) ? (
+      {isL2ChainId(chainId) && (hash || pending) ? (
         <L2Content chainId={chainId} hash={hash} onDismiss={onDismiss} pendingText={pendingText} />
-      ) : attemptingTxn ? (
+      ) : pending ? (
         <ConfirmationPendingContent onDismiss={onDismiss} pendingText={pendingText} />
       ) : hash ? (
         <TransactionSubmittedContent

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -23,7 +23,7 @@ export default function ConfirmSwapModal({
   onConfirm,
   onDismiss,
   swapErrorMessage,
-  attemptingTxn,
+  txPending,
   txHash,
   swapQuoteReceivedDate,
   fiatValueInput,
@@ -31,7 +31,7 @@ export default function ConfirmSwapModal({
 }: {
   trade: InterfaceTrade
   originalTrade: InterfaceTrade | undefined
-  attemptingTxn: boolean
+  txPending: boolean
   txHash: string | undefined
   allowedSlippage: Percent
   onAcceptChanges: () => void
@@ -125,7 +125,7 @@ export default function ConfirmSwapModal({
       <TransactionConfirmationModal
         isOpen
         onDismiss={onModalDismiss}
-        attemptingTxn={attemptingTxn}
+        pending={txPending}
         hash={txHash}
         content={confirmationContent}
         pendingText={pendingText}

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -164,7 +164,7 @@ function AddLiquidity() {
 
   // modal and loading
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
-  const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirm
+  const [txPending, setTxPending] = useState<boolean>(false) // clicked confirm
 
   // txn values
   const deadline = useTransactionDeadline() // custom from users settings
@@ -274,7 +274,7 @@ function AddLiquidity() {
         }
       }
 
-      setAttemptingTxn(true)
+      setTxPending(true)
 
       provider
         .getSigner()
@@ -289,7 +289,7 @@ function AddLiquidity() {
             .getSigner()
             .sendTransaction(newTxn)
             .then((response: TransactionResponse) => {
-              setAttemptingTxn(false)
+              setTxPending(false)
               addTransaction(response, {
                 type: TransactionType.ADD_LIQUIDITY_V3_POOL,
                 baseCurrencyId: currencyId(baseCurrency),
@@ -309,7 +309,7 @@ function AddLiquidity() {
         })
         .catch((error) => {
           console.error('Failed to send transaction', error)
-          setAttemptingTxn(false)
+          setTxPending(false)
           // we only care if the error is something _other_ than the user rejected the tx
           if (error?.code !== 4001) {
             console.error(error)
@@ -574,7 +574,7 @@ function AddLiquidity() {
         <TransactionConfirmationModal
           isOpen={showConfirm}
           onDismiss={handleDismissConfirmation}
-          attemptingTxn={attemptingTxn}
+          pending={txPending}
           hash={txHash}
           content={() => (
             <ConfirmationModalContent

--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -93,7 +93,7 @@ export default function AddLiquidity() {
 
   // modal and loading
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
-  const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirm
+  const [txPending, setTxPending] = useState<boolean>(false) // clicked confirm
 
   // txn values
   const deadline = useTransactionDeadline() // custom from users settings
@@ -181,14 +181,14 @@ export default function AddLiquidity() {
       value = null
     }
 
-    setAttemptingTxn(true)
+    setTxPending(true)
     await estimate(...args, value ? { value } : {})
       .then((estimatedGasLimit) =>
         method(...args, {
           ...(value ? { value } : {}),
           gasLimit: calculateGasMargin(estimatedGasLimit),
         }).then((response) => {
-          setAttemptingTxn(false)
+          setTxPending(false)
 
           addTransaction(response, {
             type: TransactionType.ADD_LIQUIDITY_V2_POOL,
@@ -208,7 +208,7 @@ export default function AddLiquidity() {
         })
       )
       .catch((error) => {
-        setAttemptingTxn(false)
+        setTxPending(false)
         // we only care if the error is something _other_ than the user rejected the tx
         if (error?.code !== 4001) {
           console.error(error)
@@ -328,7 +328,7 @@ export default function AddLiquidity() {
           <TransactionConfirmationModal
             isOpen={showConfirm}
             onDismiss={handleDismissConfirmation}
-            attemptingTxn={attemptingTxn}
+            pending={txPending}
             hash={txHash}
             content={() => (
               <ConfirmationModalContent

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -639,7 +639,7 @@ function PositionPageContent() {
           <TransactionConfirmationModal
             isOpen={showConfirm}
             onDismiss={() => setShowConfirm(false)}
-            attemptingTxn={collecting}
+            pending={collecting}
             hash={collectMigrationHash ?? ''}
             content={() => (
               <ConfirmationModalContent

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -100,12 +100,12 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
   const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_REMOVE_V3_LIQUIDITY_SLIPPAGE_TOLERANCE) // custom from users
 
   const [showConfirm, setShowConfirm] = useState(false)
-  const [attemptingTxn, setAttemptingTxn] = useState(false)
-  const [txnHash, setTxnHash] = useState<string | undefined>()
+  const [txPending, setTxPending] = useState(false)
+  const [txHash, setTxHash] = useState<string | undefined>()
   const addTransaction = useTransactionAdder()
   const positionManager = useV3NFTPositionManagerContract()
   const burn = useCallback(async () => {
-    setAttemptingTxn(true)
+    setTxPending(true)
     if (
       !positionManager ||
       !liquidityValue0 ||
@@ -158,8 +158,8 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
               action: 'RemoveV3',
               label: [liquidityValue0.currency.symbol, liquidityValue1.currency.symbol].join('/'),
             })
-            setTxnHash(response.hash)
-            setAttemptingTxn(false)
+            setTxHash(response.hash)
+            setTxPending(false)
             addTransaction(response, {
               type: TransactionType.REMOVE_LIQUIDITY_V3,
               baseCurrencyId: currencyId(liquidityValue0.currency),
@@ -170,7 +170,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
           })
       })
       .catch((error) => {
-        setAttemptingTxn(false)
+        setTxPending(false)
         console.error(error)
       })
   }, [
@@ -193,12 +193,12 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
   const handleDismissConfirmation = useCallback(() => {
     setShowConfirm(false)
     // if there was a tx hash, we want to clear the input
-    if (txnHash) {
+    if (txHash) {
       onPercentSelectForSlider(0)
     }
-    setAttemptingTxn(false)
-    setTxnHash('')
-  }, [onPercentSelectForSlider, txnHash])
+    setTxPending(false)
+    setTxHash('')
+  }, [onPercentSelectForSlider, txHash])
 
   const pendingText = (
     <Trans>
@@ -281,8 +281,8 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
       <TransactionConfirmationModal
         isOpen={showConfirm}
         onDismiss={handleDismissConfirmation}
-        attemptingTxn={attemptingTxn}
-        hash={txnHash ?? ''}
+        pending={txPending}
+        hash={txHash ?? ''}
         content={() => (
           <ConfirmationModalContent
             title={<Trans>Remove Liquidity</Trans>}

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -79,7 +79,7 @@ function RemoveLiquidity() {
   // modal and loading
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
   const [showDetailed, setShowDetailed] = useState<boolean>(false)
-  const [attemptingTxn, setAttemptingTxn] = useState(false) // clicked confirm
+  const [txPending, setTxPending] = useState(false) // clicked confirm
 
   // txn values
   const [txHash, setTxHash] = useState<string>('')
@@ -268,12 +268,12 @@ function RemoveLiquidity() {
       const methodName = methodNames[indexOfSuccessfulEstimation]
       const safeGasEstimate = safeGasEstimates[indexOfSuccessfulEstimation]
 
-      setAttemptingTxn(true)
+      setTxPending(true)
       await router[methodName](...args, {
         gasLimit: safeGasEstimate,
       })
         .then((response: TransactionResponse) => {
-          setAttemptingTxn(false)
+          setTxPending(false)
 
           addTransaction(response, {
             type: TransactionType.REMOVE_LIQUIDITY_V3,
@@ -292,7 +292,7 @@ function RemoveLiquidity() {
           })
         })
         .catch((error: Error) => {
-          setAttemptingTxn(false)
+          setTxPending(false)
           // we only care if the error is something _other_ than the user rejected the tx
           console.error(error)
         })
@@ -447,7 +447,7 @@ function RemoveLiquidity() {
           <TransactionConfirmationModal
             isOpen={showConfirm}
             onDismiss={handleDismissConfirmation}
-            attemptingTxn={attemptingTxn}
+            pending={txPending}
             hash={txHash ? txHash : ''}
             content={() => (
               <ConfirmationModalContent

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -334,18 +334,18 @@ export function Swap({
   }, [navigate])
 
   // modal and loading
-  const [{ showConfirm, tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
-    showConfirm: boolean
-    tradeToConfirm: InterfaceTrade | undefined
-    attemptingTxn: boolean
-    swapErrorMessage: string | undefined
+  const [{ showConfirmSwapModal, originalTrade, swapErrorMessage, txPending, txHash }, setSwapState] = useState<{
+    showConfirmSwapModal: boolean
+    originalTrade: InterfaceTrade | undefined
+    txPending: boolean
     txHash: string | undefined
+    swapErrorMessage: string | undefined
   }>({
-    showConfirm: false,
-    tradeToConfirm: undefined,
-    attemptingTxn: false,
-    swapErrorMessage: undefined,
+    showConfirmSwapModal: false,
+    originalTrade: undefined,
+    txPending: false,
     txHash: undefined,
+    swapErrorMessage: undefined,
   })
 
   const formattedAmounts = useMemo(
@@ -419,17 +419,17 @@ export function Swap({
     }
     setSwapState((currentState) => ({
       ...currentState,
-      attemptingTxn: true,
-      swapErrorMessage: undefined,
+      txPending: true,
       txHash: undefined,
+      swapErrorMessage: undefined,
     }))
     swapCallback()
       .then((hash) => {
         setSwapState((currentState) => ({
           ...currentState,
-          attemptingTxn: false,
-          swapErrorMessage: undefined,
+          txPending: false,
           txHash: hash,
+          swapErrorMessage: undefined,
         }))
         sendEvent({
           category: 'Swap',
@@ -452,9 +452,9 @@ export function Swap({
       .catch((error) => {
         setSwapState((currentState) => ({
           ...currentState,
-          attemptingTxn: false,
-          swapErrorMessage: error.message,
+          txPending: false,
           txHash: undefined,
+          swapErrorMessage: error.message,
         }))
       })
   }, [
@@ -478,7 +478,7 @@ export function Swap({
   }, [stablecoinPriceImpact, trade])
 
   const handleConfirmDismiss = useCallback(() => {
-    setSwapState((currentState) => ({ ...currentState, showConfirm: false }))
+    setSwapState((currentState) => ({ ...currentState, showConfirmSwapModal: false }))
     // if there was a tx hash, we want to clear the input
     if (txHash) {
       onUserInput(Field.INPUT, '')
@@ -486,7 +486,7 @@ export function Swap({
   }, [onUserInput, txHash])
 
   const handleAcceptChanges = useCallback(() => {
-    setSwapState((currentState) => ({ ...currentState, tradeToConfirm: trade }))
+    setSwapState((currentState) => ({ ...currentState, originalTrade: trade }))
   }, [trade])
 
   const handleInputSelect = useCallback(
@@ -578,12 +578,12 @@ export function Swap({
         showCancel={true}
       />
       <SwapHeader autoSlippage={autoSlippage} />
-      {trade && showConfirm && (
+      {trade && showConfirmSwapModal && (
         <ConfirmSwapModal
           trade={trade}
-          originalTrade={tradeToConfirm}
+          originalTrade={originalTrade}
           onAcceptChanges={handleAcceptChanges}
-          attemptingTxn={attemptingTxn}
+          txPending={txPending}
           txHash={txHash}
           allowedSlippage={allowedSlippage}
           onConfirm={handleSwap}
@@ -781,11 +781,11 @@ export function Swap({
                   handleSwap()
                 } else {
                   setSwapState({
-                    tradeToConfirm: trade,
-                    attemptingTxn: false,
-                    swapErrorMessage: undefined,
-                    showConfirm: true,
+                    showConfirmSwapModal: true,
+                    originalTrade: trade,
+                    txPending: false,
                     txHash: undefined,
+                    swapErrorMessage: undefined,
                   })
                 }
               }}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Refactors state names for the swap confirmation modal to clarify a tricksy bit of code.
