### PR TITLE
fix: language updating in search bar

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { t, Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 import { sendAnalyticsEvent, Trace, TraceEvent, useTrace } from '@uniswap/analytics'
 import { BrowserEvent, InterfaceElementName, InterfaceEventName, InterfaceSectionName } from '@uniswap/analytics-events'
 import { useWeb3React } from '@web3-react/core'
@@ -102,7 +102,7 @@ export const SearchBar = () => {
     ...trace,
   }
   const placeholderText = useMemo(() => {
-    return isMobileOrTablet ? t`Search` : t`Search tokens and NFT collections`
+    return isMobileOrTablet ? `Search` : `Search tokens and NFT collections`
   }, [isMobileOrTablet])
 
   const handleKeyPress = useCallback(


### PR DESCRIPTION
## Description
* Language in search bar was not changing when accessing uni from url with lang param
* this was caused by double translating the strings it seems like, it was being translated in a function then translated again in the trans tag


_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2214/language-does-not-update-in-search-bar



<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

https://github.com/Uniswap/interface/assets/9094792/2a59f482-e96f-4547-8f4e-be3d05aeec33



### After


https://github.com/Uniswap/interface/assets/9094792/4fe23259-5135-4077-9065-3e7ce1647fac



