### PR TITLE
chore: remove Google Analytics from CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,9 +19,9 @@
     <meta
       http-equiv="Content-Security-Policy"
       <% if (process.env.REACT_APP_CSP_ALLOW_UNSAFE_EVAL) { %>
-        content="script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inline' 'unsafe-eval'"
+        content="script-src 'self' 'unsafe-inline' 'unsafe-eval'"
       <% } else { %>
-        content="script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com 'unsafe-inline'"
+        content="script-src 'self' 'unsafe-inline'"
       <% } %>
     />
 
@@ -36,8 +36,6 @@
       See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-
-    <link rel="preconnect" href="https://www.google-analytics.com/" />
 
     <link rel="preload" href="%PUBLIC_URL%/fonts/Inter-roman.var.woff2" as="font" type="font/woff2" crossorigin />
 

--- a/src/components/analytics/GoogleAnalyticsProvider.tsx
+++ b/src/components/analytics/GoogleAnalyticsProvider.tsx
@@ -1,4 +1,5 @@
-import ReactGA from 'react-ga4'
+/* eslint-disable no-unused-vars */
+
 import { GaOptions, InitOptions, UaEventOptions } from 'react-ga4/types/ga4'
 
 /**
@@ -6,7 +7,7 @@ import { GaOptions, InitOptions, UaEventOptions } from 'react-ga4/types/ga4'
  */
 export default class GoogleAnalyticsProvider {
   public sendEvent(event: string | UaEventOptions, params?: any) {
-    ReactGA.event(event, params)
+    // ReactGA.event(event, params)
   }
 
   public initialize(
@@ -19,11 +20,11 @@ export default class GoogleAnalyticsProvider {
       gtagOptions?: any
     }
   ) {
-    ReactGA.initialize(GA_MEASUREMENT_ID, options)
+    // ReactGA.initialize(GA_MEASUREMENT_ID, options)
   }
 
   public set(fieldsObject: any) {
-    ReactGA.set(fieldsObject)
+    // ReactGA.set(fieldsObject)
   }
 
   public outboundLink(
@@ -34,18 +35,18 @@ export default class GoogleAnalyticsProvider {
     },
     hitCallback: () => unknown
   ) {
-    ReactGA.outboundLink({ label }, hitCallback)
+    // ReactGA.outboundLink({ label }, hitCallback)
   }
 
   public pageview(path?: string, _?: string[], title?: string) {
-    ReactGA.pageview(path, _, title)
+    // ReactGA.pageview(path, _, title)
   }
 
   public ga(...args: any[]) {
-    ReactGA.ga(...args)
+    // ReactGA.ga(...args)
   }
 
   public gaCommandSendTiming(timingCategory: any, timingVar: any, timingValue: any, timingLabel: any) {
-    ReactGA._gaCommandSendTiming(timingCategory, timingVar, timingValue, timingLabel)
+    // ReactGA._gaCommandSendTiming(timingCategory, timingVar, timingValue, timingLabel)
   }
 }

--- a/src/components/analytics/GoogleAnalyticsProvider.tsx
+++ b/src/components/analytics/GoogleAnalyticsProvider.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
 
+// TODO(WEB-2166): Delete this file when we remove Google Analytics completely.
+
 import { GaOptions, InitOptions, UaEventOptions } from 'react-ga4/types/ga4'
 
 /**


### PR DESCRIPTION
## Description
Disables Google Analytics by changing the provider to not send any events. Also removes Google Analytics and Google Tag Manager from the CSP.

Once we migrate the events to Amplitude, we can merge this PR: https://github.com/Uniswap/interface/pull/6554

## Test plan
### QA (ie manual testing)
- [x] Web vitals are not being sent to GA
- [x] Init is not happening
- [x] Events are not being sent 

### Automated testing
- [ ] Unit test
- [ ] Integration/E2E test
N/A