### PR TITLE
fix: Bug with flipping ura feature flag on/off in dev mode

### DIFF
--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -71,9 +71,9 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     refetchOnMountOrArgChange: 2 * 60,
   })
 
-  const tradeResult = v2TradeResult ?? legacyAPITradeResult
-  const currentTradeResult = currentLegacyAPITradeResult ?? currentV2TradeResult
-  const isError = isLegacyAPIError || isV2APIError
+  const [tradeResult, currentTradeResult, isError] = shouldUseRoutingApiV2
+    ? [v2TradeResult, currentV2TradeResult, isV2APIError]
+    : [legacyAPITradeResult, currentLegacyAPITradeResult, isLegacyAPIError]
 
   const isCurrent = currentTradeResult === tradeResult
 


### PR DESCRIPTION
This fixes a bug with the URA feature flagging logic where turning it on/off without reloading the page will cause stale trade results to show on the page (because both v2 trades and legacy trades can be cached in rtk-query). Note this is only a problem in dev/staging mode because regular feature flagging logic only resets on page loads, so only one of the trades can be defined at a time.
