### PR TITLE
fix: remove avax flag check for background radiant

### DIFF
--- a/src/theme/components/RadialGradientByChainUpdater.ts
+++ b/src/theme/components/RadialGradientByChainUpdater.ts
@@ -1,6 +1,5 @@
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { useIsAvalancheEnabled } from 'featureFlags/flags/avalanche'
 import { useIsNftPage } from 'hooks/useIsNftPage'
 import { useEffect } from 'react'
 import { useDarkModeManager } from 'theme/components/ThemeToggle'
@@ -32,7 +31,6 @@ export default function RadialGradientByChainUpdater(): null {
   const { chainId } = useWeb3React()
   const [darkMode] = useDarkModeManager()
   const isNftPage = useIsNftPage()
-  const isAvalancheEnabled = useIsAvalancheEnabled()
 
   // manage background color
   useEffect(() => {
@@ -99,9 +97,6 @@ export default function RadialGradientByChainUpdater(): null {
         break
       }
       case ChainId.AVALANCHE: {
-        if (!isAvalancheEnabled) {
-          break
-        }
         setBackground(backgroundResetStyles)
         const avaxLightGradient =
           'radial-gradient(100% 100% at 50% 0%, rgba(255, 251, 242, 0.8) 0%, rgba(255, 244, 249, 0.6958) 50.52%, rgba(255, 255, 255, 0) 100%), #FFFFFF'


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- background gradient is not properly loading for avalanche due to the feature flag on prod, now that the feature is live this is no longer needed. This change will not be backported into main

<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
![Screenshot 2023-07-12 at 10 12 58 AM](https://github.com/Uniswap/interface/assets/11512321/c4385c89-fe2e-45d2-b9ac-ac82c8a3cba8)



### After
![Screenshot 2023-07-12 at 10 13 46 AM](https://github.com/Uniswap/interface/assets/11512321/5c41bc77-461d-407d-b0e8-27cb449d56f9)


## Test plan
### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Avax gradient appears on dpeloy preview
