### PR TITLE
build: rm global yarn cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,6 @@ runs:
       with:
         node-version: 18
         registry-url: https://registry.npmjs.org
-        cache: 'yarn'
 
     - uses: actions/cache@v3
       id: install-cache

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,7 @@ runs:
       with:
         node-version: 18
         registry-url: https://registry.npmjs.org
+        # cache is intentionally omitted, as it is faster with yarn v1 to cache node_modules.
 
     - uses: actions/cache@v3
       id: install-cache


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Removes the global yarn cache, as implemented through [actions/setup-node](https://github.com/actions/setup-node).

Although this is the _recommended_ way to cache, it is anecdotally less performant with (classic) yarn v1, which we use. Instead, it is more performant (by 20-40s) to directly cache `node_modules/` only. Caching _both_, as is currently done, spends 20-40s unzipping the global cache, which is then unused if `node_modules/` is already present.

Test runs (to prove efficacy):
- Run with global cache (no node_modules cache): [1m4s setup](https://github.com/Uniswap/interface/actions/runs/5346256239/jobs/9693538433)
- Run with node_modules cache (no global cache): [21s setup](https://github.com/Uniswap/interface/actions/runs/5346255742/jobs/9693004399?pr=6822)


<!-- Delete inapplicable lines: -->
_Relevant docs:_ [recommended caching through actions/setup-node](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data) (unused)
