### PR TITLE
fix: hide pending orders from GQL

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
@@ -12,6 +12,7 @@ import {
   NftApproveForAllPartsFragment,
   NftTransferPartsFragment,
   SwapOrderDetailsPartsFragment,
+  SwapOrderStatus,
   TokenApprovalPartsFragment,
   TokenAssetPartsFragment,
   TokenTransferPartsFragment,
@@ -289,6 +290,9 @@ function getLogoSrcs(changes: TransactionChanges): string[] {
 }
 
 function parseUniswapXOrder({ details, chain, timestamp }: OrderActivity): Activity | undefined {
+  // We currently only support displaying pending activity sent from the current client, so we hide pending activty fetched remotely
+  if (details.orderStatus === SwapOrderStatus.Open) return undefined
+
   const { inputToken, inputTokenQuantity, outputToken, outputTokenQuantity, orderStatus } = details
   const uniswapXOrderStatus = OrderStatusTable[orderStatus]
   const { status, statusMessage, title } = OrderTextTable[uniswapXOrderStatus]

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
@@ -290,7 +290,8 @@ function getLogoSrcs(changes: TransactionChanges): string[] {
 }
 
 function parseUniswapXOrder({ details, chain, timestamp }: OrderActivity): Activity | undefined {
-  // We currently only support displaying pending activity sent from the current client, so we hide pending activty fetched remotely
+  // We currently only have a polling mechanism for locally-sent pending orders, so we hide remote pending orders since they won't update upon completion
+  // TODO(WEB-2487): Add polling mechanism for remote orders to allow displaying remote pending orders
   if (details.orderStatus === SwapOrderStatus.Open) return undefined
 
   const { inputToken, inputTokenQuantity, outputToken, outputTokenQuantity, orderStatus } = details


### PR DESCRIPTION
hides pending items returned by GQL, as our current strategy is to only show locally stored pending swaps