### PR TITLE
fix: temp block BASE tokens in universal search

### DIFF
--- a/src/graphql/data/SearchTokens.ts
+++ b/src/graphql/data/SearchTokens.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import invariant from 'tiny-invariant'
 
 import { Chain, SearchTokensQuery, useSearchTokensQuery } from './__generated__/types-and-hooks'
-import { chainIdToBackendName } from './util'
+import { BACKEND_SUPPORTED_CHAINS, chainIdToBackendName } from './util'
 
 gql`
   query SearchTokens($searchQuery: String!) {
@@ -96,7 +96,10 @@ export function useSearchTokens(searchQuery: string, chainId: number) {
     const searchChain = chainIdToBackendName(chainId)
     // Stores results, allowing overwriting cross-chain tokens w/ more 'relevant token'
     const selectionMap: { [projectId: string]: SearchToken } = {}
-    data?.searchTokens?.forEach((token) => {
+    const filteredTokens = data?.searchTokens?.filter((token) =>
+      (BACKEND_SUPPORTED_CHAINS as ReadonlyArray<Chain>).includes(token.chain)
+    )
+    filteredTokens?.forEach((token) => {
       if (token.project?.id) {
         const existing = selectionMap[token.project.id]
         selectionMap[token.project.id] = dedupeCrosschainTokens(token, existing, searchChain)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- BE added BASE tokens in the universal search, but not for the TDP query
- This leads to users being able to get to a broken page from the search bar
- We also had manually listed BASE as coming soon and have some blocks on the UX
- FIX: filter out any results from chains the UX does not support

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C04D07TQBT4/p1692096823352609


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="542" alt="Screenshot 2023-08-15 at 8 45 14 AM" src="https://github.com/Uniswap/interface/assets/11512321/103529db-e175-446f-80fd-94b5d070ffb4">



### After
<img width="541" alt="Screenshot 2023-08-15 at 8 44 55 AM" src="https://github.com/Uniswap/interface/assets/11512321/510c94b7-1d91-4ce0-ac46-9d761afb31f3">



## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Search for base tokens in universal search on prod and see results such as TOSHI
- [ ] In this deploy do not see BASE results
