### PR TITLE
fix: Catch routing-api v2 no liquidity error case

### DIFF
--- a/src/state/routing/v2Slice.ts
+++ b/src/state/routing/v2Slice.ts
@@ -80,7 +80,10 @@ export const routingApiV2 = createApi({
                 // cast as any here because we do a runtime check on it being an object before indexing into .errorCode
                 const errorData = response.error.data as any
                 // NO_ROUTE should be treated as a valid response to prevent retries.
-                if (typeof errorData === 'object' && errorData?.errorCode === 'NO_ROUTE') {
+                if (
+                  typeof errorData === 'object' &&
+                  (errorData?.errorCode === 'NO_ROUTE' || errorData?.detail === 'No quotes available')
+                ) {
                   return { data: { state: QuoteState.NOT_FOUND } }
                 }
               } catch {


### PR DESCRIPTION
routing-api v2 has a new error format where the `error.detail` is `No quotes available`, so catch this case for displaying insufficient liquidity.

<img width="542" alt="image" src="https://github.com/Uniswap/interface/assets/59578595/2e67ee0f-36df-4461-b5d8-ce6d96c2a7f5">
