### PR TITLE
fix: UI bug causing SettingsTab and NetworkAlert components collide.

### DIFF
--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components/macro'
 import { ExternalLink, HideSmall } from 'theme'
 import { colors } from 'theme/colors'
 import { useDarkModeManager } from 'theme/components/ThemeToggle'
-import { Z_INDEX } from 'theme/zIndex'
 
 import { AutoRow } from '../Row'
 
@@ -130,7 +129,6 @@ const LinkOutToBridge = styled(ExternalLink)`
   padding: 6px 8px;
   text-decoration: none !important;
   width: 100%;
-  z-index: ${Z_INDEX.hover};
 `
 
 const StyledArrowUpRight = styled(ArrowUpRight)`


### PR DESCRIPTION
## Description

- This pull request resolves a UI bug where the SettingsTab and NetworkAlert components are colliding due to conflicting z-index values. 

### Changes Made:
- Removed z-Index property of  ```LinkOutToBridge``` component in NetworkAlert.tsx file.

## Screen capture

### Before

<img width="598" alt="Screenshot 2023-07-11 at 10 02 26 PM" src="https://github.com/Uniswap/interface/assets/97949943/ed8e3a73-f9cb-434f-8d9b-135465c82312">

### After

<img width="598" alt="Screenshot 2023-07-11 at 10 33 23 PM" src="https://github.com/Uniswap/interface/assets/97949943/b388da08-fe67-4508-ad33-7c4815a3f57f">

### Testing Done:

- Tested the modified code locally.
- Confirmed that after removing the z-index property, the components no longer collide and are displayed correctly.
- Ensured that the removal of the z-index does not introduce any new UI issues.

