### PR TITLE
chore: removed an unused label property.

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -582,9 +582,6 @@ export function Swap({
         <SwapSection>
           <Trace section={InterfaceSectionName.CURRENCY_INPUT_PANEL}>
             <SwapCurrencyInputPanel
-              label={
-                independentField === Field.OUTPUT && !showWrap ? <Trans>From (at most)</Trans> : <Trans>From</Trans>
-              }
               disabled={disableTokenInputs}
               value={formattedAmounts[Field.INPUT]}
               showMaxButton={showMaxButton}
@@ -629,7 +626,6 @@ export function Swap({
                 value={formattedAmounts[Field.OUTPUT]}
                 disabled={disableTokenInputs}
                 onUserInput={handleTypeOutput}
-                label={independentField === Field.INPUT && !showWrap ? <Trans>To (at least)</Trans> : <Trans>To</Trans>}
                 showMaxButton={false}
                 hideBalance={false}
                 fiatValue={showFiatValueOutput ? fiatValueOutput : undefined}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
summary:
Fixed an issue with `label="[object Object]"` in SwapCurrencyInputPanel.

details:
As label prop, `<Tran / >` jsx was passed as a styled div and the label of the div element of the deployed service was checked for the value `[object Object]`.

Removed the label prop because it was found to be an unused prop and the SwapCurrencyInputPanel component was also found to be not referenced on any page other than swap.

Modified both the Input and Output field components.

https://github.com/Uniswap/interface/blob/1c4a383a4906f058c3c255e89f4a93dee576d7a3/src/pages/Swap/index.tsx#L584-L587

https://github.com/Uniswap/interface/blob/1c4a383a4906f058c3c255e89f4a93dee576d7a3/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx#L245

https://github.com/Uniswap/interface/blob/1c4a383a4906f058c3c255e89f4a93dee576d7a3/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx#L28

<!-- Delete inapplicable lines: -->

<!-- Delete this section if your change does not affect UI. -->

<!-- Delete this section if your change is not a bug fix. -->

<!-- Include steps to reproduce the bug. -->

<!-- Include steps to test the change, ensuring no regression. -->

<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->
