### PR TITLE
fix: Handle scientific notation for NFT Details pricing

### DIFF
--- a/src/graphql/data/nft/Details.test.ts
+++ b/src/graphql/data/nft/Details.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from 'test-utils/render'
+
+import { useNftAssetDetails } from './Details'
+
+describe('useNftAssetDetails', () => {
+  it('should handle listing.price.value of 1e-18 without crashing', () => {
+    // Mock the useDetailsQuery hook
+    const mockUseDetailsQuery = jest.fn(() => ({
+      data: {
+        nftAssets: {
+          edges: [
+            {
+              node: {
+                listings: {
+                  edges: [
+                    {
+                      node: {
+                        price: {
+                          value: 1e-18,
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+      loading: false,
+    }))
+    jest.mock('../__generated__/types-and-hooks', () => ({
+      useDetailsQuery: mockUseDetailsQuery,
+    }))
+    const { result } = renderHook(() => useNftAssetDetails('address', 'tokenId'))
+    expect(result.current.data[0].priceInfo.ETHPrice).toBe('0')
+  })
+})

--- a/src/graphql/data/nft/Details.ts
+++ b/src/graphql/data/nft/Details.ts
@@ -1,6 +1,7 @@
 import { parseEther } from '@ethersproject/units'
 import gql from 'graphql-tag'
 import { CollectionInfoForAsset, GenieAsset, Markets, SellOrder } from 'nft/types'
+import { wrapScientificNotation } from 'nft/utils'
 import { useMemo } from 'react'
 
 import { NftAsset, useDetailsQuery } from '../__generated__/types-and-hooks'
@@ -105,7 +106,7 @@ export function useNftAssetDetails(
   const asset = queryData?.nftAssets?.edges[0]?.node as NonNullable<NftAsset> | undefined
   const collection = asset?.collection
   const listing = asset?.listings?.edges[0]?.node
-  const ethPrice = parseEther(listing?.price?.value?.toString() ?? '0').toString()
+  const ethPrice = parseEther(wrapScientificNotation(listing?.price?.value?.toString() ?? '0')).toString()
 
   return useMemo(
     () => ({


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- We previously didn't handle scientific notation from the NFT Details page graphql query. This would cause the page to crash. 
- This PR uses the helper function `wrapScientificNotation` created for the other queries such as in `src/graphql/data/nft/Asset.ts`

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Go to this page on [prod](https://app.uniswap.org/#/nfts/asset/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/77326181508430453689739176957591610751915480417413688521678058865045294703857) or [staging](https://app.corn-staging.com/#/nfts/asset/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/77326181508430453689739176957591610751915480417413688521678058865045294703857)
2. Page should crash

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Went to the same asset page on [preview](https://interface-git-cab-detailsscinotation-uniswap.vercel.app/#/nfts/asset/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/77326181508430453689739176957591610751915480417413688521678058865045294703857) and the page does not crash
