### PR TITLE
fix: log the error message instead of [object Object]

### DIFF
--- a/src/hooks/usePermitAllowance.ts
+++ b/src/hooks/usePermitAllowance.ts
@@ -8,8 +8,7 @@ import { useContract } from 'hooks/useContract'
 import { useSingleCallResult } from 'lib/hooks/multicall'
 import ms from 'ms.macro'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { UserRejectedRequestError } from 'utils/errors'
-import { didUserReject } from 'utils/swapErrorToUserReadableMessage'
+import { throwReadableError } from 'utils/errors'
 
 const PERMIT_EXPIRATION = ms`30d`
 const PERMIT_SIG_EXPIRATION = ms`30m`
@@ -83,10 +82,7 @@ export function useUpdatePermitAllowance(
       return
     } catch (e: unknown) {
       const symbol = token?.symbol ?? 'Token'
-      if (didUserReject(e)) {
-        throw new UserRejectedRequestError(`${symbol} permit allowance failed: User rejected signature`)
-      }
-      throw new Error(`${symbol} permit allowance failed: ${e instanceof Error ? e.message : e}`)
+      throwReadableError(`${symbol} permit allowance failed:`, e)
     }
   }, [account, chainId, nonce, onPermitSignature, provider, spender, token])
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,3 @@
-import { didUserReject } from './swapErrorToUserReadableMessage'
-
 // You may throw an instance of this class when the user rejects a request in their wallet.
 // The benefit is that you can distinguish this error from other errors using didUserReject().
 export class UserRejectedRequestError extends Error {
@@ -9,13 +7,10 @@ export class UserRejectedRequestError extends Error {
   }
 }
 
-export function throwReadableError(errorText: string, error: unknown) {
-  if (didUserReject(error)) {
-    throw new UserRejectedRequestError(`${errorText} 👺 User rejected signature`)
-  }
+export function toReadableError(errorText: string, error: unknown) {
   if (typeof error === 'object' && error !== null) {
     const e = error as Error & { reason?: string }
-    throw new Error(`${errorText} 👺 ${e.message ?? e.reason ?? 'unknown'}`)
+    return new Error(`${errorText} 👺 ${e.message ?? e.reason ?? 'unknown'}`)
   }
-  throw new Error(`${errorText} 👺 ${error}`)
+  return new Error(`${errorText} 👺 ${error}`)
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+import { didUserReject } from './swapErrorToUserReadableMessage'
+
 // You may throw an instance of this class when the user rejects a request in their wallet.
 // The benefit is that you can distinguish this error from other errors using didUserReject().
 export class UserRejectedRequestError extends Error {
@@ -5,4 +7,15 @@ export class UserRejectedRequestError extends Error {
     super(message)
     this.name = 'UserRejectedRequestError'
   }
+}
+
+export function throwReadableError(errorText: string, error: unknown) {
+  if (didUserReject(error)) {
+    throw new UserRejectedRequestError(`${errorText} 👺 User rejected signature`)
+  }
+  if (typeof error === 'object' && error !== null) {
+    const e = error as Error & { reason?: string }
+    throw new Error(`${errorText} 👺 ${e.message ?? e.reason ?? 'unknown'}`)
+  }
+  throw new Error(`${errorText} 👺 ${error}`)
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
We are currently debugging a permit-related bug in walletconnect v2 and this catch block is logging `[object Object]` instead of the `error.message` value.

_Linear:_ https://linear.app/uniswap/issue/WEB-2368/improve-permit2-error-logging

![image](https://github.com/Uniswap/interface/assets/5773490/7aecf08e-d889-4010-b4b0-2e8d290af731)

![image](https://github.com/Uniswap/interface/assets/5773490/78da53bb-2bab-44c8-a6dd-79abcf4ef0b1)
