### PR TITLE
fix: change style of mobile pool buttons and menu

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -53,11 +53,6 @@ const MenuFlyout = styled.span<{ flyoutAlignment?: FlyoutAlignment }>`
       : css`
           left: 0rem;
         `};
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
-    bottom: unset;
-    right: 0;
-    left: unset;
-  `};
 `
 
 const MenuItem = styled(ExternalLink)`

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -62,15 +62,13 @@ const ButtonRow = styled(RowFixed)`
     width: 100%;
     flex-direction: row;
     justify-content: space-between;
-    flex-direction: row-reverse;
   `};
 `
 const PoolMenu = styled(Menu)`
   margin-left: 0;
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
     flex: 1 1 auto;
-    width: 49%;
-    right: 0px;
+    width: 50%;
   `};
 
   a {
@@ -129,7 +127,7 @@ const ResponsiveButtonPrimary = styled(ButtonPrimary)`
   width: fit-content;
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
     flex: 1 1 auto;
-    width: 100%;
+    width: 50%;
   `};
 `
 

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -29,47 +29,41 @@ const PageWrapper = styled(AutoColumn)`
   max-width: 870px;
   width: 100%;
 
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
+  @media (max-width: ${({ theme }) => `${theme.breakpoint.md}px`}) {
     max-width: 800px;
-  `};
-
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
-    max-width: 500px;
-  `};
-
-  @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.md}px`}) {
     padding-top: 48px;
   }
 
-  @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
+  @media (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
+    max-width: 500px;
     padding-top: 20px;
   }
 `
 const TitleRow = styled(RowBetween)`
   color: ${({ theme }) => theme.textSecondary};
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
+  @media (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     flex-wrap: wrap;
     gap: 12px;
     width: 100%;
-  `};
+  }
 `
 const ButtonRow = styled(RowFixed)`
   & > *:not(:last-child) {
     margin-left: 8px;
   }
 
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
+  @media (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     width: 100%;
     flex-direction: row;
     justify-content: space-between;
-  `};
+  }
 `
 const PoolMenu = styled(Menu)`
   margin-left: 0;
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
+  @media (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     flex: 1 1 auto;
     width: 50%;
-  `};
+  }
 
   a {
     width: 100%;
@@ -91,7 +85,7 @@ const MoreOptionsButton = styled(ButtonGray)`
   margin-right: 8px;
 `
 
-const MoreOptionsText = styled(ThemedText.DeprecatedBody)`
+const MoreOptionsText = styled(ThemedText.BodyPrimary)`
   align-items: center;
   display: flex;
 `
@@ -125,10 +119,10 @@ const ResponsiveButtonPrimary = styled(ButtonPrimary)`
   font-size: 16px;
   padding: 6px 8px;
   width: fit-content;
-  ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToSmall`
+  @media (max-width: ${({ theme }) => `${theme.breakpoint.sm}px`}) {
     flex: 1 1 auto;
     width: 50%;
-  `};
+  }
 `
 
 const MainContentWrapper = styled.main`
@@ -178,12 +172,12 @@ function WrongNetworkCard() {
 
             <MainContentWrapper>
               <ErrorContainer>
-                <ThemedText.DeprecatedBody color={theme.textTertiary} textAlign="center">
+                <ThemedText.BodyPrimary color={theme.textTertiary} textAlign="center">
                   <NetworkIcon strokeWidth={1.2} />
                   <div data-testid="pools-unsupported-err">
                     <Trans>Your connected network is unsupported.</Trans>
                   </div>
-                </ThemedText.DeprecatedBody>
+                </ThemedText.BodyPrimary>
               </ErrorContainer>
             </MainContentWrapper>
           </AutoColumn>
@@ -299,12 +293,12 @@ export default function Pool() {
                 />
               ) : (
                 <ErrorContainer>
-                  <ThemedText.DeprecatedBody color={theme.textTertiary} textAlign="center">
+                  <ThemedText.BodyPrimary color={theme.textTertiary} textAlign="center">
                     <InboxIcon strokeWidth={1} style={{ marginTop: '2em' }} />
                     <div>
                       <Trans>Your active V3 liquidity positions will appear here.</Trans>
                     </div>
-                  </ThemedText.DeprecatedBody>
+                  </ThemedText.BodyPrimary>
                   {!showConnectAWallet && closedPositions.length > 0 && (
                     <ButtonText
                       style={{ marginTop: '.5rem' }}


### PR DESCRIPTION
## Description
[WEB-2473](https://linear.app/uniswap/issue/WEB-2473/pool-page-on-mweb-new-position-and-more-buttons-should-be-50percent) identifies a couple of issues with the style of the buttons on the mobile web "Pools" page. As requested, this PR:
* Switches the order of the buttons so that (from left to right) "More" appears first, followed by "New Position"
* Changes the sizing of the buttons so that they share the space equally
* Switches the alignment of the fly-out menu from right to left, now that the "More" button is on the left side of the page

In order to include this last change, it was necessary to fix an issue with the `Menu` component, specifically the `MenuFlyout` implementation of alignment props and styling. The old implementation worked for larger screen sizes but was being permanently overriden to right-alignment for medium sizes and smaller (i.e. mobile). Now the alignment will be correct for all screen sizes.

_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2473/pool-page-on-mweb-new-position-and-more-buttons-should-be-50percent

## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| <img width="547" alt="Old Mobile" src="https://github.com/Uniswap/interface/assets/18626088/0689194a-06f4-44de-a779-f624ffc5d287"> | <img width="922" alt="Old Desktop" src="https://github.com/Uniswap/interface/assets/18626088/357660c9-b8c4-4d67-ac3e-c9ee67502c42"> |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| <img width="547" alt="New Mobile" src="https://github.com/Uniswap/interface/assets/18626088/191ac7b1-a620-4d5f-8a67-6bef6a3cd603">  | <img width="921" alt="New Desktop" src="https://github.com/Uniswap/interface/assets/18626088/d547278b-2f25-4a2c-877f-17a7872502a8"> |

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error
1. Visit the Pools [page](https://app.uniswap.org/#/pools) with a mobile screen size (720 pixels or smaller)
2. Observe that the ordering of the buttons (from left to right) is "New Position," followed by "More"
3. Observe that the size of the "New Position" button is significantly larger than the "More" button
4. Observe that the fly-out menu is right-aligned with the "More" button, even though it is left-aligned in the [code](https://github.com/Uniswap/interface/blob/4d084d0055c2ab0f6ec7d60acd43f8ee50d756b7/src/pages/Pool/index.tsx#L276)

### QA (ie manual testing)
- [x] Visit the preview link and see that the above observations have been corrected
- [x] This PR changes the style of the Menu component, which is used throughout the app, so report any unintended changes to other menus that may have been relying on the broken behavior


#### Devices
Previously, all devices with screen size of 960px or smaller had menu fly-outs that were permanently right-aligned. This PR honors the `flyoutAlignment` props that are passed by parent components. Since right is actually the default alignment if no props are passed, any components that didn't care to set the alignment will remain unchanged. Any components that have the alignment set to left (but weren't) will now actually be aligned to the left.

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
- [x] Integration/E2E test
