### PR TITLE
fix: Use separate GQL chain type on interface

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/index.tsx
@@ -3,8 +3,12 @@ import { useAccountDrawer } from 'components/AccountDrawer'
 import Column from 'components/Column'
 import { LoadingBubble } from 'components/Tokens/loading'
 import { getYear, isSameDay, isSameMonth, isSameWeek, isSameYear } from 'date-fns'
-import { TransactionStatus, useTransactionListQuery } from 'graphql/data/__generated__/types-and-hooks'
-import { PollingInterval } from 'graphql/data/util'
+import {
+  AssetActivityPartsFragment,
+  TransactionStatus,
+  useTransactionListQuery,
+} from 'graphql/data/__generated__/types-and-hooks'
+import { ChainReplace, isInterfaceSupportedGqlChain, PollingInterval } from 'graphql/data/util'
 import { atom, useAtom } from 'jotai'
 import { EmptyWalletModule } from 'nft/components/profile/view/EmptyWalletContent'
 import { useEffect, useMemo } from 'react'
@@ -144,7 +148,11 @@ export function ActivityTab({ account }: { account: string }) {
   }, [drawerOpen, lastFetched, refetch, setLastFetched])
 
   const activityGroups = useMemo(() => {
-    const remoteMap = parseRemoteActivities(data?.portfolios?.[0].assetActivities)
+    const remoteMap = parseRemoteActivities(
+      data?.portfolios?.[0].assetActivities?.filter((activity) =>
+        isInterfaceSupportedGqlChain(activity.chain)
+      ) as ChainReplace<AssetActivityPartsFragment>[]
+    )
     const allActivities = combineActivities(localMap, remoteMap, account)
     return createGroups(allActivities)
   }, [data?.portfolios, localMap, account])

--- a/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
@@ -4,7 +4,7 @@ import { formatNumber, NumberType } from '@uniswap/conedison/format'
 import Row from 'components/Row'
 import { formatDelta } from 'components/Tokens/TokenDetails/PriceChart'
 import { PortfolioBalancesQuery, usePortfolioBalancesQuery } from 'graphql/data/__generated__/types-and-hooks'
-import { getTokenDetailsURL, gqlToCurrency } from 'graphql/data/util'
+import { ChainReplace, getTokenDetailsURL, gqlToCurrency, isInterfaceSupportedGqlChain } from 'graphql/data/util'
 import { useAtomValue } from 'jotai/utils'
 import { EmptyWalletModule } from 'nft/components/profile/view/EmptyWalletContent'
 import { useCallback, useMemo, useState } from 'react'
@@ -68,14 +68,26 @@ export default function Tokens({ account }: { account: string }) {
       {visibleTokens.map(
         (tokenBalance) =>
           tokenBalance.token &&
-          meetsThreshold(tokenBalance, hideSmallBalances) && (
-            <TokenRow key={tokenBalance.id} {...tokenBalance} token={tokenBalance.token} />
+          meetsThreshold(tokenBalance, hideSmallBalances) &&
+          isInterfaceSupportedGqlChain(tokenBalance.token.chain) && (
+            <TokenRow
+              key={tokenBalance.id}
+              {...tokenBalance}
+              token={tokenBalance.token as ChainReplace<PortfolioToken>}
+            />
           )
       )}
       <ExpandoRow isExpanded={showHiddenTokens} toggle={toggleHiddenTokens} numItems={hiddenTokens.length}>
         {hiddenTokens.map(
           (tokenBalance) =>
-            tokenBalance.token && <TokenRow key={tokenBalance.id} {...tokenBalance} token={tokenBalance.token} />
+            tokenBalance.token &&
+            isInterfaceSupportedGqlChain(tokenBalance.token.chain) && (
+              <TokenRow
+                key={tokenBalance.id}
+                {...tokenBalance}
+                token={tokenBalance.token as ChainReplace<PortfolioToken>}
+              />
+            )
         )}
       </ExpandoRow>
     </PortfolioTabWrapper>
@@ -90,7 +102,7 @@ type TokenBalance = NonNullable<
   NonNullable<NonNullable<PortfolioBalancesQuery['portfolios']>[number]>['tokenBalances']
 >[number]
 
-type PortfolioToken = NonNullable<TokenBalance['token']>
+type PortfolioToken = ChainReplace<NonNullable<TokenBalance['token']>>
 
 function TokenRow({ token, quantity, denominatedValue, tokenProjectMarket }: TokenBalance & { token: PortfolioToken }) {
   const percentChange = tokenProjectMarket?.pricePercentChange?.value ?? 0

--- a/src/components/Logo/QueryTokenLogo.tsx
+++ b/src/components/Logo/QueryTokenLogo.tsx
@@ -3,13 +3,13 @@ import { TokenStandard } from 'graphql/data/__generated__/types-and-hooks'
 import { SearchToken } from 'graphql/data/SearchTokens'
 import { TokenQueryData } from 'graphql/data/Token'
 import { TopToken } from 'graphql/data/TopTokens'
-import { CHAIN_NAME_TO_CHAIN_ID } from 'graphql/data/util'
+import { CHAIN_NAME_TO_CHAIN_ID, ChainReplace } from 'graphql/data/util'
 
 import AssetLogo, { AssetLogoBaseProps } from './AssetLogo'
 
 export default function QueryTokenLogo(
   props: AssetLogoBaseProps & {
-    token?: TopToken | TokenQueryData | SearchToken
+    token?: ChainReplace<TopToken | TokenQueryData | SearchToken>
   }
 ) {
   const chainId = props.token?.chain ? CHAIN_NAME_TO_CHAIN_ID[props.token?.chain] : undefined

--- a/src/components/Tokens/TokenDetails/index.tsx
+++ b/src/components/Tokens/TokenDetails/index.tsx
@@ -26,7 +26,7 @@ import { checkWarning } from 'constants/tokenSafety'
 import { TokenPriceQuery } from 'graphql/data/__generated__/types-and-hooks'
 import { Chain, TokenQuery, TokenQueryData } from 'graphql/data/Token'
 import { QueryToken } from 'graphql/data/Token'
-import { CHAIN_NAME_TO_CHAIN_ID, getTokenDetailsURL } from 'graphql/data/util'
+import { CHAIN_NAME_TO_CHAIN_ID, ChainReplace, getTokenDetailsURL, InterfaceGqlChain } from 'graphql/data/util'
 import { useOnGlobalChainSwitch } from 'hooks/useGlobalChainSwitch'
 import { UNKNOWN_TOKEN_SYMBOL, useTokenFromActiveNetwork } from 'lib/hooks/useCurrency'
 import { Swap } from 'pages/Swap'
@@ -67,7 +67,7 @@ function useOnChainToken(address: string | undefined, skip: boolean) {
 function useRelevantToken(
   address: string | undefined,
   pageChainId: number,
-  tokenQueryData: TokenQueryData | undefined
+  tokenQueryData: ChainReplace<TokenQueryData> | undefined
 ) {
   const { chainId: activeChainId } = useWeb3React()
   const queryToken = useMemo(() => {
@@ -89,8 +89,8 @@ function useRelevantToken(
 type TokenDetailsProps = {
   urlAddress?: string
   inputTokenAddress?: string
-  chain: Chain
-  tokenQuery: TokenQuery
+  chain: InterfaceGqlChain
+  tokenQuery: ChainReplace<TokenQuery>
   tokenPriceQuery?: TokenPriceQuery
   onChangeTimePeriod: OnChangeTimePeriod
 }

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -7,7 +7,7 @@ import SparklineChart from 'components/Charts/SparklineChart'
 import QueryTokenLogo from 'components/Logo/QueryTokenLogo'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { SparklineMap, TopToken } from 'graphql/data/TopTokens'
-import { CHAIN_NAME_TO_CHAIN_ID, getTokenDetailsURL, validateUrlChainParam } from 'graphql/data/util'
+import { CHAIN_NAME_TO_CHAIN_ID, ChainReplace, getTokenDetailsURL, validateUrlChainParam } from 'graphql/data/util'
 import { useAtomValue } from 'jotai/utils'
 import { ForwardedRef, forwardRef } from 'react'
 import { CSSProperties, ReactNode } from 'react'
@@ -424,7 +424,7 @@ export function LoadingRow(props: { first?: boolean; last?: boolean }) {
 interface LoadedRowProps {
   tokenListIndex: number
   tokenListLength: number
-  token: NonNullable<TopToken>
+  token: NonNullable<ChainReplace<TopToken>>
   sparklineMap: SparklineMap
   sortRank: number
 }

--- a/src/graphql/data/Token.ts
+++ b/src/graphql/data/Token.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 import { TokenQuery } from './__generated__/types-and-hooks'
-import { CHAIN_NAME_TO_CHAIN_ID } from './util'
+import { CHAIN_NAME_TO_CHAIN_ID, ChainReplace } from './util'
 
 // The difference between Token and TokenProject:
 // Token: an on-chain entity referring to a contract (e.g. uni token on ethereum 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984)
@@ -69,7 +69,7 @@ export type TokenQueryData = TokenQuery['token']
 
 // TODO: Return a QueryToken from useTokenQuery instead of TokenQueryData to make it more usable in Currency-centric interfaces.
 export class QueryToken extends WrappedTokenInfo {
-  constructor(address: string, data: NonNullable<TokenQueryData>, logoSrc?: string) {
+  constructor(address: string, data: ChainReplace<NonNullable<TokenQueryData>>, logoSrc?: string) {
     super({
       chainId: CHAIN_NAME_TO_CHAIN_ID[data.chain],
       address,

--- a/src/graphql/data/TrendingTokens.ts
+++ b/src/graphql/data/TrendingTokens.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag'
 import { useMemo } from 'react'
 
-import { useTrendingTokensQuery } from './__generated__/types-and-hooks'
-import { chainIdToBackendName, unwrapToken } from './util'
+import { TrendingTokensQuery, useTrendingTokensQuery } from './__generated__/types-and-hooks'
+import { chainIdToBackendName, ChainReplace, isInterfaceSupportedGqlChain, unwrapToken } from './util'
 
 gql`
   query TrendingTokens($chain: Chain!) {
@@ -43,9 +43,12 @@ gql`
 export default function useTrendingTokens(chainId?: number) {
   const chain = chainIdToBackendName(chainId)
   const { data, loading } = useTrendingTokensQuery({ variables: { chain } })
+  const topTokens = data?.topTokens?.filter((token) => isInterfaceSupportedGqlChain(token.chain)) as ChainReplace<
+    TrendingTokensQuery['topTokens']
+  >
 
   return useMemo(
-    () => ({ data: data?.topTokens?.map((token) => unwrapToken(chainId ?? 1, token)), loading }),
-    [chainId, data?.topTokens, loading]
+    () => ({ data: topTokens?.map((token) => unwrapToken(chainId ?? 1, token)), loading }),
+    [chainId, topTokens, loading]
   )
 }

--- a/src/pages/TokenDetails/index.tsx
+++ b/src/pages/TokenDetails/index.tsx
@@ -1,8 +1,8 @@
 import TokenDetails from 'components/Tokens/TokenDetails'
 import { TokenDetailsPageSkeleton } from 'components/Tokens/TokenDetails/Skeleton'
 import { NATIVE_CHAIN_ID } from 'constants/tokens'
-import { useTokenPriceQuery, useTokenQuery } from 'graphql/data/__generated__/types-and-hooks'
-import { TimePeriod, toHistoryDuration, validateUrlChainParam } from 'graphql/data/util'
+import { TokenQuery, useTokenPriceQuery, useTokenQuery } from 'graphql/data/__generated__/types-and-hooks'
+import { ChainReplace, TimePeriod, toHistoryDuration, validateUrlChainParam } from 'graphql/data/util'
 import useParsedQueryString from 'hooks/useParsedQueryString'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
@@ -57,12 +57,11 @@ export default function TokenDetailsPage() {
   }, [setCurrentPriceQuery, tokenPriceQuery])
 
   if (!tokenQuery) return <TokenDetailsPageSkeleton />
-
   return (
     <TokenDetails
       urlAddress={tokenAddress}
       chain={chain}
-      tokenQuery={tokenQuery}
+      tokenQuery={tokenQuery as ChainReplace<TokenQuery>}
       tokenPriceQuery={currentPriceQuery}
       onChangeTimePeriod={setTimePeriod}
       inputTokenAddress={parsedInputTokenAddress}

--- a/src/utils/currencyKey.ts
+++ b/src/utils/currencyKey.ts
@@ -2,8 +2,7 @@ import { Currency } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import { NATIVE_CHAIN_ID } from 'constants/tokens'
 import { TokenStandard } from 'graphql/data/__generated__/types-and-hooks'
-import { Chain } from 'graphql/data/Token'
-import { fromGraphQLChain } from 'graphql/data/util'
+import { fromGraphQLChain, InterfaceGqlChain } from 'graphql/data/util'
 
 export type CurrencyKey = string
 
@@ -18,7 +17,7 @@ export function currencyKey(currency: Currency): CurrencyKey {
 
 export function currencyKeyFromGraphQL(contract: {
   address?: string
-  chain: Chain
+  chain: InterfaceGqlChain
   standard?: TokenStandard
 }): CurrencyKey {
   const chainId = fromGraphQLChain(contract.chain)

--- a/src/utils/nativeTokens.ts
+++ b/src/utils/nativeTokens.ts
@@ -1,8 +1,8 @@
 import { nativeOnChain } from 'constants/tokens'
 import { Chain } from 'graphql/data/__generated__/types-and-hooks'
-import { CHAIN_NAME_TO_CHAIN_ID } from 'graphql/data/util'
+import { CHAIN_NAME_TO_CHAIN_ID, InterfaceGqlChain } from 'graphql/data/util'
 
-export function getNativeTokenDBAddress(chain: Chain): string | undefined {
+export function getNativeTokenDBAddress(chain: InterfaceGqlChain): string | undefined {
   const pageChainId = CHAIN_NAME_TO_CHAIN_ID[chain]
   if (pageChainId === undefined) {
     return undefined


### PR DESCRIPTION
prototype but basically uses a separate `InterfaceGqlChain` type that is a subset of both `SupportedChainId` and `Chain` to denote that this is a chain we actually support and can parse on interface

it:
- filters through existing data to only accept data on supported chains
- allows backend to add new chains whenever they want without messing up our own type checks
- needs more work here but can basically add new chains to query from gql in one place
