### PR TITLE
feat: revoke USDT approvals in ConfirmSwapModal

### DIFF
--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -116,7 +116,7 @@ function useConfirmModalState({
         case ConfirmModalState.RESETTING_USDT:
           setConfirmModalState(ConfirmModalState.RESETTING_USDT)
           invariant(allowance.state === AllowanceState.REQUIRED, 'Allowance should be required')
-          await allowance.revoke().catch((e) => catchUserReject(e, PendingModalError.TOKEN_APPROVAL_ERROR))
+          allowance.revoke().catch((e) => catchUserReject(e, PendingModalError.TOKEN_APPROVAL_ERROR))
           break
         case ConfirmModalState.APPROVING_TOKEN:
           setConfirmModalState(ConfirmModalState.APPROVING_TOKEN)

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -175,6 +175,15 @@ function useConfirmModalState({
     }
   }, [allowance, performStep, previousSetupApprovalNeeded])
 
+  const previousRevocationPending = usePrevious(
+    allowance.state === AllowanceState.REQUIRED && allowance.isRevocationPending
+  )
+  useEffect(() => {
+    if (allowance.state === AllowanceState.REQUIRED && previousRevocationPending && !allowance.isRevocationPending) {
+      performStep(ConfirmModalState.APPROVING_TOKEN)
+    }
+  }, [allowance, performStep, previousRevocationPending])
+
   useEffect(() => {
     // Automatically triggers the next phase if the local modal state still thinks we're in the approval phase,
     // but the allowance has been set. This will automaticaly trigger the swap.

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -12,6 +12,7 @@ import Badge from 'components/Badge'
 import Modal, { MODAL_TRANSITION_DURATION } from 'components/Modal'
 import { RowFixed } from 'components/Row'
 import { getChainInfo } from 'constants/chainInfo'
+import { USDT } from 'constants/tokens'
 import { useMaxAmountIn } from 'hooks/useMaxAmountIn'
 import { Allowance, AllowanceState } from 'hooks/usePermit2Allowance'
 import usePrevious from 'hooks/usePrevious'
@@ -79,10 +80,11 @@ function useConfirmModalState({
   // at the bottom of the modal, even after they complete steps 1 and 2.
   const generateRequiredSteps = useCallback(() => {
     const steps: PendingConfirmModalState[] = []
-    // Any existing USDT allowance needs to be reset before we can approve the new amount.
+    // Any existing USDT allowance needs to be reset before we can approve the new amount (mainnet only).
+    // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
     if (
       allowance.state === AllowanceState.REQUIRED &&
-      allowance.token.symbol === 'USDT' &&
+      allowance.token.equals(USDT) &&
       allowance.allowedAmount.greaterThan(0)
     ) {
       steps.push(ConfirmModalState.RESETTING_USDT)

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -12,7 +12,7 @@ import Badge from 'components/Badge'
 import Modal, { MODAL_TRANSITION_DURATION } from 'components/Modal'
 import { RowFixed } from 'components/Row'
 import { getChainInfo } from 'constants/chainInfo'
-import { USDT } from 'constants/tokens'
+import { USDT as USDT_MAINNET } from 'constants/tokens'
 import { useMaxAmountIn } from 'hooks/useMaxAmountIn'
 import { Allowance, AllowanceState } from 'hooks/usePermit2Allowance'
 import usePrevious from 'hooks/usePrevious'
@@ -84,7 +84,7 @@ function useConfirmModalState({
     // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
     if (
       allowance.state === AllowanceState.REQUIRED &&
-      allowance.token.equals(USDT) &&
+      allowance.token.equals(USDT_MAINNET) &&
       allowance.allowedAmount.greaterThan(0)
     ) {
       steps.push(ConfirmModalState.RESETTING_USDT)

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -27,7 +27,7 @@ import {
 import { TradeSummary } from './TradeSummary'
 
 export const PendingModalContainer = styled(ColumnCenter)`
-  margin: 48px 0 28px;
+  margin: 48px 0 8px;
 `
 
 const HeaderContainer = styled(ColumnCenter)<{ $disabled?: boolean }>`

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -27,7 +27,7 @@ import {
 import { TradeSummary } from './TradeSummary'
 
 export const PendingModalContainer = styled(ColumnCenter)`
-  margin: 48px 0 8px;
+  margin: 48px 0 28px;
 `
 
 const HeaderContainer = styled(ColumnCenter)<{ $disabled?: boolean }>`
@@ -87,7 +87,10 @@ const StepTitleAnimationContainer = styled(Column)<{ disableEntranceAnimation?: 
 // This component is used for all steps after ConfirmModalState.REVIEWING
 export type PendingConfirmModalState = Extract<
   ConfirmModalState,
-  ConfirmModalState.APPROVING_TOKEN | ConfirmModalState.PERMITTING | ConfirmModalState.PENDING_CONFIRMATION
+  | ConfirmModalState.APPROVING_TOKEN
+  | ConfirmModalState.PERMITTING
+  | ConfirmModalState.PENDING_CONFIRMATION
+  | ConfirmModalState.RESETTING_USDT
 >
 
 interface PendingModalStep {
@@ -105,6 +108,7 @@ interface PendingModalContentProps {
   swapTxHash?: string
   hideStepIndicators?: boolean
   tokenApprovalPending?: boolean
+  revocationPending?: boolean
 }
 
 interface ContentArgs {
@@ -114,13 +118,29 @@ interface ContentArgs {
   swapConfirmed: boolean
   swapPending: boolean
   tokenApprovalPending: boolean
+  revocationPending: boolean
   swapTxHash?: string
   chainId?: number
 }
 
 function getContent(args: ContentArgs): PendingModalStep {
-  const { step, approvalCurrency, swapConfirmed, swapPending, tokenApprovalPending, trade, swapTxHash, chainId } = args
+  const {
+    step,
+    approvalCurrency,
+    swapConfirmed,
+    swapPending,
+    tokenApprovalPending,
+    revocationPending,
+    trade,
+    swapTxHash,
+    chainId,
+  } = args
   switch (step) {
+    case ConfirmModalState.RESETTING_USDT:
+      return {
+        title: t`Reset USDT Approval`,
+        label: revocationPending ? t`Pending...` : t`Proceed in your wallet`,
+      }
     case ConfirmModalState.APPROVING_TOKEN:
       return {
         title: t`Enable spending ${approvalCurrency?.symbol ?? 'this token'} on Uniswap`,
@@ -167,6 +187,7 @@ export function PendingModalContent({
   swapTxHash,
   hideStepIndicators,
   tokenApprovalPending = false,
+  revocationPending = false,
 }: PendingModalContentProps) {
   const { chainId } = useWeb3React()
   const swapConfirmed = useIsTransactionConfirmed(swapTxHash)
@@ -177,6 +198,7 @@ export function PendingModalContent({
     swapConfirmed,
     swapPending,
     tokenApprovalPending,
+    revocationPending,
     swapTxHash,
     trade,
     chainId,
@@ -213,7 +235,7 @@ export function PendingModalContent({
           <LoadingIndicatorOverlay />
         )}
       </LogoContainer>
-      <HeaderContainer gap="md" $disabled={tokenApprovalPending || (swapPending && !showSuccess)}>
+      <HeaderContainer gap="md" $disabled={revocationPending || tokenApprovalPending || (swapPending && !showSuccess)}>
         <AnimationWrapper>
           {steps.map((step) => {
             const { title, subtitle } = getContent({
@@ -222,6 +244,7 @@ export function PendingModalContent({
               swapConfirmed,
               swapPending,
               tokenApprovalPending,
+              revocationPending,
               swapTxHash,
               trade,
             })

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -138,7 +138,8 @@ function getContent(args: ContentArgs): PendingModalStep {
   switch (step) {
     case ConfirmModalState.RESETTING_USDT:
       return {
-        title: t`Reset USDT Approval`,
+        title: t`Reset USDT`,
+        subtitle: t`USDT requires resetting approval when spending limits are too low.`,
         label: revocationPending ? t`Pending...` : t`Proceed in your wallet`,
       }
     case ConfirmModalState.APPROVING_TOKEN:
@@ -216,24 +217,25 @@ export function PendingModalContent({
   return (
     <PendingModalContainer gap="lg">
       <LogoContainer>
-        {/* Shown during the first step, and fades out afterwards. */}
+        {/* Shown during the setup approval step, and fades out afterwards. */}
         {currentStep === ConfirmModalState.APPROVING_TOKEN && <PaperIcon />}
-        {/* Shown during the first step as a small badge. */}
-        {/* Scales up once we transition from first to second step. */}
-        {/* Fades out after the second step. */}
+        {/* Shown during the setup approval step as a small badge. */}
+        {/* Scales up once we transition from setup approval to permit signature. */}
+        {/* Fades out after the permit signature. */}
         {currentStep !== ConfirmModalState.PENDING_CONFIRMATION && (
           <CurrencyLoader
             currency={trade?.inputAmount.currency}
             asBadge={currentStep === ConfirmModalState.APPROVING_TOKEN}
           />
         )}
-        {/* Shown only during the third step under "success" conditions, and scales in. */}
+        {/* Shown only during the final step under "success" conditions, and scales in. */}
         {currentStep === ConfirmModalState.PENDING_CONFIRMATION && showSuccess && <AnimatedEntranceConfirmationIcon />}
-        {/* Scales in for the first step if the approval is pending onchain confirmation. */}
-        {/* Scales in for the third step if the swap is pending user signature or onchain confirmation. */}
-        {((currentStep === ConfirmModalState.PENDING_CONFIRMATION && !showSuccess) || tokenApprovalPending) && (
-          <LoadingIndicatorOverlay />
-        )}
+        {/* Scales in for the USDT revoke allowance step if the revoke is pending onchain confirmation. */}
+        {/* Scales in for the setup approval step if the approval is pending onchain confirmation. */}
+        {/* Scales in for the final step if the swap is pending user signature or onchain confirmation. */}
+        {((currentStep === ConfirmModalState.PENDING_CONFIRMATION && !showSuccess) ||
+          tokenApprovalPending ||
+          revocationPending) && <LoadingIndicatorOverlay />}
       </LogoContainer>
       <HeaderContainer gap="md" $disabled={revocationPending || tokenApprovalPending || (swapPending && !showSuccess)}>
         <AnimationWrapper>

--- a/src/hooks/useTokenAllowance.ts
+++ b/src/hooks/useTokenAllowance.ts
@@ -48,7 +48,8 @@ export function useUpdateTokenAllowance(
       if (!contract) throw new Error('missing contract')
       if (!spender) throw new Error('missing spender')
 
-      const allowance = MaxUint256.toString()
+      const maxAllowance = MaxUint256.toString()
+      const allowance = amount.equalTo(0) ? '0' : maxAllowance
       const response = await contract.approve(spender, allowance)
       return {
         response,


### PR DESCRIPTION
## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

adds a new, optional, first step to the ConfirmSwapModal flow which resets USDT (mainnet) approval to zero before asking for a new, increased, approval amount. this is only needed for USDT mainnet.

from the USDT mainnet token contract:
```
 /**
    * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
    * @param _spender The address which will spend the funds.
    * @param _value The amount of tokens to be spent.
    */
    function approve(address _spender, uint _value) public onlyPayloadSize(2 * 32) {

        // To change the approve amount you first have to reduce the addresses`
        //  allowance to zero by calling `approve(_spender, 0)` if it is not
        //  already 0 to mitigate the race condition described here:
        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
        require(!((_value != 0) && (allowed[msg.sender][_spender] != 0)));

        allowed[msg.sender][_spender] = _value;
        Approval(msg.sender, _spender, _value);
    }
```


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2153/permit2-flow-special-case-usdt-approval


<!-- Delete this section if your change does not affect UI. -->
## Screen capture



https://github.com/Uniswap/interface/assets/66155195/df2809d7-d96b-4179-82f2-7667347587b5




## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] verify that the step occurs when expected, and that it solves the problem of not being able to set a higher token allowance for USDT when you have a previous one set already



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test (existing tests pass)
- [x] Integration/E2E test (added new test case in next PR)
