### PR TITLE
fix: test id based on address & chain instead of ticker

### DIFF
--- a/cypress/e2e/universal-search.test.ts
+++ b/cypress/e2e/universal-search.test.ts
@@ -24,7 +24,7 @@ describe('Universal search bar', () => {
     openSearch()
     getSearchBar().clear().type('uni')
 
-    cy.get(getTestSelector(`searchbar-token-row-${UNI_ADDRESS}`))
+    cy.get(getTestSelector(`searchbar-token-row-ETHEREUM-${UNI_ADDRESS}`))
       .should('contain.text', 'Uniswap')
       .and('contain.text', 'UNI')
       .and('contain.text', '$')
@@ -35,7 +35,7 @@ describe('Universal search bar', () => {
     openSearch()
     cy.get(getTestSelector('searchbar-dropdown'))
       .contains(getTestSelector('searchbar-dropdown'), 'Recent searches')
-      .find(getTestSelector(`searchbar-token-row-${UNI_ADDRESS}`))
+      .find(getTestSelector(`searchbar-token-row-ETHEREUM-${UNI_ADDRESS}`))
       .should('exist')
   })
 
@@ -56,13 +56,13 @@ describe('Universal search bar', () => {
       // Seed recent results with UNI.
       openSearch()
       getSearchBar().type('uni')
-      cy.get(getTestSelector(`searchbar-token-row-${UNI_ADDRESS}`))
+      cy.get(getTestSelector(`searchbar-token-row-ETHEREUM-${UNI_ADDRESS}`))
       getSearchBar().clear().type('{esc}')
 
       // Search a different token by name.
       openSearch()
       getSearchBar().type('eth')
-      cy.get(getTestSelector('searchbar-token-row-NATIVE'))
+      cy.get(getTestSelector('searchbar-token-row-ETHEREUM-NATIVE'))
 
       // Validate that we go to the searched/selected result.
       getSearchBar().type('{enter}')

--- a/cypress/e2e/universal-search.test.ts
+++ b/cypress/e2e/universal-search.test.ts
@@ -3,7 +3,7 @@ import { UNI } from 'constants/tokens'
 
 import { getTestSelector } from '../utils'
 
-const UNI_ADDRESS = UNI[ChainId.MAINNET].address
+const UNI_ADDRESS = UNI[ChainId.MAINNET].address.toLowerCase()
 
 describe('Universal search bar', () => {
   function openSearch() {

--- a/cypress/e2e/universal-search.test.ts
+++ b/cypress/e2e/universal-search.test.ts
@@ -3,7 +3,7 @@ import { UNI } from 'constants/tokens'
 
 import { getTestSelector } from '../utils'
 
-const UNI_ADDRESS = UNI[ChainId.MAINNET]
+const UNI_ADDRESS = UNI[ChainId.MAINNET].address
 
 describe('Universal search bar', () => {
   function openSearch() {

--- a/cypress/e2e/universal-search.test.ts
+++ b/cypress/e2e/universal-search.test.ts
@@ -1,4 +1,9 @@
+import { ChainId } from '@uniswap/sdk-core'
+import { UNI } from 'constants/tokens'
+
 import { getTestSelector } from '../utils'
+
+const UNI_ADDRESS = UNI[ChainId.MAINNET]
 
 describe('Universal search bar', () => {
   function openSearch() {
@@ -19,7 +24,7 @@ describe('Universal search bar', () => {
     openSearch()
     getSearchBar().clear().type('uni')
 
-    cy.get(getTestSelector('searchbar-token-row-UNI'))
+    cy.get(getTestSelector(`searchbar-token-row-${UNI_ADDRESS}`))
       .should('contain.text', 'Uniswap')
       .and('contain.text', 'UNI')
       .and('contain.text', '$')
@@ -30,7 +35,7 @@ describe('Universal search bar', () => {
     openSearch()
     cy.get(getTestSelector('searchbar-dropdown'))
       .contains(getTestSelector('searchbar-dropdown'), 'Recent searches')
-      .find(getTestSelector('searchbar-token-row-UNI'))
+      .find(getTestSelector(`searchbar-token-row-${UNI_ADDRESS}`))
       .should('exist')
   })
 
@@ -51,13 +56,13 @@ describe('Universal search bar', () => {
       // Seed recent results with UNI.
       openSearch()
       getSearchBar().type('uni')
-      cy.get(getTestSelector('searchbar-token-row-UNI'))
+      cy.get(getTestSelector(`searchbar-token-row-${UNI_ADDRESS}`))
       getSearchBar().clear().type('{esc}')
 
       // Search a different token by name.
       openSearch()
       getSearchBar().type('eth')
-      cy.get(getTestSelector('searchbar-token-row-ETH'))
+      cy.get(getTestSelector('searchbar-token-row-NATIVE'))
 
       // Validate that we go to the searched/selected result.
       getSearchBar().type('{enter}')

--- a/src/components/NavBar/SuggestionRow.tsx
+++ b/src/components/NavBar/SuggestionRow.tsx
@@ -160,7 +160,7 @@ export const TokenRow = ({ token, isHovered, setHoveredIndex, toggleOpen, index,
 
   return (
     <Link
-      data-testid={`searchbar-token-row-${token.symbol}`}
+      data-testid={`searchbar-token-row-${token.address ?? 'NATIVE'}`}
       to={tokenDetailsPath}
       onClick={handleClick}
       onMouseEnter={() => !isHovered && setHoveredIndex(index)}

--- a/src/components/NavBar/SuggestionRow.tsx
+++ b/src/components/NavBar/SuggestionRow.tsx
@@ -160,7 +160,7 @@ export const TokenRow = ({ token, isHovered, setHoveredIndex, toggleOpen, index,
 
   return (
     <Link
-      data-testid={`searchbar-token-row-${token.address ?? 'NATIVE'}`}
+      data-testid={`searchbar-token-row-${token.chain}-${token.address ?? 'NATIVE'}`}
       to={tokenDetailsPath}
       onClick={handleClick}
       onMouseEnter={() => !isHovered && setHoveredIndex(index)}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- The Universal Search test is failing on main because the search for `uni` is returning two results with the ticker of `UNI` 
- We currently use the ticker as the unique identifier
- This PR changes to use the token address and chain as the unique identifier

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C052ARNFZGU/p1692120073832699

<!-- Delete this section if your change does not affect UI. -->
## Screen capture
![Screenshot 2023-08-15 at 10 34 18 AM](https://github.com/Uniswap/interface/assets/11512321/1cce7115-f57a-4c2e-ac74-335063f7aa79)
![cypress-screenshot](https://github.com/Uniswap/interface/assets/11512321/30b80a32-0814-4903-a5a0-dfaeee8ffdf9)

