### PR TITLE
fix: check chainId in findCancelTx

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
@@ -19,7 +19,8 @@ function findCancelTx(localActivity: Activity, remoteMap: ActivityMap, account: 
     if (
       remoteTx.nonce === localActivity.nonce &&
       remoteTx.from.toLowerCase() === account.toLowerCase() &&
-      remoteTx.hash.toLowerCase() !== localActivity.hash.toLowerCase()
+      remoteTx.hash.toLowerCase() !== localActivity.hash.toLowerCase() &&
+      remoteTx.chainId === localActivity.chainId
     ) {
       return remoteTx.hash
     }
@@ -37,6 +38,10 @@ function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = 
     const remoteActivity = (remoteMap?.[hash] ?? {}) as Activity
 
     if (localActivity.cancelled) {
+      if (localActivity.chainId !== remoteActivity.chainId) {
+        acc.push(remoteActivity)
+        return acc
+      }
       // Remote data only contains data of the cancel tx, rather than the original tx, so we prefer local data here
       acc.push(localActivity)
     } else {
@@ -67,6 +72,7 @@ export function useAllActivities(account: string) {
       if (!localActivity) return
 
       const cancelHash = findCancelTx(localActivity, remoteMap, account)
+
       if (cancelHash) updateCancelledTx(localActivity.hash, localActivity.chainId, cancelHash)
     })
   }, [account, localMap, remoteMap, updateCancelledTx])

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
@@ -38,6 +38,7 @@ function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = 
     const remoteActivity = (remoteMap?.[hash] ?? {}) as Activity
 
     if (localActivity.cancelled) {
+      // Hides misleading activities caused by cross-chain nonce collisions previously being incorrectly labelled as cancelled txs in redux
       if (localActivity.chainId !== remoteActivity.chainId) {
         acc.push(remoteActivity)
         return acc


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

We are marking transactions as cancelled if we detect the same nonce but a different hash - even if that other transaction is on a different chain.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2621/screen-bugs-out-when-making-base-tx-while-mini-port-is-open


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/66155195/7efa4deb-f9dd-4712-936f-302345fec0e6




### After

https://github.com/Uniswap/interface/assets/66155195/996670de-1adb-49aa-8ba3-a33d85070cd8



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. make a swap on base with the MP activity tab open

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] make a swap on base with the MP activity tab open, ensure it's correct. and that previously "cancelled" txs are not cancelled


