### PR TITLE
chore: remove walletConnectV2 flag

### DIFF
--- a/src/components/AccountDrawer/UniwalletModal.tsx
+++ b/src/components/AccountDrawer/UniwalletModal.tsx
@@ -1,17 +1,14 @@
 import { Trans } from '@lingui/macro'
 import { sendAnalyticsEvent } from '@uniswap/analytics'
 import { InterfaceElementName } from '@uniswap/analytics-events'
-import { WalletConnect } from '@web3-react/walletconnect'
 import { WalletConnect as WalletConnectv2 } from '@web3-react/walletconnect-v2'
 import Column, { AutoColumn } from 'components/Column'
 import Modal from 'components/Modal'
 import { RowBetween } from 'components/Row'
-import { uniwalletConnectConnection, uniwalletWCV2ConnectConnection } from 'connection'
+import { uniwalletWCV2ConnectConnection } from 'connection'
 import { ActivationStatus, useActivationState } from 'connection/activate'
 import { ConnectionType } from 'connection/types'
-import { UniwalletConnect } from 'connection/WalletConnect'
 import { UniwalletConnect as UniwalletConnectV2 } from 'connection/WalletConnectV2'
-import { useWalletConnectV2AsDefault } from 'featureFlags/flags/walletConnectV2'
 import { QRCodeSVG } from 'qrcode.react'
 import { useEffect, useState } from 'react'
 import styled, { useTheme } from 'styled-components/macro'
@@ -51,21 +48,12 @@ export default function UniwalletModal() {
     uniswapWalletConnectors.includes(activationState.connection.type) &&
     !!uri
 
-  const walletConnectV2AsDefault = useWalletConnectV2AsDefault()
-
   useEffect(() => {
-    if (walletConnectV2AsDefault) {
-      const connectorV2 = uniwalletWCV2ConnectConnection.connector as WalletConnectv2
-      connectorV2.events.addListener(UniwalletConnectV2.UNI_URI_AVAILABLE, (uri: string) => {
-        uri && setUri(uri)
-      })
-    } else {
-      const connectorV1 = uniwalletConnectConnection.connector as WalletConnect
-      connectorV1.events.addListener(UniwalletConnect.UNI_URI_AVAILABLE, (uri: string) => {
-        uri && setUri(uri)
-      })
-    }
-  }, [walletConnectV2AsDefault])
+    const connectorV2 = uniwalletWCV2ConnectConnection.connector as WalletConnectv2
+    connectorV2.events.addListener(UniwalletConnectV2.UNI_URI_AVAILABLE, (uri: string) => {
+      uri && setUri(uri)
+    })
+  }, [])
 
   useEffect(() => {
     if (open) sendAnalyticsEvent('Uniswap wallet modal opened')

--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -3,7 +3,6 @@ import { DetailsV2Variant, useDetailsV2Flag } from 'featureFlags/flags/nftDetail
 import { useRoutingAPIForPriceFlag } from 'featureFlags/flags/priceRoutingApi'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { UnifiedRouterVariant, useRoutingAPIV2Flag } from 'featureFlags/flags/unifiedRouter'
-import { useWalletConnectV2Flag } from 'featureFlags/flags/walletConnectV2'
 import { useUpdateAtom } from 'jotai/utils'
 import { Children, PropsWithChildren, ReactElement, ReactNode, useCallback, useState } from 'react'
 import { X } from 'react-feather'
@@ -221,12 +220,6 @@ export default function FeatureFlagModal() {
         value={useRoutingAPIForPriceFlag()}
         featureFlag={FeatureFlag.routingAPIPrice}
         label="Use the URA or routing-api for price fetches"
-      />
-      <FeatureFlagOption
-        variant={BaseVariant}
-        value={useWalletConnectV2Flag()}
-        featureFlag={FeatureFlag.walletConnectV2}
-        label="Uses WalletConnect V2 as default wallet connect connection"
       />
       <FeatureFlagGroup name="Debug">
         <FeatureFlagOption

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -6,7 +6,6 @@ import { getConnections, networkConnection } from 'connection'
 import { ActivationStatus, useActivationState } from 'connection/activate'
 import { ConnectionType } from 'connection/types'
 import { isSupportedChain } from 'constants/chains'
-import { useWalletConnectV2AsDefault } from 'featureFlags/flags/walletConnectV2'
 import { useEffect } from 'react'
 import { Settings } from 'react-feather'
 import styled from 'styled-components/macro'
@@ -46,11 +45,7 @@ export default function WalletModal({ openSettings }: { openSettings: () => void
 
   const { activationState } = useActivationState()
 
-  const walletConnectV2AsDefault = useWalletConnectV2AsDefault()
-  const hiddenWalletConnectTypes = [
-    walletConnectV2AsDefault ? ConnectionType.WALLET_CONNECT : ConnectionType.WALLET_CONNECT_V2,
-    walletConnectV2AsDefault ? ConnectionType.UNISWAP_WALLET : ConnectionType.UNISWAP_WALLET_V2,
-  ]
+  const hiddenWalletConnectTypes = [ConnectionType.WALLET_CONNECT, ConnectionType.UNISWAP_WALLET]
 
   // Keep the network connector in sync with any active user connector to prevent chain-switching on wallet disconnection.
   useEffect(() => {

--- a/src/featureFlags/flags/walletConnectV2.ts
+++ b/src/featureFlags/flags/walletConnectV2.ts
@@ -1,9 +1,0 @@
-import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
-
-export function useWalletConnectV2Flag(): BaseVariant {
-  return useBaseFlag(FeatureFlag.walletConnectV2)
-}
-
-export function useWalletConnectV2AsDefault(): boolean {
-  return useWalletConnectV2Flag() === BaseVariant.Enabled
-}

--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -14,7 +14,6 @@ export enum FeatureFlag {
   debounceSwapQuote = 'debounce_swap_quote',
   nativeUsdcArbitrum = 'web_usdc_arbitrum',
   routingAPIPrice = 'routing_api_price',
-  walletConnectV2 = 'walletconnect_v2',
 }
 
 interface FeatureFlagsContextType {


### PR DESCRIPTION
Removes the defaulting logic as we should always show WalletConnect v2.