### PR TITLE
fix: dont show balance error when quote is loading

### DIFF
--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -176,14 +176,15 @@ export function useDerivedSwapInfo(state: SwapState, chainId: ChainId | undefine
     }
 
     // compare input balance to max input based on version
-    const [balanceIn, maxAmountIn] = [currencyBalances[Field.INPUT], trade?.trade?.maximumAmountIn(allowedSlippage)]
+    const balanceIn = currencyBalances[Field.INPUT]
+    const maxAmountIn = trade?.trade?.maximumAmountIn(allowedSlippage)
 
-    if (balanceIn && maxAmountIn && balanceIn.lessThan(maxAmountIn)) {
+    if (trade.state !== TradeState.LOADING && balanceIn && maxAmountIn && balanceIn.lessThan(maxAmountIn)) {
       inputError = <Trans>Insufficient {balanceIn.currency.symbol} balance</Trans>
     }
 
     return inputError
-  }, [account, currencies, parsedAmount, to, currencyBalances, trade.trade, allowedSlippage])
+  }, [account, currencies, parsedAmount, to, currencyBalances, trade?.trade, trade.state, allowedSlippage])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Stop showing an "insufficient balance" error if the quote is still loading.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2492/insufficient-balance-should-read-from-input-currency-if-trade-is-still


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After


https://github.com/Uniswap/interface/assets/66155195/2600c54b-73a6-4ff5-9923-2fa57b5c5346




## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
