### PR TITLE
fix: allow unsupported chain in pwat

### DIFF
--- a/src/nft/hooks/usePermit2Approval.ts
+++ b/src/nft/hooks/usePermit2Approval.ts
@@ -3,6 +3,7 @@ import { InterfaceEventName } from '@uniswap/analytics-events'
 import { CurrencyAmount, SupportedChainId, Token } from '@uniswap/sdk-core'
 import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
 import { useWeb3React } from '@web3-react/core'
+import { isSupportedChain } from 'constants/chains'
 import usePermit2Allowance, { AllowanceState } from 'hooks/usePermit2Allowance'
 import { useCallback, useMemo, useState } from 'react'
 import invariant from 'tiny-invariant'
@@ -15,7 +16,7 @@ function getURAddress(chainId?: number, nftURAddress?: string) {
     return nftURAddress ?? UNIVERSAL_ROUTER_ADDRESS(chainId)
   }
 
-  return UNIVERSAL_ROUTER_ADDRESS(chainId)
+  return isSupportedChain(chainId) ? UNIVERSAL_ROUTER_ADDRESS(chainId) : undefined
 }
 
 export default function usePermit2Approval(


### PR DESCRIPTION
this logic was removed in #6127 which caused the bag not to fail properly when switching to an unsupported chain

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
