### PR TITLE
fix: :bug: #6969

### DIFF
--- a/src/components/swap/GasBreakdownTooltip.tsx
+++ b/src/components/swap/GasBreakdownTooltip.tsx
@@ -4,13 +4,12 @@ import { useWeb3React } from '@web3-react/core'
 import { AutoColumn } from 'components/Column'
 import UniswapXRouterLabel, { UniswapXGradient } from 'components/RouterLabel/UniswapXRouterLabel'
 import Row from 'components/Row'
+import { getChainInfo } from 'constants/chainInfo'
 import { ReactNode } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import { isClassicTrade, isUniswapXTrade } from 'state/routing/utils'
 import styled from 'styled-components/macro'
 import { Divider, ExternalLink, ThemedText } from 'theme'
-
-import { getChainInfo } from '../../constants/chainInfo'
 
 const Container = styled(AutoColumn)`
   padding: 4px;

--- a/src/components/swap/GasBreakdownTooltip.tsx
+++ b/src/components/swap/GasBreakdownTooltip.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { formatNumber, NumberType } from '@uniswap/conedison/format'
+import { useWeb3React } from '@web3-react/core'
 import { AutoColumn } from 'components/Column'
 import UniswapXRouterLabel, { UniswapXGradient } from 'components/RouterLabel/UniswapXRouterLabel'
 import Row from 'components/Row'
@@ -8,6 +9,8 @@ import { InterfaceTrade } from 'state/routing/types'
 import { isClassicTrade, isUniswapXTrade } from 'state/routing/utils'
 import styled from 'styled-components/macro'
 import { Divider, ExternalLink, ThemedText } from 'theme'
+
+import { getChainInfo } from '../../constants/chainInfo'
 
 const Container = styled(AutoColumn)`
   padding: 4px;
@@ -54,10 +57,15 @@ export function GasBreakdownTooltip({
   hideFees?: boolean
   hideUniswapXDescription?: boolean
 }) {
+  const { chainId } = useWeb3React()
+
   const swapEstimate = isClassicTrade(trade) ? trade.gasUseEstimateUSD : undefined
   const approvalEstimate = trade.approveInfo.needsApprove ? trade.approveInfo.approveGasEstimateUSD : undefined
   const wrapEstimate =
     isUniswapXTrade(trade) && trade.wrapInfo.needsWrap ? trade.wrapInfo.wrapGasEstimateUSD : undefined
+
+  const chainInfo = getChainInfo(chainId)
+
   return (
     <Container gap="md">
       {(wrapEstimate || approvalEstimate) && !hideFees && (
@@ -83,7 +91,7 @@ export function GasBreakdownTooltip({
           <Trans>
             <InlineUniswapXGradient>UniswapX</InlineUniswapXGradient> aggregates liquidity sources for better prices and
             gas free swaps.
-          </Trans>{' '}
+          </Trans>
           <ExternalLink href="https://support.uniswap.org/hc/en-us/articles/17515415311501">
             <InlineLink>
               <Trans>Learn more</Trans>
@@ -92,7 +100,7 @@ export function GasBreakdownTooltip({
         </ThemedText.Caption>
       ) : (
         <ThemedText.Caption color="textSecondary">
-          <Trans>Network Fees are paid to the Ethereum network to secure transactions.</Trans>{' '}
+          <Trans>Network Fees are paid to the {chainInfo?.label ?? ''} network to secure transactions.</Trans>{' '}
           <ExternalLink href="https://support.uniswap.org/hc/en-us/articles/8370337377805-What-is-a-network-fee-">
             <InlineLink>
               <Trans>Learn more</Trans>

--- a/src/components/swap/GasBreakdownTooltip.tsx
+++ b/src/components/swap/GasBreakdownTooltip.tsx
@@ -91,7 +91,7 @@ export function GasBreakdownTooltip({
           <Trans>
             <InlineUniswapXGradient>UniswapX</InlineUniswapXGradient> aggregates liquidity sources for better prices and
             gas free swaps.
-          </Trans>
+          </Trans>{' '}
           <ExternalLink href="https://support.uniswap.org/hc/en-us/articles/17515415311501">
             <InlineLink>
               <Trans>Learn more</Trans>


### PR DESCRIPTION
Inserted chain label instead of hardcoded "Ethereum" value

## Description
Fixes #6969 
Translation string had the name of the chain hardcoded, `Ethereum` which I changed. Changed the translations in Crowdin for Romanian, Italian and Russian since those are the ones I know. Let me know if I need to change all.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_after |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| paste_after  | paste_after |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
