### PR TITLE
build: invalidate typecheck cache for dep changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,9 @@ jobs:
       - uses: ./.github/actions/cache-on-main
         with:
           path: node_modules/.cache
-          key: ${{ runner.os }}-tsc-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-tsc-
+          # Types must be regenerated if any typings change: dependencies or the GraphQL schema.
+          key: ${{ runner.os }}-tsc-${{ hashFiles('yarn.lock', 'src/graphql/**/schema.graphql') }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-tsc-${{ hashFiles('yarn.lock', 'src/graphql/**/schema.graphql') }}
       - run: yarn typecheck
       - if: failure() && github.ref_name == 'main'
         uses: ./.github/actions/report


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Invalidates the typecheck build cache (for testing) if dependencies change.

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C047U65H422/p1688662674473499