### PR TITLE
fix: update arbitrum subgraph

### DIFF
--- a/src/graphql/thegraph/apollo.ts
+++ b/src/graphql/thegraph/apollo.ts
@@ -5,15 +5,10 @@ import store from '../../state/index'
 
 const CHAIN_SUBGRAPH_URL: Record<number, string> = {
   [SupportedChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
-
-  [SupportedChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-minimal',
-
+  [SupportedChainId.ARBITRUM_ONE]: 'https://thegraph.com/hosted-service/subgraph/ianlapham/uniswap-arbitrum-one',
   [SupportedChainId.OPTIMISM]: 'https://api.thegraph.com/subgraphs/name/ianlapham/optimism-post-regenesis',
-
   [SupportedChainId.POLYGON]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-polygon',
-
   [SupportedChainId.CELO]: 'https://api.thegraph.com/subgraphs/name/jesse-sawa/uniswap-celo',
-
   [SupportedChainId.BNB]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-bsc',
 }
 


### PR DESCRIPTION
## Description
Uses the latest subgraph for arbitrum data. This doesn't resolve the CX linked within that ticket, but it will make sure we use a more recently updated graph.

_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2031/switch-out-arbitrum-subgraph-for-updated-one

### QA (ie manual testing)
- [x] Test all the position pages
- [x] Test mini portfolio
- [x] Test token details pages

### Automated testing
- [ ] Unit test
- [ ] Integration/E2E test

As long as existing tests pass, I think that's good.