### PR TITLE
fix: swap flashes wrong value when output cleared

### DIFF
--- a/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
+++ b/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
@@ -258,7 +258,7 @@ export default function SwapCurrencyInputPanel({
           {!hideInput && (
             <StyledNumericalInput
               className="token-amount-input"
-              value={value}
+              value={loading ? '' : value}
               onUserInput={onUserInput}
               disabled={!chainAllowed || disabled}
               $loading={loading}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes swap flashing the wrong value after the input is cleared.

Added a useState to the `swap/hooks.tsx` file to check to see if the state of the trade before the current one was `INVALID` and if so, sets the cached trade to `undefined` until a new quote is fetched.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-1930


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/35351983/24015931-5315-4667-9629-588f14cd8949




### After


https://github.com/Uniswap/interface/assets/35351983/68d5f7ca-b3b2-41cf-9c69-9a495e3e40d6




## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Select two random assets on any network
2. Input an amount and wait for the quote to fetch
3. Clear the input
4. Enter another amount
5. When fetching the quote, the output amount should be the previous amount instead of 0

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Test input bar when changed to another value (should have the previous amount in the output bar) and from 0 (should have 0 in the output bar)




### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
