### PR TITLE
fix: filter more CSP errors

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -128,6 +128,18 @@ describe('beforeSend', () => {
       expect(beforeSend(ERROR, { originalException })).toBeNull()
     })
 
+    it('filters blocked frame errors', () => {
+      const originalException = new Error(
+        'Blocked a frame with origin "https://app.uniswap.org" from accessing a cross-origin frame.'
+      )
+      expect(beforeSend(ERROR, { originalException })).toBeNull()
+    })
+
+    it('fiters write permission denied errors', () => {
+      const originalException = new Error('NotAllowedError: Write permission denied.')
+      expect(beforeSend(ERROR, { originalException })).toBeNull()
+    })
+
     it('filters CSP unsafe-eval compile/instatiate errors', () => {
       const originalException = new Error(
         "Refused to compile or instantiate WebAssembly module because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self' https://www.google-a..."

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -69,9 +69,9 @@ function shouldRejectError(error: EventHint['originalException']) {
     // Content security policy 'unsafe-eval' errors can be filtered out because there are expected failures.
     // For example, if a user runs an eval statement in console this error would still get thrown.
     // TODO(WEB-2348): We should extend this to filter out any type of CSP error.
-    if (error.message.match(/'unsafe-eval'.*content security policy/i)) {
-      return true
-    }
+    if (error.message.match(/'unsafe-eval'.*content security policy/i)) return true
+    if (error.message.match(/Blocked a frame with origin "*" from accessing a cross-origin frame./)) return true
+    if (error.message.match(/NotAllowedError: Write permission denied./)) return true
 
     // WebAssembly compilation fails because we do not allow 'unsafe-eval' in our CSP.
     // Any thrown errors are due to 3P extensions/applications, so we do not need to handle them.


### PR DESCRIPTION
## Description
Removes more CSP errors that we shouldn't be alerted on.

https://uniswap-labs.sentry.io/issues/4251643566/?project=4504255148851200&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=4

https://uniswap-labs.sentry.io/issues/3789706876/?project=4504255148851200&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=21

## Test plan
### Automated testing
- [x] Unit test
- [ ] Integration/E2E test
