### PR TITLE
test(e2e): skip outdated disconnect-wallet test

### DIFF
--- a/cypress/e2e/wallet-connection/connect.test.ts
+++ b/cypress/e2e/wallet-connection/connect.test.ts
@@ -1,6 +1,6 @@
 import { getTestSelector } from '../../utils'
 
-describe('disconnect wallet', () => {
+describe.skip('disconnect wallet', () => {
   it('should clear state', () => {
     cy.visit('/swap', { ethereum: 'hardhat' })
     cy.get('#swap-currency-input .token-amount-input').clear().type('1')


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Skips a test that - due to a merge mishap - is failing due to testing an outdated feature.