### PR TITLE
feat: Use routing-api or URA for price fetches behind feature flag

### DIFF
--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -1,6 +1,7 @@
 import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'featureFlags'
 import { useNativeUSDCArbitrumFlag } from 'featureFlags/flags/nativeUsdcArbitrum'
 import { DetailsV2Variant, useDetailsV2Flag } from 'featureFlags/flags/nftDetails'
+import { useRoutingAPIForPriceFlag } from 'featureFlags/flags/priceRoutingApi'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { UnifiedRouterVariant, useRoutingAPIV2Flag } from 'featureFlags/flags/unifiedRouter'
 import { useUpdateAtom } from 'jotai/utils'
@@ -220,6 +221,12 @@ export default function FeatureFlagModal() {
         value={useNativeUSDCArbitrumFlag()}
         featureFlag={FeatureFlag.nativeUsdcArbitrum}
         label="Enable Circle native USDC on Arbitrum"
+      />
+      <FeatureFlagOption
+        variant={BaseVariant}
+        value={useRoutingAPIForPriceFlag()}
+        featureFlag={FeatureFlag.routingAPIPrice}
+        label="Use the URA or routing-api for price fetches"
       />
       <FeatureFlagGroup name="Debug">
         <FeatureFlagOption

--- a/src/featureFlags/flags/priceRoutingApi.ts
+++ b/src/featureFlags/flags/priceRoutingApi.ts
@@ -1,0 +1,9 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+export function useRoutingAPIForPriceFlag(): BaseVariant {
+  return useBaseFlag(FeatureFlag.routingAPIPrice)
+}
+
+export function useRoutingAPIForPrice(): boolean {
+  return useRoutingAPIForPriceFlag() === BaseVariant.Enabled
+}

--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -13,6 +13,7 @@ export enum FeatureFlag {
   uraEnabled = 'ura_enabled',
   debounceSwapQuote = 'debounce_swap_quote',
   nativeUsdcArbitrum = 'web_usdc_arbitrum',
+  routingAPIPrice = 'routing_api_price',
 }
 
 interface FeatureFlagsContextType {

--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -1,4 +1,5 @@
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { useRoutingAPIForPrice } from 'featureFlags/flags/priceRoutingApi'
 import { useMemo } from 'react'
 import { GetQuoteArgs, INTERNAL_ROUTER_PREFERENCE_PRICE, RouterPreference } from 'state/routing/slice'
 import { currencyAddressForSwapQuote } from 'state/routing/utils'
@@ -21,6 +22,7 @@ export function useRoutingAPIArguments({
   tradeType: TradeType
   routerPreference: RouterPreference | typeof INTERNAL_ROUTER_PREFERENCE_PRICE
 }): GetQuoteArgs | undefined {
+  const isRoutingAPIPrice = useRoutingAPIForPrice()
   return useMemo(
     () =>
       !tokenIn || !tokenOut || !amount || tokenIn.equals(tokenOut) || tokenIn.wrapped.equals(tokenOut.wrapped)
@@ -37,7 +39,8 @@ export function useRoutingAPIArguments({
             tokenOutSymbol: tokenOut.wrapped.symbol,
             routerPreference,
             tradeType,
+            isRoutingAPIPrice,
           },
-    [amount, routerPreference, tokenIn, tokenOut, tradeType]
+    [amount, routerPreference, tokenIn, tokenOut, tradeType, isRoutingAPIPrice]
   )
 }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -40,6 +40,7 @@ export interface GetQuoteArgs {
   amount: string
   routerPreference: RouterPreference | typeof INTERNAL_ROUTER_PREFERENCE_PRICE
   tradeType: TradeType
+  isRoutingAPIPrice?: boolean
 }
 
 enum QuoteState {
@@ -83,7 +84,7 @@ export const routingApi = createApi({
         )
       },
       async queryFn(args, _api, _extraOptions, fetch) {
-        if (shouldUseAPIRouter(args.routerPreference)) {
+        if (shouldUseAPIRouter(args)) {
           try {
             const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, tradeType } = args
             const type = isExactInput(tradeType) ? 'exactIn' : 'exactOut'

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -187,8 +187,11 @@ export function currencyAddressForSwapQuote(currency: Currency): string {
   return currency.address
 }
 
-export function shouldUseAPIRouter(
-  routerPreference?: RouterPreference | typeof INTERNAL_ROUTER_PREFERENCE_PRICE
-): boolean {
+export function shouldUseAPIRouter(args: GetQuoteArgs): boolean {
+  const { routerPreference, isRoutingAPIPrice } = args
+  if (routerPreference === INTERNAL_ROUTER_PREFERENCE_PRICE && isRoutingAPIPrice) {
+    return true
+  }
+
   return routerPreference === RouterPreference.API || routerPreference === RouterPreference.AUTO
 }

--- a/src/state/routing/v2Slice.ts
+++ b/src/state/routing/v2Slice.ts
@@ -54,8 +54,7 @@ export const routingApiV2 = createApi({
         )
       },
       async queryFn(args: GetQuoteArgs, _api, _extraOptions, fetch) {
-        const routerPreference = args.routerPreference
-        if (shouldUseAPIRouter(routerPreference)) {
+        if (shouldUseAPIRouter(args)) {
           try {
             const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, tradeType } = args
             const type = isExactInput(tradeType) ? 'EXACT_INPUT' : 'EXACT_OUTPUT'


### PR DESCRIPTION
## Description
This PR adds a feature flag for moving price fetches to the routing-api. Currently all price fetches go through the client side router~

Note that price fetches = token -> ETH route. We always use gql to get ETH -> USD.

### UI
No UI changes


## Test plan
In local, toggle the feature flag `routing_api_price` on/off (also maybe in combination with `ura_enabled`) to see that the price quotes are going through the routing api instead of client side router.
