### PR TITLE
feat: use path-based router with hash fallback for IPFS

### DIFF
--- a/.github/workflows/4-deploy-to-prod.yml
+++ b/.github/workflows/4-deploy-to-prod.yml
@@ -23,7 +23,10 @@ jobs:
 
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      
       - run: yarn build
+        env:
+          IS_IPFS_BUILD: 1
 
       - name: Bump and tag
         id: github-tag-action

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { Provider } from 'react-redux'
-import { HashRouter } from 'react-router-dom'
+import { BrowserRouter, HashRouter } from 'react-router-dom'
 import { SystemThemeUpdater } from 'theme/components/ThemeToggle'
 
 import Web3Provider from './components/Web3Provider'
@@ -49,12 +49,14 @@ const queryClient = new QueryClient()
 
 const container = document.getElementById('root') as HTMLElement
 
+const Router = process.env.IS_IPFS_BUILD ? HashRouter : BrowserRouter
+
 createRoot(container).render(
   <StrictMode>
     <Provider store={store}>
       <FeatureFlagsProvider>
         <QueryClientProvider client={queryClient}>
-          <HashRouter>
+          <Router>
             <LanguageProvider>
               <Web3Provider>
                 <ApolloProvider client={apolloClient}>
@@ -68,7 +70,7 @@ createRoot(container).render(
                 </ApolloProvider>
               </Web3Provider>
             </LanguageProvider>
-          </HashRouter>
+          </Router>
         </QueryClientProvider>
       </FeatureFlagsProvider>
     </Provider>


### PR DESCRIPTION
## Description

As per the design doc, using the path-based router for Cloudflare deployments (and environments that support catch-all index.html) with hash fallback for IPFS.

This in theory should not require any further work, as most linking is handled internally by `<Link />` and other primitives from React Router that abstract this away for us already.
