### PR TITLE
fix: Router label copy

### DIFF
--- a/src/components/RouterLabel/RouterLabel.test.tsx
+++ b/src/components/RouterLabel/RouterLabel.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import {
+  TEST_DUTCH_TRADE_ETH_INPUT,
+  TEST_TRADE_EXACT_INPUT,
+  TEST_TRADE_EXACT_INPUT_API,
+} from '../../test-utils/constants'
+import { render, screen } from '../../test-utils/render'
+import RouterLabel from '.'
+
+describe('RouterLabel', () => {
+  it('renders correct label for UniswapX trade', () => {
+    render(<RouterLabel trade={TEST_DUTCH_TRADE_ETH_INPUT} />)
+    expect(screen.getByText('Uniswap X')).toBeInTheDocument()
+  })
+
+  it('renders correct label for classic trade with client routing', () => {
+    render(<RouterLabel trade={TEST_TRADE_EXACT_INPUT} />)
+    expect(screen.getByText('Uniswap Client')).toBeInTheDocument()
+  })
+
+  it('renders correct label for classic trade with API routing', () => {
+    render(<RouterLabel trade={TEST_TRADE_EXACT_INPUT_API} />)
+    expect(screen.getByText('Uniswap API')).toBeInTheDocument()
+  })
+})

--- a/src/components/RouterLabel/UniswapXRouterLabel.test.tsx
+++ b/src/components/RouterLabel/UniswapXRouterLabel.test.tsx
@@ -1,0 +1,16 @@
+import { mocked } from 'test-utils/mocked'
+import { render, screen } from 'test-utils/render'
+import { v4 as uuid } from 'uuid'
+
+import UniswapXRouterLabel from './UniswapXRouterLabel'
+
+jest.mock('uuid')
+
+describe('UniswapXRouterLabel', () => {
+  it('matches snapshot', () => {
+    mocked(uuid).mockReturnValue('test-id')
+    const { asFragment } = render(<UniswapXRouterLabel>test router label</UniswapXRouterLabel>)
+    expect(screen.getByText('test router label')).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/RouterLabel/__snapshots__/UniswapXRouterLabel.test.tsx.snap
+++ b/src/components/RouterLabel/__snapshots__/UniswapXRouterLabel.test.tsx.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UniswapXRouterLabel matches snapshot 1`] = `
+<DocumentFragment>
+  .c0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  width: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  gap: 4px;
+}
+
+.c2 {
+  color: #4673fa;
+}
+
+@supports (-webkit-background-clip:text) and (-webkit-text-fill-color:transparent) {
+  .c2 {
+    background-image: linear-gradient(91.39deg,#4673fa -101.76%,#9646fa 101.76%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}
+
+<div
+    class="c0 c1"
+    style="display: inline-flex;"
+    width="auto"
+  >
+    <svg
+      fill="none"
+      height="14"
+      viewBox="0 0 10 14"
+      width="10"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <lineargradient
+          gradientUnits="userSpaceOnUse"
+          id="AutoRouterIconGradienttest-id"
+          x1="-10.1807"
+          x2="10.6573"
+          y1="-12.0006"
+          y2="-11.6017"
+        >
+          <stop
+            stop-color="#4673FA"
+          />
+          <stop
+            offset="1"
+            stop-color="#9646FA"
+          />
+        </lineargradient>
+      </defs>
+      <path
+        d="M9.97131 6.19803C9.91798 6.07737 9.79866 6.00003 9.66666 6.00003H6.66666V1.00003C6.66666 0.862034 6.58201 0.738037 6.45267 0.688704C6.32267 0.638704 6.17799 0.674696 6.08532 0.776696L0.0853237 7.44336C-0.00267631 7.54136 -0.0253169 7.68137 0.0286831 7.80204C0.0820164 7.9227 0.20133 8.00003 0.33333 8.00003H3.33333V13C3.33333 13.138 3.41799 13.262 3.54732 13.3114C3.58665 13.326 3.62666 13.3334 3.66666 13.3334C3.75933 13.3334 3.85 13.2947 3.91467 13.2227L9.91467 6.55603C10.0027 6.4587 10.0246 6.31803 9.97131 6.19803Z"
+        fill="url(#AutoRouterIconGradienttest-id)"
+      />
+    </svg>
+    <div
+      class="c2"
+    >
+      test router label
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/RouterLabel/index.tsx
+++ b/src/components/RouterLabel/index.tsx
@@ -1,4 +1,4 @@
-import { InterfaceTrade } from 'state/routing/types'
+import { InterfaceTrade, QuoteMethod } from 'state/routing/types'
 import { isUniswapXTrade } from 'state/routing/utils'
 import { ThemedText } from 'theme'
 
@@ -12,7 +12,7 @@ export default function RouterLabel({ trade }: { trade: InterfaceTrade }) {
       </UniswapXRouterLabel>
     )
   }
-  if (trade.fromClientRouter) {
+  if (trade.quoteMethod === QuoteMethod.CLIENT_SIDE || trade.quoteMethod === QuoteMethod.CLIENT_SIDE_FALLBACK) {
     return <ThemedText.BodySmall>Uniswap Client</ThemedText.BodySmall>
   }
   return <ThemedText.BodySmall>Uniswap API</ThemedText.BodySmall>

--- a/src/components/swap/__snapshots__/AdvancedSwapDetails.test.tsx.snap
+++ b/src/components/swap/__snapshots__/AdvancedSwapDetails.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`AdvancedSwapDetails.tsx matches base snapshot 1`] = `
           <div
             class="c7 css-zhpkf8"
           >
-            Uniswap API
+            Uniswap Client
           </div>
         </div>
       </div>

--- a/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
@@ -391,7 +391,7 @@ exports[`SwapDetailsDropdown.tsx renders a trade 1`] = `
                   <div
                     class="c9 css-zhpkf8"
                   >
-                    Uniswap API
+                    Uniswap Client
                   </div>
                 </div>
               </div>

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -113,7 +113,6 @@ export class ClassicTrade extends Trade<Currency, Currency, TradeType> {
   gasUseEstimateUSD?: number // gas estimate for swaps
   blockNumber: string | null | undefined
   isUniswapXBetter: boolean | undefined
-  fromClientRouter: boolean | undefined
   requestId: string | undefined
   quoteMethod: QuoteMethod
 
@@ -132,7 +131,6 @@ export class ClassicTrade extends Trade<Currency, Currency, TradeType> {
     isUniswapXBetter?: boolean
     requestId?: string
     quoteMethod: QuoteMethod
-    fromClientRouter?: boolean
     approveInfo: ApproveInfo
     v2Routes: {
       routev2: V2Route<Currency, Currency>

--- a/src/test-utils/constants.ts
+++ b/src/test-utils/constants.ts
@@ -48,6 +48,21 @@ export const TEST_TRADE_EXACT_INPUT = new ClassicTrade({
   quoteMethod: QuoteMethod.CLIENT_SIDE,
 })
 
+export const TEST_TRADE_EXACT_INPUT_API = new ClassicTrade({
+  v3Routes: [
+    {
+      routev3: new V3Route([TEST_POOL_12], TEST_TOKEN_1, TEST_TOKEN_2),
+      inputAmount: toCurrencyAmount(TEST_TOKEN_1, 1000),
+      outputAmount: toCurrencyAmount(TEST_TOKEN_2, 1000),
+    },
+  ],
+  v2Routes: [],
+  tradeType: TradeType.EXACT_INPUT,
+  gasUseEstimateUSD: 1.0,
+  approveInfo: { needsApprove: false },
+  quoteMethod: QuoteMethod.ROUTING_API,
+})
+
 export const TEST_TRADE_EXACT_OUTPUT = new ClassicTrade({
   v3Routes: [
     {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes a bug in the `RouterLabel` component where we checked an unused field to determine if the routing was client-side. now we correctly use the `QuoteMethod` field. 

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2597/fix-routerlabel-copy-for-local-routing


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="1383" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/000152de-1bc4-4d97-8480-36897d4c2c18">


### After

<img width="1383" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/4d4c8ae2-5946-4ff0-a283-a1688c25794f">



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. load a quote with client side routing forced and notice it still says "API"

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] repeat above steps, notice it says "client" instead of "API"

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
- [x] Integration/E2E test N/A
