### PR TITLE
fix: do not cache gql across CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -40,16 +40,11 @@ runs:
       run: yarn contracts
       shell: bash
 
-    # GraphQL is generated from schema. The schema is always fetched, but if unchanged, graphql does not need to be re-generated.
-    - run: yarn graphql:fetch
-      shell: bash
-    - uses: actions/cache@v3
-      id: graphql-cache
-      with:
-        path: src/graphql/**/__generated__
-        key: ${{ runner.os }}-graphql-${{ hashFiles('src/graphql/**/schema.graphql') }}
-    - if: steps.graphql-cache.outputs.cache-hit != 'true'
-      run: yarn graphql:generate
+    # GraphQL is generated from schema and client-side graphql queries. The schema is always fetched and changes to
+    # client-side queries are hard to detect, so it is always re-generated.
+    # TODO(WEB-2498): Cache based on both fetched schema and client-side graphql queries.
+    # This will require some processing: cp all literal graphql tags into a separate file and hash it?
+    - run: yarn graphql
       shell: bash
 
     # Messages are extracted from source.


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Removes the caching of generated gql across CI builds, as it was incorrectly keyed only on the backend schema, despite also being dependent on frontend queries.

Includes a TODO for a ticket (WEB-2498) to re-introduce a cache for the correct keys.