### PR TITLE
fix: format currency amounts as strings in logging

### DIFF
--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -93,7 +93,7 @@ export const formatSwapQuoteReceivedEventProperties = (
     swap_quote_block_number: isClassicTrade(trade) ? trade.blockNumber : undefined,
     swap_quote_received_timestamp: swapQuoteReceivedDate.getTime(),
     allowed_slippage_basis_points: formatPercentInBasisPointsNumber(allowedSlippage),
-    token_in_amount_max: trade.maximumAmountIn(allowedSlippage),
-    token_out_amount_min: trade.minimumAmountOut(allowedSlippage),
+    token_in_amount_max: trade.maximumAmountIn(allowedSlippage).toFixed(2),
+    token_out_amount_min: trade.minimumAmountOut(allowedSlippage).toFixed(2),
   }
 }

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -93,7 +93,7 @@ export const formatSwapQuoteReceivedEventProperties = (
     swap_quote_block_number: isClassicTrade(trade) ? trade.blockNumber : undefined,
     swap_quote_received_timestamp: swapQuoteReceivedDate.getTime(),
     allowed_slippage_basis_points: formatPercentInBasisPointsNumber(allowedSlippage),
-    token_in_amount_max: trade.maximumAmountIn(allowedSlippage).toFixed(2),
-    token_out_amount_min: trade.minimumAmountOut(allowedSlippage).toFixed(2),
+    token_in_amount_max: trade.maximumAmountIn(allowedSlippage).toExact(),
+    token_out_amount_min: trade.minimumAmountOut(allowedSlippage).toExact(),
   }
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
fixes the format of the values for `token_in_amount_max` and `token_out_amount_min` so that they don't create new properties in the aplitude backend. they should be formatted as strings when sent to amplitude.



<!-- Delete this section if your change does not affect UI. -->
## Screen capture

<img width="492" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/9647b8e9-b3b6-4880-aab7-294643ef33aa">

