### PR TITLE
fix: make swc not break WalletConnect by targeting a newer version of es

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/swcrc",
+  // has to duplicate from package.json, see swc issue: https://swc.rs/docs/configuration/compilation#env
+  "env": {
+    "targets": "> 0.5%, not dead"
+  },
   "jsc": {
     "keepClassNames": true,
     "experimental": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,8 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      ">0.5%",
+      "not dead"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
fixes breaking wallet connect / uniswap wallet connect on main

had to leave it in package.json because otherwise craco fails.

to repro: it was erroring if you hit connect => uniswap wallet and not allowing connection, this should fix that