### PR TITLE
feat: Sort chains based on user relevance

### DIFF
--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -7,7 +7,13 @@ import { getConnection } from 'connection'
 import { ConnectionType } from 'connection/types'
 import { WalletConnectV2 } from 'connection/WalletConnectV2'
 import { getChainInfo } from 'constants/chainInfo'
-import { L1_CHAIN_IDS, L2_CHAIN_IDS, TESTNET_CHAIN_IDS, UniWalletSupportedChains } from 'constants/chains'
+import {
+  getChainPriority,
+  L1_CHAIN_IDS,
+  L2_CHAIN_IDS,
+  TESTNET_CHAIN_IDS,
+  UniWalletSupportedChains,
+} from 'constants/chains'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import useSelectChain from 'hooks/useSelectChain'
 import useSyncChainQuery from 'hooks/useSyncChainQuery'
@@ -59,17 +65,19 @@ export const ChainSelector = ({ leftAlign }: ChainSelectorProps) => {
   const [supportedChains, unsupportedChains] = useMemo(() => {
     const { supported, unsupported } = NETWORK_SELECTOR_CHAINS.filter(
       (chain: number) => showTestnets || !TESTNET_CHAIN_IDS.includes(chain)
-    ).reduce(
-      (acc, chain) => {
-        if (walletSupportsChain.includes(chain)) {
-          acc.supported.push(chain)
-        } else {
-          acc.unsupported.push(chain)
-        }
-        return acc
-      },
-      { supported: [], unsupported: [] } as Record<string, ChainId[]>
     )
+      .sort((a, b) => getChainPriority(a) - getChainPriority(b))
+      .reduce(
+        (acc, chain) => {
+          if (walletSupportsChain.includes(chain)) {
+            acc.supported.push(chain)
+          } else {
+            acc.unsupported.push(chain)
+          }
+          return acc
+        },
+        { supported: [], unsupported: [] } as Record<string, ChainId[]>
+      )
     return [supported, unsupported]
   }, [showTestnets, walletSupportsChain])
 

--- a/src/constants/chains.test.ts
+++ b/src/constants/chains.test.ts
@@ -1,0 +1,28 @@
+import { ChainId } from '@uniswap/sdk-core'
+
+import { getChainPriority } from './chains'
+
+// Define an array of test cases with chainId and expected priority
+const testCases: { chainId: ChainId; expectedPriority: number }[] = [
+  { chainId: ChainId.MAINNET, expectedPriority: 0 },
+  { chainId: ChainId.GOERLI, expectedPriority: 0 },
+  { chainId: ChainId.SEPOLIA, expectedPriority: 0 },
+  { chainId: ChainId.POLYGON, expectedPriority: 1 },
+  { chainId: ChainId.POLYGON_MUMBAI, expectedPriority: 1 },
+  { chainId: ChainId.ARBITRUM_ONE, expectedPriority: 2 },
+  { chainId: ChainId.ARBITRUM_GOERLI, expectedPriority: 2 },
+  { chainId: ChainId.OPTIMISM, expectedPriority: 3 },
+  { chainId: ChainId.OPTIMISM_GOERLI, expectedPriority: 3 },
+  { chainId: ChainId.BNB, expectedPriority: 4 },
+  { chainId: ChainId.AVALANCHE, expectedPriority: 5 },
+  { chainId: ChainId.CELO, expectedPriority: 6 },
+  { chainId: ChainId.CELO_ALFAJORES, expectedPriority: 6 },
+]
+
+// Run the tests
+testCases.forEach(({ chainId, expectedPriority }) => {
+  test(`getChainPriority - ${chainId}`, () => {
+    const priority = getChainPriority(chainId)
+    expect(priority).toBe(expectedPriority)
+  })
+})

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -90,3 +90,35 @@ export type SupportedL2ChainId = (typeof L2_CHAIN_IDS)[number]
 export function isPolygonChain(chainId: number): chainId is ChainId.POLYGON | ChainId.POLYGON_MUMBAI {
   return chainId === ChainId.POLYGON || chainId === ChainId.POLYGON_MUMBAI
 }
+
+/**
+ * Get the priority of a chainId based on its relevance to the user.
+ * @param {ChainId} chainId - The chainId to determine the priority for.
+ * @returns {number} The priority of the chainId, the lower the priority, the earlier it should be displayed, with base of MAINNET=0.
+ */
+export function getChainPriority(chainId: ChainId): number {
+  switch (chainId) {
+    case ChainId.MAINNET:
+    case ChainId.GOERLI:
+    case ChainId.SEPOLIA:
+      return 0
+    case ChainId.POLYGON:
+    case ChainId.POLYGON_MUMBAI:
+      return 1
+    case ChainId.ARBITRUM_ONE:
+    case ChainId.ARBITRUM_GOERLI:
+      return 2
+    case ChainId.OPTIMISM:
+    case ChainId.OPTIMISM_GOERLI:
+      return 3
+    case ChainId.BNB:
+      return 4
+    case ChainId.AVALANCHE:
+      return 5
+    case ChainId.CELO:
+    case ChainId.CELO_ALFAJORES:
+      return 6
+    default:
+      return 7
+  }
+}

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -180,8 +180,8 @@ export function logSentryErrorForUnsupportedChain({
 export const BACKEND_SUPPORTED_CHAINS = [
   Chain.Ethereum,
   Chain.Polygon,
-  Chain.Optimism,
   Chain.Arbitrum,
+  Chain.Optimism,
   Chain.Celo,
 ] as const
 export const BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS = [ChainId.BNB, ChainId.AVALANCHE] as const


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
**Context: ** The ordering of chains in the network and token explore switcher have been based on when we added support. This isn't aligned with optimal user experience. We were requested to update the ordering to be Ethereum, Polygon, Arbitrum, Optimism, BNB, Avalanche, Celo.

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C0508SQBTRC/p1688761943887769?thread_ts=1688758414.422639&cid=C0508SQBTRC


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

Network Switcher w/o Testnets
<img width="300" alt="Screenshot 2023-07-11 at 3 42 14 PM" src="https://github.com/Uniswap/interface/assets/11512321/7a07a0d6-cb7e-46a3-bedd-471a7a807bd2">
Network Switcher w/ Testnets
<img width="300" alt="Screenshot 2023-07-11 at 3 41 40 PM" src="https://github.com/Uniswap/interface/assets/11512321/d70a7622-ed82-48a4-8dd8-87b240c89855">
Network Switcher when using UniWallet
<img width="477" alt="Screenshot 2023-07-11 at 3 43 18 PM" src="https://github.com/Uniswap/interface/assets/11512321/4f08294f-d134-4aab-8e73-6eada461b58e">
Token Explore
<img width="348" alt="Screenshot 2023-07-11 at 3 57 39 PM" src="https://github.com/Uniswap/interface/assets/11512321/e4d2a0f6-1906-4ceb-a135-04eccaaa4aeb">


## Test plan
### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Added unit tests to help ensure ordering is maintained