### PR TITLE
fix: filter user reject errors temporarily

### DIFF
--- a/src/tracing/errors.test.ts
+++ b/src/tracing/errors.test.ts
@@ -54,9 +54,9 @@ describe('beforeSend', () => {
     expect(beforeSend(ERROR, { originalException })).toBe(ERROR)
   })
 
-  it('propagates user rejected request errors', () => {
+  it('filters user rejected request errors', () => {
     const originalException = new Error('user rejected transaction')
-    expect(beforeSend(ERROR, { originalException })).toBe(ERROR)
+    expect(beforeSend(ERROR, { originalException })).toBeNull()
   })
 
   it('filters block number polling errors', () => {

--- a/src/tracing/errors.ts
+++ b/src/tracing/errors.ts
@@ -1,4 +1,5 @@
 import { ClientOptions, ErrorEvent, EventHint } from '@sentry/types'
+import { didUserReject } from 'utils/swapErrorToUserReadableMessage'
 
 // `responseStatus` is only currently supported on certain browsers.
 // see: https://caniuse.com/mdn-api_performanceresourcetiming_responsestatus
@@ -49,6 +50,10 @@ function shouldRejectError(error: EventHint['originalException']) {
       const method = JSON.parse(error.requestBody).method
       if (method === 'eth_blockNumber') return true
     }
+
+    // If the error is based on a user rejecting, it should not be considered an exception.
+    // TODO(WEB-2398): we should catch these errors and handle them gracefully instead.
+    if (didUserReject(error)) return true
 
     // If the error is a network change, it should not be considered an exception.
     if (error.message.match(/underlying network changed/)) return true


### PR DESCRIPTION
## Description
I've changed my mind on this a few times. First I added this filter https://github.com/Uniswap/interface/pull/6330 because it was high volume. Then I removed the filter here https://github.com/Uniswap/interface/pull/6533 because I felt this was something we should be handling. I then ignored it in Sentry directly so we didn't get alerted.

I do have a WIP to fix this here but haven't had time to finish it. https://github.com/Uniswap/interface/pull/6348

The problem is we now have an alert which checks for crash free session rate, and unfortunately ignored errors still count against that metric. So I'd like to temporarily pause sending these until we merge the other PR.

_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2398/catch-user-rejection-errors

## Test plan
### Automated testing
- [x] Unit test
- [ ] Integration/E2E test
