### PR TITLE
fix: closes settings state when MP is closed

### DIFF
--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -28,10 +28,12 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
   useEffect(() => {
     if (!drawerOpen && menu === MenuState.SETTINGS) {
       // wait for the drawer to close before resetting the menu
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         closeSettings()
       }, 250)
+      return () => clearTimeout(timer)
     }
+    return
   }, [drawerOpen, menu, closeSettings])
 
   return (

--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -1,7 +1,6 @@
 import { useWeb3React } from '@web3-react/core'
 import Column from 'components/Column'
 import WalletModal from 'components/WalletModal'
-import { useCallback, useState } from 'react'
 import styled from 'styled-components/macro'
 
 import AuthenticatedHeader from './AuthenticatedHeader'
@@ -17,13 +16,17 @@ enum MenuState {
   SETTINGS,
 }
 
-function DefaultMenu() {
+function DefaultMenu({
+  menu,
+  openSettings,
+  closeSettings,
+}: {
+  menu: MenuState
+  openSettings: () => void
+  closeSettings: () => void
+}) {
   const { account } = useWeb3React()
   const isAuthenticated = !!account
-
-  const [menu, setMenu] = useState<MenuState>(MenuState.DEFAULT)
-  const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
-  const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
 
   return (
     <DefaultMenuWrap>

--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -1,6 +1,7 @@
 import { useWeb3React } from '@web3-react/core'
 import Column from 'components/Column'
 import WalletModal from 'components/WalletModal'
+import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components/macro'
 
 import AuthenticatedHeader from './AuthenticatedHeader'
@@ -16,17 +17,22 @@ enum MenuState {
   SETTINGS,
 }
 
-function DefaultMenu({
-  menu,
-  openSettings,
-  closeSettings,
-}: {
-  menu: MenuState
-  openSettings: () => void
-  closeSettings: () => void
-}) {
+function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
   const { account } = useWeb3React()
   const isAuthenticated = !!account
+
+  const [menu, setMenu] = useState<MenuState>(MenuState.DEFAULT)
+  const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
+  const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
+
+  useEffect(() => {
+    if (!drawerOpen && menu === MenuState.SETTINGS) {
+      // wait for the drawer to close before resetting the menu
+      setTimeout(() => {
+        closeSettings()
+      }, 250)
+    }
+  }, [drawerOpen, menu, closeSettings])
 
   return (
     <DefaultMenuWrap>

--- a/src/components/AccountDrawer/index.tsx
+++ b/src/components/AccountDrawer/index.tsx
@@ -4,7 +4,7 @@ import { ScrollBarStyles } from 'components/Common'
 import { useWindowSize } from 'hooks/useWindowSize'
 import { atom } from 'jotai'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { ChevronsRight } from 'react-feather'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ClickableStyle } from 'theme'
@@ -17,11 +17,6 @@ const DRAWER_WIDTH = '320px'
 const DRAWER_MARGIN = '8px'
 const DRAWER_OFFSET = '10px'
 const DRAWER_TOP_MARGIN_MOBILE_WEB = '72px'
-
-enum MenuState {
-  DEFAULT,
-  SETTINGS,
-}
 
 const accountDrawerOpenAtom = atom(false)
 
@@ -164,19 +159,6 @@ const CloseDrawer = styled.div`
 function AccountDrawer() {
   const [walletDrawerOpen, toggleWalletDrawer] = useAccountDrawer()
 
-  const [menu, setMenu] = useState<MenuState>(MenuState.DEFAULT)
-  const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
-  const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
-
-  useEffect(() => {
-    if (!walletDrawerOpen && menu === MenuState.SETTINGS) {
-      // wait for the drawer to close before resetting the menu
-      setTimeout(() => {
-        closeSettings()
-      }, 250)
-    }
-  }, [walletDrawerOpen, menu, closeSettings])
-
   const scrollRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!walletDrawerOpen) {
@@ -233,7 +215,7 @@ function AccountDrawer() {
       <AccountDrawerWrapper open={walletDrawerOpen}>
         {/* id used for child InfiniteScrolls to reference when it has reached the bottom of the component */}
         <AccountDrawerScrollWrapper ref={scrollRef} id="wallet-dropdown-scroll-wrapper">
-          <DefaultMenu menu={menu} openSettings={openSettings} closeSettings={closeSettings} />
+          <DefaultMenu drawerOpen={walletDrawerOpen} />
         </AccountDrawerScrollWrapper>
       </AccountDrawerWrapper>
     </Container>

--- a/src/components/AccountDrawer/index.tsx
+++ b/src/components/AccountDrawer/index.tsx
@@ -4,7 +4,7 @@ import { ScrollBarStyles } from 'components/Common'
 import { useWindowSize } from 'hooks/useWindowSize'
 import { atom } from 'jotai'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ChevronsRight } from 'react-feather'
 import styled from 'styled-components/macro'
 import { BREAKPOINTS, ClickableStyle } from 'theme'
@@ -17,6 +17,11 @@ const DRAWER_WIDTH = '320px'
 const DRAWER_MARGIN = '8px'
 const DRAWER_OFFSET = '10px'
 const DRAWER_TOP_MARGIN_MOBILE_WEB = '72px'
+
+enum MenuState {
+  DEFAULT,
+  SETTINGS,
+}
 
 const accountDrawerOpenAtom = atom(false)
 
@@ -158,6 +163,20 @@ const CloseDrawer = styled.div`
 
 function AccountDrawer() {
   const [walletDrawerOpen, toggleWalletDrawer] = useAccountDrawer()
+
+  const [menu, setMenu] = useState<MenuState>(MenuState.DEFAULT)
+  const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
+  const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
+
+  useEffect(() => {
+    if (!walletDrawerOpen && menu === MenuState.SETTINGS) {
+      // wait for the drawer to close before resetting the menu
+      setTimeout(() => {
+        closeSettings()
+      }, 250)
+    }
+  }, [walletDrawerOpen, menu, closeSettings])
+
   const scrollRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!walletDrawerOpen) {
@@ -214,7 +233,7 @@ function AccountDrawer() {
       <AccountDrawerWrapper open={walletDrawerOpen}>
         {/* id used for child InfiniteScrolls to reference when it has reached the bottom of the component */}
         <AccountDrawerScrollWrapper ref={scrollRef} id="wallet-dropdown-scroll-wrapper">
-          <DefaultMenu />
+          <DefaultMenu menu={menu} openSettings={openSettings} closeSettings={closeSettings} />
         </AccountDrawerScrollWrapper>
       </AccountDrawerWrapper>
     </Container>

--- a/src/components/AccountDrawer/index.tsx
+++ b/src/components/AccountDrawer/index.tsx
@@ -158,7 +158,6 @@ const CloseDrawer = styled.div`
 
 function AccountDrawer() {
   const [walletDrawerOpen, toggleWalletDrawer] = useAccountDrawer()
-
   const scrollRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!walletDrawerOpen) {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Closes the settings menu state when the account drawer is closed. Passes additional parameter `walletDrawerOpen` into `DefaultMenu` and adds a `useEffect` that changes `MenuState` back to `DEFAULT` if set to `SETTINGS`. Added 250 ms delay to allow close animation to happen properly before resetting the menu state. 

<!-- Delete inapplicable lines: -->
_Linear ticket:_ WEB-2542

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/35351983/15cf8051-7d46-4467-9c8b-4290219b877d




### After


https://github.com/Uniswap/interface/assets/35351983/c088cd37-8599-4835-9fe3-8b9e76949087



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
