### PR TITLE
fix: tick labels respond to width of the graph

### DIFF
--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -258,6 +258,7 @@ export function PriceChart({ width, height, prices: originalPrices, timePeriod }
     setDisplayPrice(endingPrice)
   }, [setCrosshair, setDisplayPrice, endingPrice])
 
+  // Resets the crosshair when the time period is changed, to avoid stale UI
   useEffect(() => {
     setCrosshair(null)
   }, [timePeriod])

--- a/src/components/Tokens/TokenDetails/PriceChart.tsx
+++ b/src/components/Tokens/TokenDetails/PriceChart.tsx
@@ -258,7 +258,23 @@ export function PriceChart({ width, height, prices: originalPrices, timePeriod }
     setDisplayPrice(endingPrice)
   }, [setCrosshair, setDisplayPrice, endingPrice])
 
+  useEffect(() => {
+    setCrosshair(null)
+  }, [timePeriod])
+
   const [tickFormatter, crosshairDateFormatter, ticks] = tickFormat(timePeriod, locale)
+  //max ticks based on screen size
+  const maxTicks = Math.floor(width / 100)
+  function calculateTicks(ticks: NumberValue[]) {
+    const newTicks = []
+    const tickSpacing = Math.floor(ticks.length / maxTicks)
+    for (let i = 1; i < ticks.length; i += tickSpacing) {
+      newTicks.push(ticks[i])
+    }
+    return newTicks
+  }
+
+  const updatedTicks = maxTicks > 0 ? (ticks.length > maxTicks ? calculateTicks(ticks) : ticks) : []
   const delta = calculateDelta(startingPrice.value, displayPrice.value)
   const formattedDelta = formatDelta(delta)
   const arrow = getDeltaArrow(delta)
@@ -327,7 +343,7 @@ export function PriceChart({ width, height, prices: originalPrices, timePeriod }
                 tickLength={4}
                 hideTicks={true}
                 tickTransform="translate(0 -5)"
-                tickValues={ticks}
+                tickValues={updatedTicks}
                 top={graphHeight - 1}
                 tickLabelProps={() => ({
                   fill: theme.textSecondary,


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Fixes ticks on x-axis for mobile devices so that the labels are responsive and reformat based on the size of the width. 

Added a function in `PriceChart.tsx` that splices the `ticks` array based on the current width of the screen/graph.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-859


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

https://github.com/Uniswap/interface/assets/35351983/5d1d4377-3955-41e5-af13-0273ab0729b3




### After


https://github.com/Uniswap/interface/assets/35351983/22c38f48-d5ad-475d-83c9-578919ab6edc



## Test plan


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Test tick labels on different sized screens

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
