### PR TITLE
chore: feature flag cleanup for routing_api_price

### DIFF
--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -2,7 +2,6 @@ import { BaseVariant, FeatureFlag, featureFlagSettings, useUpdateFlag } from 'fe
 import { useCurrencyConversionFlag } from 'featureFlags/flags/currencyConversion'
 import { useForceUniswapXOnFlag } from 'featureFlags/flags/forceUniswapXOn'
 import { useMultichainUXFlag } from 'featureFlags/flags/multichainUx'
-import { useRoutingAPIForPriceFlag } from 'featureFlags/flags/priceRoutingApi'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { UniswapXVariant, useUniswapXFlag } from 'featureFlags/flags/uniswapx'
 import { useUniswapXEthOutputFlag } from 'featureFlags/flags/uniswapXEthOutput'
@@ -230,12 +229,6 @@ export default function FeatureFlagModal() {
         value={useUniswapXEthOutputFlag()}
         featureFlag={FeatureFlag.uniswapXEthOutputEnabled}
         label="Enable eth output for UniswapX orders"
-      />
-      <FeatureFlagOption
-        variant={BaseVariant}
-        value={useRoutingAPIForPriceFlag()}
-        featureFlag={FeatureFlag.routingAPIPrice}
-        label="Use the routing-api v2 for price fetches"
       />
       <FeatureFlagOption
         variant={BaseVariant}

--- a/src/featureFlags/flags/priceRoutingApi.ts
+++ b/src/featureFlags/flags/priceRoutingApi.ts
@@ -1,9 +1,0 @@
-import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
-
-export function useRoutingAPIForPriceFlag(): BaseVariant {
-  return useBaseFlag(FeatureFlag.routingAPIPrice)
-}
-
-export function useRoutingAPIForPrice(): boolean {
-  return useRoutingAPIForPriceFlag() === BaseVariant.Enabled
-}

--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -12,7 +12,6 @@ export enum FeatureFlag {
   debounceSwapQuote = 'debounce_swap_quote',
   uniswapXEnabled = 'uniswapx_enabled', // enables sending dutch_limit config to routing-api
   uniswapXSyntheticQuote = 'uniswapx_synthetic_quote',
-  routingAPIPrice = 'routing_api_price',
   forceUniswapXOn = 'uniswapx_force_on', // forces routing-api's feature flag for uniswapx to turn on as well
   uniswapXEthOutputEnabled = 'uniswapx_eth_output_enabled',
   multichainUX = 'multichain_ux',

--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -1,6 +1,5 @@
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { useForceUniswapXOn } from 'featureFlags/flags/forceUniswapXOn'
-import { useRoutingAPIForPrice } from 'featureFlags/flags/priceRoutingApi'
 import { useUniswapXEnabled } from 'featureFlags/flags/uniswapx'
 import { useUniswapXEthOutputEnabled } from 'featureFlags/flags/uniswapXEthOutput'
 import { useUniswapXSyntheticQuoteEnabled } from 'featureFlags/flags/uniswapXUseSyntheticQuote'
@@ -33,7 +32,6 @@ export function useRoutingAPIArguments({
   const uniswapXForceSyntheticQuotes = useUniswapXSyntheticQuoteEnabled()
   const forceUniswapXOn = useForceUniswapXOn()
   const userDisabledUniswapX = useUserDisabledUniswapX()
-  const isRoutingAPIPrice = useRoutingAPIForPrice()
   const uniswapXEthOutputEnabled = useUniswapXEthOutputEnabled()
 
   return useMemo(
@@ -53,7 +51,6 @@ export function useRoutingAPIArguments({
             tokenOutSymbol: tokenOut.wrapped.symbol,
             routerPreference,
             tradeType,
-            isRoutingAPIPrice,
             needsWrapIfUniswapX: tokenIn.isNative,
             uniswapXEnabled,
             uniswapXForceSyntheticQuotes,
@@ -68,7 +65,6 @@ export function useRoutingAPIArguments({
       tokenIn,
       tokenOut,
       tradeType,
-      isRoutingAPIPrice,
       uniswapXEnabled,
       uniswapXForceSyntheticQuotes,
       forceUniswapXOn,

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -47,7 +47,6 @@ export interface GetQuoteArgs {
   uniswapXEthOutputEnabled: boolean
   forceUniswapXOn: boolean
   userDisabledUniswapX: boolean
-  isRoutingAPIPrice?: boolean
 }
 
 // from https://github.com/Uniswap/routing-api/blob/main/lib/handlers/schema.ts

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -17,7 +17,6 @@ import {
   DutchOrderTrade,
   GetQuoteArgs,
   InterfaceTrade,
-  INTERNAL_ROUTER_PREFERENCE_PRICE,
   isClassicQuoteResponse,
   PoolType,
   QuoteMethod,
@@ -326,12 +325,7 @@ export function isUniswapXTrade(trade?: InterfaceTrade): trade is DutchOrderTrad
 }
 
 export function shouldUseAPIRouter(args: GetQuoteArgs): boolean {
-  const { routerPreference, isRoutingAPIPrice } = args
-  if (routerPreference === INTERNAL_ROUTER_PREFERENCE_PRICE && isRoutingAPIPrice) {
-    return true
-  }
-
-  return routerPreference === RouterPreference.API || routerPreference === RouterPreference.X
+  return args.routerPreference !== RouterPreference.CLIENT
 }
 
 export function getTransactionCount(trade: InterfaceTrade): number {


### PR DESCRIPTION
delet feature flag and make routing-api the default for price lookups

![image](https://github.com/Uniswap/interface/assets/59578595/63ade2ae-829e-41ef-9454-0a948343b3b2)
