### PR TITLE
fix: add back the disabled Base entry in the tokens page selector

### DIFF
--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -10,7 +10,6 @@ import { HistoryDuration, SafetyLevel } from 'graphql/data/__generated__/types-a
 import { useTrendingCollections } from 'graphql/data/nft/TrendingCollections'
 import { SearchToken } from 'graphql/data/SearchTokens'
 import useTrendingTokens from 'graphql/data/TrendingTokens'
-import { BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS } from 'graphql/data/util'
 import { useDisableNFTRoutes } from 'hooks/useDisableNFTRoutes'
 import { useIsNftPage } from 'hooks/useIsNftPage'
 import { Box } from 'nft/components/Box'
@@ -137,7 +136,8 @@ interface SearchBarDropdownProps {
 export const SearchBarDropdown = (props: SearchBarDropdownProps) => {
   const { isLoading } = props
   const { chainId } = useWeb3React()
-  const showChainComingSoonBadge = chainId && BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS.includes(chainId) && !isLoading
+  const COMING_SOON_CHAINS = new Set([ChainId.BNB, ChainId.AVALANCHE])
+  const showChainComingSoonBadge = chainId && COMING_SOON_CHAINS.has(chainId) && !isLoading
   const logoUri = getChainInfo(chainId)?.logoUrl
 
   return (

--- a/src/components/Tokens/TokenTable/NetworkFilter.tsx
+++ b/src/components/Tokens/TokenTable/NetworkFilter.tsx
@@ -1,11 +1,8 @@
+import { ChainId } from '@uniswap/sdk-core'
 import Badge from 'components/Badge'
 import { getChainInfo } from 'constants/chainInfo'
-import {
-  BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS,
-  BACKEND_SUPPORTED_CHAINS,
-  supportedChainIdFromGQLChain,
-  validateUrlChainParam,
-} from 'graphql/data/util'
+import { Chain } from 'graphql/data/__generated__/types-and-hooks'
+import { supportedChainIdFromGQLChain, validateUrlChainParam } from 'graphql/data/util'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { useRef } from 'react'
 import { Check, ChevronDown, ChevronUp } from 'react-feather'
@@ -123,6 +120,9 @@ export default function NetworkFilter() {
 
   const chainInfo = getChainInfo(supportedChainIdFromGQLChain(currentChainName))
 
+  const SUPPORTED_CHAINS = [Chain.Ethereum, Chain.Polygon, Chain.Arbitrum, Chain.Optimism, Chain.Celo]
+  const UNSUPPORTED_CHAINS = [ChainId.AVALANCHE, ChainId.BASE, ChainId.BNB]
+
   return (
     <StyledMenu ref={node}>
       <NetworkFilterOption
@@ -146,8 +146,9 @@ export default function NetworkFilter() {
       </NetworkFilterOption>
       {open && (
         <MenuTimeFlyout>
-          {BACKEND_SUPPORTED_CHAINS.map((network) => {
+          {SUPPORTED_CHAINS.map((network) => {
             const chainInfo = getChainInfo(supportedChainIdFromGQLChain(network))
+            if (!chainInfo) return null
             return (
               <InternalLinkMenuItem
                 key={network}
@@ -169,8 +170,8 @@ export default function NetworkFilter() {
               </InternalLinkMenuItem>
             )
           })}
-          {BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS.map((network) => {
-            const chainInfo = getChainInfo(network)
+          {UNSUPPORTED_CHAINS.map((network) => {
+            const chainInfo = getChainInfo(network as ChainId)
             return (
               <InternalLinkMenuItem
                 key={network}

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -130,14 +130,23 @@ const URL_CHAIN_PARAM_TO_BACKEND: { [key: string]: InterfaceGqlChain } = {
   avalanche: Chain.Avalanche,
 }
 
+const SUPPORTED_CHAINS = new Set([
+  Chain.Arbitrum,
+  Chain.Avalanche,
+  Chain.Base,
+  Chain.Bnb,
+  Chain.Celo,
+  Chain.Ethereum,
+  Chain.Optimism,
+  Chain.Polygon,
+])
 /**
  * @param chainName parsed in chain name from url query parameter
  * @returns if chainName is a valid chain name supported by the backend, returns the backend chain name, otherwise returns Chain.Ethereum
  */
 export function validateUrlChainParam(chainName: string | undefined) {
   const isValidChainName = chainName && URL_CHAIN_PARAM_TO_BACKEND[chainName]
-  const isValidBackEndChain =
-    isValidChainName && (BACKEND_SUPPORTED_CHAINS as ReadonlyArray<Chain>).includes(isValidChainName)
+  const isValidBackEndChain = isValidChainName && SUPPORTED_CHAINS.has(isValidChainName)
   return isValidBackEndChain ? URL_CHAIN_PARAM_TO_BACKEND[chainName] : Chain.Ethereum
 }
 
@@ -179,16 +188,6 @@ export function logSentryErrorForUnsupportedChain({
     Sentry.captureException(new Error(errorMessage))
   })
 }
-
-export const BACKEND_SUPPORTED_CHAINS = [
-  Chain.Ethereum,
-  Chain.Polygon,
-  Chain.Arbitrum,
-  Chain.Optimism,
-  Chain.Celo,
-  Chain.Base,
-] as const
-export const BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS = [ChainId.BNB, ChainId.AVALANCHE] as const
 
 export function getTokenDetailsURL({
   address,


### PR DESCRIPTION
Base was removed from the "unsupported" chains list because most backend functionality supports it, but we still don't have the necessary data to support the tokens page. This PR adds back the disabled ux in the dropdown. 

<img width="469" alt="image" src="https://github.com/Uniswap/interface/assets/5773490/7d96c840-4bce-4f83-a990-78cdacdf00e2">
