### PR TITLE
fix: Reduce default slippage to 0.5%

### DIFF
--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -47,7 +47,7 @@ import { currencyId } from '../../utils/currencyId'
 import AppBody from '../AppBody'
 import { ClickableText, MaxButton, Wrapper } from '../Pool/styleds'
 
-const DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE = new Percent(5, 100)
+const DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
 export default function RemoveLiquidityWrapper() {
   const { chainId } = useWeb3React()


### PR DESCRIPTION
Change the default slippage from 5% to 0.5%


## Description
changes default slippage in the remove liquidity page from 5% to 0.5%


<!-- Delete inapplicable lines: -->
_Slack thread:_ https://unigrantsprogram.slack.com/archives/C04SNJ6TVAS/p1688057329109219


