### PR TITLE
test(e2e): wait for usdc price to de-flake

### DIFF
--- a/cypress/e2e/swap/swap.test.ts
+++ b/cypress/e2e/swap/swap.test.ts
@@ -44,6 +44,9 @@ describe('Swap', () => {
         // Select USDC
         cy.get('#swap-currency-output .open-currency-select-button').click()
         cy.get(getTestSelector('token-search-input')).type(USDC_MAINNET.address)
+
+        // Wait for price to populate so we don't overload the hardhat node with calls
+        cy.get(`.token-item-${USDC_MAINNET.address}`).contains(initialBalance)
         cy.contains('USDC').click()
 
         // Enter amount to swap


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Waits for USDC price to load (from hardhat node) before continuing, to de-flake hardhat slowness.

### QA (ie manual testing)
I'll run this repeatedly on cypress to check for flakes 🤞 