### PR TITLE
fix: update text in ConfirmSwapModal

### DIFF
--- a/src/components/swap/PendingModalContent/PendingModalContent.test.tsx
+++ b/src/components/swap/PendingModalContent/PendingModalContent.test.tsx
@@ -1,3 +1,5 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { TradeFillType } from 'state/routing/types'
 import { useIsTransactionConfirmed } from 'state/transactions/hooks'
 import { TEST_TRADE_EXACT_INPUT } from 'test-utils/constants'
 import { mocked } from 'test-utils/mocked'
@@ -68,6 +70,37 @@ describe('PendingModalContent', () => {
       expect(screen.getByText('Proceed in your wallet')).toBeInTheDocument()
       expect(screen.getByText('Why is this required?')).toBeInTheDocument()
       expect(screen.queryByText('Enable spending ABC on Uniswap')).not.toBeInTheDocument()
+    })
+
+    it('renders the correct label for a submitted classic order', () => {
+      render(
+        <PendingModalContent
+          steps={[
+            ConfirmModalState.APPROVING_TOKEN,
+            ConfirmModalState.PERMITTING,
+            ConfirmModalState.PENDING_CONFIRMATION,
+          ]}
+          currentStep={ConfirmModalState.PENDING_CONFIRMATION}
+          trade={TEST_TRADE_EXACT_INPUT}
+          swapResult={{
+            type: TradeFillType.Classic,
+            response: {
+              hash: '12345',
+              confirmations: 0,
+              from: '0x12345',
+              wait: jest.fn(),
+              nonce: 0,
+              gasLimit: BigNumber.from(100000),
+              data: '0xmockdata',
+              value: BigNumber.from(100000),
+              chainId: 1,
+            },
+          }}
+        />
+      )
+      expect(screen.getByText('Swap submitted')).toBeInTheDocument()
+      expect(screen.getByText('View on Explorer')).toBeInTheDocument()
+      expect(screen.queryByText('Proceed in your wallet')).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -186,13 +186,13 @@ function getContent(args: ContentArgs): PendingModalStep {
       let labelText: string | null = null
       let href: string | null = null
 
-      if (chainId && swapConfirmed && swapResult && swapResult.type === TradeFillType.Classic) {
-        labelText = t`View on Explorer`
-        href = getExplorerLink(chainId, swapResult.response.hash, ExplorerDataType.TRANSACTION)
-      } else if (swapPending && trade?.fillType === TradeFillType.UniswapX) {
+      if (swapPending && trade?.fillType === TradeFillType.UniswapX) {
         labelText = t`Learn more about swapping with UniswapX`
         href = 'https://support.uniswap.org/hc/en-us/articles/17515415311501'
-      } else if (swapPending) {
+      } else if (chainId && (swapConfirmed || swapPending) && swapResult && swapResult.type === TradeFillType.Classic) {
+        labelText = t`View on Explorer`
+        href = getExplorerLink(chainId, swapResult.response.hash, ExplorerDataType.TRANSACTION)
+      } else {
         labelText = t`Proceed in your wallet`
       }
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

replaces the text "Proceed in your wallet" with "view on explorer" after you've already submitted the swap transaction.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2482/change-proceed-in-your-wallet-to-view-on-block-explorer


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

![image](https://github.com/Uniswap/interface/assets/66155195/526b2eba-3b96-4898-9ea4-4c6dd7676765)

### After
 
<img width="492" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/5e3e4cb5-3f60-41bc-a40a-b62a320c3ab0">



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. go through the classic swap flow and check the text AFTER you've signed the transaction but BEFORE it is confirmed.

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually verified that the text is now correct


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test - added for this case
