### PR TITLE
fix: fail UR transaction if chain IDs don't match

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -11,7 +11,6 @@ import {
   V3_MIGRATOR_ADDRESSES,
 } from '@uniswap/sdk-core'
 import QuoterV2Json from '@uniswap/swap-router-contracts/artifacts/contracts/lens/QuoterV2.sol/QuoterV2.json'
-import UniversalRouterJson from '@uniswap/universal-router/artifacts/contracts/UniversalRouter.sol/UniversalRouter.json'
 import IUniswapV2PairJson from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import IUniswapV2Router02Json from '@uniswap/v2-periphery/build/IUniswapV2Router02.json'
 import QuoterJson from '@uniswap/v3-periphery/artifacts/contracts/lens/Quoter.sol/Quoter.json'
@@ -45,7 +44,6 @@ const { abi: TickLensABI } = TickLensJson
 const { abi: MulticallABI } = UniswapInterfaceMulticallJson
 const { abi: NFTPositionManagerABI } = NonfungiblePositionManagerJson
 const { abi: V2MigratorABI } = V3MigratorJson
-const { abi: UniversalRouterABI } = UniversalRouterJson
 
 // returns null on errors
 export function useContract<T extends Contract = Contract>(
@@ -138,10 +136,6 @@ export function usePairContract(pairAddress?: string, withSignerIfPossible?: boo
 
 export function useV2RouterContract(): Contract | null {
   return useContract(V2_ROUTER_ADDRESS, IUniswapV2Router02ABI, true)
-}
-
-export function useUniversalRouterContract(address: string | undefined): Contract | null {
-  return useContract(address, UniversalRouterABI, true)
 }
 
 export function useInterfaceMulticall() {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -140,7 +140,7 @@ export function useV2RouterContract(): Contract | null {
   return useContract(V2_ROUTER_ADDRESS, IUniswapV2Router02ABI, true)
 }
 
-export function useUniversalRouterContract(address: string): Contract | null {
+export function useUniversalRouterContract(address: string | undefined): Contract | null {
   return useContract(address, UniversalRouterABI, true)
 }
 

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -11,6 +11,7 @@ import {
   V3_MIGRATOR_ADDRESSES,
 } from '@uniswap/sdk-core'
 import QuoterV2Json from '@uniswap/swap-router-contracts/artifacts/contracts/lens/QuoterV2.sol/QuoterV2.json'
+import UniversalRouterJson from '@uniswap/universal-router/artifacts/contracts/UniversalRouter.sol/UniversalRouter.json'
 import IUniswapV2PairJson from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import IUniswapV2Router02Json from '@uniswap/v2-periphery/build/IUniswapV2Router02.json'
 import QuoterJson from '@uniswap/v3-periphery/artifacts/contracts/lens/Quoter.sol/Quoter.json'
@@ -44,6 +45,7 @@ const { abi: TickLensABI } = TickLensJson
 const { abi: MulticallABI } = UniswapInterfaceMulticallJson
 const { abi: NFTPositionManagerABI } = NonfungiblePositionManagerJson
 const { abi: V2MigratorABI } = V3MigratorJson
+const { abi: UniversalRouterABI } = UniversalRouterJson
 
 // returns null on errors
 export function useContract<T extends Contract = Contract>(
@@ -136,6 +138,10 @@ export function usePairContract(pairAddress?: string, withSignerIfPossible?: boo
 
 export function useV2RouterContract(): Contract | null {
   return useContract(V2_ROUTER_ADDRESS, IUniswapV2Router02ABI, true)
+}
+
+export function useUniversalRouterContract(address: string): Contract | null {
+  return useContract(address, UniversalRouterABI, true)
 }
 
 export function useInterfaceMulticall() {

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -58,6 +58,8 @@ export function useUniversalRouterSwapCallback(
         if (!chainId) throw new Error('missing chainId')
         if (!provider) throw new Error('missing provider')
         if (!trade) throw new Error('missing trade')
+        const connectedChainId = await provider.getSigner().getChainId()
+        if (chainId !== connectedChainId) throw new Error('signer chainId does not match')
 
         setTraceData('slippageTolerance', options.slippageTolerance.toFixed(2))
         const { calldata: data, value } = SwapRouter.swapERC20CallParameters(trade, {
@@ -70,7 +72,6 @@ export function useUniversalRouterSwapCallback(
         const tx = {
           from: account,
           to: UNIVERSAL_ROUTER_ADDRESS(chainId),
-          chainId,
           data,
           // TODO(https://github.com/Uniswap/universal-router-sdk/issues/113): universal-router-sdk returns a non-hexlified value.
           ...(value && !isZero(value) ? { value: toHex(value) } : {}),

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -58,9 +58,6 @@ export function useUniversalRouterSwapCallback(
         if (!chainId) throw new Error('missing chainId')
         if (!provider) throw new Error('missing provider')
         if (!trade) throw new Error('missing trade')
-        const urAddress = UNIVERSAL_ROUTER_ADDRESS(chainId)
-        const urCode = await provider.getCode(urAddress)
-        if (!urCode || urCode.length === 0 || urCode === '0x') throw new Error('UR contract not deployed')
 
         setTraceData('slippageTolerance', options.slippageTolerance.toFixed(2))
         const { calldata: data, value } = SwapRouter.swapERC20CallParameters(trade, {
@@ -72,7 +69,8 @@ export function useUniversalRouterSwapCallback(
 
         const tx = {
           from: account,
-          to: urAddress,
+          to: UNIVERSAL_ROUTER_ADDRESS(chainId),
+          chainId,
           data,
           // TODO(https://github.com/Uniswap/universal-router-sdk/issues/113): universal-router-sdk returns a non-hexlified value.
           ...(value && !isZero(value) ? { value: toHex(value) } : {}),

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -52,7 +52,7 @@ export function useUniversalRouterSwapCallback(
   const { account, chainId, provider } = useWeb3React()
   const analyticsContext = useTrace()
 
-  const universalRouter = useUniversalRouterContract(UNIVERSAL_ROUTER_ADDRESS(chainId ?? 1))
+  const universalRouter = useUniversalRouterContract(chainId ? UNIVERSAL_ROUTER_ADDRESS(chainId) : undefined)
 
   return useCallback(async () => {
     return trace('swap.send', async ({ setTraceData, setTraceStatus, setTraceError }) => {


### PR DESCRIPTION
this may prevent a mysterious potential bug causing users to send funds to the mainnet UR address on base

from the ethers docs

transactionRequest.chainId ⇒ number | Promise< number >
The chain ID this transaction is authorized on, as specified by [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
If the chain ID is 0 will disable EIP-155 and the transaction will be valid on any network. This can be dangerous and care should be taken, since it allows transactions to be replayed on networks that were possibly not intended. Intentionally-replayable transactions are also disabled by default on recent versions of Geth and require configuration to enable.
