### PR TITLE
fix: Clear input and output when wrapping and unwrapping

### DIFF
--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -60,7 +60,7 @@ export default function useWrapCallback(
   inputCurrency: Currency | undefined | null,
   outputCurrency: Currency | undefined | null,
   typedValue: string | undefined
-): { wrapType: WrapType; execute?: () => Promise<void>; inputError?: WrapInputError } {
+): { wrapType: WrapType; execute?: () => Promise<string>; inputError?: WrapInputError } {
   const { chainId, account } = useWeb3React()
   const wethContract = useWETHContract()
   const balance = useCurrencyBalance(account ?? undefined, inputCurrency ?? undefined)
@@ -127,8 +127,10 @@ Please file a bug detailing how this happened - https://github.com/Uniswap/inter
                     ...eventProperties,
                     type: WrapType.WRAP,
                   })
+                  return txReceipt.hash
                 } catch (error) {
                   console.error('Could not deposit', error)
+                  throw error
                 }
               }
             : undefined,
@@ -156,8 +158,10 @@ Please file a bug detailing how this happened - https://github.com/Uniswap/inter
                     ...eventProperties,
                     type: WrapType.UNWRAP,
                   })
+                  return txReceipt.hash
                 } catch (error) {
                   console.error('Could not withdraw', error)
+                  throw error
                 }
               }
             : undefined,

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -466,11 +466,15 @@ export function Swap({
   const handleOnWrap = useCallback(() => {
     if (!onWrap) return
     onWrap()
-      .then(() => {
+      .then((hash) => {
+        setSwapState((currentState) => ({
+          ...currentState,
+          swapError: undefined,
+          txHash: hash,
+        }))
         onUserInput(Field.INPUT, '')
       })
       .catch((error) => {
-        console.log(error)
         if (!didUserReject(error)) {
           sendAnalyticsEvent(SwapEventName.SWAP_ERROR, {
             wrapType,

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -463,6 +463,29 @@ export function Swap({
     tradeToConfirm,
   ])
 
+  const handleOnWrap = useCallback(() => {
+    if (!onWrap) return
+    onWrap()
+      .then(() => {
+        onUserInput(Field.INPUT, '')
+      })
+      .catch((error) => {
+        console.log(error)
+        if (!didUserReject(error)) {
+          sendAnalyticsEvent(SwapEventName.SWAP_ERROR, {
+            wrapType,
+            input: currencies[Field.INPUT],
+            output: currencies[Field.OUTPUT],
+          })
+        }
+        setSwapState((currentState) => ({
+          ...currentState,
+          swapError: error,
+          txHash: undefined,
+        }))
+      })
+  }, [currencies, onUserInput, onWrap, wrapType])
+
   // errors
   const [swapQuoteReceivedDate, setSwapQuoteReceivedDate] = useState<Date | undefined>()
 
@@ -707,7 +730,7 @@ export function Swap({
           ) : showWrap ? (
             <ButtonPrimary
               disabled={Boolean(wrapInputError)}
-              onClick={onWrap}
+              onClick={handleOnWrap}
               fontWeight={600}
               data-testid="wrap-button"
             >


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- `useWrapCallback` now passes back txhash or throws error
- add `handleOnWrap` callback to clear input/output fields on a successful wrap or log error and don't clear input

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2449/to-and-from-fields-not-0d-out-avax


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

Unwrap
![unwrapClear](https://github.com/Uniswap/interface/assets/11512321/528a36e2-e115-4d8e-ac0e-3ddee4232c46)

Reject and Wrap
![wrapClear](https://github.com/Uniswap/interface/assets/11512321/4d9a4562-ec68-49fa-b5f4-e67ea284ed86)

## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Inputs clear on wrap
- [x] Inputs clear on unwrap
- [x] Log error but don't clear input