### PR TITLE
test: skip SwapDetailsDropdown tests

### DIFF
--- a/src/components/swap/SwapDetailsDropdown.test.tsx
+++ b/src/components/swap/SwapDetailsDropdown.test.tsx
@@ -4,6 +4,7 @@ import { act, render, screen } from 'test-utils/render'
 
 import SwapDetailsDropdown from './SwapDetailsDropdown'
 
+// TODO(WEB-2120): Reenable tests after mocking trade fetch in this file
 describe.skip('SwapDetailsDropdown.tsx', () => {
   it('renders a trade', () => {
     const { asFragment } = render(

--- a/src/components/swap/SwapDetailsDropdown.test.tsx
+++ b/src/components/swap/SwapDetailsDropdown.test.tsx
@@ -4,7 +4,7 @@ import { act, render, screen } from 'test-utils/render'
 
 import SwapDetailsDropdown from './SwapDetailsDropdown'
 
-describe('SwapDetailsDropdown.tsx', () => {
+describe.skip('SwapDetailsDropdown.tsx', () => {
   it('renders a trade', () => {
     const { asFragment } = render(
       <SwapDetailsDropdown


### PR DESCRIPTION
Tests depend on network requests, which may cause flakiness. These tests should have the network requests mocked, then be re-enabled.
