### PR TITLE
feat: add loading indicator to activity tab in mini portfolio

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/index.tsx
@@ -96,7 +96,7 @@ export default function MiniPortfolio({ account }: { account: string }) {
   const [currentPage, setCurrentPage] = useState(isNftPage ? 1 : 0)
   const shouldDisableNFTRoutes = useAtomValue(shouldDisableNFTRoutesAtom)
 
-  const Page = Pages[currentPage].component
+  const { component: Page, key: currentKey } = Pages[currentPage]
 
   const allTransactions = useAllTransactions()
   const hasPendingTransactions = useMemo(() => {
@@ -108,7 +108,9 @@ export default function MiniPortfolio({ account }: { account: string }) {
         <Nav data-testid="mini-portfolio-navbar">
           {Pages.map(({ title, loggingElementName, key }, index) => {
             if (shouldDisableNFTRoutes && loggingElementName.includes('nft')) return null
-            const showPendingActivitySpinner = Boolean(key === 'activity' && hasPendingTransactions)
+            const showPendingActivitySpinner = Boolean(
+              key === 'activity' && hasPendingTransactions && currentKey !== 'activity'
+            )
             return (
               <TraceEvent
                 events={[BrowserEvent.onClick]}

--- a/src/components/AccountDrawer/MiniPortfolio/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/index.tsx
@@ -6,10 +6,10 @@ import { LoaderV2 } from 'components/Icons/LoadingSpinner'
 import { AutoRow } from 'components/Row'
 import { useIsNftPage } from 'hooks/useIsNftPage'
 import { useAtomValue } from 'jotai/utils'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { shouldDisableNFTRoutesAtom } from 'state/application/atoms'
-import { useAllTransactions } from 'state/transactions/hooks'
-import styled from 'styled-components/macro'
+import { useHasPendingTransactions } from 'state/transactions/hooks'
+import styled, { useTheme } from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
 import { ActivityTab } from './Activity'
@@ -93,16 +93,14 @@ const Pages: Array<Page> = [
 
 export default function MiniPortfolio({ account }: { account: string }) {
   const isNftPage = useIsNftPage()
+  const theme = useTheme()
   const [currentPage, setCurrentPage] = useState(isNftPage ? 1 : 0)
   const [activityUnread, setActivityUnread] = useState(false)
   const shouldDisableNFTRoutes = useAtomValue(shouldDisableNFTRoutesAtom)
 
   const { component: Page, key: currentKey } = Pages[currentPage]
 
-  const allTransactions = useAllTransactions()
-  const hasPendingTransactions = useMemo(() => {
-    return Object.values(allTransactions).filter((tx) => !tx.receipt).length > 0
-  }, [allTransactions])
+  const hasPendingTransactions = useHasPendingTransactions()
 
   useEffect(() => {
     if (hasPendingTransactions && currentKey !== 'activity') setActivityUnread(true)
@@ -114,8 +112,8 @@ export default function MiniPortfolio({ account }: { account: string }) {
         <Nav data-testid="mini-portfolio-navbar">
           {Pages.map(({ title, loggingElementName, key }, index) => {
             if (shouldDisableNFTRoutes && loggingElementName.includes('nft')) return null
-            const isActivity = key === 'activity' && currentKey !== 'activity'
-            const showActivityIndicator = isActivity && (hasPendingTransactions || activityUnread)
+            const isUnselectedActivity = key === 'activity' && currentKey !== 'activity'
+            const showActivityIndicator = isUnselectedActivity && (hasPendingTransactions || activityUnread)
             const handleNavItemClick = () => {
               setCurrentPage(index)
               if (key === 'activity') setActivityUnread(false)
@@ -136,7 +134,7 @@ export default function MiniPortfolio({ account }: { account: string }) {
                         <LoaderV2 />
                       ) : (
                         <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <circle cx="4" cy="4" r="4" fill="#4C82FB" />
+                          <circle cx="4" cy="4" r="4" fill={theme.accentAction} />
                         </svg>
                       )}
                     </>

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -119,3 +119,10 @@ export function useHasPendingApproval(token?: Token, spender?: string): boolean 
     [allTransactions, spender, token?.address]
   )
 }
+
+export function useHasPendingTransactions() {
+  const allTransactions = useAllTransactions()
+  return useMemo(() => {
+    return Object.values(allTransactions).filter((tx) => !tx.receipt).length > 0
+  }, [allTransactions])
+}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2010/ui-disconnect-between-activity-history-loading-and-interaction


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | <img width="410" alt="image" src="https://github.com/Uniswap/interface/assets/5773490/4756afc4-cbb2-42c4-ae44-6347cf7b5106">  |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
|  mobile | <img width="405" alt="image" src="https://github.com/Uniswap/interface/assets/5773490/93604340-93e3-4680-bc86-b481626c3069"> |

### "unread" notification
<img width="118" alt="image" src="https://github.com/Uniswap/interface/assets/5773490/63869a17-52ab-4604-a022-983fa0a93a6c">

## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] broadcast a transaction
- [ ] expect a loading spinner on the "activity" tab header
- [ ] when the transaction confirms, expect an "unread" notification on the activity tab
- [ ] expect the dot unread notification to clear when you click on the tab


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


