### PR TITLE
build: rm ignored en-US

### DIFF
--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Add translations
         run: |
+          rm src/locales/en-US.po
           git add src/locales/*.po
           git commit -m 'ci(t9n): download translations from crowdin'
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Removes src/locales/en-US.po before adding src/locales/*.po, so that git will not fatally error on adding a .gitignore'd file.

See recent failure: https://github.com/Uniswap/interface/actions/runs/5292757297/jobs/9580029550