### PR TITLE
feat: filter moz-extension errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -76,15 +76,27 @@ describe('beforeSend', () => {
     expect(beforeSend(ERROR, { originalException })).toBeNull()
   })
 
-  it('filters chrome-extension errors', () => {
-    const originalException = new Error()
-    originalException.stack = ` 
-      TypeError: Cannot create proxy with a non-object as target or handler
-        at pa(chrome-extension://kbjhmlgclljgdhmhffjofbobmficicjp/proxy-window-evm.a5430696.js:22:216604)
-        at da(chrome-extension://kbjhmlgclljgdhmhffjofbobmficicjp/proxy-window-evm.a5430696.js:22:212968)
-        at a(../../../../src/helpers.ts:98:1)
-    `
-    expect(beforeSend(ERROR, { originalException })).toBeNull()
+  describe('filters browser extension errors', () => {
+    it('filters chrome-extension errors', () => {
+      const originalException = new Error()
+      originalException.stack = ` 
+        TypeError: Cannot create proxy with a non-object as target or handler
+          at pa(chrome-extension://kbjhmlgclljgdhmhffjofbobmficicjp/proxy-window-evm.a5430696.js:22:216604)
+          at da(chrome-extension://kbjhmlgclljgdhmhffjofbobmficicjp/proxy-window-evm.a5430696.js:22:212968)
+          at a(../../../../src/helpers.ts:98:1)
+      `
+      expect(beforeSend(ERROR, { originalException })).toBeNull()
+    })
+
+    it('filters moz-extension errors', () => {
+      const originalException = new Error()
+      originalException.stack = ` 
+        Error: Permission denied to access property "apply"
+          at WINDOW.onunhandledrejection(../node_modules/@sentry/src/instrument.ts:610:1)
+          at y/h.onunhandledrejection(moz-extension://95cafb7b-6038-4bdd-b832-d3a58544601d/content_script/inpage_sol.js:143:16274)
+      `
+      expect(beforeSend(ERROR, { originalException })).toBeNull()
+    })
   })
 
   describe('OneKey', () => {

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -58,9 +58,9 @@ function shouldRejectError(error: EventHint['originalException']) {
     // Therefore, this can be ignored.
     if (error.message.match(/Unexpected token '<'/)) return true
 
-    // Errors coming from a Chrome Extension can be ignored for now. These errors are usually caused by extensions injecting
+    // Errors coming from a browser extension can be ignored. These errors are usually caused by extensions injecting
     // scripts into the page, which we cannot control.
-    if (error.stack?.match(/chrome-extension:\/\//i)) return true
+    if (error.stack?.match(/-extension:\/\//i)) return true
 
     // Errors coming from OneKey (a desktop wallet) can be ignored for now.
     // These errors are either application-specific, or they will be thrown separately outside of OneKey.


### PR DESCRIPTION
## Description
Filters errors like https://uniswap-labs.sentry.io/issues/4187963215/?project=4504255148851200&referrer=slack which caused an alert/page.

_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2339/improve-sentry-filtering-to-catch-mozilla-extensions

## Test plan
### Automated testing
- [x] Unit test
- [x] Integration/E2E test (NA)