### PR TITLE
chore: Feature flag cleanup for Arbitrum native USDC

### DIFF
--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -1,5 +1,4 @@
 import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'featureFlags'
-import { useNativeUSDCArbitrumFlag } from 'featureFlags/flags/nativeUsdcArbitrum'
 import { DetailsV2Variant, useDetailsV2Flag } from 'featureFlags/flags/nftDetails'
 import { useRoutingAPIForPriceFlag } from 'featureFlags/flags/priceRoutingApi'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
@@ -215,12 +214,6 @@ export default function FeatureFlagModal() {
         value={useRoutingAPIV2Flag()}
         featureFlag={FeatureFlag.uraEnabled}
         label="Enable the Unified Routing API"
-      />
-      <FeatureFlagOption
-        variant={BaseVariant}
-        value={useNativeUSDCArbitrumFlag()}
-        featureFlag={FeatureFlag.nativeUsdcArbitrum}
-        label="Enable Circle native USDC on Arbitrum"
       />
       <FeatureFlagOption
         variant={BaseVariant}

--- a/src/components/SearchModal/CommonBases.tsx
+++ b/src/components/SearchModal/CommonBases.tsx
@@ -4,8 +4,7 @@ import { Currency } from '@uniswap/sdk-core'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/Logo/CurrencyLogo'
 import { AutoRow } from 'components/Row'
-import { COMMON_BASES, COMMON_BASES_V2 } from 'constants/routing'
-import { useNativeUSDCArbitrumEnabled } from 'featureFlags/flags/nativeUsdcArbitrum'
+import { COMMON_BASES } from 'constants/routing'
 import { useTokenInfoFromActiveList } from 'hooks/useTokenInfoFromActiveList'
 import { getTokenAddress } from 'lib/utils/analytics'
 import { Text } from 'rebass'
@@ -60,9 +59,7 @@ export default function CommonBases({
   searchQuery: string
   isAddressSearch: string | false
 }) {
-  const nativeUsdcArbitrumEnabled = useNativeUSDCArbitrumEnabled()
-  const commonBases = nativeUsdcArbitrumEnabled ? COMMON_BASES_V2 : COMMON_BASES
-  const bases = chainId !== undefined ? commonBases[chainId] ?? [] : []
+  const bases = chainId !== undefined ? COMMON_BASES[chainId] ?? [] : []
 
   return bases.length > 0 ? (
     <MobileWrapper gap="md">

--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -4,7 +4,6 @@ import { SupportedChainId } from 'constants/chains'
 
 import {
   AMPL,
-  BRIDGED_USDC_ARBITRUM,
   BTC_BSC,
   BUSD_BSC,
   CAKE_BSC,
@@ -154,7 +153,7 @@ export const COMMON_BASES: ChainCurrencyList = {
   [SupportedChainId.ARBITRUM_ONE]: [
     nativeOnChain(SupportedChainId.ARBITRUM_ONE),
     DAI_ARBITRUM_ONE,
-    BRIDGED_USDC_ARBITRUM,
+    USDC_ARBITRUM,
     USDT_ARBITRUM_ONE,
     WBTC_ARBITRUM_ONE,
     WRAPPED_NATIVE_CURRENCY[SupportedChainId.ARBITRUM_ONE] as Token,
@@ -208,19 +207,6 @@ export const COMMON_BASES: ChainCurrencyList = {
     ETH_BSC,
     BTC_BSC,
     BUSD_BSC,
-  ],
-}
-
-// This is the same as COMMON_BASES except it swaps out Bridged USDC on arbitrum for native USDC.
-export const COMMON_BASES_V2: ChainCurrencyList = {
-  ...COMMON_BASES,
-  [SupportedChainId.ARBITRUM_ONE]: [
-    nativeOnChain(SupportedChainId.ARBITRUM_ONE),
-    DAI_ARBITRUM_ONE,
-    USDC_ARBITRUM,
-    USDT_ARBITRUM_ONE,
-    WBTC_ARBITRUM_ONE,
-    WRAPPED_NATIVE_CURRENCY[SupportedChainId.ARBITRUM_ONE] as Token,
   ],
 }
 

--- a/src/featureFlags/flags/nativeUsdcArbitrum.ts
+++ b/src/featureFlags/flags/nativeUsdcArbitrum.ts
@@ -1,9 +1,0 @@
-import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
-
-export function useNativeUSDCArbitrumFlag(): BaseVariant {
-  return useBaseFlag(FeatureFlag.nativeUsdcArbitrum)
-}
-
-export function useNativeUSDCArbitrumEnabled(): boolean {
-  return useNativeUSDCArbitrumFlag() === BaseVariant.Enabled
-}


### PR DESCRIPTION
This PR just cleans up the feature flag logic for turning on native USDC in arbitrum's token selector as a common base.

Note we still use Bridged USDC for stablecoin price lookup (in the case that ETH price lookup fails) because it has a lot more TVL compared to native USDC, so the price lookup is more accurate on Bridged USDC for now.
