### PR TITLE
fix: use deferred value to avoid suspense issues with inputting text

### DIFF
--- a/src/components/Suspense/SuspenseWithPreviousRenderAsFallback.tsx
+++ b/src/components/Suspense/SuspenseWithPreviousRenderAsFallback.tsx
@@ -1,5 +1,4 @@
-import usePrevious from 'hooks/usePrevious'
-import React, { Suspense } from 'react'
+import React, { Suspense, useDeferredValue } from 'react'
 
 /**
  * This is useful for keeping the "last rendered" components on-screen while any suspense
@@ -9,6 +8,7 @@ import React, { Suspense } from 'react'
  */
 
 export const SuspenseWithPreviousRenderAsFallback = (props: { children: React.ReactNode }) => {
-  const previousContents = usePrevious(props.children)
-  return <Suspense fallback={previousContents ?? null}>{props.children}</Suspense>
+  const previousChildren = useDeferredValue(props.children)
+
+  return <Suspense fallback={previousChildren ?? null}>{props.children}</Suspense>
 }


### PR DESCRIPTION
use deferred value to avoid suspense issues with inputting text during supsended render causing errors

<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2525/[web][ipados][search]-deleting-any-search-causes-an-error-in-the-page
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

If you hit backspace on a search it breaks search pretty often

### After

No break

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
