### PR TITLE
fix: time interval axis overlap

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -186,14 +186,17 @@ export function PriceChart({ width, height, prices: originalPrices, timePeriod }
     const startDateWithOffset = new Date((startingPrice.timestamp.valueOf() + offsetTime) * 1000)
     const endDateWithOffset = new Date((endingPrice.timestamp.valueOf() - offsetTime) * 1000)
     switch (timePeriod) {
-      case TimePeriod.HOUR:
+      case TimePeriod.HOUR: {
+        const interval = timeMinute.every(5)
+
         return [
           hourFormatter(locale),
           dayHourFormatter(locale),
-          (timeMinute.every(5) ?? timeMinute)
-            .range(startDateWithOffset, endDateWithOffset, 2)
+          (interval ?? timeMinute)
+            .range(startDateWithOffset, endDateWithOffset, interval ? 2 : 10)
             .map((x) => x.valueOf() / 1000),
         ]
+      }
       case TimePeriod.DAY:
         return [
           hourFormatter(locale),


### PR DESCRIPTION
## Description
* fixed interval overlapped caused by `interval.every(5)` being undefined initially so it was rendering 30 intervals (1 for every other second) which caused an overlap
* also there seems to be a cache issue which is causing a day to be sent automatically and thats whats initially being brought in for the hour

* update confirmed to be a bug on the BE side however this change is still better incase `interval` is undefined


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-1842/[web][tokens]-there-is-an-overlap-when-user-select-1h
_Slack thread:_
_Relevant docs:_


### Before
![Screen Shot 2023-06-06 at 5 46 04 PM](https://github.com/Uniswap/interface/assets/9094792/c3b0e3d6-6d52-49f3-babf-1765c790a479)


### After
![Screen Shot 2023-06-06 at 6 00 18 PM](https://github.com/Uniswap/interface/assets/9094792/bb616a24-47c3-4281-9b89-38d5f3e84172)

