### PR TITLE
fix: use coned function for chart prices

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import { formatUSDPrice } from '@uniswap/conedison/format'
 import { AxisBottom, TickFormatter } from '@visx/axis'
 import { localPoint } from '@visx/event'
 import { EventType } from '@visx/event/lib/types'
@@ -23,7 +24,6 @@ import {
   monthYearDayFormatter,
   weekFormatter,
 } from 'utils/formatChartTimes'
-import { formatDollar } from 'utils/formatNumbers'
 
 const DATA_EMPTY = { value: 0, timestamp: 0 }
 
@@ -276,7 +276,7 @@ export function PriceChart({ width, height, prices: originalPrices, timePeriod }
       <ChartHeader data-cy="chart-header">
         {displayPrice.value ? (
           <>
-            <TokenPrice>{formatDollar({ num: displayPrice.value, isPrice: true })}</TokenPrice>
+            <TokenPrice>{formatUSDPrice(displayPrice.value)}</TokenPrice>
             <DeltaContainer>
               {formattedDelta}
               <ArrowCell>{arrow}</ArrowCell>

--- a/src/utils/formatNumbers.test.ts
+++ b/src/utils/formatNumbers.test.ts
@@ -1,12 +1,7 @@
 import { CurrencyAmount, Price } from '@uniswap/sdk-core'
 import { renBTC, USDC_MAINNET } from 'constants/tokens'
 
-import {
-  currencyAmountToPreciseFloat,
-  formatDollar,
-  formatTransactionAmount,
-  priceToPreciseFloat,
-} from './formatNumbers'
+import { currencyAmountToPreciseFloat, formatTransactionAmount, priceToPreciseFloat } from './formatNumbers'
 
 describe('currencyAmountToPreciseFloat', () => {
   it('small number', () => {
@@ -90,65 +85,5 @@ describe('formatTransactionAmount', () => {
   it('Number ≥ 1M extra long', () => {
     // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
     expect(formatTransactionAmount(1234567890123456.789)).toEqual('1.234568e+15')
-  })
-})
-
-describe('formatDollar for a price', () => {
-  const isPrice = true
-  it('undefined or null', () => {
-    expect(formatDollar({ num: undefined, isPrice })).toEqual('-')
-    expect(formatDollar({ num: null, isPrice })).toEqual('-')
-  })
-  it('0', () => {
-    expect(formatDollar({ num: 0, isPrice })).toEqual('$0.00')
-  })
-  it('< 0.000001', () => {
-    expect(formatDollar({ num: 0.00000000011231231432, isPrice })).toEqual('$1.12e-10')
-  })
-  it('num >= 0.000001 && num < 0.1', () => {
-    expect(formatDollar({ num: 0.00123123124, isPrice })).toEqual('$0.00123')
-  })
-  it('num >= 0.1 && num < 1.05', () => {
-    expect(formatDollar({ num: 0.812831, isPrice })).toEqual('$0.813')
-  })
-  it('lessPreciseStablecoinValues number less than 1, rounds to 0.999', () => {
-    expect(formatDollar({ num: 0.9994, isPrice, lessPreciseStablecoinValues: true })).toEqual('$0.999')
-  })
-  it('lessPreciseStablecoinValues number less than, rounds to 1.00', () => {
-    expect(formatDollar({ num: 0.9995, isPrice, lessPreciseStablecoinValues: true })).toEqual('$1.00')
-  })
-  it('lessPreciseStablecoinValues number greater than 1', () => {
-    expect(formatDollar({ num: 1.0000001, isPrice, lessPreciseStablecoinValues: true })).toEqual('$1.00')
-  })
-  it('number is greater than 1 million', () => {
-    expect(formatDollar({ num: 11192312.408, isPrice })).toEqual('$1.12e+7')
-  })
-  it('number in the thousands', () => {
-    expect(formatDollar({ num: 1234.408, isPrice })).toEqual('$1,234.41')
-  })
-  it('number is greater than 1.05', () => {
-    expect(formatDollar({ num: 102312.408, isPrice })).toEqual('$102,312.41')
-  })
-})
-
-describe('formatDollar for a non-price amount', () => {
-  it('undefined or null', () => {
-    expect(formatDollar({ num: undefined })).toEqual('-')
-    expect(formatDollar({ num: null })).toEqual('-')
-  })
-  it('0', () => {
-    expect(formatDollar({ num: 0 })).toEqual('$0.00')
-  })
-  it('< 0.000001', () => {
-    expect(formatDollar({ num: 0.0000000001 })).toEqual('$<0.000001')
-  })
-  it('num >= 0.000001 && num < 0.1', () => {
-    expect(formatDollar({ num: 0.00123123124 })).toEqual('$0.00123')
-  })
-  it('num >= 0.1 && num < 1.05', () => {
-    expect(formatDollar({ num: 0.812831 })).toEqual('$0.813')
-  })
-  it('number is greater than 1.05', () => {
-    expect(formatDollar({ num: 102312.408 })).toEqual('$102.31K')
   })
 })

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -1,7 +1,6 @@
 /* Copied from Uniswap/v-3: https://github.com/Uniswap/v3-info/blob/master/src/utils/numbers.ts */
 import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 import { DEFAULT_LOCALE } from 'constants/locales'
-import numbro from 'numbro'
 
 // Convert [CurrencyAmount] to number with necessary precision for price formatting.
 export const currencyAmountToPreciseFloat = (currencyAmount: CurrencyAmount<Currency> | undefined) => {
@@ -21,78 +20,6 @@ export const priceToPreciseFloat = (price: Price<Currency, Currency> | undefined
     return parseFloat(price.toSignificant(6))
   }
   return floatForLargerNumbers
-}
-
-interface FormatDollarArgs {
-  num?: number | null
-  isPrice?: boolean
-  lessPreciseStablecoinValues?: boolean
-  digits?: number
-  round?: boolean
-}
-
-/**
- * Returns a USD dollar or equivalent denominated numerical value formatted
- * in human readable string for use in template.
- *
- * Adheres to guidelines for prices and other numbers defined here:
- * https://www.notion.so/uniswaplabs/Number-standards-fbb9f533f10e4e22820722c2f66d23c0
- * @param num numerical value denominated in USD or USD equivalent
- * @param isPrice whether the amount represents a price or not
- * @param lessPreciseStablecoinValues whether or not we should show less precise values for
- * stablecoins (around 1$ in value always) for the sake of readability
- * @param digits number of digits after the decimal for non-price amounts
- * @param round whether or not to round up non-price amounts
- */
-export const formatDollar = ({
-  num,
-  isPrice = false,
-  lessPreciseStablecoinValues = false,
-  digits = 2,
-  round = true,
-}: FormatDollarArgs): string => {
-  // For USD dollar denominated prices.
-  if (isPrice) {
-    if (num === 0) return '$0.00'
-    if (!num) return '-'
-    if (num < 0.000001) {
-      return `$${num.toExponential(2)}`
-    }
-    if ((num >= 0.000001 && num < 0.1) || num > 1000000) {
-      return `$${Number(num).toPrecision(3)}`
-    }
-    // We only show 2 decimal places in explore table for stablecoin value ranges
-    // for the sake of readability (as opposed to the usual 3 elsewhere).
-    if (num >= 0.1 && num < (lessPreciseStablecoinValues ? 0.9995 : 1.05)) {
-      return `$${num.toFixed(3)}`
-    }
-    return `$${Number(num.toFixed(2)).toLocaleString(DEFAULT_LOCALE, { minimumFractionDigits: 2 })}`
-  }
-  // For volume dollar amounts, like market cap, total value locked, etc.
-  else {
-    if (num === 0) return '$0.00'
-    if (!num) return '-'
-    if (num < 0.000001) {
-      return '$<0.000001'
-    }
-    if (num >= 0.000001 && num < 0.1) {
-      return `$${Number(num).toPrecision(3)}`
-    }
-    if (num >= 0.1 && num < 1.05) {
-      return `$${num.toFixed(3)}`
-    }
-
-    return numbro(num)
-      .formatCurrency({
-        average: round,
-        mantissa: num > 1000 ? 2 : digits,
-        abbreviations: {
-          million: 'M',
-          billion: 'B',
-        },
-      })
-      .toUpperCase()
-  }
 }
 
 /**


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Uses coned formatUSDPrice function and deletes formatDollar function from the repo. This fixes an issue where stablecoin prices had three trailing 0's

<!-- Delete inapplicable lines: -->
[Linear ticket](https://linear.app/uniswap/issue/WEB-2063/token-explore-stablecoins-should-only-have-2-decimals)


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="358" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/341d9d48-128b-4ed0-be8e-a7eb3bdb2607">


### After
<img width="332" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/ddefad2d-95e8-4fd4-9b37-711d4a2864ee">


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] View charts of stablecoins, expect to see $1.00
- [ ] View charts of less-stable stablecoins (LUSD) and ensure we still are displaying enough decimals
- [ ] View charts of lowest priced tokens & highest priced tokens


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
