### PR TITLE
fix: remove shadow and gap on mobile

### DIFF
--- a/src/components/NavBar/MenuDropdown.tsx
+++ b/src/components/NavBar/MenuDropdown.tsx
@@ -137,7 +137,7 @@ export const MenuDropdown = () => {
         </NavIcon>
 
         {isOpen && (
-          <NavDropdown top={{ sm: 'unset', lg: '56' }} bottom={{ sm: '56', lg: 'unset' }} right="0">
+          <NavDropdown top={{ sm: 'unset', lg: '56' }} bottom={{ sm: '50', lg: 'unset' }} right="0">
             <Column gap="16">
               <Column paddingX="8" gap="4">
                 <Box display={{ sm: 'none', lg: 'flex', xxl: 'none' }}>

--- a/src/components/NavBar/NavDropdown.css.ts
+++ b/src/components/NavBar/NavDropdown.css.ts
@@ -11,7 +11,6 @@ const baseNavDropdown = style([
     paddingBottom: '8',
     paddingTop: '8',
   }),
-  {},
 ])
 
 export const NavDropdown = style([

--- a/src/components/NavBar/NavDropdown.css.ts
+++ b/src/components/NavBar/NavDropdown.css.ts
@@ -11,9 +11,7 @@ const baseNavDropdown = style([
     paddingBottom: '8',
     paddingTop: '8',
   }),
-  {
-    boxShadow: '0px 4px 12px 0px #00000026',
-  },
+  {},
 ])
 
 export const NavDropdown = style([
@@ -22,7 +20,7 @@ export const NavDropdown = style([
     position: 'absolute',
     borderRadius: '12',
   }),
-  {},
+  { boxShadow: '0px 4px 12px 0px #00000026' },
 ])
 
 export const mobileNavDropdown = style([
@@ -32,7 +30,7 @@ export const mobileNavDropdown = style([
     borderTopRightRadius: '12',
     borderTopLeftRadius: '12',
     top: 'unset',
-    bottom: '56',
+    bottom: '50',
     left: '0',
     right: '0',
     width: 'full',


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Removed the box shadow and gap for `NavDropdown` menus on mobile. 


<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB: 1010
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="310" alt="Screenshot 2023-07-10 at 1 56 30 PM" src="https://github.com/Uniswap/interface/assets/35351983/348c8557-5359-458c-b276-fe418ec309bd">
<img width="309" alt="Screenshot 2023-07-10 at 1 56 24 PM" src="https://github.com/Uniswap/interface/assets/35351983/6736e642-dc0d-4a8d-ae00-da3fb47adc21">



### After

<img width="308" alt="Screenshot 2023-07-10 at 1 56 09 PM" src="https://github.com/Uniswap/interface/assets/35351983/a4add934-647a-4b5a-85d7-bd3724e4e16d">
<img width="310" alt="Screenshot 2023-07-10 at 1 58 55 PM" src="https://github.com/Uniswap/interface/assets/35351983/00c224ac-f40d-4cd8-a384-345a2eea557f">



## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Test dropdowns manually on mobile and web

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
