### PR TITLE
fix: handle BE avax support

### DIFF
--- a/src/constants/chains.test.ts
+++ b/src/constants/chains.test.ts
@@ -2,6 +2,7 @@ import { SupportedChainId as SdkSupportedChainId } from '@uniswap/sdk-core'
 
 import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from './chains'
 
+// These tests will be deprecated as part of the moving of ChainId to sdk-core
 describe('ChainIds', () => {
   describe('SupportedChainId', () => {
     it('derives from sdk-core', () => {
@@ -9,7 +10,7 @@ describe('ChainIds', () => {
         .filter((chainId) => typeof chainId === 'number')
         .map((value) => value.toString())
       const InterfaceChains = Object.values(SupportedChainId)
-        .filter((chainId) => typeof chainId === 'number')
+        .filter((chainId) => typeof chainId === 'number' && chainId !== SupportedChainId.AVALANCHE)
         .map((value) => value.toString())
       const isSubset = InterfaceChains.every((value) => SDKChains.includes(value))
       expect(isSubset).toBe(true)

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -24,6 +24,7 @@ export enum SupportedChainId {
   CELO_ALFAJORES = 44787,
 
   BNB = 56,
+  AVALANCHE = 43114,
 }
 
 export const UniWalletSupportedChains = [
@@ -46,6 +47,7 @@ export const CHAIN_IDS_TO_NAMES = {
   [SupportedChainId.OPTIMISM]: 'optimism',
   [SupportedChainId.OPTIMISM_GOERLI]: 'optimism_goerli',
   [SupportedChainId.BNB]: 'bnb',
+  [SupportedChainId.AVALANCHE]: 'avalanche',
 }
 
 /**

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -100,6 +100,15 @@ export const FALLBACK_URLS = {
     'https://bsc-dataseed4.defibit.io',
     'https://rpc.ankr.com/bsc',
   ],
+  [SupportedChainId.AVALANCHE]: [
+    // "Safe" URLs
+    'https://api.avax.network/ext/bc/C/rpc',
+    'https://rpc.ankr.com/avalanche',
+    'https://avalanche.blockpi.network/v1/rpc/public',
+    'https://avalanche-c-chain.publicnode.com',
+    'https://endpoints.omniatech.io/v1/avax/mainnet/public',
+    'https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc',
+  ],
 }
 
 /**
@@ -143,4 +152,8 @@ export const RPC_URLS = {
   [SupportedChainId.CELO]: FALLBACK_URLS[SupportedChainId.CELO],
   [SupportedChainId.CELO_ALFAJORES]: FALLBACK_URLS[SupportedChainId.CELO_ALFAJORES],
   [SupportedChainId.BNB]: [QUICKNODE_RPC_URL, ...FALLBACK_URLS[SupportedChainId.BNB]],
+  [SupportedChainId.AVALANCHE]: [
+    `https://avalanche-mainnet.infura.io/v3/${INFURA_KEY}`,
+    ...FALLBACK_URLS[SupportedChainId.AVALANCHE],
+  ],
 }

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -70,4 +70,5 @@ export const RPC_PROVIDERS: { [key in SupportedChainId]: StaticJsonRpcProvider }
   [SupportedChainId.CELO]: new AppJsonRpcProvider(SupportedChainId.CELO),
   [SupportedChainId.CELO_ALFAJORES]: new AppJsonRpcProvider(SupportedChainId.CELO_ALFAJORES),
   [SupportedChainId.BNB]: new AppJsonRpcProvider(SupportedChainId.BNB),
+  [SupportedChainId.AVALANCHE]: new AppJsonRpcProvider(SupportedChainId.AVALANCHE),
 }

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -130,6 +130,7 @@ export const CHAIN_NAME_TO_CHAIN_ID: { [key in Chain]: SupportedChainId } = {
   [Chain.Arbitrum]: SupportedChainId.ARBITRUM_ONE,
   [Chain.UnknownChain]: SupportedChainId.MAINNET,
   [Chain.Bnb]: SupportedChainId.BNB,
+  [Chain.Avalanche]: SupportedChainId.AVALANCHE,
 }
 
 export function fromGraphQLChain(chain: Chain): SupportedChainId {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
BE has added AVAX as a ChainId and now shows avax tokens in the miniportfolio. We'll need an interim state before #6776 is fully merged where this no longer causes builds to fail. **Avalanche swapping, LPing, wrapping, etc will still not be supported as a result of this PR.** This is the minimal amount of content needed to prevent the build from crashing. Yes this will cause merge conflicts with my branch which I will have to resolve. Thank you for asking.

<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture
AVAX still not supported
![Screen Shot 2023-06-23 at 10 52 45 ](https://github.com/Uniswap/interface/assets/11512321/6b66f2cf-f581-486e-9e8a-8cffa5ece4b8)
![Screen Shot 2023-06-23 at 10 52 51 ](https://github.com/Uniswap/interface/assets/11512321/838297c6-d44c-4af2-917c-27a911365c10)
