### PR TITLE
feat: update infura fork block height for cypress tests to be dynamic

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,12 +4,6 @@ import { UNIVERSAL_ROUTER_CREATION_BLOCK } from '@uniswap/universal-router-sdk'
 /* eslint-env node */
 require('dotenv').config()
 
-// Block selection is arbitrary, as e2e tests will build up their own state.
-// The only requirement is that all infrastructure under test (eg Permit2 contracts) are already deployed.
-// TODO(WEB-2187): Make more dynamic to avoid manually updating
-// const BLOCK_NUMBER = 17693163
-// const POLYGON_BLOCK_NUMBER = 43600000
-
 const forkingConfig = {
   httpHeaders: {
     Origin: 'localhost:3000', // infura allowlists requests by origin

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,5 @@
 import { ChainId } from '@uniswap/sdk-core'
+import { UNIVERSAL_ROUTER_CREATION_BLOCK } from '@uniswap/universal-router-sdk'
 
 /* eslint-env node */
 require('dotenv').config()
@@ -6,8 +7,8 @@ require('dotenv').config()
 // Block selection is arbitrary, as e2e tests will build up their own state.
 // The only requirement is that all infrastructure under test (eg Permit2 contracts) are already deployed.
 // TODO(WEB-2187): Make more dynamic to avoid manually updating
-const BLOCK_NUMBER = 17693163
-const POLYGON_BLOCK_NUMBER = 43600000
+// const BLOCK_NUMBER = 17693163
+// const POLYGON_BLOCK_NUMBER = 43600000
 
 const forkingConfig = {
   httpHeaders: {
@@ -18,12 +19,12 @@ const forkingConfig = {
 const forks = {
   [ChainId.MAINNET]: {
     url: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-    blockNumber: BLOCK_NUMBER,
+    blockNumber: UNIVERSAL_ROUTER_CREATION_BLOCK(ChainId.MAINNET),
     ...forkingConfig,
   },
   [ChainId.POLYGON]: {
     url: `https://polygon-mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-    blockNumber: POLYGON_BLOCK_NUMBER,
+    blockNumber: UNIVERSAL_ROUTER_CREATION_BLOCK(ChainId.POLYGON),
     ...forkingConfig,
   },
 }

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@uniswap/smart-order-router": "^3.13.7",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/uniswapx-sdk": "^1.0.1",
-    "@uniswap/universal-router-sdk": "^1.5.4",
+    "@uniswap/universal-router-sdk": "^1.5.6",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v2-sdk": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6385,10 +6385,10 @@
     "@uniswap/sdk-core" "^4.0.3"
     ethers "^5.7.0"
 
-"@uniswap/universal-router-sdk@^1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.4.tgz#9eb2a578b12fdc38ca18300ff708b3d4a86297c8"
-  integrity sha512-9vbB1AFFW3QeZWjtRFE0PVnMa2L+yjJpbU9EqCaEAYdR3+T4zx8fuml+84XUQzjKTp1cnndwusc1Mm+g0/Djpg==
+"@uniswap/universal-router-sdk@^1.5.4", "@uniswap/universal-router-sdk@^1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.6.tgz#274a6ac5df032c34544005fe329aa9e2aac9ade6"
+  integrity sha512-ZD27U+kugMRJRVEX0oWZsRCw1n5vBN3I17Q22IWE+w/WhOJSppUr6PLo9u4HRdqXTZET7gubnlRc0LOAEkkSkQ==
   dependencies:
     "@uniswap/permit2-sdk" "^1.2.0"
     "@uniswap/router-sdk" "^1.6.0"


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Update UR SDK
- Import `UNIVERSAL_ROUTER_CREATION_BLOCK` to get dynamically get block height per chain that UR was deployed to

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2205/import-a-minimum-block-height-in-hardhatconfigjs-from-universal-router