### PR TITLE
fix: make sure MenuItem in navbar doesnt wrap text and overflow is cutoff if super long

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -47,10 +47,18 @@ const MenuItem = ({ href, dataTestId, id, isActive, children }: MenuItemProps) =
       style={{ textDecoration: 'none' }}
       data-testid={dataTestId}
     >
-      {children}
+      <MenuItemText>{children}</MenuItemText>
     </NavLink>
   )
 }
+
+const MenuItemText = styled.span`
+  display: inline;
+  overflow: hidden;
+  max-width: 250px;
+  text-overflow: ellipsis;
+  white-space: pre;
+`
 
 export const PageTabs = () => {
   const { pathname } = useLocation()


### PR DESCRIPTION

<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->

Fix wrapping in navbar


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-825/[nav]-tabs-do-not-text-wrap
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="499" alt="CleanShot 2023-08-02 at 10 03 46@2x" src="https://github.com/Uniswap/interface/assets/12100/b6dc98d5-c301-4b6e-b17e-787f4bf6d32b">






### After

<img width="488" alt="CleanShot 2023-08-02 at 10 04 03@2x" src="https://github.com/Uniswap/interface/assets/12100/e1d6d3e7-83af-45f2-922b-9733d908231d">

I made it handle super super long ones, though that shouldn't ever appear, if we had some accidental translation that was like 7 words I think it's better to make it cut off than just push the entire navbar out of screen, it's pretty generous:


<img width="629" alt="CleanShot 2023-08-02 at 10 07 11@2x" src="https://github.com/Uniswap/interface/assets/12100/16846e31-9fa3-4e86-a4b6-e0545d688add">



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
