### PR TITLE
fix: filter WalletConnect keychain errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -163,4 +163,18 @@ describe('beforeSend', () => {
       expect(beforeSend(ERROR, { originalException })).toBeNull()
     })
   })
+
+  describe('matching key WalletConnect errors', () => {
+    it('filters keychain errors', () => {
+      const originalException = new TypeError(
+        'No matching key. keychain: 426c1cdfb685ab9bcfc38b605c99af185ce4dfd69770d6dce15fa1edcfbc9f0d'
+      )
+      expect(beforeSend(ERROR, { originalException })).toBeNull()
+    })
+
+    const originalException = new Error('No matching key. proposal: 1687374037823867')
+    it('filters proposal errors', () => {
+      expect(beforeSend(ERROR, { originalException })).toBeNull()
+    })
+  })
 })

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -88,6 +88,9 @@ function shouldRejectError(error: EventHint['originalException']) {
 
     // These are caused by user navigation away from the page before a request has finished.
     if (error instanceof DOMException && error.name === 'AbortError') return true
+
+    // Caused by a WalletConnect dependency. These don't create a customer facing issue, so they can be ignored.
+    if (error.message.match(/^No matching key\. (\w+): (.+)$/)) return true
   }
 
   return false


### PR DESCRIPTION
## Description
Filters out https://uniswap-labs.sentry.io/issues/4252488102/events/68d97dec223d4737a5e59200994d04b9/merged/?project=4504255148851200&referrer=previous-event

The number of events is too high for our costs, and this is not creating a customer impact. WalletConnect may improve the naming to be more specific, or stop throwing the error on their side.

### Automated testing
- [x] Unit test
- [ ] Integration/E2E test
