### PR TITLE
fix: searchbar showing incorrect spacing at medium size

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -134,11 +134,11 @@ export const SearchBar = () => {
     <Trace section={InterfaceSectionName.NAVBAR_SEARCH}>
       <Box
         data-cy="search-bar"
-        position={{ sm: 'fixed', md: 'absolute', xl: 'relative' }}
+        position={{ sm: 'fixed', md: 'absolute', navSearchInputVisible: 'relative' }}
         width={{ sm: isOpen ? 'viewWidth' : 'auto', md: 'auto' }}
         ref={searchRef}
         className={styles.searchBarContainerNft}
-        display={{ sm: isOpen ? 'inline-block' : 'none', xl: 'inline-block' }}
+        display={{ sm: isOpen ? 'inline-block' : 'none', navSearchInputVisible: 'inline-block' }}
       >
         <Row
           className={clsx(


### PR DESCRIPTION
## Description

Fixes searchbar height issue

<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2100


<!-- Delete this section if your change does not affect UI. -->
## Screen capture


Before:

<img width="626" alt="CleanShot 2023-05-23 at 12 48 25@2x" src="https://github.com/Uniswap/interface/assets/12100/9c1dc532-a6f9-46ca-bcc8-96c954940cf3">

After:

<img width="745" alt="CleanShot 2023-05-23 at 12 48 40@2x" src="https://github.com/Uniswap/interface/assets/12100/ebbe302f-a656-48a3-b91a-1e0b05c0698c">


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

On the main searchbar

<!-- Include steps to reproduce the bug. -->
1. Have to get the size to be above md but below xl where the search icon is small and to the right side, ~1075px wide works

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Resize browser to 1075px wide
- [ ] Open search
- [ ] Should have a normal display matching the wider width (above 1100px)


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->

All web browsers


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
