### PR TITLE
fix: remove mainnet from optional chains list

### DIFF
--- a/src/connection/WalletConnectV2.ts
+++ b/src/connection/WalletConnectV2.ts
@@ -1,8 +1,6 @@
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { WalletConnect, WalletConnectConstructorArgs } from '@web3-react/walletconnect-v2'
-import { SupportedChainId } from 'constants/chains'
-import { L1_CHAIN_IDS } from 'constants/chains'
-import { L2_CHAIN_IDS } from 'constants/chains'
+import { L1_CHAIN_IDS, L2_CHAIN_IDS, SupportedChainId } from 'constants/chains'
 import { Z_INDEX } from 'theme/zIndex'
 
 import { RPC_URLS } from '../constants/networks'

--- a/src/connection/WalletConnectV2.ts
+++ b/src/connection/WalletConnectV2.ts
@@ -1,6 +1,8 @@
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { WalletConnect, WalletConnectConstructorArgs } from '@web3-react/walletconnect-v2'
 import { SupportedChainId } from 'constants/chains'
+import { L1_CHAIN_IDS } from 'constants/chains'
+import { L2_CHAIN_IDS } from 'constants/chains'
 import { Z_INDEX } from 'theme/zIndex'
 
 import { RPC_URLS } from '../constants/networks'
@@ -14,6 +16,7 @@ const RPC_URLS_WITHOUT_FALLBACKS = Object.entries(RPC_URLS).reduce(
   }),
   {}
 )
+const optionalChains = [...L1_CHAIN_IDS, ...L2_CHAIN_IDS].filter((x) => x !== SupportedChainId.MAINNET)
 
 export class WalletConnectV2Popup extends WalletConnect {
   ANALYTICS_EVENT = 'Wallet Connect QR Scan'
@@ -27,7 +30,7 @@ export class WalletConnectV2Popup extends WalletConnect {
       actions,
       options: {
         projectId: process.env.REACT_APP_WALLET_CONNECT_PROJECT_ID as string,
-        optionalChains: Object.keys(RPC_URLS_WITHOUT_FALLBACKS).map((key) => Number(key)),
+        optionalChains,
         chains: [SupportedChainId.MAINNET],
         showQrModal: qrcode,
         rpcMap: RPC_URLS_WITHOUT_FALLBACKS,


### PR DESCRIPTION
@JackShort found a bug caused by the duplicate inclusion of mainnet in `chains` and `optionalChains`

