### PR TITLE
fix: use click instead of enter in search test

### DIFF
--- a/cypress/e2e/universal-search.test.ts
+++ b/cypress/e2e/universal-search.test.ts
@@ -41,11 +41,8 @@ describe('Universal search bar', () => {
     // Search a different token by name.
     getSearchBar().type('eth')
 
-    // Validate ETH result now exists.
-    cy.get('[data-cy="searchbar-token-row-ETH"]')
-
-    // Hit enter
-    getSearchBar().type('{enter}')
+    // Validate ETH result now exists and click it.
+    cy.get('[data-cy="searchbar-token-row-ETH"]').click()
 
     // Validate we went to ethereum address
     cy.url().should('contain', 'tokens/ethereum/NATIVE')


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

this test is now flaking out because sometimes cypress's `type({enter})` doesn't actually trigger the navigation to the selected token. i'm hoping this will help the flakiness. 

