### PR TITLE
test: delegate infura calls to hardhat in cypress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,7 @@ jobs:
           COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
           CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
           CYPRESS_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+          NODE_OPTIONS: "--max_old_space_size=4096"
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Tests are currently hard to understand because cypress will use different infura keys depending on how it is built: hardhat will use dev keys, while the actual build will differ between `yarn start` and `yarn build`.

This updates the cypress tests to always delegate infura calls to hardhat. This fixes two problems:
- infura will now always return data
- infura data will now be N*Sync with hardhat, so that the block number provider doesn't get stuck at a block height above the fork