### PR TITLE
fix: use ConfirmSwapModal in expert mode

### DIFF
--- a/src/nft/components/details/detailsV2/__snapshots__/DataPage.test.tsx.snap
+++ b/src/nft/components/details/detailsV2/__snapshots__/DataPage.test.tsx.snap
@@ -558,7 +558,7 @@ exports[`data page loads with header showing 1`] = `
             </div>
           </div>
           <div
-            class="reset_base__1klryar0 sprinkles_display_flex_sm__rgw6ez4ry sprinkles_flexDirection_row_sm__rgw6ez4uh sprinkles_alignItems_center_sm__rgw6ez3k c27"
+            class="reset_base__1klryar0 sprinkles_display_flex_sm__rgw6ez4t4 sprinkles_flexDirection_row_sm__rgw6ez4vn sprinkles_alignItems_center_sm__rgw6ez3k c27"
           >
             <span>
               Activity Content
@@ -1159,7 +1159,7 @@ exports[`data page loads without header showing 1`] = `
             </div>
           </div>
           <div
-            class="reset_base__1klryar0 sprinkles_display_flex_sm__rgw6ez4ry sprinkles_flexDirection_row_sm__rgw6ez4uh sprinkles_alignItems_center_sm__rgw6ez3k c27"
+            class="reset_base__1klryar0 sprinkles_display_flex_sm__rgw6ez4t4 sprinkles_flexDirection_row_sm__rgw6ez4vn sprinkles_alignItems_center_sm__rgw6ez3k c27"
           >
             <span>
               Activity Content

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -699,17 +699,13 @@ export function Swap({
             >
               <ButtonError
                 onClick={() => {
-                  if (isExpertMode) {
-                    handleSwap()
-                  } else {
-                    setSwapState({
-                      tradeToConfirm: trade,
-                      attemptingTxn: false,
-                      swapError: undefined,
-                      showConfirm: true,
-                      txHash: undefined,
-                    })
-                  }
+                  setSwapState({
+                    tradeToConfirm: trade,
+                    attemptingTxn: false,
+                    swapError: undefined,
+                    showConfirm: true,
+                    txHash: undefined,
+                  })
                 }}
                 id="swap-button"
                 data-testid="swap-button"


### PR DESCRIPTION
Fixes the swap flow for users who are still in expert mode  and need permit2 approvals for a token

### test plan

added e2e test for full permit2 flow with expert mode enabled. 

failing test without the change:
<img width="1394" alt="Screenshot 2023-05-31 at 2 24 12 PM" src="https://github.com/Uniswap/interface/assets/66155195/6a39e039-31b5-4bce-91d2-5e3ebc777378">


passing test with change in the CI of this PR