### PR TITLE
fix: Handle Scientific Notation for NFT Collection Activity Prices

### DIFF
--- a/src/graphql/data/nft/NftActivity.ts
+++ b/src/graphql/data/nft/NftActivity.ts
@@ -1,6 +1,7 @@
 import { WatchQueryFetchPolicy } from '@apollo/client'
 import gql from 'graphql-tag'
 import { ActivityEvent } from 'nft/types'
+import { wrapScientificNotation } from 'nft/utils'
 import { useCallback, useMemo } from 'react'
 
 import { NftActivityFilterInput, useNftActivityQuery } from '../__generated__/types-and-hooks'
@@ -120,7 +121,7 @@ export function useNftActivity(filter: NftActivityFilterInput, first?: number, f
           toAddress: activity.toAddress,
           transactionHash: activity.transactionHash,
           orderStatus: activity.orderStatus,
-          price: activity.price?.value.toString(),
+          price: wrapScientificNotation(activity.price?.value),
           symbol: asset?.collection?.image?.url,
           quantity: activity.quantity,
           url: activity.url,

--- a/src/nft/utils/currency.ts
+++ b/src/nft/utils/currency.ts
@@ -75,9 +75,8 @@ export const formatWeiToDecimal = (amount: string, removeZeroes = false) => {
 }
 
 // prevent BigNumber overflow by properly handling scientific notation and comma delimited values
-export function wrapScientificNotation(value: string | number): string {
-  return parseFloat(value.toString())
-    .toLocaleString('fullwide', { useGrouping: false })
-    .replace(',', '.')
-    .replace(' ', '')
+export function wrapScientificNotation(value?: string | number): string {
+  return value
+    ? parseFloat(value.toString()).toLocaleString('fullwide', { useGrouping: false }).replace(',', '.').replace(' ', '')
+    : ''
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Scientific notation for price is causing a crash on the NFT Activity Page. This properly wraps the data point when parsed in to prevent the crash and allow the number to be converted to a `BigNumber`.
- Pushing for not using Scientific Notation for prices on our GQL BE

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2484/is-this-a-known-issue-%F0%9F%A4%94-getting-it-on-the-nft-e2e-test
_Slack thread:_ https://uniswapteam.slack.com/archives/C02T729PMQE/p1689349833728619


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### After
<img width="1034" alt="Screenshot 2023-07-14 at 9 12 27 AM" src="https://github.com/Uniswap/interface/assets/11512321/e5f812e7-fb51-4b62-ab0b-1f7f6ab35520">


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. https://app.uniswap.org/#/nfts/collection/0xbd3531da5cf5857e7cfaa92426877b022e612cf8/activity

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Go to Pudgy Penguins Activity page and see prices load