### PR TITLE
fix: icons no longer clip

### DIFF
--- a/src/components/AccountDrawer/AuthenticatedHeader.tsx
+++ b/src/components/AccountDrawer/AuthenticatedHeader.tsx
@@ -104,7 +104,6 @@ const StatusWrapper = styled.div`
   display: inline-block;
   width: 70%;
   max-width: 70%;
-  overflow: hidden;
   padding-right: 14px;
   display: inline-flex;
 `


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Fixes icon clipping in MiniPortfolio. 

Removed `overflow` style in `StatusWrapper` to prevent the icons from being clipped.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2349


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="377" alt="Screenshot 2023-06-21 at 3 47 24 PM" src="https://github.com/Uniswap/interface/assets/35351983/0b07e151-ef7d-44f2-b85c-a9068b4c7894">




### After


<img width="372" alt="Screenshot 2023-06-21 at 3 56 24 PM" src="https://github.com/Uniswap/interface/assets/35351983/797bb389-ac03-4bac-be03-1458b4c47648">


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Open up MiniPortfolio

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Check MiniPortfolio operates normally

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
