### PR TITLE
chore: add to blocked nft infringing collections

### DIFF
--- a/src/nft/utils/collection.ts
+++ b/src/nft/utils/collection.ts
@@ -30,4 +30,8 @@ export const blocklistedCollections = [
   '0x85c08fffa9510f87019efdcf986301873cbb10d6',
   '0xd5eeac01b0d1d929d6cffaaf78020af137277293',
   '0x88e49f9fd4cc3d30f2f46c652f59fb52c4874f23',
+  '0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7',
+  '0xd945f759d422ae30a6166838317b937de08380e3',
+  '0x8e52fb89b6311bd9ec36bd7cea9a0c311fd27a92',
+  '0x2079c2765462af6d78a9ccbddb6ff3c6d4ba2e24',
 ]


### PR DESCRIPTION
* Blocks the following infringing NFT collections:
COLLECTION: Zora, contract address: 0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7
COLLECTION: Zora API Genesis Hackathon, contract address: 0xd945f759d422ae30a6166838317b937de08380e3
COLLECTION: Zora Labs Project, contract address: 0x8e52fb89b6311bd9ec36bd7cea9a0c311fd27a92
COLLECTION: Zorb Viz, contract address: 0x2079c2765462af6d78a9ccbddb6ff3c6d4ba2e24

_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2624/block-nft-infringing-collections
