### PR TITLE
build: use context.sha

### DIFF
--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -21,7 +21,7 @@ jobs:
             const statuses = await github.rest.repos.listCommitStatusesForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.payload.head_commit.sha
+              ref: context.sha
             })
             const status = statuses.data.find(status => status.context === 'Test / promotion')?.state || 'missing'
             core.info('Status: ' + status)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
             github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.head_commit.sha,
+              sha: context.sha,
               state: 'pending',
               context: 'Test / promotion',
               description: 'Running tests...',
@@ -197,7 +197,7 @@ jobs:
             github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.head_commit.sha,
+              sha: context.sha,
               state: ${{ env.STATUS }} ? 'success' : 'failure',
               context: 'Test / promotion',
               description: ${{ env.STATUS }} ? 'All tests passed' : 'One or more tests failed and are blocking promotion',


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fix usage of head commit sha by using the supplied [sha](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L13C14-L13C14) from github-script. This should fix `pre`/`post` checks on `main`.