### PR TITLE
fix: use ConfirmSwapModal in expert mode

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -693,17 +693,13 @@ export function Swap({
           ) : (
             <ButtonError
               onClick={() => {
-                if (isExpertMode) {
-                  handleSwap()
-                } else {
-                  setSwapState({
-                    tradeToConfirm: trade,
-                    attemptingTxn: false,
-                    swapError: undefined,
-                    showConfirm: true,
-                    txHash: undefined,
-                  })
-                }
+                setSwapState({
+                  tradeToConfirm: trade,
+                  attemptingTxn: false,
+                  swapError: undefined,
+                  showConfirm: true,
+                  txHash: undefined,
+                })
               }}
               id="swap-button"
               data-testid="swap-button"


### PR DESCRIPTION
Fixes the swap flow for users who are still in expert mode  and need permit2 approvals for a token

### test plan

added e2e test for full permit2 flow with expert mode enabled. 

failing test without the change:
<img width="1394" alt="Screenshot 2023-05-31 at 2 24 12 PM" src="https://github.com/Uniswap/interface/assets/66155195/6a39e039-31b5-4bce-91d2-5e3ebc777378">


passing test with change in the CI of this PR


### plan to merge this fix into `main`

PR already exists: https://github.com/Uniswap/interface/pull/6673?no-redirect=1