### PR TITLE
feat: adding more fingerprints for deeplink apps

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
       "namespace": "android_app",
       "package_name": "com.uniswap",
       "sha256_cert_fingerprints":
-        ["97:A5:81:51:DA:AF:8F:6E:65:3A:90:1E:82:12:6C:FB:61:2D:36:C7:CF:20:61:6B:A3:4C:52:CA:BC:58:43:8E"]
+        ["97:A5:81:51:DA:AF:8F:6E:65:3A:90:1E:82:12:6C:FB:61:2D:36:C7:CF:20:61:6B:A3:4C:52:CA:BC:58:43:8E", "F9:E9:E3:F0:04:28:66:62:81:44:50:7E:D6:A9:5F:B9:65:39:02:70:1D:13:74:15:D3:E1:A3:1B:D4:38:3A:1F"]
     }
   },
   [
@@ -15,7 +15,7 @@
         "namespace": "android_app",
         "package_name": "com.uniswap.beta",
         "sha256_cert_fingerprints":
-          ["E5:39:87:DC:4D:FD:4C:1B:A6:74:36:7D:3A:3B:6B:ED:9E:B3:66:89:92:8A:1B:B8:FC:1B:22:56:56:B4:46:A3"]
+          ["E5:39:87:DC:4D:FD:4C:1B:A6:74:36:7D:3A:3B:6B:ED:9E:B3:66:89:92:8A:1B:B8:FC:1B:22:56:56:B4:46:A3", "54:4B:62:33:17:9B:5F:A8:E6:5D:D3:A6:E5:9D:80:5F:A5:02:7F:E2:14:B8:C1:7A:AC:4B:8D:E0:65:49:87:41"]
       }
     }
   ],
@@ -26,7 +26,7 @@
         "namespace": "android_app",
         "package_name": "com.uniswap.dev",
         "sha256_cert_fingerprints":
-          ["A8:A7:D4:DE:46:8E:BE:F6:DE:3B:62:2B:A7:26:60:F2:9A:4C:CD:AF:A6:96:C9:E5:7C:91:68:A1:29:2A:48:D3"]
+          ["A8:A7:D4:DE:46:8E:BE:F6:DE:3B:62:2B:A7:26:60:F2:9A:4C:CD:AF:A6:96:C9:E5:7C:91:68:A1:29:2A:48:D3", "02:E6:1C:76:8C:75:C3:78:C8:8C:FE:7B:2E:8F:4B:E1:FA:47:F2:F6:1A:DB:57:69:4A:41:99:C6:71:2C:AB:E3", "FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C"]
       }
     }
   ]


### PR DESCRIPTION
## Description
Adds SHA fingerprints for app signed with our local keystores since dev and beta variants are not usually signed by Google Play. 
* For dev bundle id, adds both dev keystore and debug keystore in case we want local testing. 

## Test plan

Manual testing once deployed to vercel + prod domain. 
