### PR TITLE
fix: Trust wallet loading state

### DIFF
--- a/src/components/NavBar/ChainSelectorRow.tsx
+++ b/src/components/NavBar/ChainSelectorRow.tsx
@@ -96,7 +96,7 @@ export default function ChainSelectorRow({ disabled, targetChain, onSelectChain,
       )}
       <Status>
         {active && <CheckMarkIcon width={LOGO_SIZE} height={LOGO_SIZE} color={theme.accentActive} />}
-        {isPending && <Loader width={LOGO_SIZE} height={LOGO_SIZE} />}
+        {!active && isPending && <Loader width={LOGO_SIZE} height={LOGO_SIZE} />}
       </Status>
     </Container>
   )


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes the wallet connect loading state on network switch for Trust Wallet.

Prior to changes, all wallets (not just Trust Wallet) had an issue where the  `CheckMarkIcon` and `Loader` would appear at the same time. However, due to what I assume is a faster response rate?? within the other wallets, the ChainSelector menu would close almost immediately causing the issue to not be seen. However, with Trust Wallet, which has a slower response rate?? this issue is exacerbated making the issue more apparent.

Added an additional condition to display the `Loader` so that once we are on the current chain, it only displays the `CheckMarkIcon` while it waits for the ChainSelector to recognize the change the close the menu automatically.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2011


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

https://github.com/Uniswap/interface/assets/35351983/1da5dd25-185f-48ad-8bf4-839c30775a46




### After


https://github.com/Uniswap/interface/assets/35351983/ecf7cf39-64fe-4cef-903f-5e459fbbd439



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Switch Networks while using Trust Wallet

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Check with Trust Wallet and other Wallets to ensure that the ChainSelector still works

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
