### PR TITLE
fix: clip long token names

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
@@ -82,6 +82,11 @@ export default function Tokens({ account }: { account: string }) {
 const TokenBalanceText = styled(ThemedText.BodySecondary)`
   ${EllipsisStyle}
 `
+const TokenNameText = styled(ThemedText.SubHeader)`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: no-wrap;
+`
 
 type TokenBalance = NonNullable<
   NonNullable<NonNullable<PortfolioBalancesQuery['portfolios']>[number]>['tokenBalances']
@@ -116,7 +121,7 @@ function TokenRow({ token, quantity, denominatedValue, tokenProjectMarket }: Tok
     >
       <PortfolioRow
         left={<PortfolioLogo chainId={currency.chainId} currencies={[currency]} size="40px" />}
-        title={<ThemedText.SubHeader>{token?.name}</ThemedText.SubHeader>}
+        title={<TokenNameText>{token?.name}</TokenNameText>}
         descriptor={
           <TokenBalanceText>
             {formatNumber(quantity, NumberType.TokenNonTx)} {token?.symbol}

--- a/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
@@ -83,9 +83,7 @@ const TokenBalanceText = styled(ThemedText.BodySecondary)`
   ${EllipsisStyle}
 `
 const TokenNameText = styled(ThemedText.SubHeader)`
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: no-wrap;
+  ${EllipsisStyle}
 `
 
 type TokenBalance = NonNullable<


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Long single-word token names (e.g. "HarryPotterObamaSonic10Inu" a.k.a. "The People's Bitcoin") overflow the title area and overlap with other elements. This PR clips these names with an ellipsis, following the same convention as the balance text.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2595/token-names-that-dont-have-a-space-in-the-name-wont-wrap-see


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| <img width="343" alt="Clip Name Before Mobile" src="https://github.com/Uniswap/interface/assets/18626088/65b8ba00-f041-488c-8667-33269d5c6938"> | <img width="1510" alt="Clip Name Before Desktop" src="https://github.com/Uniswap/interface/assets/18626088/aef05189-b675-41ac-b09e-22e80e5d6df7"> |

### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| <img width="339" alt="Clip Name After Mobile" src="https://github.com/Uniswap/interface/assets/18626088/0f7d8e87-8675-4250-b1f1-f5aa43557a4f">  | <img width="1510" alt="Clip Name After Desktop" src="https://github.com/Uniswap/interface/assets/18626088/c0945194-4884-4031-aab3-7a6dbb599041"> |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Open Mini Portfolio for any wallet that has a balance of tokens with a long name (e.g. $BITCOIN)
2. If the name is too long for the portfolio area, the name will overlap with the denominated value on the right
3. Use the preview link to verify that now the token name is clipped with an ellipsis on the right end