### PR TITLE
feat: :sparkles: a search bar for languages

### DIFF
--- a/src/components/AccountDrawer/LanguageSelector.tsx
+++ b/src/components/AccountDrawer/LanguageSelector.tsx
@@ -1,0 +1,96 @@
+import { t, Trans } from '@lingui/macro'
+import { ChangeEvent, Fragment, useState } from 'react'
+import { Check } from 'react-feather'
+import { Link } from 'react-router-dom'
+import styled, { useTheme } from 'styled-components/macro'
+
+import { LOCALE_LABEL, SUPPORTED_LOCALES, SupportedLocale } from '../../constants/locales'
+import { useActiveLocale } from '../../hooks/useActiveLocale'
+import { useLocationLinkProps } from '../../hooks/useLocationLinkProps'
+import { ClickableStyle, ThemedText } from '../../theme'
+
+const SectionTitle = styled(ThemedText.SubHeader)`
+  color: ${({ theme }) => theme.textSecondary};
+  padding-bottom: 24px;
+  display: flex;
+  justify-content: space-between;
+`
+
+const InternalLinkMenuItem = styled(Link)`
+  ${ClickableStyle}
+  flex: 1;
+  color: ${({ theme }) => theme.textTertiary};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 12px 0;
+  justify-content: space-between;
+  text-decoration: none;
+  color: ${({ theme }) => theme.textPrimary};
+`
+
+const SearchBox = styled.input`
+  padding: 4px 6px;
+  border-radius: 6px;
+  backdrop-filter: blur(60px);
+  background: transparent;
+  width: 60%;
+
+  background-color: ${(props) => props.theme.background};
+  color: ${(props) => props.theme.textPrimary};
+  border: 1px solid ${(props) => props.theme.backgroundInteractive};
+
+  ::placeholder {
+    color: ${(props) => props.theme.textSecondary};
+  }
+  :-ms-input-placeholder {
+    color: ${(props) => props.theme.textSecondary};
+  }
+  ::-ms-input-placeholder {
+    color: ${(props) => props.theme.textSecondary};
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+`
+
+function LanguageMenuItem({ locale, isActive }: { locale: SupportedLocale; isActive: boolean }) {
+  const { to, onClick } = useLocationLinkProps(locale)
+  const theme = useTheme()
+
+  if (!to) return null
+
+  return (
+    <InternalLinkMenuItem onClick={onClick} to={to}>
+      <ThemedText.BodySmall data-testid="wallet-language-item">{LOCALE_LABEL[locale]}</ThemedText.BodySmall>
+      {isActive && <Check color={theme.accentActive} opacity={1} size={20} />}
+    </InternalLinkMenuItem>
+  )
+}
+
+export function LanguageSelector() {
+  const [search, setSearch] = useState('')
+
+  const activeLocale = useActiveLocale()
+
+  const handleInputChange = (ev: ChangeEvent<HTMLInputElement>) => {
+    setSearch(ev.target.value)
+  }
+
+  const filteredLocales = SUPPORTED_LOCALES.filter((locale) =>
+    LOCALE_LABEL[locale].toLowerCase().includes(search.toLocaleLowerCase())
+  )
+
+  return (
+    <Fragment>
+      <SectionTitle data-testid="wallet-header">
+        <Trans>Language</Trans>
+        <SearchBox type="text" onChange={handleInputChange} placeholder={t`Search`} value={search} />
+      </SectionTitle>
+      {filteredLocales.map((locale) => (
+        <LanguageMenuItem locale={locale} isActive={activeLocale === locale} key={locale} />
+      ))}
+    </Fragment>
+  )
+}

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -1,49 +1,20 @@
 import { Trans } from '@lingui/macro'
-import { LOCALE_LABEL, SUPPORTED_LOCALES, SupportedLocale } from 'constants/locales'
-import { useActiveLocale } from 'hooks/useActiveLocale'
-import { useLocationLinkProps } from 'hooks/useLocationLinkProps'
-import { Check } from 'react-feather'
-import { Link } from 'react-router-dom'
-import styled, { useTheme } from 'styled-components/macro'
-import { ClickableStyle, ThemedText } from 'theme'
+import styled from 'styled-components/macro'
+import { ThemedText } from 'theme'
 import ThemeToggle from 'theme/components/ThemeToggle'
 
 import { AnalyticsToggle } from './AnalyticsToggle'
 import { GitVersionRow } from './GitVersionRow'
+import { LanguageSelector } from './LanguageSelector'
 import { SlideOutMenu } from './SlideOutMenu'
 import { SmallBalanceToggle } from './SmallBalanceToggle'
 import { TestnetsToggle } from './TestnetsToggle'
 
-const InternalLinkMenuItem = styled(Link)`
-  ${ClickableStyle}
-  flex: 1;
-  color: ${({ theme }) => theme.textTertiary};
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 12px 0;
-  justify-content: space-between;
-  text-decoration: none;
-  color: ${({ theme }) => theme.textPrimary};
-`
-
-function LanguageMenuItem({ locale, isActive }: { locale: SupportedLocale; isActive: boolean }) {
-  const { to, onClick } = useLocationLinkProps(locale)
-  const theme = useTheme()
-
-  if (!to) return null
-
-  return (
-    <InternalLinkMenuItem onClick={onClick} to={to}>
-      <ThemedText.BodySmall data-testid="wallet-language-item">{LOCALE_LABEL[locale]}</ThemedText.BodySmall>
-      {isActive && <Check color={theme.accentActive} opacity={1} size={20} />}
-    </InternalLinkMenuItem>
-  )
-}
-
 const SectionTitle = styled(ThemedText.SubHeader)`
   color: ${({ theme }) => theme.textSecondary};
   padding-bottom: 24px;
+  display: flex;
+  justify-content: space-between;
 `
 
 const ToggleWrapper = styled.div`
@@ -54,8 +25,6 @@ const ToggleWrapper = styled.div`
 `
 
 export default function SettingsMenu({ onClose }: { onClose: () => void }) {
-  const activeLocale = useActiveLocale()
-
   return (
     <SlideOutMenu title={<Trans>Settings</Trans>} onClose={onClose}>
       <SectionTitle>
@@ -67,13 +36,7 @@ export default function SettingsMenu({ onClose }: { onClose: () => void }) {
         <AnalyticsToggle />
         <TestnetsToggle />
       </ToggleWrapper>
-
-      <SectionTitle data-testid="wallet-header">
-        <Trans>Language</Trans>
-      </SectionTitle>
-      {SUPPORTED_LOCALES.map((locale) => (
-        <LanguageMenuItem locale={locale} isActive={activeLocale === locale} key={locale} />
-      ))}
+      <LanguageSelector />
       <GitVersionRow />
     </SlideOutMenu>
   )


### PR DESCRIPTION
Created a search bar for languages and extrapolated it into separate component

## Description
Added a search input box for when selecting languages. 
Motivation: took me a second to find my native language so I thought one would be nice.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| <img width="377" alt="image" src="https://github.com/Uniswap/interface/assets/45937542/ccd765e2-6359-4dfe-8b4a-fe4d70af1740"> | <img width="352" alt="image" src="https://github.com/Uniswap/interface/assets/45937542/1a9f9cc6-8c42-4304-997c-51144a0cfff0"> |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| <img width="386" alt="image" src="https://github.com/Uniswap/interface/assets/45937542/a2c0f64e-ee57-47dd-8b2e-06a2a3f0470a"> | <img width="340" alt="image" src="https://github.com/Uniswap/interface/assets/45937542/2b512678-2bfa-4870-8292-59dcf2607957"> |