### PR TITLE
fix: uniswap wallet deeplinking

### DIFF
--- a/src/components/AccountDrawer/UniwalletModal.tsx
+++ b/src/components/AccountDrawer/UniwalletModal.tsx
@@ -13,6 +13,7 @@ import { QRCodeSVG } from 'qrcode.react'
 import { useEffect, useState } from 'react'
 import styled, { useTheme } from 'styled-components/macro'
 import { CloseIcon, ThemedText } from 'theme'
+import { isIOS } from 'utils/userAgent'
 
 import uniPng from '../../assets/images/uniwallet_modal_icon.png'
 import { DownloadButton } from './DownloadButton'
@@ -41,8 +42,9 @@ export default function UniwalletModal() {
   const { activationState, cancelActivation } = useActivationState()
   const [uri, setUri] = useState<string>()
 
-  // Displays the modal if a Uniswap Wallet Connection is pending & qrcode URI is available
+  // Displays the modal if not on iOS, a Uniswap Wallet Connection is pending, & qrcode URI is available
   const open =
+    !isIOS &&
     activationState.status === ActivationStatus.PENDING &&
     activationState.connection.type === ConnectionType.UNISWAP_WALLET_V2 &&
     !!uri

--- a/src/connection/WalletConnectV2.ts
+++ b/src/connection/WalletConnectV2.ts
@@ -83,10 +83,7 @@ export class UniwalletConnect extends WalletConnectV2 {
 
       // Opens deeplink to Uniswap Wallet if on iOS
       if (isIOS) {
-        const newTab = window.open(`https://uniswap.org/app/wc?uri=${encodeURIComponent(uri)}`)
-
-        // Fixes blank tab opening on mobile Chrome
-        newTab?.close()
+        window.location.href = `uniswap://wc?uri=${encodeURIComponent(uri)}`
       }
     })
   }


### PR DESCRIPTION
Updates the custom uniswap wallet connector to use a regular deeplink (uniswap://wc) rather than a universal link (uniswap.org/wc...), since the universal link stopped functioning correctly. This makes the uniswap modal's link consistent with the link the proprietary walletconnect connector uses.

Also updates the uniswap wallet modal to not display on iOS, correcting visual lag that would appear upon the the wallet navigating back to interface after successfully walletconnecting.

In addition, we now set `window.location.href` rather than using `window.open`, which is the more correct way to deeplink from mobile browsers (window.open may be hindered by popup blockers or security measures, whereas window.location.href enables the operating system to handle the link appropriately, automatically launching the corresponding app if installed)

Safari (app Installed)

https://github.com/Uniswap/interface/assets/39385577/b9e63bc5-3998-491c-bf4d-1261bff2ab3d

Chrome (app installed)

https://github.com/Uniswap/interface/assets/39385577/6d32728b-f6ef-410e-985d-bcd2ea7e9a8f

Safari (app not installed)

https://github.com/Uniswap/interface/assets/39385577/5bac612b-b275-4c11-9c0c-bc3978d95e2a


Chrome (app not installed)

https://github.com/Uniswap/interface/assets/39385577/fe5f2634-723a-4c0f-b44c-9bafc9af32e0




