### PR TITLE
build: block promotion to prod on tests

### DIFF
--- a/.github/workflows/3-staging-to-prod.yml
+++ b/.github/workflows/3-staging-to-prod.yml
@@ -14,6 +14,21 @@ jobs:
     environment:
       name: push/prod
     steps:
+      - name: Check test status
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const statuses = await github.rest.repos.listCommitStatusesForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.head_commit.sha
+            })
+            const status = statuses.data.find(status => status.context === 'Test / promotion')?.state || 'missing'
+            core.info('Status: ' + status)
+            if (status !== 'success') {
+              core.setFailed('"Test / promotion" must be successful before pushing')
+            }
+
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           token: ${{ secrets.RELEASE_SERVICE_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Block promotion to prod on a successful test suite. See https://github.com/Uniswap/interface/pull/6898.

## Test plan
This has essentially been tested via staging, as staging already includes this block.
You can also verify that the required `Test / Promotion` status is set on commits pushed to the `releases/staging` branch.