### PR TITLE
feat: add time to sign analytics

### DIFF
--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -88,7 +88,6 @@ export function useUniswapXSwapCallback({
             trade,
             allowedSlippage,
             fiatValues,
-            // measures the amount of time the user took to sign the permit message in their wallet
             timeToSignSinceRequestMs: Date.now() - beforeSign,
           }),
           ...analyticsContext,

--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -80,6 +80,7 @@ export function useUniswapXSwapCallback({
           }
         }
 
+        const beforeSign = Date.now()
         const { signature, updatedOrder } = await signDutchOrder()
 
         sendAnalyticsEvent(SwapEventName.SWAP_SIGNED, {
@@ -87,6 +88,8 @@ export function useUniswapXSwapCallback({
             trade,
             allowedSlippage,
             fiatValues,
+            // measures the amount of time the user took to sign the permit message in their wallet
+            timeToSignSinceRequestMs: Date.now() - beforeSign,
           }),
           ...analyticsContext,
         })

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -91,6 +91,7 @@ export function useUniversalRouterSwapCallback(
         }
         const gasLimit = calculateGasMargin(gasEstimate)
         setTraceData('gasLimit', gasLimit.toNumber())
+        const beforeSign = Date.now()
         const response = await provider
           .getSigner()
           .sendTransaction({ ...tx, gasLimit })
@@ -98,6 +99,7 @@ export function useUniversalRouterSwapCallback(
             sendAnalyticsEvent(SwapEventName.SWAP_SIGNED, {
               ...formatSwapSignedAnalyticsEventProperties({
                 trade,
+                timeToSignSinceRequestMs: Date.now() - beforeSign,
                 allowedSlippage: options.slippageTolerance,
                 fiatValues,
                 txHash: response.hash,

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -65,15 +65,18 @@ export const formatSwapSignedAnalyticsEventProperties = ({
   allowedSlippage,
   fiatValues,
   txHash,
+  timeToSignSinceRequestMs,
 }: {
   trade: InterfaceTrade
   allowedSlippage: Percent
   fiatValues: { amountIn?: number; amountOut?: number }
   txHash?: string
+  timeToSignSinceRequestMs?: number
 }) => ({
   transaction_hash: txHash,
   token_in_amount_usd: fiatValues.amountIn,
   token_out_amount_usd: fiatValues.amountOut,
+  time_to_sign_since_request_ms: timeToSignSinceRequestMs,
   ...formatCommonPropertiesForTrade(trade, allowedSlippage),
 })
 

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -76,6 +76,7 @@ export const formatSwapSignedAnalyticsEventProperties = ({
   transaction_hash: txHash,
   token_in_amount_usd: fiatValues.amountIn,
   token_out_amount_usd: fiatValues.amountOut,
+  // measures the amount of time the user took to sign the permit message or swap tx in their wallet
   time_to_sign_since_request_ms: timeToSignSinceRequestMs,
   ...formatCommonPropertiesForTrade(trade, allowedSlippage),
 })


### PR DESCRIPTION
This adds metrics about how long users take to sign uniswapx permit message and classic uniswap transaction requests