### PR TITLE
feat: custom colors for rich link previews

### DIFF
--- a/functions/constants.ts
+++ b/functions/constants.ts
@@ -2,3 +2,75 @@ export const WATERMARK_URL = 'https://app.uniswap.org/images/324x74_App_Watermar
 export const CHECK_URL = 'https://app.uniswap.org/images/54x54_Verified_Check.svg'
 
 export const DEFAULT_COLOR = [35, 43, 43]
+
+export const predefinedTokenColors: { [key: string]: number[] } = {
+  // old WBTC
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png':
+    [240, 146, 65],
+  // new WBTC
+  'https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1548822744': [240, 146, 65],
+  // DAI
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png':
+    [250, 176, 27],
+  // UNI
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png':
+    [230, 53, 140],
+  // BUSD
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x4Fabb145d64652a948d72533023f6E7A623C7C53/logo.png':
+    [239, 186, 9],
+  // AI-X
+  'https://s2.coinmarketcap.com/static/img/coins/64x64/26984.png': [41, 161, 241],
+  // ETH
+  'https://token-icons.s3.amazonaws.com/eth.png': [73, 112, 213],
+  // HARRYPOTTERSHIBAINUBITCOIN
+  'https://assets.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1684117567': [
+    222, 49, 16,
+  ],
+  // PEPE
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x6982508145454Ce325dDbE47a25d4ec3d2311933/logo.png':
+    [62, 174, 20],
+  // Unibot V2
+  'https://s2.coinmarketcap.com/static/img/coins/64x64/25436.png': [74, 10, 79],
+  // UNIBOT v1
+  'https://assets.coingecko.com/coins/images/30462/small/logonoline_%281%29.png?1687510315': [74, 10, 79],
+  // USDC
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png':
+    [0, 102, 217],
+  // HEX
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39/logo.png':
+    [249, 63, 140],
+  // MONG
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x1ce270557C1f68Cfb577b856766310Bf8B47FD9C/logo.png':
+    [169, 109, 255],
+  // ARB
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1/logo.png':
+    [41, 161, 241],
+  // PSYOP
+  'https://s2.coinmarketcap.com/static/img/coins/64x64/25422.png': [232, 143, 0],
+  // MATIC
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png':
+    [169, 109, 255],
+  // TURBO
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA35923162C49cF95e6BF26623385eb431ad920D3/logo.png':
+    [189, 110, 41],
+  // AIDOGE
+  'https://assets.coingecko.com/coins/images/29852/large/photo_2023-04-18_14-25-28.jpg?1681799160': [41, 161, 241],
+  // SIMPSON
+  'https://assets.coingecko.com/coins/images/30243/large/1111.png?1683692033': [232, 143, 0],
+  // OX
+  'https://assets.coingecko.com/coins/images/30604/large/Logo2.png?1685522119': [41, 89, 217],
+  // ANGLE
+  'https://assets.coingecko.com/coins/images/19060/large/ANGLE_Token-light.png?1666774221': [255, 85, 85],
+  // APE
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x4d224452801ACEd8B2F0aebE155379bb5D594381/logo.png':
+    [5, 74, 169],
+  // GUSD
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd/logo.png':
+    [0, 164, 189],
+  // OGN
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26/logo.png':
+    [5, 74, 169],
+  // RPL
+  'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xD33526068D116cE69F19A9ee46F0bd304F21A51f/logo.png':
+    [255, 123, 79],
+}

--- a/functions/global-setup.ts
+++ b/functions/global-setup.ts
@@ -4,7 +4,7 @@ module.exports = async function globalSetup() {
   globalThis.servers = await setup({
     command: `yarn start:cloud`,
     port: 3000,
-    launchTimeout: 50000,
+    launchTimeout: 80000,
   })
   // Wait for wrangler to return a request before running tests
   for (let i = 0; i < 3; i++) {

--- a/functions/utils/getColor.ts
+++ b/functions/utils/getColor.ts
@@ -2,11 +2,14 @@ import { Buffer } from 'buffer'
 import JPEG from 'jpeg-js'
 import PNG from 'png-ts'
 
-import { DEFAULT_COLOR } from '../constants'
+import { DEFAULT_COLOR, predefinedTokenColors } from '../constants'
 
 export default async function getColor(image: string | undefined) {
   if (!image) {
     return DEFAULT_COLOR
+  }
+  if (image in predefinedTokenColors) {
+    return predefinedTokenColors[image]
   }
   try {
     const data = await fetch(image)


### PR DESCRIPTION
Imports predefined colors from widgets to use for rich link previews.

Also updates `launchTimeout` due to increased flakiness caused by jest timing out before the server sets up properly.

<img width="1124" alt="Screenshot 2023-08-11 at 11 17 01 AM" src="https://github.com/Uniswap/interface/assets/35351983/4e6c28c9-27d7-4717-a379-3ce666f6cdb0">
