### PR TITLE
fix: token bridge pointer bug

### DIFF
--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components/macro'
 import { ExternalLink, HideSmall } from 'theme'
 import { colors } from 'theme/colors'
 import { useDarkModeManager } from 'theme/components/ThemeToggle'
+import { Z_INDEX } from 'theme/zIndex'
 
 import { AutoRow } from '../Row'
 
@@ -124,7 +125,7 @@ const LinkOutToBridge = styled(ExternalLink)`
   padding: 6px 8px;
   text-decoration: none !important;
   width: 100%;
-  z-index: 1;
+  z-index: ${Z_INDEX.hover};
 `
 
 const StyledArrowUpRight = styled(ArrowUpRight)`

--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -122,9 +122,9 @@ const LinkOutToBridge = styled(ExternalLink)`
   font-size: 16px;
   justify-content: space-between;
   padding: 6px 8px;
-  margin-right: 12px;
   text-decoration: none !important;
   width: 100%;
+  z-index: 1;
 `
 
 const StyledArrowUpRight = styled(ArrowUpRight)`


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Fixes the pointer bug when selecting the token bridge banner on the Swap page. Before the banner would not be selected if the pointer came from the left side. Now the banner is selected from all locations on the banner.

Accomplished by adding some CSS styling to the `LinkOutToBridge` tag in the `NetworkAlert` component. First set `z-index` to 1 due to some weird overlap between the `LinkOutToBridge` tag and the `ContentWrapper` tag. Also removed the `margin-right` as it was causing the link to not cover the entirety of the banner's area. 


<!-- Delete inapplicable lines: -->
_Linear ticket:_ Web-2102


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before



https://github.com/Uniswap/interface/assets/35351983/24d40a41-be51-4c84-bb32-9911afeca78b




### After


https://github.com/Uniswap/interface/assets/35351983/eb7242d3-3f17-4d19-bb26-3b74bba42743




## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Go to the Swap page and change network to Polygon
2. Try and hover over the banner from the left side

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Test to make sure banner selected on all chains and that it redirects properly


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
