### PR TITLE
fix: remove sentry logging for swap failures

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -1,5 +1,4 @@
 import { Trans } from '@lingui/macro'
-import * as Sentry from '@sentry/react'
 import { sendAnalyticsEvent, Trace, TraceEvent, useTrace } from '@uniswap/analytics'
 import {
   BrowserEvent,
@@ -439,12 +438,6 @@ export function Swap({
         })
       })
       .catch((error) => {
-        if (!didUserReject(error)) {
-          Sentry.withScope((scope) => {
-            scope.setExtra('confirmedTrade', tradeToConfirm)
-            Sentry.captureException(error)
-          })
-        }
         setSwapState((currentState) => ({
           ...currentState,
           swapError: error,
@@ -459,7 +452,6 @@ export function Swap({
     account,
     trade?.inputAmount?.currency?.symbol,
     trade?.outputAmount?.currency?.symbol,
-    tradeToConfirm,
   ])
 
   // errors


### PR DESCRIPTION
reverts https://github.com/Uniswap/interface/pull/6698/files from the staging branch

this logging is too noisy and causing false positive alerts in sentry + pagerduty. we want this mostly for analytics, so it will be better to use amplitude instead