### PR TITLE
fix: token margin in searchbar

### DIFF
--- a/src/components/NavBar/SuggestionRow.tsx
+++ b/src/components/NavBar/SuggestionRow.tsx
@@ -174,7 +174,7 @@ export const TokenRow = ({ token, isHovered, setHoveredIndex, toggleOpen, index,
           symbol={token.symbol}
           size="36px"
           backupImg={token.project?.logoUrl}
-          style={{ paddingRight: '8px' }}
+          style={{ marginRight: '8px' }}
         />
         <Column className={styles.suggestionPrimaryContainer}>
           <Row gap="4" width="full">


### PR DESCRIPTION
* fixes the token icon margin in the searchbar

### Before
![Screen Shot 2023-08-14 at 1 08 01 PM](https://github.com/Uniswap/interface/assets/9094792/6701f713-963a-4a1d-9f97-39a2604d4759)



### After
![Screen Shot 2023-08-14 at 1 07 25 PM](https://github.com/Uniswap/interface/assets/9094792/0f97a498-6bb5-42ce-8523-ffd329005503)

