### PR TITLE
fix: add distance check from white for token rich link previews

### DIFF
--- a/functions/api/image/tokens/[[index]].tsx
+++ b/functions/api/image/tokens/[[index]].tsx
@@ -28,7 +28,7 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
       return new Response('Asset not found.', { status: 404 })
     }
 
-    const [fontData, palette] = await Promise.all([getFont(), getColor(data.ogImage)])
+    const [fontData, palette] = await Promise.all([getFont(), getColor(data.ogImage, true)])
 
     const networkLogo = getNetworkLogoUrl(networkName.toUpperCase())
 

--- a/functions/utils/getColor.test.ts
+++ b/functions/utils/getColor.test.ts
@@ -22,7 +22,7 @@ test('should return the average color of a white PNG image', async () => {
 test('should return the average color of a white PNG image with whiteness dimmed', async () => {
   const image = 'https://www.cac.cornell.edu/wiki/images/4/44/White_square.png'
   const color = await getColor(image, true)
-  expect(color).toEqual([35, 43, 43])
+  expect(color).toEqual(DEFAULT_COLOR)
 })
 
 test('should return the average color of a black JPG image', async () => {

--- a/functions/utils/getColor.test.ts
+++ b/functions/utils/getColor.test.ts
@@ -22,7 +22,7 @@ test('should return the average color of a white PNG image', async () => {
 test('should return the average color of a white PNG image with whiteness dimmed', async () => {
   const image = 'https://www.cac.cornell.edu/wiki/images/4/44/White_square.png'
   const color = await getColor(image, true)
-  expect(color).toEqual([235, 235, 235])
+  expect(color).toEqual([226, 226, 226])
 })
 
 test('should return the average color of a black JPG image', async () => {

--- a/functions/utils/getColor.test.ts
+++ b/functions/utils/getColor.test.ts
@@ -22,7 +22,7 @@ test('should return the average color of a white PNG image', async () => {
 test('should return the average color of a white PNG image with whiteness dimmed', async () => {
   const image = 'https://www.cac.cornell.edu/wiki/images/4/44/White_square.png'
   const color = await getColor(image, true)
-  expect(color).toEqual([226, 226, 226])
+  expect(color).toEqual([35, 43, 43])
 })
 
 test('should return the average color of a black JPG image', async () => {

--- a/functions/utils/getColor.test.ts
+++ b/functions/utils/getColor.test.ts
@@ -13,10 +13,10 @@ test('should return the average color of a blue PNG image', async () => {
   expect(color).toEqual([2, 6, 251])
 })
 
-test('should return the average color of a white PNG image', async () => {
+test('should return the average color of a white PNG image with whiteness dimmed a bit due to distance', async () => {
   const image = 'https://www.cac.cornell.edu/wiki/images/4/44/White_square.png'
   const color = await getColor(image)
-  expect(color).toEqual([255, 255, 255])
+  expect(color).toEqual([235, 235, 235])
 })
 
 test('should return the average color of a black JPG image', async () => {

--- a/functions/utils/getColor.test.ts
+++ b/functions/utils/getColor.test.ts
@@ -13,9 +13,15 @@ test('should return the average color of a blue PNG image', async () => {
   expect(color).toEqual([2, 6, 251])
 })
 
-test('should return the average color of a white PNG image with whiteness dimmed a bit due to distance', async () => {
+test('should return the average color of a white PNG image', async () => {
   const image = 'https://www.cac.cornell.edu/wiki/images/4/44/White_square.png'
   const color = await getColor(image)
+  expect(color).toEqual([255, 255, 255])
+})
+
+test('should return the average color of a white PNG image with whiteness dimmed', async () => {
+  const image = 'https://www.cac.cornell.edu/wiki/images/4/44/White_square.png'
+  const color = await getColor(image, true)
   expect(color).toEqual([235, 235, 235])
 })
 

--- a/functions/utils/getColor.ts
+++ b/functions/utils/getColor.ts
@@ -67,9 +67,9 @@ function getAverageColor(arrayBuffer: Uint8Array, type: string, checkDistance: b
     const distance = Math.sqrt(Math.pow(r - 255, 2) + Math.pow(g - 255, 2) + Math.pow(b - 255, 2))
 
     if (distance < 50) {
-      r -= 20
-      g -= 20
-      b -= 20
+      r = Math.max(0, r - 29)
+      g = Math.max(0, g - 29)
+      b = Math.max(0, b - 29)
     }
   }
 

--- a/functions/utils/getColor.ts
+++ b/functions/utils/getColor.ts
@@ -67,9 +67,7 @@ function getAverageColor(arrayBuffer: Uint8Array, type: string, checkDistance: b
     const distance = Math.sqrt(Math.pow(r - 255, 2) + Math.pow(g - 255, 2) + Math.pow(b - 255, 2))
 
     if (distance < 50) {
-      r = Math.max(0, r - 29)
-      g = Math.max(0, g - 29)
-      b = Math.max(0, b - 29)
+      return DEFAULT_COLOR
     }
   }
 

--- a/functions/utils/getColor.ts
+++ b/functions/utils/getColor.ts
@@ -4,7 +4,7 @@ import PNG from 'png-ts'
 
 import { DEFAULT_COLOR, predefinedTokenColors } from '../constants'
 
-export default async function getColor(image: string | undefined) {
+export default async function getColor(image: string | undefined, checkDistance = false) {
   if (!image) {
     return DEFAULT_COLOR
   }
@@ -17,13 +17,13 @@ export default async function getColor(image: string | undefined) {
     const arrayBuffer = Buffer.from(buffer)
 
     const type = data.headers.get('content-type') ?? ''
-    return getAverageColor(arrayBuffer, type)
+    return getAverageColor(arrayBuffer, type, checkDistance)
   } catch (e) {
     return DEFAULT_COLOR
   }
 }
 
-function getAverageColor(arrayBuffer: Uint8Array, type?: string) {
+function getAverageColor(arrayBuffer: Uint8Array, type: string, checkDistance: boolean) {
   let pixels
   switch (type) {
     case 'image/png': {
@@ -63,12 +63,14 @@ function getAverageColor(arrayBuffer: Uint8Array, type?: string) {
   g = Math.floor(g / (pixelCount - transparentPixels))
   b = Math.floor(b / (pixelCount - transparentPixels))
 
-  const distance = Math.sqrt(Math.pow(r - 255, 2) + Math.pow(g - 255, 2) + Math.pow(b - 255, 2))
+  if (checkDistance) {
+    const distance = Math.sqrt(Math.pow(r - 255, 2) + Math.pow(g - 255, 2) + Math.pow(b - 255, 2))
 
-  if (distance < 50) {
-    r -= 20
-    g -= 20
-    b -= 20
+    if (distance < 50) {
+      r -= 20
+      g -= 20
+      b -= 20
+    }
   }
 
   return [r, g, b]

--- a/functions/utils/getColor.ts
+++ b/functions/utils/getColor.ts
@@ -63,5 +63,13 @@ function getAverageColor(arrayBuffer: Uint8Array, type?: string) {
   g = Math.floor(g / (pixelCount - transparentPixels))
   b = Math.floor(b / (pixelCount - transparentPixels))
 
+  const distance = Math.sqrt(Math.pow(r - 255, 2) + Math.pow(g - 255, 2) + Math.pow(b - 255, 2))
+
+  if (distance < 50) {
+    r -= 20
+    g -= 20
+    b -= 20
+  }
+
   return [r, g, b]
 }


### PR DESCRIPTION
Fixes issue of Token Rich Link Previews background color being too white from color extraction by adding an additional check at the end to check distance from [255, 255, 255] and dimming accordingly.

Before:
![0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-1](https://github.com/Uniswap/interface/assets/35351983/ff18c299-1329-48f7-80af-95ee0d205edd)

After:
![0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2](https://github.com/Uniswap/interface/assets/35351983/f5d70293-6750-4329-99d5-121e7020b4d6)
