### PR TITLE
fix: uniswapx review modal success display

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/OffchainActivityModal.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/OffchainActivityModal.tsx
@@ -77,6 +77,7 @@ function Loader() {
 }
 
 const Success = styled(AnimatedEntranceConfirmationIcon)`
+  position: relative;
   margin-bottom: 10px;
 `
 

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -265,13 +265,10 @@ export function PendingModalContent({
   const { chainId } = useWeb3React()
 
   const swapStatus = useSwapTransactionStatus(swapResult)
+  const order = useOrder(swapResult?.type === TradeFillType.UniswapX ? swapResult.response.orderHash : '')
 
-  const classicSwapConfirmed = swapStatus === TransactionStatus.Confirmed
+  const swapConfirmed = swapStatus === TransactionStatus.Confirmed || order?.status === UniswapXOrderStatus.FILLED
   const wrapConfirmed = useIsTransactionConfirmed(wrapTxHash)
-  // TODO(UniswapX): Support UniswapX status here too
-  const uniswapXSwapConfirmed = Boolean(swapResult)
-
-  const swapConfirmed = swapResult?.type === TradeFillType.Classic ? classicSwapConfirmed : uniswapXSwapConfirmed
 
   const swapPending = swapResult !== undefined && !swapConfirmed
   const wrapPending = wrapTxHash != undefined && !wrapConfirmed
@@ -287,8 +284,6 @@ export function PendingModalContent({
     trade,
     chainId,
   })
-
-  const order = useOrder(swapResult?.type === TradeFillType.UniswapX ? swapResult.response.orderHash : '')
 
   const currentStepContainerRef = useRef<HTMLDivElement>(null)
   useUnmountingAnimation(currentStepContainerRef, () => AnimationType.EXITING)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes regression where a UniswapX order would immediately display as successful, before being filled or failing.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

https://github.com/Uniswap/interface/assets/39385577/30ca80d1-277f-430c-a43e-9b9659b47f73

### After

https://github.com/Uniswap/interface/assets/39385577/4c9101bb-ecc4-4cec-9e20-2b69e52c2ba5

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Submit a gouda order, see immediate success rather than a swap pending state

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Submit a gouda order, ensure "Swap submitted" is displayed before success is shown


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

e2e tests are being written for gouda swaps in a sep ticket