### PR TITLE
chore: moving language selection to own settings panel

### DIFF
--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -23,7 +23,7 @@ describe('Wallet Dropdown', () => {
     })
   }
 
-  function itChangesLocale(featureFlag = false) {
+  function itChangesLocale({ featureFlag = false }: { featureFlag?: boolean } = {}) {
     it('should change locale', () => {
       cy.contains('Uniswap available in: English').should('not.exist')
 
@@ -57,7 +57,7 @@ describe('Wallet Dropdown', () => {
       cy.get(getTestSelector('web3-status-connected')).click()
       cy.get(getTestSelector('wallet-settings')).click()
     })
-    itChangesLocale(true)
+    itChangesLocale({ featureFlag: true })
   })
 
   describe('testnet toggle', () => {

--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -1,3 +1,5 @@
+import { FeatureFlag } from 'featureFlags'
+
 import { getTestSelector } from '../utils'
 
 describe('Wallet Dropdown', () => {
@@ -23,16 +25,21 @@ describe('Wallet Dropdown', () => {
 
   function itChangesLocale() {
     it('should change locale', () => {
-      cy.contains('Uniswap available in: English').should('not.exist')
+      const testLanguageSettings = () => {
+        cy.contains('Uniswap available in: English').should('not.exist')
+        cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
+        cy.location('search').should('match', /\?lng=af-ZA$/)
+        cy.contains('Uniswap available in: English')
 
+        cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
+        cy.location('search').should('match', /\?lng=en-US$/)
+        cy.contains('Uniswap available in: English').should('not.exist')
+      }
+
+      testLanguageSettings()
+      cy.visit('/swap', { featureFlags: [FeatureFlag.currencyConversion] })
       cy.get(getTestSelector('language-settings-button')).click()
-      cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
-      cy.location('search').should('match', /\?lng=af-ZA$/)
-      cy.contains('Uniswap available in: English')
-
-      cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
-      cy.location('search').should('match', /\?lng=en-US$/)
-      cy.contains('Uniswap available in: English').should('not.exist')
+      testLanguageSettings()
     })
   }
 

--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -25,6 +25,7 @@ describe('Wallet Dropdown', () => {
     it('should change locale', () => {
       cy.contains('Uniswap available in: English').should('not.exist')
 
+      cy.get(getTestSelector('language-settings-button')).click()
       cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
       cy.location('search').should('match', /\?lng=af-ZA$/)
       cy.contains('Uniswap available in: English')

--- a/cypress/e2e/wallet-dropdown.test.ts
+++ b/cypress/e2e/wallet-dropdown.test.ts
@@ -23,23 +23,21 @@ describe('Wallet Dropdown', () => {
     })
   }
 
-  function itChangesLocale() {
+  function itChangesLocale(featureFlag = false) {
     it('should change locale', () => {
-      const testLanguageSettings = () => {
-        cy.contains('Uniswap available in: English').should('not.exist')
-        cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
-        cy.location('search').should('match', /\?lng=af-ZA$/)
-        cy.contains('Uniswap available in: English')
+      cy.contains('Uniswap available in: English').should('not.exist')
 
-        cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
-        cy.location('search').should('match', /\?lng=en-US$/)
-        cy.contains('Uniswap available in: English').should('not.exist')
+      if (featureFlag) {
+        cy.get(getTestSelector('language-settings-button')).click()
       }
 
-      testLanguageSettings()
-      cy.visit('/swap', { featureFlags: [FeatureFlag.currencyConversion] })
-      cy.get(getTestSelector('language-settings-button')).click()
-      testLanguageSettings()
+      cy.get(getTestSelector('wallet-language-item')).contains('Afrikaans').click({ force: true })
+      cy.location('search').should('match', /\?lng=af-ZA$/)
+      cy.contains('Uniswap available in: English')
+
+      cy.get(getTestSelector('wallet-language-item')).contains('English').click({ force: true })
+      cy.location('search').should('match', /\?lng=en-US$/)
+      cy.contains('Uniswap available in: English').should('not.exist')
     })
   }
 
@@ -51,6 +49,15 @@ describe('Wallet Dropdown', () => {
     })
     itChangesTheme()
     itChangesLocale()
+  })
+
+  describe('should change locale with feature flag', () => {
+    beforeEach(() => {
+      cy.visit('/', { featureFlags: [FeatureFlag.currencyConversion] })
+      cy.get(getTestSelector('web3-status-connected')).click()
+      cy.get(getTestSelector('wallet-settings')).click()
+    })
+    itChangesLocale(true)
   })
 
   describe('testnet toggle', () => {

--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import AuthenticatedHeader from './AuthenticatedHeader'
+import LanguageMenu from './LanguageMenu'
 import SettingsMenu from './SettingsMenu'
 
 const DefaultMenuWrap = styled(Column)`
@@ -15,6 +16,7 @@ const DefaultMenuWrap = styled(Column)`
 enum MenuState {
   DEFAULT,
   SETTINGS,
+  LANGUAGE_SETTINGS,
 }
 
 function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
@@ -24,6 +26,8 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
   const [menu, setMenu] = useState<MenuState>(MenuState.DEFAULT)
   const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
   const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
+  const closeLanguageSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
+  const openLanguageSettings = useCallback(() => setMenu(MenuState.LANGUAGE_SETTINGS), [])
 
   useEffect(() => {
     if (!drawerOpen && menu === MenuState.SETTINGS) {
@@ -44,7 +48,10 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
         ) : (
           <WalletModal openSettings={openSettings} />
         ))}
-      {menu === MenuState.SETTINGS && <SettingsMenu onClose={closeSettings} />}
+      {menu === MenuState.SETTINGS && (
+        <SettingsMenu onClose={closeSettings} openLanguageSettings={openLanguageSettings} />
+      )}
+      {menu === MenuState.LANGUAGE_SETTINGS && <LanguageMenu onClose={closeLanguageSettings} />}
     </DefaultMenuWrap>
   )
 }

--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -27,7 +27,6 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
   const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
   const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
   const openLanguageSettings = useCallback(() => setMenu(MenuState.LANGUAGE_SETTINGS), [])
-  const closeLanguageSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
 
   useEffect(() => {
     if (!drawerOpen && menu !== MenuState.DEFAULT) {
@@ -51,7 +50,7 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
       {menu === MenuState.SETTINGS && (
         <SettingsMenu onClose={closeSettings} openLanguageSettings={openLanguageSettings} />
       )}
-      {menu === MenuState.LANGUAGE_SETTINGS && <LanguageMenu onClose={closeLanguageSettings} />}
+      {menu === MenuState.LANGUAGE_SETTINGS && <LanguageMenu onClose={openSettings} />}
     </DefaultMenuWrap>
   )
 }

--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -26,11 +26,11 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
   const [menu, setMenu] = useState<MenuState>(MenuState.DEFAULT)
   const openSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
   const closeSettings = useCallback(() => setMenu(MenuState.DEFAULT), [])
-  const closeLanguageSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
   const openLanguageSettings = useCallback(() => setMenu(MenuState.LANGUAGE_SETTINGS), [])
+  const closeLanguageSettings = useCallback(() => setMenu(MenuState.SETTINGS), [])
 
   useEffect(() => {
-    if (!drawerOpen && menu === MenuState.SETTINGS) {
+    if (!drawerOpen && menu !== MenuState.DEFAULT) {
       // wait for the drawer to close before resetting the menu
       const timer = setTimeout(() => {
         closeSettings()

--- a/src/components/AccountDrawer/LanguageMenu.tsx
+++ b/src/components/AccountDrawer/LanguageMenu.tsx
@@ -35,14 +35,22 @@ function LanguageMenuItem({ locale, isActive }: { locale: SupportedLocale; isAct
   )
 }
 
-export default function LanguageMenu({ onClose }: { onClose: () => void }) {
+export function LanguageMenuItems() {
   const activeLocale = useActiveLocale()
 
   return (
-    <SlideOutMenu title={<Trans>Language</Trans>} onClose={onClose}>
+    <>
       {SUPPORTED_LOCALES.map((locale) => (
         <LanguageMenuItem locale={locale} isActive={activeLocale === locale} key={locale} />
       ))}
+    </>
+  )
+}
+
+export default function LanguageMenu({ onClose }: { onClose: () => void }) {
+  return (
+    <SlideOutMenu title={<Trans>Language</Trans>} onClose={onClose}>
+      <LanguageMenuItems />
     </SlideOutMenu>
   )
 }

--- a/src/components/AccountDrawer/LanguageMenu.tsx
+++ b/src/components/AccountDrawer/LanguageMenu.tsx
@@ -12,7 +12,6 @@ import { SlideOutMenu } from './SlideOutMenu'
 const InternalLinkMenuItem = styled(Link)`
   ${ClickableStyle}
   flex: 1;
-  color: ${({ theme }) => theme.textTertiary};
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/components/AccountDrawer/LanguageMenu.tsx
+++ b/src/components/AccountDrawer/LanguageMenu.tsx
@@ -1,0 +1,49 @@
+import { Trans } from '@lingui/macro'
+import { LOCALE_LABEL, SUPPORTED_LOCALES, SupportedLocale } from 'constants/locales'
+import { useActiveLocale } from 'hooks/useActiveLocale'
+import { useLocationLinkProps } from 'hooks/useLocationLinkProps'
+import { Check } from 'react-feather'
+import { Link } from 'react-router-dom'
+import styled, { useTheme } from 'styled-components'
+import { ClickableStyle, ThemedText } from 'theme'
+
+import { SlideOutMenu } from './SlideOutMenu'
+
+const InternalLinkMenuItem = styled(Link)`
+  ${ClickableStyle}
+  flex: 1;
+  color: ${({ theme }) => theme.textTertiary};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 12px 0;
+  justify-content: space-between;
+  text-decoration: none;
+  color: ${({ theme }) => theme.textPrimary};
+`
+
+function LanguageMenuItem({ locale, isActive }: { locale: SupportedLocale; isActive: boolean }) {
+  const { to, onClick } = useLocationLinkProps(locale)
+  const theme = useTheme()
+
+  if (!to) return null
+
+  return (
+    <InternalLinkMenuItem onClick={onClick} to={to}>
+      <ThemedText.BodySmall data-testid="wallet-language-item">{LOCALE_LABEL[locale]}</ThemedText.BodySmall>
+      {isActive && <Check color={theme.accentActive} opacity={1} size={20} />}
+    </InternalLinkMenuItem>
+  )
+}
+
+export default function LanguageMenu({ onClose }: { onClose: () => void }) {
+  const activeLocale = useActiveLocale()
+
+  return (
+    <SlideOutMenu title={<Trans>Language</Trans>} onClose={onClose}>
+      {SUPPORTED_LOCALES.map((locale) => (
+        <LanguageMenuItem locale={locale} isActive={activeLocale === locale} key={locale} />
+      ))}
+    </SlideOutMenu>
+  )
+}

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/macro'
 import Column from 'components/Column'
 import Row from 'components/Row'
 import { LOCALE_LABEL } from 'constants/locales'
+import { useCurrencyConversionFlagEnabled } from 'featureFlags/flags/currencyConversion'
 import { useActiveLocale } from 'hooks/useActiveLocale'
 import { ReactNode } from 'react'
 import { ChevronRight } from 'react-feather'
@@ -11,6 +12,7 @@ import ThemeToggle from 'theme/components/ThemeToggle'
 
 import { AnalyticsToggle } from './AnalyticsToggle'
 import { GitVersionRow } from './GitVersionRow'
+import { LanguageMenuItems } from './LanguageMenu'
 import { SlideOutMenu } from './SlideOutMenu'
 import { SmallBalanceToggle } from './SmallBalanceToggle'
 import { TestnetsToggle } from './TestnetsToggle'
@@ -67,6 +69,7 @@ export default function SettingsMenu({
   onClose: () => void
   openLanguageSettings: () => void
 }) {
+  const currencyConversionEnabled = useCurrencyConversionFlagEnabled()
   const activeLocale = useActiveLocale()
 
   return (
@@ -82,13 +85,23 @@ export default function SettingsMenu({
             <AnalyticsToggle />
             <TestnetsToggle />
           </ToggleWrapper>
+          {!currencyConversionEnabled && (
+            <>
+              <SectionTitle data-testid="wallet-header">
+                <Trans>Language</Trans>
+              </SectionTitle>
+              <LanguageMenuItems />
+            </>
+          )}
 
-          <SettingsButton
-            title={<Trans>Language</Trans>}
-            currentState={LOCALE_LABEL[activeLocale]}
-            onClick={openLanguageSettings}
-            testId="language-settings-button"
-          />
+          {currencyConversionEnabled && (
+            <SettingsButton
+              title={<Trans>Language</Trans>}
+              currentState={LOCALE_LABEL[activeLocale]}
+              onClick={openLanguageSettings}
+              testId="language-settings-button"
+            />
+          )}
         </div>
         <GitVersionRow />
       </Container>

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -6,7 +6,7 @@ import { useActiveLocale } from 'hooks/useActiveLocale'
 import { ReactNode } from 'react'
 import { ChevronRight } from 'react-feather'
 import styled from 'styled-components'
-import { ThemedText } from 'theme'
+import { ClickableStyle, ThemedText } from 'theme'
 import ThemeToggle from 'theme/components/ThemeToggle'
 
 import { AnalyticsToggle } from './AnalyticsToggle'
@@ -33,7 +33,7 @@ const ToggleWrapper = styled.div`
 `
 
 const SettingsButtonWrapper = styled(Row)`
-  cursor: pointer;
+  ${ClickableStyle}
 `
 
 const StyledChevron = styled(ChevronRight)`

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -44,12 +44,14 @@ const SettingsButton = ({
   title,
   currentState,
   onClick,
+  testId,
 }: {
   title: ReactNode
   currentState: ReactNode
   onClick: () => void
+  testId?: string
 }) => (
-  <SettingsButtonWrapper align="center" justify="space-between" onClick={onClick}>
+  <SettingsButtonWrapper data-testid={testId} align="center" justify="space-between" onClick={onClick}>
     <ThemedText.SubHeaderSmall color="textPrimary">{title}</ThemedText.SubHeaderSmall>
     <Row gap="xs" align="center" width="min-content">
       <ThemedText.LabelMedium color="textPrimary">{currentState}</ThemedText.LabelMedium>
@@ -85,6 +87,7 @@ export default function SettingsMenu({
             title={<Trans>Language</Trans>}
             currentState={LOCALE_LABEL[activeLocale]}
             onClick={openLanguageSettings}
+            testId="language-settings-button"
           />
         </div>
         <GitVersionRow />

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -1,11 +1,12 @@
 import { Trans } from '@lingui/macro'
-import { LOCALE_LABEL, SUPPORTED_LOCALES, SupportedLocale } from 'constants/locales'
+import Column from 'components/Column'
+import Row from 'components/Row'
+import { LOCALE_LABEL } from 'constants/locales'
 import { useActiveLocale } from 'hooks/useActiveLocale'
-import { useLocationLinkProps } from 'hooks/useLocationLinkProps'
-import { Check } from 'react-feather'
-import { Link } from 'react-router-dom'
-import styled, { useTheme } from 'styled-components'
-import { ClickableStyle, ThemedText } from 'theme'
+import { ReactNode } from 'react'
+import { ChevronRight } from 'react-feather'
+import styled from 'styled-components'
+import { ThemedText } from 'theme'
 import ThemeToggle from 'theme/components/ThemeToggle'
 
 import { AnalyticsToggle } from './AnalyticsToggle'
@@ -14,32 +15,10 @@ import { SlideOutMenu } from './SlideOutMenu'
 import { SmallBalanceToggle } from './SmallBalanceToggle'
 import { TestnetsToggle } from './TestnetsToggle'
 
-const InternalLinkMenuItem = styled(Link)`
-  ${ClickableStyle}
-  flex: 1;
-  color: ${({ theme }) => theme.textTertiary};
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 12px 0;
+const Container = styled(Column)`
+  height: 100%;
   justify-content: space-between;
-  text-decoration: none;
-  color: ${({ theme }) => theme.textPrimary};
 `
-
-function LanguageMenuItem({ locale, isActive }: { locale: SupportedLocale; isActive: boolean }) {
-  const { to, onClick } = useLocationLinkProps(locale)
-  const theme = useTheme()
-
-  if (!to) return null
-
-  return (
-    <InternalLinkMenuItem onClick={onClick} to={to}>
-      <ThemedText.BodySmall data-testid="wallet-language-item">{LOCALE_LABEL[locale]}</ThemedText.BodySmall>
-      {isActive && <Check color={theme.accentActive} opacity={1} size={20} />}
-    </InternalLinkMenuItem>
-  )
-}
 
 const SectionTitle = styled(ThemedText.SubHeader)`
   color: ${({ theme }) => theme.textSecondary};
@@ -53,28 +32,63 @@ const ToggleWrapper = styled.div`
   margin-bottom: 24px;
 `
 
-export default function SettingsMenu({ onClose }: { onClose: () => void }) {
+const SettingsButtonWrapper = styled(Row)`
+  cursor: pointer;
+`
+
+const StyledChevron = styled(ChevronRight)`
+  color: ${({ theme }) => theme.textSecondary};
+`
+
+const SettingsButton = ({
+  title,
+  currentState,
+  onClick,
+}: {
+  title: ReactNode
+  currentState: ReactNode
+  onClick: () => void
+}) => (
+  <SettingsButtonWrapper align="center" justify="space-between" onClick={onClick}>
+    <ThemedText.SubHeaderSmall color="textPrimary">{title}</ThemedText.SubHeaderSmall>
+    <Row gap="xs" align="center" width="min-content">
+      <ThemedText.LabelMedium color="textPrimary">{currentState}</ThemedText.LabelMedium>
+      <StyledChevron size={20} />
+    </Row>
+  </SettingsButtonWrapper>
+)
+
+export default function SettingsMenu({
+  onClose,
+  openLanguageSettings,
+}: {
+  onClose: () => void
+  openLanguageSettings: () => void
+}) {
   const activeLocale = useActiveLocale()
 
   return (
     <SlideOutMenu title={<Trans>Settings</Trans>} onClose={onClose}>
-      <SectionTitle>
-        <Trans>Preferences</Trans>
-      </SectionTitle>
-      <ToggleWrapper>
-        <ThemeToggle />
-        <SmallBalanceToggle />
-        <AnalyticsToggle />
-        <TestnetsToggle />
-      </ToggleWrapper>
+      <Container>
+        <div>
+          <SectionTitle data-testid="wallet-header">
+            <Trans>Preferences</Trans>
+          </SectionTitle>
+          <ToggleWrapper>
+            <ThemeToggle />
+            <SmallBalanceToggle />
+            <AnalyticsToggle />
+            <TestnetsToggle />
+          </ToggleWrapper>
 
-      <SectionTitle data-testid="wallet-header">
-        <Trans>Language</Trans>
-      </SectionTitle>
-      {SUPPORTED_LOCALES.map((locale) => (
-        <LanguageMenuItem locale={locale} isActive={activeLocale === locale} key={locale} />
-      ))}
-      <GitVersionRow />
+          <SettingsButton
+            title={<Trans>Language</Trans>}
+            currentState={LOCALE_LABEL[activeLocale]}
+            onClick={openLanguageSettings}
+          />
+        </div>
+        <GitVersionRow />
+      </Container>
     </SlideOutMenu>
   )
 }

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -42,6 +42,10 @@ const StyledChevron = styled(ChevronRight)`
   color: ${({ theme }) => theme.textSecondary};
 `
 
+const LanguageLabel = styled(Row)`
+  white-space: nowrap;
+`
+
 const SettingsButton = ({
   title,
   currentState,
@@ -55,10 +59,10 @@ const SettingsButton = ({
 }) => (
   <SettingsButtonWrapper data-testid={testId} align="center" justify="space-between" onClick={onClick}>
     <ThemedText.SubHeaderSmall color="textPrimary">{title}</ThemedText.SubHeaderSmall>
-    <Row gap="xs" align="center" width="min-content">
+    <LanguageLabel gap="xs" align="center" width="min-content">
       <ThemedText.LabelMedium color="textPrimary">{currentState}</ThemedText.LabelMedium>
       <StyledChevron size={20} />
-    </Row>
+    </LanguageLabel>
   </SettingsButtonWrapper>
 )
 

--- a/src/components/AccountDrawer/SlideOutMenu.tsx
+++ b/src/components/AccountDrawer/SlideOutMenu.tsx
@@ -1,9 +1,10 @@
+import Column from 'components/Column'
 import { ScrollBarStyles } from 'components/Common'
 import { ArrowLeft } from 'react-feather'
 import styled from 'styled-components'
 import { ClickableStyle, ThemedText } from 'theme'
 
-const Menu = styled.div`
+const Menu = styled(Column)`
   width: 100%;
   overflow: auto;
   margin-top: 4px;

--- a/src/featureFlags/flags/currencyConversion.ts
+++ b/src/featureFlags/flags/currencyConversion.ts
@@ -3,3 +3,7 @@ import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
 export function useCurrencyConversionFlag(): BaseVariant {
   return useBaseFlag(FeatureFlag.currencyConversion)
 }
+
+export function useCurrencyConversionFlagEnabled(): boolean {
+  return useCurrencyConversionFlag() === BaseVariant.Enabled
+}

--- a/src/theme/components/text.tsx
+++ b/src/theme/components/text.tsx
@@ -43,6 +43,9 @@ export const ThemedText = {
   Hero(props: TextProps) {
     return <TextWrapper fontWeight={500} fontSize={48} color="textPrimary" {...props} />
   },
+  LabelMedium(props: TextProps) {
+    return <TextWrapper fontWeight={500} fontSize={16} color="textPrimary" lineHeight="20px" {...props} />
+  },
   LabelSmall(props: TextProps) {
     return <TextWrapper fontWeight={600} fontSize={14} color="textSecondary" {...props} />
   },


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
* updating language selection screen to new designs (behind a feature flag): [https://www.figma.com/file/MOvvpkzygJdxCA3BY9mN1O/Mini-portfolio-v1?type=design&node-id=1860-47891&mode=design&t=TKiQ94vfRQFBdQAg-0](url)

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| ![Screen Shot 2023-08-15 at 6 26 47 PM](https://github.com/Uniswap/interface/assets/9094792/e2f7427e-27b0-49c0-9ecf-2d0c269c10fa) | ![Screen Shot 2023-08-15 at 6 26 10 PM](https://github.com/Uniswap/interface/assets/9094792/d2bd3aff-1a6f-4804-b7ef-68467d8c885e) |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| ![Screen Shot 2023-08-15 at 6 26 59 PM](https://github.com/Uniswap/interface/assets/9094792/752ad1a0-f72a-49b9-ae2c-339c1285d869) | ![Screen Shot 2023-08-15 at 6 26 31 PM](https://github.com/Uniswap/interface/assets/9094792/ba51c023-956f-460b-849c-8674fe1f1dc3) |
