### PR TITLE
fix: wrap fiat value if too large

### DIFF
--- a/src/components/CurrencyInputPanel/FiatValue.tsx
+++ b/src/components/CurrencyInputPanel/FiatValue.tsx
@@ -7,6 +7,7 @@ import { MouseoverTooltip } from 'components/Tooltip'
 import { useMemo } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
+import { formatTransactionAmount } from 'utils/formatNumbers'
 import { warningSeverity } from 'utils/prices'
 
 const FiatLoadingBubble = styled(LoadingBubble)`
@@ -35,11 +36,19 @@ export function FiatValue({
     return <FiatLoadingBubble />
   }
 
+  let formattedValue = formatNumber(fiatValue.data, NumberType.FiatTokenPrice)
+  if (formattedValue.length > 18) {
+    //Removes the dollar sign at the start, commas, and decimal places
+    formattedValue = formattedValue.slice(1).replaceAll(',', '').slice(0, -4)
+    formattedValue = formatTransactionAmount(Number(formattedValue))
+    formattedValue = '$' + formattedValue + 'T'
+  }
+
   return (
     <Row gap="sm">
       <ThemedText.BodySmall>
         {fiatValue.data ? (
-          formatNumber(fiatValue.data, NumberType.FiatTokenPrice)
+          formattedValue
         ) : (
           <MouseoverTooltip text={<Trans>Not enough liquidity to show accurate USD value.</Trans>}>-</MouseoverTooltip>
         )}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Wraps `fiatValue` to scientific notion if over 10 trillion to prevent issue where text would be to large and push balance/max outside of the boxes. 

<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2424


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

![image (2)](https://github.com/Uniswap/interface/assets/35351983/3f6e6e14-d25a-4b24-8716-c406a8ff7d33)



### After


<img width="1142" alt="Screenshot 2023-08-01 at 11 11 33 AM" src="https://github.com/Uniswap/interface/assets/35351983/0c8998fa-8dcd-4621-8518-8821c7ea7ce9">
<img width="1136" alt="Screenshot 2023-08-01 at 11 11 26 AM" src="https://github.com/Uniswap/interface/assets/35351983/4f0f3ee7-4736-4533-8105-46c90637f070">
<img width="402" alt="Screenshot 2023-08-01 at 11 15 18 AM" src="https://github.com/Uniswap/interface/assets/35351983/1cefcc4a-7a68-4612-be67-e9713a6b1a6c">



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
