### PR TITLE
fix: polygon bridge link leading to error page

### DIFF
--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -148,7 +148,7 @@ const CHAIN_INFO: ChainInfoMap = {
   [SupportedChainId.POLYGON]: {
     networkType: NetworkType.L1,
     blockWaitMsBeforeWarning: ms`10m`,
-    bridge: 'https://wallet.polygon.technology',
+    bridge: 'https://wallet.polygon.technology/polygon/bridge',
     docs: 'https://polygon.io/',
     explorer: 'https://polygonscan.com/',
     infoLink: 'https://info.uniswap.org/#/polygon/',

--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -148,7 +148,7 @@ const CHAIN_INFO: ChainInfoMap = {
   [SupportedChainId.POLYGON]: {
     networkType: NetworkType.L1,
     blockWaitMsBeforeWarning: ms`10m`,
-    bridge: 'https://wallet.polygon.technology/login',
+    bridge: 'https://wallet.polygon.technology',
     docs: 'https://polygon.io/',
     explorer: 'https://polygonscan.com/',
     infoLink: 'https://info.uniswap.org/#/polygon/',


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes the Polygon token bridge link on the Swap page when connected to the Polygon Network. Originally, the link took users to an Error 404 page before redirecting them to the proper bridging page.

Now the link takes users directly to the proper bridging page without navigating to the Error 404 page. This was done by changing the `bridge` link in `chainInfo.ts` from "https://wallet.polygon.technology/login" to "https://wallet.polygon.technology"


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2101

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Go to the Swap page and change network to Polygon
2. Click the "Polygon Token Bridge" banner

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Link redirects users to proper bridge page without error

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A

<img width="1240" alt="Screenshot 2023-05-30 at 9 57 47 AM" src="https://github.com/Uniswap/interface/assets/35351983/252b25e4-0947-476e-b863-12de2367a9a1">

<img width="1235" alt="Screenshot 2023-05-30 at 9 57 56 AM" src="https://github.com/Uniswap/interface/assets/35351983/7bc2df53-b5a5-4b12-a0c7-473664fe27cd">


