### PR TITLE
fix: improve currency select styling

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -68,12 +68,11 @@ const CurrencySelect = styled(ButtonGray)<{
   selected: boolean
   hideInput?: boolean
   disabled?: boolean
+  labelOnly?: boolean
 }>`
   align-items: center;
   background-color: ${({ selected, theme }) => (selected ? theme.backgroundInteractive : theme.accentAction)};
   opacity: ${({ disabled }) => (!disabled ? 1 : 0.4)};
-  box-shadow: ${({ selected }) => (selected ? 'none' : '0px 6px 10px rgba(0, 0, 0, 0.075)')};
-  box-shadow: 0px 6px 10px rgba(0, 0, 0, 0.075);
   color: ${({ selected, theme }) => (selected ? theme.textPrimary : theme.white)};
   cursor: pointer;
   border-radius: 16px;
@@ -92,6 +91,7 @@ const CurrencySelect = styled(ButtonGray)<{
     background-color: ${({ selected, theme }) => (selected ? theme.deprecated_bg3 : darken(0.05, theme.accentAction))};
   }
   visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+  ${({ labelOnly }) => labelOnly && `pointer-events: none`}
 `
 
 const InputRow = styled.div<{ selected: boolean }>`
@@ -259,6 +259,7 @@ export default function CurrencyInputPanel({
                 setModalOpen(true)
               }
             }}
+            labelOnly={!onCurrencySelect}
           >
             <Aligner>
               <RowFixed>

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -68,7 +68,7 @@ const CurrencySelect = styled(ButtonGray)<{
   selected: boolean
   hideInput?: boolean
   disabled?: boolean
-  labelOnly?: boolean
+  pointerEvents?: string
 }>`
   align-items: center;
   background-color: ${({ selected, theme }) => (selected ? theme.backgroundInteractive : theme.accentAction)};
@@ -91,7 +91,7 @@ const CurrencySelect = styled(ButtonGray)<{
     background-color: ${({ selected, theme }) => (selected ? theme.deprecated_bg3 : darken(0.05, theme.accentAction))};
   }
   visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
-  ${({ labelOnly }) => labelOnly && `pointer-events: none`}
+  ${({ pointerEvents }) => pointerEvents && `pointer-events: none`}
 `
 
 const InputRow = styled.div<{ selected: boolean }>`
@@ -259,7 +259,7 @@ export default function CurrencyInputPanel({
                 setModalOpen(true)
               }
             }}
-            labelOnly={!onCurrencySelect}
+            pointerEvents={!onCurrencySelect ? 'none' : undefined}
           >
             <Aligner>
               <RowFixed>


### PR DESCRIPTION
### Overview
[[WEB-2481]](https://linear.app/uniswap/issue/WEB-2481/new-pool-position-page-in-light-mode-has-drop-shadows-on-buttons) addresses styling issues with the dropdown for currency selection, which is used across several web pages:
* Add Liquidity (V2 and V3)
* Remove Liquidity (V2)
* Create Proposal

These pages all use the `CurrencyInputPanel`, which internally builds on the `CurrencySelect` component (the drop-down button, which has the `box-shadow` style applied to it). This PR removes the shadow.

In addition to the shadow, the `CurrencySelect` component on the V3 "Add Liquidity" page has a second issue. In the Deposit section of the page, the user is intended to enter the amounts of each currency that will be deposited into the pool. They cannot and should not use the `CurrencySelect` to change the currency; that is handled above in the "Select Pairs" section. Even though the drop-down menu is disabled, the `CurrencySelect` still behaves as a button, reacting to hover events by changing the color, making the cursor a pointer, and appearing clickable. In order to make it clear that this component is non-interactive, this PR removes pointer events, making it a label only.

### Testing Instructions
Using the preview link, examine the `CurrencyInputPanel` components on each of the pages that use it:
* Add Liquidity V3: `/add/ETH` ([preview](https://interface-git-fork-gnewfield-web-2481-remove-cur-b352c5-uniswap.vercel.app/#/add/ETH/0x6B175474E89094C44Da98b954EedeAC495271d0F/3000?minPrice=929.479600&maxPrice=3717.918400))
* Add Liquidity V2: `/add/v2/ETH` ([preview](https://interface-git-fork-gnewfield-web-2481-remove-cur-b352c5-uniswap.vercel.app/#/add/v2/ETH/0x6B175474E89094C44Da98b954EedeAC495271d0F))
* Remove Liquidity V2: `/remove/v2/ETH/0x6B175474E89094C44Da98b954EedeAC495271d0F` ([preview](https://interface-git-fork-gnewfield-web-2481-remove-cur-b352c5-uniswap.vercel.app/#/remove/v2/ETH/0x6B175474E89094C44Da98b954EedeAC495271d0F))
  * Note: must switch from "Simple" to "Detailed" view, in order to see the `CurrencySelect` components
* Create Proposal: `/vote/create-proposal` ([preview](https://interface-git-fork-gnewfield-web-2481-remove-cur-b352c5-uniswap.vercel.app/#/vote/create-proposal))

Verify that the drop-down behaves as expected, allowing the user to select various currencies as input to the given activity. For adding and removing liquidity, also ensure that the other `CurrencyInputPanel` functionality works as expected, such as entering numeric values for deposit / withdrawal and selecting the maximum amount available in both cases.

Screenshots of the above pages (without the changes from this PR) are attached. The preview links can be used to view the updated experience.

<img width="500" alt="V3 Add Liquidity " src="https://github.com/Uniswap/interface/assets/18626088/b40073a7-4459-4427-8a67-9f7214be421a">
<img width="500" alt="Create Proposal" src="https://github.com/Uniswap/interface/assets/18626088/63d933ad-1dc9-4504-b0a8-53a56b883b6b">
<img width="500" alt="V3 Deposit" src="https://github.com/Uniswap/interface/assets/18626088/02fa8063-0b45-4af9-bf83-06233d1b09d4">
<img width="500" alt="V2 Remove Liquidity" src="https://github.com/Uniswap/interface/assets/18626088/c0264135-9f37-4102-ac99-14a861369652">
<img width="500" alt="V2 Add Liquidity" src="https://github.com/Uniswap/interface/assets/18626088/a1096800-c994-4c9c-a205-372f55575fc6">