### PR TITLE
feat: change rich link previews to Basel

### DIFF
--- a/functions/api/image/nfts/asset/[[index]].tsx
+++ b/functions/api/image/nfts/asset/[[index]].tsx
@@ -58,9 +58,8 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
         height: 630,
         fonts: [
           {
-            name: 'Inter',
+            name: 'Basel Medium',
             data: fontData,
-            style: 'normal',
           },
         ],
       }

--- a/functions/api/image/nfts/collection/[index].tsx
+++ b/functions/api/image/nfts/collection/[index].tsx
@@ -80,18 +80,27 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
                   style={{
                     gap: '12px',
                     fontSize: '72px',
-                    fontFamily: 'Inter',
+                    fontFamily: 'Basel Medium',
                     color: 'white',
                     display: 'flex',
                     flexDirection: 'row',
-                    alignItems: 'center',
+                    alignItems: 'flex-end',
                     flexWrap: 'wrap',
+                    lineHeight: '64px',
                   }}
                 >
                   {words.map((word: string) => (
                     <text key={word + index}>{word}</text>
                   ))}
-                  {data.isVerified && <img src={CHECK_URL} height="54px" />}
+                  {data.isVerified && (
+                    <img
+                      src={CHECK_URL}
+                      height="54px"
+                      style={{
+                        marginBottom: '-2px',
+                      }}
+                    />
+                  )}
                 </div>
                 <img src={WATERMARK_URL} alt="Uniswap" height="72px" width="324px" />
               </div>
@@ -104,9 +113,8 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
         height: 630,
         fonts: [
           {
-            name: 'Inter',
+            name: 'Basel Medium',
             data: fontData,
-            style: 'normal',
           },
         ],
       }

--- a/functions/api/image/tokens/[[index]].tsx
+++ b/functions/api/image/tokens/[[index]].tsx
@@ -97,7 +97,7 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
                 >
                   <div
                     style={{
-                      fontFamily: 'Inter',
+                      fontFamily: 'Basel Medium',
                       fontSize: '48px',
                       lineHeight: '58px',
                       color: 'white',
@@ -121,11 +121,9 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
               )}
               <div
                 style={{
-                  fontFamily: 'Inter',
+                  fontFamily: 'Basel Medium',
                   fontSize: '72px',
-                  lineHeight: '58px',
-                  marginLeft: '-5px',
-                  marginTop: '24px',
+                  marginTop: '48px',
                 }}
               >
                 {name}
@@ -141,10 +139,10 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
               >
                 <div
                   style={{
-                    fontFamily: 'Inter',
+                    fontFamily: 'Basel Book',
                     fontSize: '168px',
-                    lineHeight: '133px',
-                    marginLeft: '-13px',
+                    marginLeft: '-8px',
+                    lineHeight: '168px',
                   }}
                 >
                   {data.symbol}
@@ -160,9 +158,12 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
         height: 630,
         fonts: [
           {
-            name: 'Inter',
+            name: 'Basel Book',
             data: fontData,
-            style: 'normal',
+          },
+          {
+            name: 'Basel Medium',
+            data: fontData,
           },
         ],
       }


### PR DESCRIPTION
Updates Rich Link Previews to use Basel instead of Inter.

TODO: Actually change `getFont` function to import Basel font instead of Inter. 