### PR TITLE
fix: show bnb pool positions in mini port

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Pools/useMultiChainPositions.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Pools/useMultiChainPositions.tsx
@@ -47,6 +47,7 @@ const DEFAULT_CHAINS = [
   SupportedChainId.OPTIMISM,
   SupportedChainId.POLYGON,
   SupportedChainId.CELO,
+  SupportedChainId.BNB,
 ]
 
 type UseMultiChainPositionsData = { positions?: PositionInfo[]; loading: boolean }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- show bnb pool positions in mini port

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
![Screenshot 2023-07-05 at 9 18 28 AM](https://github.com/Uniswap/interface/assets/11512321/acd63ebc-7189-4c10-ae17-e4c3fad8eccf)



### After
![Screenshot 2023-07-05 at 9 17 53 AM](https://github.com/Uniswap/interface/assets/11512321/f4531867-a33f-4a24-95a4-fe8b67ae687e)


## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Use [impersonator](https://www.impersonator.xyz/) with this address which has bnb pools: 0x5f392dc5d86439318e2895625ee5e436f9155075
- [x] Test above address on prod to not see Bnb pools
- [x] Test on vercel link and see Bnb pools