### PR TITLE
fix: bottom padding on error modal

### DIFF
--- a/src/components/swap/PendingModalContent/ErrorModalContent.tsx
+++ b/src/components/swap/PendingModalContent/ErrorModalContent.tsx
@@ -64,7 +64,7 @@ export function ErrorModalContent({ errorType, onRetry }: ErrorModalContentProps
         </Row>
       </ColumnCenter>
       <Row justify="center">
-        <ButtonPrimary marginX="24px" onClick={onRetry}>
+        <ButtonPrimary marginX="24px" marginBottom="16px" onClick={onRetry}>
           <Trans>Retry</Trans>
         </ButtonPrimary>
       </Row>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes an incorrect padding on the swap error modal



<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="789" alt="Screenshot 2023-06-13 at 2 47 03 PM" src="https://github.com/Uniswap/interface/assets/66155195/ff8dedc8-0f20-4b31-8e2d-1f8a913e3d40">


### After


<img width="789" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/3d57657e-d19d-4ba4-92fa-2a8f460c62da">



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. induce an error during the swap flow (e.g. by using WCv2.0 with a wallet that doesn't support signatures yet)

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] eyes

