### PR TITLE
build: set null environment for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == 'main' && 'notify/test' }}
+      name: ${{ github.ref_name == 'main' && 'notify/test' || null }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Uses a "ternary" statement to set a null environment for the test.yml workflow.

This is necessary to avoid "temporarily deployed to false" commit comments on the PR, as described in https://github.com/orgs/community/discussions/36919#discussioncomment-4110859.