### PR TITLE
fix: display already-loaded imgs with no transition

### DIFF
--- a/src/components/Logo/AssetLogo.tsx
+++ b/src/components/Logo/AssetLogo.tsx
@@ -76,7 +76,11 @@ export default function AssetLogo({
 }: AssetLogoProps) {
   const [src, nextSrc] = useTokenLogoSource(address, chainId, isNative, backupImg)
   const L2Icon = getChainInfo(chainId)?.circleLogoUrl
-  const [imgLoaded, setImgLoaded] = useState(false)
+  const [imgLoaded, setImgLoaded] = useState(() => {
+    const img = document.createElement('img')
+    img.src = src ?? ''
+    return src ? img.complete : false
+  })
 
   return (
     <LogoContainer style={style}>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fix image loading so that already-loaded images do not fade in, but are immediately displayed.
This fixes the transition to /swap from the landing page. It also improves Token Selector transitions.

_before_

https://github.com/Uniswap/interface/assets/5403956/19619584-610c-4d46-8f27-4020f787aec8