### PR TITLE
fix: re-enable UniswapX after disabling

### DIFF
--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -60,7 +60,7 @@ const DEFAULT_QUERY_PARAMS = {
 }
 
 function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
-  const { account, tradeType, tokenOutAddress, tokenInChainId, uniswapXForceSyntheticQuotes } = args
+  const { account, tradeType, tokenOutAddress, tokenInChainId, uniswapXForceSyntheticQuotes, routerPreference } = args
 
   const uniswapx = {
     useSyntheticQuotes: uniswapXForceSyntheticQuotes,
@@ -82,7 +82,7 @@ function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
   // so even if the user has selected UniswapX as their router preference, force them to receive a Classic quote.
   if (
     !args.uniswapXEnabled ||
-    args.userDisabledUniswapX ||
+    (args.userDisabledUniswapX && routerPreference !== RouterPreference.X) ||
     tokenOutIsNative ||
     tradeType === TradeType.EXACT_OUTPUT ||
     !isUniswapXSupportedChain(tokenInChainId)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

currently we're disabling UniswapX if the user ever turns off the toggle, and we don't re-enable it. this fixes the behavior for when you re-enable the option in settings.

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C02T729PMQE/p1691101980899769


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

<img width="734" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/387f5fe5-0944-45d3-ab87-1dbfeb52e54e">

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1.  manually disable uniswapX, then look at the quote request and notice that we're not requesting UniswapX

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually disable UniswapX, then re-enable and verify the quote request includes the UniswapX config

