### PR TITLE
feat: bump uniswapx-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@uniswap/sdk-core": "^4.0.3",
     "@uniswap/smart-order-router": "^3.13.7",
     "@uniswap/token-lists": "^1.0.0-beta.33",
-    "@uniswap/uniswapx-sdk": "^1.0.1",
+    "@uniswap/uniswapx-sdk": "^1.1.0",
     "@uniswap/universal-router-sdk": "^1.5.6",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",

--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -1,4 +1,5 @@
 import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'featureFlags'
+import { useForceUniswapXOnFlag } from 'featureFlags/flags/forceUniswapXOn'
 import { DetailsV2Variant, useDetailsV2Flag } from 'featureFlags/flags/nftDetails'
 import { useRoutingAPIForPriceFlag } from 'featureFlags/flags/priceRoutingApi'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
@@ -214,7 +215,13 @@ export default function FeatureFlagModal() {
         variant={UniswapXVariant}
         value={useUniswapXFlag()}
         featureFlag={FeatureFlag.uniswapXEnabled}
-        label="Enable UniswapX"
+        label="Enable UniswapX on interface"
+      />
+      <FeatureFlagOption
+        variant={BaseVariant}
+        value={useForceUniswapXOnFlag()}
+        featureFlag={FeatureFlag.forceUniswapXOn}
+        label="Force routing api to enable UniswapX"
       />
       <FeatureFlagOption
         variant={BaseVariant}

--- a/src/featureFlags/flags/forceUniswapXOn.ts
+++ b/src/featureFlags/flags/forceUniswapXOn.ts
@@ -1,0 +1,9 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+export function useForceUniswapXOnFlag(): BaseVariant {
+  return useBaseFlag(FeatureFlag.forceUniswapXOn)
+}
+
+export function useForceUniswapXOn(): boolean {
+  return useForceUniswapXOnFlag() === BaseVariant.Enabled
+}

--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -11,9 +11,10 @@ export enum FeatureFlag {
   fiatOnRampButtonOnSwap = 'fiat_on_ramp_button_on_swap_page',
   detailsV2 = 'details_v2',
   debounceSwapQuote = 'debounce_swap_quote',
-  uniswapXEnabled = 'uniswapx_enabled',
+  uniswapXEnabled = 'uniswapx_enabled', // enables sending dutch_limit config to routing-api
   uniswapXSyntheticQuote = 'uniswapx_synthetic_quote',
   routingAPIPrice = 'routing_api_price',
+  forceUniswapXOn = 'uniswapx_force_on', // forces routing-api's feature flag for uniswapx to turn on as well
 }
 
 interface FeatureFlagsContextType {

--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -1,4 +1,5 @@
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { useForceUniswapXOn } from 'featureFlags/flags/forceUniswapXOn'
 import { useRoutingAPIForPrice } from 'featureFlags/flags/priceRoutingApi'
 import { useUniswapXEnabled } from 'featureFlags/flags/uniswapx'
 import { useUniswapXSyntheticQuoteEnabled } from 'featureFlags/flags/uniswapXUseSyntheticQuote'
@@ -28,6 +29,7 @@ export function useRoutingAPIArguments({
 }): GetQuoteArgs | undefined {
   const uniswapXEnabled = useUniswapXEnabled()
   const uniswapXForceSyntheticQuotes = useUniswapXSyntheticQuoteEnabled()
+  const forceUniswapXOn = useForceUniswapXOn()
   const isRoutingAPIPrice = useRoutingAPIForPrice()
 
   return useMemo(
@@ -51,6 +53,7 @@ export function useRoutingAPIArguments({
             needsWrapIfUniswapX: tokenIn.isNative,
             uniswapXEnabled,
             uniswapXForceSyntheticQuotes,
+            forceUniswapXOn,
           },
     [
       account,
@@ -62,6 +65,7 @@ export function useRoutingAPIArguments({
       uniswapXEnabled,
       isRoutingAPIPrice,
       uniswapXForceSyntheticQuotes,
+      forceUniswapXOn,
     ]
   )
 }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -64,7 +64,7 @@ const DEFAULT_QUERY_PARAMS = {
 }
 
 function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
-  const { account, tradeType, tokenOutAddress, tokenInChainId, uniswapXForceSyntheticQuotes, forceUniswapXOn } = args
+  const { account, tradeType, tokenOutAddress, tokenInChainId, uniswapXForceSyntheticQuotes } = args
 
   const uniswapx = {
     useSyntheticQuotes: uniswapXForceSyntheticQuotes,

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -72,8 +72,6 @@ function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
     // for now recipient === swapper
     recipient: account,
     swapper: account,
-    // if forceUniswapXOn is not ON, then use the backend's default value
-    useUniswapX: forceUniswapXOn || undefined,
     routingType: URAQuoteType.DUTCH_LIMIT,
   }
 
@@ -136,7 +134,15 @@ export const routingApi = createApi({
         const fellBack = false
         if (shouldUseAPIRouter(args)) {
           try {
-            const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, tradeType } = args
+            const {
+              tokenInAddress,
+              tokenInChainId,
+              tokenOutAddress,
+              tokenOutChainId,
+              amount,
+              tradeType,
+              forceUniswapXOn,
+            } = args
             const type = isExactInput(tradeType) ? 'EXACT_INPUT' : 'EXACT_OUTPUT'
 
             const requestBody = {
@@ -146,6 +152,8 @@ export const routingApi = createApi({
               tokenOut: tokenOutAddress,
               amount,
               type,
+              // if forceUniswapXOn is not ON, then use the backend's default value
+              useUniswapX: forceUniswapXOn || undefined,
               configs: getRoutingAPIConfig(args),
             }
 

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -52,6 +52,7 @@ export interface GetQuoteArgs {
   needsWrapIfUniswapX: boolean
   uniswapXEnabled: boolean
   uniswapXForceSyntheticQuotes: boolean
+  forceUniswapXOn: boolean
   isRoutingAPIPrice?: boolean
 }
 
@@ -63,7 +64,7 @@ const DEFAULT_QUERY_PARAMS = {
 }
 
 function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
-  const { account, tradeType, tokenOutAddress, tokenInChainId, uniswapXForceSyntheticQuotes } = args
+  const { account, tradeType, tokenOutAddress, tokenInChainId, uniswapXForceSyntheticQuotes, forceUniswapXOn } = args
 
   const uniswapx = {
     useSyntheticQuotes: uniswapXForceSyntheticQuotes,
@@ -71,6 +72,7 @@ function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
     // for now recipient === swapper
     recipient: account,
     swapper: account,
+    useUniswapX: forceUniswapXOn,
     routingType: URAQuoteType.DUTCH_LIMIT,
   }
 

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -72,7 +72,8 @@ function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
     // for now recipient === swapper
     recipient: account,
     swapper: account,
-    useUniswapX: forceUniswapXOn,
+    // if forceUniswapXOn is not ON, then use the backend's default value
+    useUniswapX: forceUniswapXOn || undefined,
     routingType: URAQuoteType.DUTCH_LIMIT,
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6374,10 +6374,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz#966ba96c9ccc8f0e9e09809890b438203f2b1911"
   integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
 
-"@uniswap/uniswapx-sdk@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-1.0.1.tgz#c1378da255a710bcaa9bbf553634d70db533bd90"
-  integrity sha512-qll9TuZLWG8cbLOXy7C79vONyQgBoos/g9Xphcjdyi2O8dD/Kk7x3P2kQ7OZrcPnaJ1wOtMzKX/9PstDrjiHrQ==
+"@uniswap/uniswapx-sdk@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-1.1.0.tgz#fd0c56f7f1a820b2d47b05d020108ced35d87cbd"
+  integrity sha512-LIEaVnuqaGnm66Rt8s3XB8DzUo6gUNfI2HDarCXpS4e2wVb4FA2/hzsC41vbL4qR579cRCn/br4bNfNI6wvDWQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"


### PR DESCRIPTION
bumps SDK version

this also adds a feature flag, `forceUniswapXOn`, that forces the routing-api's backend feature flag to be on so we can test uniswapx on staging before the backend fully turns it back on.