### PR TITLE
fix: swaps with native currency destination in BNB Chain 

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -489,7 +489,7 @@ function getCeloNativeCurrency(chainId: number) {
   }
 }
 
-function isMatic(chainId: number): chainId is SupportedChainId.POLYGON | SupportedChainId.POLYGON_MUMBAI {
+export function isMatic(chainId: number): chainId is SupportedChainId.POLYGON | SupportedChainId.POLYGON_MUMBAI {
   return chainId === SupportedChainId.POLYGON_MUMBAI || chainId === SupportedChainId.POLYGON
 }
 
@@ -511,7 +511,7 @@ class MaticNativeCurrency extends NativeCurrency {
   }
 }
 
-function isBsc(chainId: number): chainId is SupportedChainId.BNB {
+export function isBsc(chainId: number): chainId is SupportedChainId.BNB {
   return chainId === SupportedChainId.BNB
 }
 

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -145,8 +145,10 @@ export enum PoolType {
 }
 
 // swap router API special cases these strings to represent native currencies
-// all chains have "ETH" as native currency symbol except for polygon
+// all chains except for bnb chain and polygon
+// have "ETH" as native currency symbol
 export enum SwapRouterNativeAssets {
   MATIC = 'MATIC',
+  BNB = 'BNB',
   ETH = 'ETH',
 }

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -3,9 +3,8 @@ import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 import { AlphaRouter, ChainId } from '@uniswap/smart-order-router'
 import { Pair, Route as V2Route } from '@uniswap/v2-sdk'
 import { FeeAmount, Pool, Route as V3Route } from '@uniswap/v3-sdk'
-import { isPolygonChain } from 'constants/chains'
 import { RPC_PROVIDERS } from 'constants/providers'
-import { nativeOnChain } from 'constants/tokens'
+import { isBsc, isMatic, nativeOnChain } from 'constants/tokens'
 import { toSupportedChainId } from 'lib/hooks/routing/clientSideSmartOrderRouter'
 
 import { GetQuoteArgs, INTERNAL_ROUTER_PREFERENCE_PRICE, RouterPreference } from './slice'
@@ -180,7 +179,9 @@ export function isExactInput(tradeType: TradeType): boolean {
 
 export function currencyAddressForSwapQuote(currency: Currency): string {
   if (currency.isNative) {
-    return isPolygonChain(currency.chainId) ? SwapRouterNativeAssets.MATIC : SwapRouterNativeAssets.ETH
+    if (isMatic(currency.chainId)) return SwapRouterNativeAssets.MATIC
+    if (isBsc(currency.chainId)) return SwapRouterNativeAssets.BNB
+    return SwapRouterNativeAssets.ETH
   }
 
   return currency.address


### PR DESCRIPTION
Fixes: #6704 

## Description

Currently Uniswap interface assumes that all chains except for Polygon have `ETH` as their native currency symbol:

https://github.com/Uniswap/interface/blob/20a06c9b5ac11bdd6078f14850ab3321a630aae9/src/state/routing/types.ts#L147-L152
https://github.com/Uniswap/interface/blob/20a06c9b5ac11bdd6078f14850ab3321a630aae9/src/state/routing/utils.ts#L181-L187

--- 

While this assumption was correct prior to BNB Chain support introduction, now we got one more native currency symbol, which is `BNB`. [It is included](https://github.com/Uniswap/smart-order-router/blob/dadd4961103d7924b869216a9bc4b4967832b7ff/src/util/chains.ts#L148-L234) in the list of native currencies in `smart-order-router`, so `routing-api` supports native `BNB` trades already.

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="400" src="https://github.com/Uniswap/interface/assets/129212060/fd7eb813-c77e-41cc-94cd-e61811b078de">


### After
<img width="400" src="https://github.com/Uniswap/interface/assets/129212060/44c49e99-645d-4a7d-ba25-5d489136cdc3">
