### PR TITLE
fix: reduce ETH amount on mainnet useUSDPrice request to 50

### DIFF
--- a/src/hooks/useUSDPrice.ts
+++ b/src/hooks/useUSDPrice.ts
@@ -13,7 +13,7 @@ import useStablecoinPrice from './useStablecoinPrice'
 // ETH amounts used when calculating spot price for a given currency.
 // The amount is large enough to filter low liquidity pairs.
 const ETH_AMOUNT_OUT: { [chainId: number]: CurrencyAmount<Currency> } = {
-  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.MAINNET), 100e18),
+  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.MAINNET), 50e18),
   [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.ARBITRUM_ONE), 10e18),
   [SupportedChainId.OPTIMISM]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.OPTIMISM), 10e18),
   [SupportedChainId.POLYGON]: CurrencyAmount.fromRawAmount(nativeOnChain(SupportedChainId.POLYGON), 10_000e18),


### PR DESCRIPTION
## Description
Reduces the ETH amount used to fetch the USD value of a token. This used to be 100 ETH, but that's a very aggressive quote which can lead to extra calls on the routing-api side to find the best route.

Instead, 50ETH is closer to the 100k USD amount we use on the `useStablecoinPrice` hook as well. We may eventually want a more dynamic way of setting this value.

## Test plan
### QA (ie manual testing)
- [x] Try quoting against a high liquidity token
- [x] Try quoting against a low liquidity token
<img width="516" alt="Screen Shot 2023-05-24 at 3 26 59 PM" src="https://github.com/Uniswap/interface/assets/4899429/d8926d65-d3f2-4bf7-a8ac-41e920f7d59a">
<img width="505" alt="Screen Shot 2023-05-24 at 3 27 13 PM" src="https://github.com/Uniswap/interface/assets/4899429/525d3ac1-5c5e-40d6-9985-babca63ed1e3">


### Automated testing
- [ ] Unit test
- [ ] Integration/E2E test