### PR TITLE
fix: make loading indicator for pools nft card use a shine rather than spinner

### DIFF
--- a/src/components/Loader/styled.tsx
+++ b/src/components/Loader/styled.tsx
@@ -9,22 +9,26 @@ export const loadingAnimation = keyframes`
   }
 `
 
+const shimmerMixin = css`
+  animation: ${loadingAnimation} 1.5s infinite;
+  animation-fill-mode: both;
+  background: linear-gradient(
+    to left,
+    ${({ theme }) => theme.deprecated_bg1} 25%,
+    ${({ theme }) => theme.backgroundInteractive} 50%,
+    ${({ theme }) => theme.deprecated_bg1} 75%
+  );
+  background-size: 400%;
+  will-change: background-position;
+`
+
 export const LoadingRows = styled.div`
   display: grid;
 
   & > div {
-    animation: ${loadingAnimation} 1.5s infinite;
-    animation-fill-mode: both;
-    background: linear-gradient(
-      to left,
-      ${({ theme }) => theme.deprecated_bg1} 25%,
-      ${({ theme }) => theme.backgroundInteractive} 50%,
-      ${({ theme }) => theme.deprecated_bg1} 75%
-    );
-    background-size: 400%;
+    ${shimmerMixin}
     border-radius: 12px;
     height: 2.4em;
-    will-change: background-position;
   }
 `
 
@@ -36,4 +40,10 @@ export const loadingOpacityMixin = css<{ $loading: boolean }>`
 
 export const LoadingOpacityContainer = styled.div<{ $loading: boolean }>`
   ${loadingOpacityMixin}
+`
+
+export const LoadingFullscreen = styled.div`
+  ${shimmerMixin}
+  inset: 0;
+  position: absolute;
 `

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -13,7 +13,7 @@ import { ButtonConfirmed, ButtonGray, ButtonPrimary } from 'components/Button'
 import { DarkCard, LightCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
 import DoubleCurrencyLogo from 'components/DoubleLogo'
-import Loader from 'components/Icons/LoadingSpinner'
+import { LoadingFullscreen } from 'components/Loader/styled'
 import CurrencyLogo from 'components/Logo/CurrencyLogo'
 import { RowBetween, RowFixed } from 'components/Row'
 import { Dots } from 'components/swap/styleds'
@@ -711,7 +711,8 @@ function PositionPageContent() {
             <ResponsiveRow align="flex-start">
               <HideSmall
                 style={{
-                  marginRight: '12px',
+                  height: '100%',
+                  marginRight: 12,
                 }}
               >
                 {'result' in metadata ? (
@@ -739,9 +740,11 @@ function PositionPageContent() {
                     height="100%"
                     style={{
                       minWidth: '340px',
+                      position: 'relative',
+                      overflow: 'hidden',
                     }}
                   >
-                    <Loader />
+                    <LoadingFullscreen />
                   </DarkCard>
                 )}
               </HideSmall>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2538/loading-state-for-pool-nft-looks-real-bad
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/12100/9ff86973-61dc-4564-b660-861c79bd72bd




### After


https://github.com/Uniswap/interface/assets/12100/4bb3873b-54d3-4a34-8289-7cd4e0d1301c


https://github.com/Uniswap/interface/assets/12100/c8e21394-478c-4879-8e23-4eabd2c20e6d



## Test plan

Hard to test because it really doesn't load long, I just edited the code to force show the loading state in PositionPage.tsx line 713.

Can use this url: 

- http://localhost:3000/#/pools/545032
- http://app.uniswap.org/#/pools/545032

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
