### PR TITLE
fix: failing token cloud function tests

### DIFF
--- a/functions/tokens/[[index]].ts
+++ b/functions/tokens/[[index]].ts
@@ -1,13 +1,14 @@
 /* eslint-disable import/no-unused-modules */
+import { Chain } from '../../src/graphql/data/__generated__/types-and-hooks'
 import { MetaTagInjector } from '../components/metaTagInjector'
 import getToken from '../utils/getToken'
 
 const convertTokenAddress = (tokenAddress: string, networkName: string) => {
   if (tokenAddress === 'NATIVE') {
     switch (networkName) {
-      case 'CELO':
+      case Chain.Celo:
         return '0x471EcE3750Da237f93B8E339c536989b8978a438'
-      case 'POLYGON':
+      case Chain.Polygon:
         return '0x0000000000000000000000000000000000001010'
       default:
         return undefined

--- a/functions/tokens/[[index]].ts
+++ b/functions/tokens/[[index]].ts
@@ -2,17 +2,28 @@
 import { MetaTagInjector } from '../components/metaTagInjector'
 import getToken from '../utils/getToken'
 
-const convertTokenAddress = (tokenAddress: string) => {
-  return tokenAddress && tokenAddress === 'NATIVE' ? '0x0000000000000000000000000000000000000000' : tokenAddress
+const convertTokenAddress = (tokenAddress: string, networkName: string) => {
+  if (tokenAddress === 'NATIVE') {
+    switch (networkName) {
+      case 'CELO':
+        return '0x471EcE3750Da237f93B8E339c536989b8978a438'
+      case 'POLYGON':
+        return '0x0000000000000000000000000000000000001010'
+      default:
+        return undefined
+    }
+  }
+  return tokenAddress
 }
 
 export const onRequest: PagesFunction = async ({ params, request, next }) => {
   const { index } = params
   const networkName = index[0]?.toString().toUpperCase()
-  const tokenAddress = convertTokenAddress(index[1]?.toString())
-  if (!tokenAddress) {
+  const tokenString = index[1]?.toString()
+  if (!tokenString) {
     return next()
   }
+  const tokenAddress = convertTokenAddress(tokenString, networkName)
   const tokenPromise = getToken(networkName, tokenAddress, request.url)
   const resPromise = next()
   try {

--- a/functions/utils/getToken.ts
+++ b/functions/utils/getToken.ts
@@ -11,7 +11,7 @@ function formatTitleName(symbol: string, name: string) {
   return 'View Token on Uniswap'
 }
 
-export default async function getToken(networkName: string, tokenAddress: string, url: string) {
+export default async function getToken(networkName: string, tokenAddress: string | undefined, url: string) {
   const { data } = await client.query({
     query: TokenDocument,
     variables: {


### PR DESCRIPTION
Fixes failing native token cloud function tests by removing the conversion from `NATIVE` to zero address to instead `NATIVE` to `undefined` or a predefined address for specific chains. 