### PR TITLE
fix: add margins for empty pool icon

### DIFF
--- a/src/nft/components/profile/view/__snapshots__/EmptyWalletContent.test.tsx.snap
+++ b/src/nft/components/profile/view/__snapshots__/EmptyWalletContent.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`EmptyWalletContent.tsx matches base snapshot 1`] = `
     >
       <svg
         fill="none"
-        height="85"
+        height="97"
         viewBox="0 0 81 85"
         width="81"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/nft/components/profile/view/icons.tsx
+++ b/src/nft/components/profile/view/icons.tsx
@@ -59,7 +59,7 @@ export const EmptyNftsIcon = (props: SVGProps) => {
 export const EmptyPoolsIcon = (props: SVGProps) => {
   const { primary, secondary } = useEmptyStateIconColors()
   return (
-    <svg {...props} width="81" height="85" viewBox="0 0 81 85" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg {...props} width="81" height="97" viewBox="0 0 81 85" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Adds margins between empty pool icon and empty pool title. Increase height of the `EmptyPoolIcon` to make the svg larger and add more blank space between text and icon. 


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2204


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="328" alt="Screenshot 2023-07-05 at 10 43 46 AM" src="https://github.com/Uniswap/interface/assets/35351983/9d1f4b11-c670-4766-8f87-9eeff99f3582">




### After
<img width="386" alt="Screenshot 2023-07-05 at 10 59 17 AM" src="https://github.com/Uniswap/interface/assets/35351983/a3fbdc75-2d57-4d47-99e6-673aedd30967">





## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Manually check MP on web and mobile

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
