### PR TITLE
feat: Add Circle native Arbitrum USDC to common base tokens in token selector

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.test.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.test.tsx
@@ -1,6 +1,6 @@
 import { SupportedChainId } from '@uniswap/sdk-core'
 import { DAI_ARBITRUM } from '@uniswap/smart-order-router'
-import { DAI, USDC_ARBITRUM, USDC_MAINNET } from 'constants/tokens'
+import { BRIDGED_USDC_ARBITRUM, DAI, USDC_MAINNET } from 'constants/tokens'
 import { render } from 'test-utils/render'
 
 import { PortfolioLogo } from './PortfolioLogo'
@@ -13,7 +13,7 @@ describe('PortfolioLogo', () => {
 
   it('renders with L2 icon', () => {
     const { container } = render(
-      <PortfolioLogo chainId={SupportedChainId.ARBITRUM_ONE} currencies={[DAI_ARBITRUM, USDC_ARBITRUM]} />
+      <PortfolioLogo chainId={SupportedChainId.ARBITRUM_ONE} currencies={[DAI_ARBITRUM, BRIDGED_USDC_ARBITRUM]} />
     )
     expect(container).toMatchSnapshot()
   })

--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -1,4 +1,5 @@
 import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'featureFlags'
+import { useNativeUSDCArbitrumFlag } from 'featureFlags/flags/nativeUsdcArbitrum'
 import { DetailsV2Variant, useDetailsV2Flag } from 'featureFlags/flags/nftDetails'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { UnifiedRouterVariant, useUnifiedRoutingAPIFlag } from 'featureFlags/flags/unifiedRouter'
@@ -213,6 +214,12 @@ export default function FeatureFlagModal() {
         value={useUnifiedRoutingAPIFlag()}
         featureFlag={FeatureFlag.uraEnabled}
         label="Enable the Unified Routing API"
+      />
+      <FeatureFlagOption
+        variant={BaseVariant}
+        value={useNativeUSDCArbitrumFlag()}
+        featureFlag={FeatureFlag.nativeUsdcArbitrum}
+        label="Enable Circle native USDC on Arbitrum"
       />
       <FeatureFlagGroup name="Debug">
         <FeatureFlagOption

--- a/src/components/SearchModal/CommonBases.tsx
+++ b/src/components/SearchModal/CommonBases.tsx
@@ -4,7 +4,8 @@ import { Currency } from '@uniswap/sdk-core'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/Logo/CurrencyLogo'
 import { AutoRow } from 'components/Row'
-import { COMMON_BASES } from 'constants/routing'
+import { COMMON_BASES, COMMON_BASES_V2 } from 'constants/routing'
+import { useNativeUSDCArbitrumEnabled } from 'featureFlags/flags/nativeUsdcArbitrum'
 import { useTokenInfoFromActiveList } from 'hooks/useTokenInfoFromActiveList'
 import { getTokenAddress } from 'lib/utils/analytics'
 import { Text } from 'rebass'
@@ -59,7 +60,9 @@ export default function CommonBases({
   searchQuery: string
   isAddressSearch: string | false
 }) {
-  const bases = typeof chainId !== 'undefined' ? COMMON_BASES[chainId] ?? [] : []
+  const nativeUsdcArbitrumEnabled = useNativeUSDCArbitrumEnabled()
+  const commonBases = nativeUsdcArbitrumEnabled ? COMMON_BASES_V2 : COMMON_BASES
+  const bases = chainId !== undefined ? commonBases[chainId] ?? [] : []
 
   return bases.length > 0 ? (
     <MobileWrapper gap="md">

--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -4,6 +4,7 @@ import { SupportedChainId } from 'constants/chains'
 
 import {
   AMPL,
+  BRIDGED_USDC_ARBITRUM,
   BTC_BSC,
   BUSD_BSC,
   CAKE_BSC,
@@ -149,7 +150,7 @@ export const COMMON_BASES: ChainCurrencyList = {
   [SupportedChainId.ARBITRUM_ONE]: [
     nativeOnChain(SupportedChainId.ARBITRUM_ONE),
     DAI_ARBITRUM_ONE,
-    USDC_ARBITRUM,
+    BRIDGED_USDC_ARBITRUM,
     USDT_ARBITRUM_ONE,
     WBTC_ARBITRUM_ONE,
     WRAPPED_NATIVE_CURRENCY[SupportedChainId.ARBITRUM_ONE] as Token,
@@ -203,6 +204,19 @@ export const COMMON_BASES: ChainCurrencyList = {
     ETH_BSC,
     BTC_BSC,
     BUSD_BSC,
+  ],
+}
+
+// This is the same as COMMON_BASES except it swaps out Bridged USDC on arbitrum for native USDC.
+export const COMMON_BASES_V2: ChainCurrencyList = {
+  ...COMMON_BASES,
+  [SupportedChainId.ARBITRUM_ONE]: [
+    nativeOnChain(SupportedChainId.ARBITRUM_ONE),
+    DAI_ARBITRUM_ONE,
+    USDC_ARBITRUM,
+    USDT_ARBITRUM_ONE,
+    WBTC_ARBITRUM_ONE,
+    WRAPPED_NATIVE_CURRENCY[SupportedChainId.ARBITRUM_ONE] as Token,
   ],
 }
 

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -39,9 +39,16 @@ const USDC_OPTIMISM_GOERLI = new Token(
   'USDC',
   'USD//C'
 )
-export const USDC_ARBITRUM = new Token(
+export const BRIDGED_USDC_ARBITRUM = new Token(
   SupportedChainId.ARBITRUM_ONE,
   '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+  6,
+  'USDC',
+  'USD//C'
+)
+export const USDC_ARBITRUM = new Token(
+  SupportedChainId.ARBITRUM_ONE,
+  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   6,
   'USDC',
   'USD//C'
@@ -533,7 +540,7 @@ export function getSwapCurrencyId(currency: Currency): string {
 export const TOKEN_SHORTHANDS: { [shorthand: string]: { [chainId in SupportedChainId]?: string } } = {
   USDC: {
     [SupportedChainId.MAINNET]: USDC_MAINNET.address,
-    [SupportedChainId.ARBITRUM_ONE]: USDC_ARBITRUM.address,
+    [SupportedChainId.ARBITRUM_ONE]: BRIDGED_USDC_ARBITRUM.address,
     [SupportedChainId.ARBITRUM_GOERLI]: USDC_ARBITRUM_GOERLI.address,
     [SupportedChainId.OPTIMISM]: USDC_OPTIMISM.address,
     [SupportedChainId.OPTIMISM_GOERLI]: USDC_OPTIMISM_GOERLI.address,

--- a/src/featureFlags/flags/nativeUsdcArbitrum.ts
+++ b/src/featureFlags/flags/nativeUsdcArbitrum.ts
@@ -1,6 +1,6 @@
 import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
 
-function useNativeUSDCArbitrumFlag(): BaseVariant {
+export function useNativeUSDCArbitrumFlag(): BaseVariant {
   return useBaseFlag(FeatureFlag.nativeUsdcArbitrum)
 }
 

--- a/src/featureFlags/flags/nativeUsdcArbitrum.ts
+++ b/src/featureFlags/flags/nativeUsdcArbitrum.ts
@@ -1,0 +1,9 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+function useNativeUSDCArbitrumFlag(): BaseVariant {
+  return useBaseFlag(FeatureFlag.nativeUsdcArbitrum)
+}
+
+export function useNativeUSDCArbitrumEnabled(): boolean {
+  return useNativeUSDCArbitrumFlag() === BaseVariant.Enabled
+}

--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -12,6 +12,7 @@ export enum FeatureFlag {
   detailsV2 = 'details_v2',
   uraEnabled = 'ura_enabled',
   debounceSwapQuote = 'debounce_swap_quote',
+  nativeUsdcArbitrum = 'web_usdc_arbitrum',
 }
 
 interface FeatureFlagsContextType {

--- a/src/hooks/useStablecoinPrice.ts
+++ b/src/hooks/useStablecoinPrice.ts
@@ -6,13 +6,20 @@ import { useMemo, useRef } from 'react'
 import { INTERNAL_ROUTER_PREFERENCE_PRICE } from 'state/routing/slice'
 import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
 
-import { CUSD_CELO, DAI_OPTIMISM, USDC_ARBITRUM, USDC_MAINNET, USDC_POLYGON, USDT_BSC } from '../constants/tokens'
+import {
+  BRIDGED_USDC_ARBITRUM,
+  CUSD_CELO,
+  DAI_OPTIMISM,
+  USDC_MAINNET,
+  USDC_POLYGON,
+  USDT_BSC,
+} from '../constants/tokens'
 
 // Stablecoin amounts used when calculating spot price for a given currency.
 // The amount is large enough to filter low liquidity pairs.
 const STABLECOIN_AMOUNT_OUT: { [chainId: number]: CurrencyAmount<Token> } = {
   [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC_MAINNET, 100_000e6),
-  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC_ARBITRUM, 10_000e6),
+  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(BRIDGED_USDC_ARBITRUM, 10_000e6),
   [SupportedChainId.OPTIMISM]: CurrencyAmount.fromRawAmount(DAI_OPTIMISM, 10_000e18),
   [SupportedChainId.POLYGON]: CurrencyAmount.fromRawAmount(USDC_POLYGON, 10_000e6),
   [SupportedChainId.CELO]: CurrencyAmount.fromRawAmount(CUSD_CELO, 10_000e18),


### PR DESCRIPTION
This PR adds native USDC on arbitrum behind a feature flag that should be flipped on June 8th, the launch date.

Note: We should remove the legacy logic once native USDC is fully launched :D 

Enabled state:
<img width="628" alt="image" src="https://github.com/Uniswap/interface/assets/59578595/47a5d485-b863-4436-a443-792db8234701">

Note we don't have the token logo yet because it's not available as part of any token lists. But as soon as any of our token list providers (including our own) adds, it will be available :D 