### PR TITLE
fix: position list row highlight overflowing container

### DIFF
--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -142,6 +142,7 @@ const MainContentWrapper = styled.main`
   flex-direction: column;
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
     0px 24px 32px rgba(0, 0, 0, 0.01);
+  overflow: hidden;
 `
 
 function PositionsLoadingPlaceholder() {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
* position list row is overflowing its container on highlight

<!-- Delete this section if your change does not affect UI. -->

### Before
![Screen Shot 2023-06-20 at 4 13 33 PM](https://github.com/Uniswap/interface/assets/9094792/e56dc65a-4f6e-49ff-99a9-8b1d5829ec64)


### After
![Screen Shot 2023-06-20 at 4 15 52 PM](https://github.com/Uniswap/interface/assets/9094792/ac934f65-f3ed-4a51-99ad-7562f90ee729)

