### PR TITLE
fix: add amplitude event for uniswapX orders failing to post

### DIFF
--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -106,6 +106,16 @@ export function useUniswapXSwapCallback({
         // TODO(UniswapX): For now, `errorCode` is not always present in the response, so we have to fallback
         // check for status code and perform this type narrowing.
         if (isErrorResponse(res, body)) {
+          sendAnalyticsEvent('UniswapX Order Post Error', {
+            ...formatSwapSignedAnalyticsEventProperties({
+              trade,
+              allowedSlippage,
+              fiatValues,
+            }),
+            ...analyticsContext,
+            errorCode: body.errorCode,
+            detail: body.detail,
+          })
           // TODO(UniswapX): Provide a similar utility to `swapErrorToUserReadableMessage` once
           // backend team provides a list of error codes and potential messages
           throw new Error(`${body.errorCode ?? body.detail ?? 'Unknown error'}`)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Apparently we have a high rate of failures for orders posting to the backend. While we investigate why an order might fail to post once it's sent to the backend, in the meantime we can add logging to the client to help us debug.

see this [sheet](https://docs.google.com/spreadsheets/d/1rRZZBkTFmVAhaXIEqroOrpp7sdnGdKOq_Z6I6aBkc-4/edit#gid=2044419544) for a list of unique ura quote/request IDs which have duplicate SWAP_SIGNED events but no posted order to the backend. They probably have duplicates because the user is retrying when the first attempt fails.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

<img width="1312" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/25c2dee8-d409-4008-b834-45edeb990713">


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. unsure how to trigger an error response from backend....

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually forced the response to have an error code and validated the fields of the event i'm sending

