### PR TITLE
fix: handle sorting chain sorting ties

### DIFF
--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -63,8 +63,12 @@ export const ChainSelector = ({ leftAlign }: ChainSelectorProps) => {
 
   const chains = useMemo(
     () =>
-      NETWORK_SELECTOR_CHAINS.filter((chain) => showTestnets || !TESTNET_CHAIN_IDS.has(chain)).sort((a) =>
-        walletSupportsChain.includes(a) ? -1 : 1
+      NETWORK_SELECTOR_CHAINS.filter((chain) => showTestnets || !TESTNET_CHAIN_IDS.has(chain)).sort((a, b) =>
+        walletSupportsChain.includes(a) && walletSupportsChain.includes(b)
+          ? 0
+          : walletSupportsChain.includes(a)
+          ? 1
+          : -1
       ),
     [showTestnets, walletSupportsChain]
   )


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Chrome autohandles ties differently than other browsers which caused the chain sorting to appear reversed. This explicitly handles the tie condition.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
Chrome
![Screen Shot 2023-06-23 at 10 44 33 ](https://github.com/Uniswap/interface/assets/11512321/3803e5fc-e837-447f-ac28-e7cb1357ca14)


### After
Chrome
![Screen Shot 2023-06-23 at 10 44 50 ](https://github.com/Uniswap/interface/assets/11512321/96c57d8f-1ad1-4b14-ad12-b7f103c76368)



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Go to https://interface-git-main-uniswap.vercel.app/#/swap on Chrome and open Chain Switcher

