### PR TITLE
fix: Simplify event logging for SWAP_QUOTE_RECEIVED

### DIFF
--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -61,8 +61,7 @@ export const formatSwapSignedAnalyticsEventProperties = ({
 
 export const formatSwapQuoteReceivedEventProperties = (
   trade: Trade<Currency, Currency, TradeType>,
-  gasUseEstimateUSD?: string,
-  fetchingSwapQuoteStartTime?: Date
+  gasUseEstimateUSD?: string
 ) => {
   return {
     token_in_symbol: trade.inputAmount.currency.symbol,
@@ -77,8 +76,5 @@ export const formatSwapQuoteReceivedEventProperties = (
         : undefined,
     token_in_amount: formatToDecimal(trade.inputAmount, trade.inputAmount.currency.decimals),
     token_out_amount: formatToDecimal(trade.outputAmount, trade.outputAmount.currency.decimals),
-    quote_latency_milliseconds: fetchingSwapQuoteStartTime
-      ? getDurationFromDateMilliseconds(fetchingSwapQuoteStartTime)
-      : undefined,
   }
 }


### PR DESCRIPTION
## Description
The previous version of the hook was infinite looping when `trade` is always defined, so simplify logic to just keep track of `trade` changes. Also removes the time-based logging since we have stats on the backend now


## Screen capture
No UI changes


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error
Throw in a console.log right before `sendAnalyticsEvent` and see it firing like 1 million times lol

