### PR TITLE
feat: don't fetch UniswapX quotes if user has disabled UniswapX

### DIFF
--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -6,6 +6,7 @@ import { useUniswapXSyntheticQuoteEnabled } from 'featureFlags/flags/uniswapXUse
 import { useMemo } from 'react'
 import { GetQuoteArgs, INTERNAL_ROUTER_PREFERENCE_PRICE, RouterPreference } from 'state/routing/slice'
 import { currencyAddressForSwapQuote } from 'state/routing/utils'
+import { useUserDisabledUniswapX } from 'state/user/hooks'
 
 /**
  * Returns query arguments for the Routing API query or undefined if the
@@ -30,6 +31,7 @@ export function useRoutingAPIArguments({
   const uniswapXEnabled = useUniswapXEnabled()
   const uniswapXForceSyntheticQuotes = useUniswapXSyntheticQuoteEnabled()
   const forceUniswapXOn = useForceUniswapXOn()
+  const userDisabledUniswapX = useUserDisabledUniswapX()
   const isRoutingAPIPrice = useRoutingAPIForPrice()
 
   return useMemo(
@@ -54,6 +56,7 @@ export function useRoutingAPIArguments({
             uniswapXEnabled,
             uniswapXForceSyntheticQuotes,
             forceUniswapXOn,
+            userDisabledUniswapX,
           },
     [
       account,
@@ -62,10 +65,11 @@ export function useRoutingAPIArguments({
       tokenIn,
       tokenOut,
       tradeType,
-      uniswapXEnabled,
       isRoutingAPIPrice,
+      uniswapXEnabled,
       uniswapXForceSyntheticQuotes,
       forceUniswapXOn,
+      userDisabledUniswapX,
     ]
   )
 }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -53,6 +53,7 @@ export interface GetQuoteArgs {
   uniswapXEnabled: boolean
   uniswapXForceSyntheticQuotes: boolean
   forceUniswapXOn: boolean
+  userDisabledUniswapX: boolean
   isRoutingAPIPrice?: boolean
 }
 
@@ -86,6 +87,7 @@ function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
   // so even if the user has selected UniswapX as their router preference, force them to receive a Classic quote.
   if (
     !args.uniswapXEnabled ||
+    args.userDisabledUniswapX ||
     tokenOutIsNative ||
     tradeType === TradeType.EXACT_OUTPUT ||
     !isUniswapXSupportedChain(tokenInChainId)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
only requests classic quotes if the user has disabled UniswapX in swap settings


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2559/dont-fetch-with-dutch-order-config-if-user-has-opted-out-of-uniswapx