### PR TITLE
fix: fixing price range filter passing as number

### DIFF
--- a/src/nft/components/collection/CollectionNfts.tsx
+++ b/src/nft/components/collection/CollectionNfts.tsx
@@ -1,10 +1,10 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { parseEther } from '@ethersproject/units'
 import { BrowserEvent, InterfaceElementName, NFTEventName } from '@uniswap/analytics-events'
 import { useWeb3React } from '@web3-react/core'
 import { TraceEvent } from 'analytics'
 import clsx from 'clsx'
 import { OpacityHoverState } from 'components/Common'
-import { parseEther } from 'ethers/lib/utils'
 import { NftAssetTraitInput, NftMarketplace, NftStandard } from 'graphql/data/__generated__/types-and-hooks'
 import { ASSET_PAGE_SIZE, AssetFetcherParams, useNftAssets } from 'graphql/data/nft/Asset'
 import useDebounce from 'hooks/useDebounce'
@@ -266,8 +266,8 @@ export const CollectionNfts = ({ contractAddress, collectionStats, rarityVerifie
     filter: {
       listed: buyNow,
       marketplaces: markets.length > 0 ? markets.map((market) => market.toUpperCase() as NftMarketplace) : undefined,
-      maxPrice: debouncedMaxPrice ? parseEther(debouncedMaxPrice).toString() : undefined,
-      minPrice: debouncedMinPrice ? parseEther(debouncedMinPrice).toString() : undefined,
+      maxPrice: debouncedMaxPrice ? parseEther(debouncedMaxPrice.toString()).toString() : undefined,
+      minPrice: debouncedMinPrice ? parseEther(debouncedMinPrice.toString()).toString() : undefined,
       tokenSearchQuery: debouncedSearchByNameText,
       traits:
         traits.length > 0


### PR DESCRIPTION
* app crashes when url is loaded with price range because it is passing in a number instead of a string causing it to crash

https://linear.app/uniswap/issue/WEB-2523/[safari]-blank-page-and-then-get-something-went-wrong-error-when-set