### PR TITLE
fix: added op and arb as base tokens

### DIFF
--- a/src/constants/routing.test.ts
+++ b/src/constants/routing.test.ts
@@ -1,0 +1,31 @@
+import { SupportedChainId } from './chains'
+import { COMMON_BASES } from './routing'
+
+describe('Routing', () => {
+  describe('COMMON_BASES', () => {
+    it('contains all coins for mainnet', () => {
+      const symbols = COMMON_BASES[SupportedChainId.MAINNET].map((coin) => coin.symbol)
+      expect(symbols).toEqual(['ETH', 'DAI', 'USDC', 'USDT', 'WBTC', 'WETH'])
+    })
+    it('contains all coins for arbitrum', () => {
+      const symbols = COMMON_BASES[SupportedChainId.ARBITRUM_ONE].map((coin) => coin.symbol)
+      expect(symbols).toEqual(['ETH', 'ARB', 'DAI', 'USDC', 'USDT', 'WBTC', 'WETH'])
+    })
+    it('contains all coins for optimism', () => {
+      const symbols = COMMON_BASES[SupportedChainId.OPTIMISM].map((coin) => coin.symbol)
+      expect(symbols).toEqual(['ETH', 'OP', 'DAI', 'USDC', 'USDT', 'WBTC'])
+    })
+    it('contains all coins for polygon', () => {
+      const symbols = COMMON_BASES[SupportedChainId.POLYGON].map((coin) => coin.symbol)
+      expect(symbols).toEqual(['MATIC', 'WETH', 'USDC', 'DAI', 'USDT', 'WBTC'])
+    })
+    it('contains all coins for celo', () => {
+      const symbols = COMMON_BASES[SupportedChainId.CELO].map((coin) => coin.symbol)
+      expect(symbols).toEqual(['CELO', 'cEUR', 'cUSD', 'ETH', 'USDCet', 'cMCO2'])
+    })
+    it('contains all coins for bsc', () => {
+      const symbols = COMMON_BASES[SupportedChainId.BNB].map((coin) => coin.symbol)
+      expect(symbols).toEqual(['BNB', 'DAI', 'USDC', 'USDT', 'ETH', 'BTCB', 'BUSD'])
+    })
+  })
+})

--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -4,6 +4,7 @@ import { SupportedChainId } from 'constants/chains'
 
 import {
   AMPL,
+  ARB,
   BTC_BSC,
   BUSD_BSC,
   CAKE_BSC,
@@ -25,6 +26,7 @@ import {
   FXS,
   MATIC_BSC,
   nativeOnChain,
+  OP,
   PORTAL_ETH_CELO,
   PORTAL_USDC_CELO,
   renBTC,
@@ -152,6 +154,7 @@ export const COMMON_BASES: ChainCurrencyList = {
   ],
   [SupportedChainId.ARBITRUM_ONE]: [
     nativeOnChain(SupportedChainId.ARBITRUM_ONE),
+    ARB,
     DAI_ARBITRUM_ONE,
     USDC_ARBITRUM,
     USDT_ARBITRUM_ONE,
@@ -165,6 +168,7 @@ export const COMMON_BASES: ChainCurrencyList = {
   ],
   [SupportedChainId.OPTIMISM]: [
     nativeOnChain(SupportedChainId.OPTIMISM),
+    OP,
     DAI_OPTIMISM,
     USDC_OPTIMISM,
     USDT_OPTIMISM,

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -400,6 +400,14 @@ export const ARB = new Token(
   'Arbitrum'
 )
 
+export const OP = new Token(
+  SupportedChainId.OPTIMISM,
+  '0x4200000000000000000000000000000000000042',
+  18,
+  'OP',
+  'Optimism'
+)
+
 export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } = {
   ...(WETH9 as Record<SupportedChainId, Token>),
   [SupportedChainId.OPTIMISM]: new Token(


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Added OP and ARB as base tokens on Optimism and Arbitrum respectively.

Added `OP` and `ARB` to `COMMON_BASES` array when on Arbitrum and Optimism. Added `OP` as a token. 


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2146

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="446" alt="Screenshot 2023-06-21 at 3 14 45 PM" src="https://github.com/Uniswap/interface/assets/35351983/8e50fc88-1a8d-43e1-b6e8-9b3034879797">
<img width="443" alt="Screenshot 2023-06-21 at 3 15 01 PM" src="https://github.com/Uniswap/interface/assets/35351983/6772688f-6bf4-4d8d-905f-c354c3160eb9">



### After

<img width="439" alt="Screenshot 2023-06-21 at 3 17 00 PM" src="https://github.com/Uniswap/interface/assets/35351983/e40e8b60-4863-41c2-b1a5-2002df76817b">

<img width="454" alt="Screenshot 2023-06-21 at 3 16 46 PM" src="https://github.com/Uniswap/interface/assets/35351983/1c30647b-c097-49aa-9cf9-7f53355360a2">

## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Switch to Arbitrum/Optimism and make sure tokens show up on top

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
