### PR TITLE
fix: handle both UNIWALLET and UNISWAP_WALLET in LocalStorage

### DIFF
--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -131,6 +131,12 @@ const userSlice = createSlice({
     // for all existing users with a previous version of the state in their localStorage.
     // In order to avoid this, we need to set a default value for each new property manually during hydration.
     builder.addCase(updateVersion, (state) => {
+      // If `selectedWallet` is ConnectionType.UNI_WALLET (deprecated) switch it to ConnectionType.UNISWAP_WALLET
+      // @ts-ignore
+      if (state.selectedWallet === 'UNIWALLET') {
+        state.selectedWallet = ConnectionType.UNISWAP_WALLET
+      }
+
       // If `userSlippageTolerance` is not present or its value is invalid, reset to default
       if (
         typeof state.userSlippageTolerance !== 'number' ||


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
 - resolves the bug found in prod where the app crashed for users previously connected via Uniswap because they had `UNIWALLET` as the selectedWallet in localStorage and it was updated to `UNISWAP_WALLET`. This resolves by autocasting to to the latter. Verified locally and by using vercel deploys.
