### PR TITLE
fix: prevent scrolling with settings modal open

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -5,11 +5,12 @@ import { AutoColumn } from 'components/Column'
 import { L2_CHAIN_IDS } from 'constants/chains'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { isSupportedChainId } from 'lib/hooks/routing/clientSideSmartOrderRouter'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useModalIsOpen, useToggleSettingsMenu } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
 import styled from 'styled-components/macro'
 import { Divider } from 'theme'
+import { isMobile } from 'utils/userAgent'
 
 import MaxSlippageSettings from './MaxSlippageSettings'
 import MenuButton from './MenuButton'
@@ -50,6 +51,19 @@ export default function SettingsTab({ autoSlippage, chainId }: { autoSlippage: P
 
   const toggleMenu = useToggleSettingsMenu()
   useOnClickOutside(node, isOpen ? toggleMenu : undefined)
+
+  useEffect(() => {
+    if (isOpen && isMobile) {
+      document.body.style.position = 'fixed'
+      document.body.style.top = `-${window.scrollY}px`
+      document.body.style.width = '100%'
+    } else if (isMobile) {
+      const scrollY = document.body.style.top
+      document.body.style.position = ''
+      document.body.style.top = ''
+      window.scrollTo(0, parseInt(scrollY || '0') * -1)
+    }
+  }, [isOpen])
 
   const isSupportedChain = isSupportedChainId(chainId)
 

--- a/src/components/Tokens/TokenDetails/ShareButton.tsx
+++ b/src/components/Tokens/TokenDetails/ShareButton.tsx
@@ -3,7 +3,7 @@ import { Currency } from '@uniswap/sdk-core'
 import { NATIVE_CHAIN_ID } from 'constants/tokens'
 import { chainIdToBackendName } from 'graphql/data/util'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Link, Twitter } from 'react-feather'
 import { useModalIsOpen, useToggleModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
@@ -12,6 +12,7 @@ import { ClickableStyle, CopyHelperRefType } from 'theme'
 import { colors } from 'theme/colors'
 import { opacify } from 'theme/utils'
 import { Z_INDEX } from 'theme/zIndex'
+import { isMobile } from 'utils/userAgent'
 
 import { ReactComponent as ShareIcon } from '../../../assets/svg/share.svg'
 import { CopyHelper } from '../../../theme'
@@ -86,6 +87,18 @@ export default function ShareButton({ currency }: { currency: Currency }) {
       `left=${positionX}, top=${positionY}, width=${TWITTER_WIDTH}, height=${TWITTER_HEIGHT}`
     )
   }
+
+  useEffect(() => {
+    if (open && isMobile) {
+      document.body.style.position = 'fixed'
+      document.body.style.top = `-${window.scrollY}px`
+    } else if (isMobile) {
+      const scrollY = document.body.style.top
+      document.body.style.position = ''
+      document.body.style.top = ''
+      window.scrollTo(0, parseInt(scrollY || '0') * -1)
+    }
+  }, [open])
 
   const copyHelperRef = useRef<CopyHelperRefType>(null)
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Fixes bug where screen can continue to be scrolled even when the settings/share modal are open.

Added a `useEffect` to `ShareButton.tsx` and `Settings/index.tsx` so that the document's body is fixed and unscrollable when either modal is open on mobile.

Follow this [tutorial](https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/).


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-1473


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/35351983/ff07ab1b-fd28-4765-86be-502fbc587cb9


https://github.com/Uniswap/interface/assets/35351983/512635ea-ec7f-4701-a571-6764e1e0bc9c



### After


https://github.com/Uniswap/interface/assets/35351983/a3d088ae-79b3-45de-b5a2-cb4722e3b0ca


https://github.com/Uniswap/interface/assets/35351983/523915b7-760b-4750-979d-575f193a0a86



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Go to swap, token, or nft screen on a mobile device.
2. Click the settings or share button
3. Try swiping on the background

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Go to swap screen, click settings modal, make sure the screen isn't scrollable
- [x] Go to token/nft details screen, click the share button, make sure the screen isn't scrollable
- [x] Make sure normal functions on web


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
