### PR TITLE
fix: uniswapx opt in double bounce animation

### DIFF
--- a/src/pages/Swap/UniswapXOptIn.tsx
+++ b/src/pages/Swap/UniswapXOptIn.tsx
@@ -72,15 +72,10 @@ const OptInContents = ({
   const [, setRouterPreference] = useRouterPreference()
   const dispatch = useAppDispatch()
   const [showYoureIn, setShowYoureIn] = useState(false)
-  const [isVisible, setIsVisible] = useState(false)
+  const isVisible = isOnClassic
 
   // adding this as we need to mount and then set shouldAnimate = true after it mounts to avoid a flicker on initial mount
   const [shouldAnimate, setShouldAnimate] = useState(false)
-
-  // delayed a second to allow mount animation
-  useEffect(() => {
-    setIsVisible(Boolean(trade && isOnClassic))
-  }, [isOnClassic, trade])
 
   useEffect(() => {
     if (!isVisible || shouldAnimate) return


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description

Fixes a double bounce on the X opt in animation.

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/12100/f690baf1-8ec8-4f9b-aaeb-f8f7029c2723



### After

https://github.com/Uniswap/interface/assets/12100/242c3386-79b2-4ec2-afc0-7419c1fa6e0d


### Test plan

Need a X trade and trigger it basically.
