### PR TITLE
fix: combine userState with default injected wallet in cypress setup

### DIFF
--- a/cypress/e2e/landing.test.ts
+++ b/cypress/e2e/landing.test.ts
@@ -1,9 +1,9 @@
 import { getTestSelector } from '../utils'
-import { CONNECTED_WALLET_USER_STATE, UNCONNECTED_WALLET_USER_STATE } from '../utils/user-state'
+import { CONNECTED_WALLET_USER_STATE, DISCONNECTED_WALLET_USER_STATE } from '../utils/user-state'
 
 describe('Landing Page', () => {
   it('shows landing page when no user state exists', () => {
-    cy.visit('/', { userState: UNCONNECTED_WALLET_USER_STATE })
+    cy.visit('/', { userState: DISCONNECTED_WALLET_USER_STATE })
     cy.get(getTestSelector('landing-page'))
     cy.screenshot()
   })

--- a/cypress/e2e/landing.test.ts
+++ b/cypress/e2e/landing.test.ts
@@ -1,9 +1,9 @@
 import { getTestSelector } from '../utils'
-import { CONNECTED_WALLET_USER_STATE } from '../utils/user-state'
+import { CONNECTED_WALLET_USER_STATE, UNCONNECTED_WALLET_USER_STATE } from '../utils/user-state'
 
 describe('Landing Page', () => {
   it('shows landing page when no user state exists', () => {
-    cy.visit('/', { userState: {} })
+    cy.visit('/', { userState: UNCONNECTED_WALLET_USER_STATE })
     cy.get(getTestSelector('landing-page'))
     cy.screenshot()
   })

--- a/cypress/e2e/wallet-connection/connect.test.ts
+++ b/cypress/e2e/wallet-connection/connect.test.ts
@@ -1,5 +1,5 @@
 import { getTestSelector } from '../../utils'
-import { UNCONNECTED_WALLET_USER_STATE } from '../../utils/user-state'
+import { DISCONNECTED_WALLET_USER_STATE } from '../../utils/user-state'
 
 describe('disconnect wallet', () => {
   it('should clear state', () => {
@@ -28,7 +28,7 @@ describe('disconnect wallet', () => {
 
 describe('connect wallet', () => {
   it('should load state', () => {
-    cy.visit('/swap', { ethereum: 'hardhat', userState: UNCONNECTED_WALLET_USER_STATE })
+    cy.visit('/swap', { ethereum: 'hardhat', userState: DISCONNECTED_WALLET_USER_STATE })
 
     // Connect the wallet
     cy.get(getTestSelector('navbar-connect-wallet')).contains('Connect').click()

--- a/cypress/e2e/wallet-connection/connect.test.ts
+++ b/cypress/e2e/wallet-connection/connect.test.ts
@@ -1,4 +1,5 @@
 import { getTestSelector } from '../../utils'
+import { UNCONNECTED_WALLET_USER_STATE } from '../../utils/user-state'
 
 describe('disconnect wallet', () => {
   it('should clear state', () => {
@@ -27,7 +28,7 @@ describe('disconnect wallet', () => {
 
 describe('connect wallet', () => {
   it('should load state', () => {
-    cy.visit('/swap', { ethereum: 'hardhat', userState: {} })
+    cy.visit('/swap', { ethereum: 'hardhat', userState: UNCONNECTED_WALLET_USER_STATE })
 
     // Connect the wallet
     cy.get(getTestSelector('navbar-connect-wallet')).contains('Connect').click()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -58,11 +58,7 @@ Cypress.Commands.overwrite(
             // Set initial user state.
             win.localStorage.setItem(
               'redux_localstorage_simple_user', // storage key for the user reducer using 'redux-localstorage-simple'
-              JSON.stringify(
-                options?.userState
-                  ? { ...CONNECTED_WALLET_USER_STATE, ...options.userState }
-                  : CONNECTED_WALLET_USER_STATE
-              )
+              JSON.stringify({ ...CONNECTED_WALLET_USER_STATE, ...(options?.userState ?? {}) })
             )
 
             // Set feature flags, if configured.

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -58,7 +58,11 @@ Cypress.Commands.overwrite(
             // Set initial user state.
             win.localStorage.setItem(
               'redux_localstorage_simple_user', // storage key for the user reducer using 'redux-localstorage-simple'
-              JSON.stringify(options?.userState ?? CONNECTED_WALLET_USER_STATE)
+              JSON.stringify(
+                options?.userState
+                  ? { ...CONNECTED_WALLET_USER_STATE, ...options.userState }
+                  : CONNECTED_WALLET_USER_STATE
+              )
             )
 
             // Set feature flags, if configured.

--- a/cypress/utils/user-state.ts
+++ b/cypress/utils/user-state.ts
@@ -1,3 +1,5 @@
 import { UserState } from '../../src/state/user/reducer'
 
 export const CONNECTED_WALLET_USER_STATE: Partial<UserState> = { selectedWallet: 'INJECTED' }
+
+export const UNCONNECTED_WALLET_USER_STATE: Partial<UserState> = { selectedWallet: undefined }

--- a/cypress/utils/user-state.ts
+++ b/cypress/utils/user-state.ts
@@ -2,4 +2,4 @@ import { UserState } from '../../src/state/user/reducer'
 
 export const CONNECTED_WALLET_USER_STATE: Partial<UserState> = { selectedWallet: 'INJECTED' }
 
-export const UNCONNECTED_WALLET_USER_STATE: Partial<UserState> = { selectedWallet: undefined }
+export const DISCONNECTED_WALLET_USER_STATE: Partial<UserState> = { selectedWallet: undefined }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

this allows you to set custom `userState` in a test in combination with the default injected hardhat provider being automatically connected. 




## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1.  write a test with both the `hardhat` option and some custom initial `userState` and note that the wallet isn't automatically connected at the start of the test

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] verified the wallet connects automatically with this change

