### PR TITLE
fix: adjusting slippage in a different language

### DIFF
--- a/src/components/AnimatedDropdown/index.tsx
+++ b/src/components/AnimatedDropdown/index.tsx
@@ -5,12 +5,8 @@ import useResizeObserver from 'use-resize-observer'
  * @param open conditional to show content or hide
  * @returns Wrapper to smoothly hide and expand content
  */
-export default function AnimatedDropdown({
-  open,
-  overflow = 'hidden',
-  children,
-}: React.PropsWithChildren<{ open: boolean; overflow?: string }>) {
-  const { ref, height } = useResizeObserver()
+export default function AnimatedDropdown({ open, children }: React.PropsWithChildren<{ open: boolean }>) {
+  const { ref, height, width } = useResizeObserver()
 
   const props = useSpring({
     // On initial render, `height` will be undefined as ref has not been set yet.
@@ -26,7 +22,7 @@ export default function AnimatedDropdown({
     },
   })
   return (
-    <animated.div style={{ ...props, overflow: `${open ? overflow : 'hidden'}`, width: '100%', willChange: 'height' }}>
+    <animated.div style={{ ...props, overflow: 'hidden', width, willChange: 'height' }}>
       <div ref={ref}>{children}</div>
     </animated.div>
   )

--- a/src/components/AnimatedDropdown/index.tsx
+++ b/src/components/AnimatedDropdown/index.tsx
@@ -5,7 +5,11 @@ import useResizeObserver from 'use-resize-observer'
  * @param open conditional to show content or hide
  * @returns Wrapper to smoothly hide and expand content
  */
-export default function AnimatedDropdown({ open, children }: React.PropsWithChildren<{ open: boolean }>) {
+export default function AnimatedDropdown({
+  open,
+  overflow = 'hidden',
+  children,
+}: React.PropsWithChildren<{ open: boolean; overflow?: string }>) {
   const { ref, height } = useResizeObserver()
 
   const props = useSpring({
@@ -22,7 +26,7 @@ export default function AnimatedDropdown({ open, children }: React.PropsWithChil
     },
   })
   return (
-    <animated.div style={{ ...props, overflow: 'hidden', width: '100%', willChange: 'height' }}>
+    <animated.div style={{ ...props, overflow: `${overflow}`, width: '100%', willChange: 'height' }}>
       <div ref={ref}>{children}</div>
     </animated.div>
   )

--- a/src/components/AnimatedDropdown/index.tsx
+++ b/src/components/AnimatedDropdown/index.tsx
@@ -6,7 +6,7 @@ import useResizeObserver from 'use-resize-observer'
  * @returns Wrapper to smoothly hide and expand content
  */
 export default function AnimatedDropdown({ open, children }: React.PropsWithChildren<{ open: boolean }>) {
-  const { ref, height, width } = useResizeObserver()
+  const { ref, height } = useResizeObserver()
 
   const props = useSpring({
     // On initial render, `height` will be undefined as ref has not been set yet.
@@ -22,7 +22,9 @@ export default function AnimatedDropdown({ open, children }: React.PropsWithChil
     },
   })
   return (
-    <animated.div style={{ ...props, overflow: 'hidden', width, willChange: 'height' }}>
+    <animated.div
+      style={{ ...props, overflow: 'hidden', width: '100%', minWidth: 'min-content', willChange: 'height' }}
+    >
       <div ref={ref}>{children}</div>
     </animated.div>
   )

--- a/src/components/AnimatedDropdown/index.tsx
+++ b/src/components/AnimatedDropdown/index.tsx
@@ -26,7 +26,7 @@ export default function AnimatedDropdown({
     },
   })
   return (
-    <animated.div style={{ ...props, overflow: `${overflow}`, width: '100%', willChange: 'height' }}>
+    <animated.div style={{ ...props, overflow: `${open ? overflow : 'hidden'}`, width: '100%', willChange: 'height' }}>
       <div ref={ref}>{children}</div>
     </animated.div>
   )

--- a/src/components/Settings/Input/index.tsx
+++ b/src/components/Settings/Input/index.tsx
@@ -24,6 +24,7 @@ export const InputContainer = styled(Row)<{ error?: boolean }>`
   padding: 8px 16px;
   border-radius: 12px;
   width: auto;
+  min-width: 100px;
   flex: 1;
   input {
     color: ${({ theme, error }) => (error ? theme.accentFailure : theme.textPrimary)};

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -77,7 +77,7 @@ export default function SettingsTab({
           <AutoColumn gap="16px">
             <RouterPreferenceSettings />
           </AutoColumn>
-          <AnimatedDropdown open={!isUniswapXTrade(trade)} overflow="visible">
+          <AnimatedDropdown open={!isUniswapXTrade(trade)}>
             <ExpandColumn>
               <Divider />
               <MaxSlippageSettings autoSlippage={autoSlippage} />

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -77,7 +77,7 @@ export default function SettingsTab({
           <AutoColumn gap="16px">
             <RouterPreferenceSettings />
           </AutoColumn>
-          <AnimatedDropdown open={!isUniswapXTrade(trade)}>
+          <AnimatedDropdown open={!isUniswapXTrade(trade)} overflow="visible">
             <ExpandColumn>
               <Divider />
               <MaxSlippageSettings autoSlippage={autoSlippage} />

--- a/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`SwapDetailsDropdown.tsx renders a trade 1`] = `
       </div>
     </div>
     <div
-      style="height: 0px; overflow: hidden; width: 100%; will-change: height;"
+      style="height: 0px; overflow: hidden; width: 100%; min-width: min-content; will-change: height;"
     >
       <div>
         <div


### PR DESCRIPTION
## Description
Fixes issues where languages like French and Dutch are unable to adjust slippage because the slippage input is squished

_Linear ticket:_  https://linear.app/uniswap/issue/WEB-2522/cant-adjust-slippage-in-different-language

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

![Screen Shot 2023-08-02 at 5 49 44 PM](https://github.com/Uniswap/interface/assets/9094792/019990d7-6ed4-4669-8ca3-922c3288c092)


### After

![Screen Shot 2023-08-02 at 5 50 46 PM](https://github.com/Uniswap/interface/assets/9094792/f2c44b79-6f25-42ab-8349-6b07e8ae9874)

