### PR TITLE
feat: Bump default auto-slippage to 0.5%

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -13,7 +13,7 @@ import { InterfaceTrade } from 'state/routing/types'
 import useGasPrice from './useGasPrice'
 import useStablecoinPrice, { useStablecoinAmountFromFiatValue, useStablecoinValue } from './useStablecoinPrice'
 
-const DEFAULT_AUTO_SLIPPAGE = new Percent(1, 1000) // .10%
+const DEFAULT_AUTO_SLIPPAGE = new Percent(5, 1000) // 0.5%
 
 // Base costs regardless of how many hops in the route
 const V3_SWAP_BASE_GAS_ESTIMATE = 100_000


### PR DESCRIPTION
We were seeing increased rate of swap failures after changing slippage guides - bump min default to 0.50% to see if this helps!

See discussion [here](https://uniswapteam.slack.com/archives/C04JQHU6W5C/p1686171916083419)