### PR TITLE
fix: use 100vh to position bottom sheet

### DIFF
--- a/src/components/AccountDrawer/index.tsx
+++ b/src/components/AccountDrawer/index.tsx
@@ -92,7 +92,7 @@ const Container = styled.div`
   z-index: ${Z_INDEX.fixed};
 
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
-    top: 100%;
+    top: 100vh;
     left: 0;
     right: 0;
     width: 100%;


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

on ios safari, the browser's bottom nav bar floats in and out of view, so we need to use 100vh to position the bottom sheet because it's responsive to this changing height.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2472/mini-portfolio-appears-on-scroll-on-tdp


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
see linear ticket


### After


https://github.com/Uniswap/interface/assets/66155195/19dd454d-d30b-4931-b2d2-4d81224959bb



