### PR TITLE
fix: collision of network banner and swap settings

### DIFF
--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -130,7 +130,7 @@ const LinkOutToBridge = styled(ExternalLink)`
   padding: 6px 8px;
   text-decoration: none !important;
   width: 100%;
-  z-index: ${Z_INDEX.hover};
+  z-index: ${Z_INDEX.deprecated_zero};
 `
 
 const StyledArrowUpRight = styled(ArrowUpRight)`

--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components/macro'
 import { ExternalLink, HideSmall } from 'theme'
 import { colors } from 'theme/colors'
 import { useDarkModeManager } from 'theme/components/ThemeToggle'
-import { Z_INDEX } from 'theme/zIndex'
 
 import { AutoRow } from '../Row'
 
@@ -112,6 +111,7 @@ const ContentWrapper = styled.div<{ chainId: NetworkAlertChains; darkMode: boole
     position: absolute;
     transform: rotate(25deg) translate(-90px, -40px);
     width: 300px;
+    pointer-events: none;
   }
 `
 const Header = styled.h2`
@@ -130,7 +130,6 @@ const LinkOutToBridge = styled(ExternalLink)`
   padding: 6px 8px;
   text-decoration: none !important;
   width: 100%;
-  z-index: ${Z_INDEX.deprecated_zero};
 `
 
 const StyledArrowUpRight = styled(ArrowUpRight)`


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Fixes bug with network alert overlapping with swap modal. Reduced removed zIndex of `NetworkAlert` and added property `pointer-events: none` to component wrapper to ensure that bridge pointer bug does not return.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ Web- 2440


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="914" alt="Screenshot 2023-07-10 at 3 50 21 PM" src="https://github.com/Uniswap/interface/assets/35351983/d1045c37-dfe4-46fe-9e90-0eaec40fa301">



### After


<img width="916" alt="Screenshot 2023-07-10 at 3 50 07 PM" src="https://github.com/Uniswap/interface/assets/35351983/dd140400-f18f-4971-a8c4-61992506dc64">


## Test plan

<!-- Include steps to reproduce the bug. -->
1. Switch networks and open up swap modal

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Banner still links out and has not regressed to the bug of WEB-2102

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
