### PR TITLE
fix: info labels for extended list tokens

### DIFF
--- a/src/components/TokenSafety/TokenSafetyMessage.tsx
+++ b/src/components/TokenSafety/TokenSafetyMessage.tsx
@@ -11,6 +11,7 @@ const Label = styled.div<{ color: string; backgroundColor: string }>`
   padding: 12px 20px 16px;
   background-color: ${({ backgroundColor }) => backgroundColor};
   border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.backgroundOutline};
   color: ${({ color }) => color};
 `
 
@@ -35,7 +36,8 @@ const DetailsRow = styled.div`
 `
 
 const StyledLink = styled(ExternalLink)`
-  color: ${({ theme }) => theme.textSecondary};
+  color: ${({ theme }) => theme.accentAction};
+
   font-weight: 700;
 `
 
@@ -51,10 +53,12 @@ export default function TokenSafetyMessage({ warning, tokenAddress }: TokenSafet
 
   return (
     <Label data-cy="token-safety-message" color={textColor} backgroundColor={backgroundColor}>
-      <TitleRow>
-        {warning.canProceed ? <AlertTriangle size="16px" /> : <Slash size="16px" />}
-        <Title marginLeft="7px">{warning.message}</Title>
-      </TitleRow>
+      {warning.displayLabel && (
+        <TitleRow>
+          {warning.canProceed ? <AlertTriangle size="16px" /> : <Slash size="16px" />}
+          <Title marginLeft="7px">{warning.message}</Title>
+        </TitleRow>
+      )}
 
       <DetailsRow>
         {heading}

--- a/src/components/TokenSafety/index.tsx
+++ b/src/components/TokenSafety/index.tsx
@@ -85,7 +85,7 @@ const Buttons = ({
   return warning.canProceed ? (
     <>
       <StyledButton onClick={onContinue}>
-        <Trans>I understand</Trans>
+        {warning.level === WARNING_LEVEL.MEDIUM ? <Trans>Continue</Trans> : <Trans>I understand</Trans>}
       </StyledButton>
       {showCancel && <StyledCancelButton onClick={onCancel}>Cancel</StyledCancelButton>}
     </>
@@ -183,7 +183,7 @@ function ExplorerView({ token }: { token: Token }) {
 }
 
 const StyledExternalLink = styled(ExternalLink)`
-  color: ${({ theme }) => theme.textSecondary};
+  color: ${({ theme }) => theme.accentAction};
   stroke: currentColor;
   font-weight: 600;
 `
@@ -255,6 +255,7 @@ export default function TokenSafety({
     level: WARNING_LEVEL.UNKNOWN,
     message: <Trans>Token not found</Trans>,
     canProceed: false,
+    displayLabel: true,
   }
 
   return displayWarning ? (
@@ -263,9 +264,11 @@ export default function TokenSafety({
         <AutoColumn>
           <LogoContainer>{logos}</LogoContainer>
         </AutoColumn>
-        <ShortColumn>
-          <SafetyLabel warning={displayWarning} />
-        </ShortColumn>
+        {displayWarning.displayLabel && (
+          <ShortColumn>
+            <SafetyLabel warning={displayWarning} />
+          </ShortColumn>
+        )}
         <ShortColumn>
           <InfoText>
             {heading} {description} {learnMoreUrl}

--- a/src/constants/tokenSafety.tsx
+++ b/src/constants/tokenSafety.tsx
@@ -58,24 +58,28 @@ export type Warning = {
   message: JSX.Element
   /** Determines whether triangle/slash alert icon is used, and whether this token is supported/able to be traded. */
   canProceed: boolean
+  displayLabel: boolean
 }
 
 const MediumWarning: Warning = {
   level: WARNING_LEVEL.MEDIUM,
   message: <Trans>Caution</Trans>,
   canProceed: true,
+  displayLabel: false,
 }
 
 const StrongWarning: Warning = {
   level: WARNING_LEVEL.UNKNOWN,
   message: <Trans>Warning</Trans>,
   canProceed: true,
+  displayLabel: true,
 }
 
 const BlockedWarning: Warning = {
   level: WARNING_LEVEL.BLOCKED,
   message: <Trans>Not Available</Trans>,
   canProceed: false,
+  displayLabel: true,
 }
 
 export function checkWarning(tokenAddress: string) {

--- a/src/hooks/useTokenWarningColor.ts
+++ b/src/hooks/useTokenWarningColor.ts
@@ -19,7 +19,7 @@ export const useTokenWarningColor = (level: WARNING_LEVEL) => {
 
   switch (level) {
     case WARNING_LEVEL.MEDIUM:
-      return theme.accentWarningSoft
+      return theme.backgroundFloating
     case WARNING_LEVEL.UNKNOWN:
       return theme.accentFailureSoft
     case WARNING_LEVEL.BLOCKED:


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2017


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="1512" alt="Screenshot 2023-06-01 at 10 45 20 AM" src="https://github.com/Uniswap/interface/assets/35351983/99915f17-4cba-41f9-b27e-2ceec9bdb8d9">
<img width="1512" alt="Screenshot 2023-06-01 at 10 45 51 AM" src="https://github.com/Uniswap/interface/assets/35351983/94be3d17-d7ec-45bd-94ba-7f9544a5e8c5">
<img width="1512" alt="Screenshot 2023-06-01 at 10 46 01 AM" src="https://github.com/Uniswap/interface/assets/35351983/7f528d95-6421-43fd-bd74-15e0781d8273">


### After
<img width="1512" alt="Screenshot 2023-06-01 at 10 46 33 AM" src="https://github.com/Uniswap/interface/assets/35351983/78c7ca86-8f25-4912-8fb3-857f0b04401c">
<img width="1512" alt="Screenshot 2023-06-01 at 10 46 56 AM" src="https://github.com/Uniswap/interface/assets/35351983/f5987406-564a-4d6e-91e6-926ab8a57dba">

<img width="1512" alt="Screenshot 2023-06-01 at 10 47 03 AM" src="https://github.com/Uniswap/interface/assets/35351983/0536fcaf-46f9-4cc6-9e89-1878e8995b78">



## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Test tokens on [extended list](https://docs.google.com/spreadsheets/d/1mdRA4ee1aDSYql2hl9T84hBNYnBlMLhuM8LdGosnH4o/edit#gid=1672828529) to make sure that they show info label instead of caution label
- [x] Make sure unknown and tokens not on the extended label still display warning  

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
