### PR TITLE
feat: add client and router blocknumbers to analytics

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -6,6 +6,7 @@ import { SwapRouter, UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-
 import { FeeOptions, toHex } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { sendAnalyticsEvent, useTrace } from 'analytics'
+import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { formatCommonPropertiesForTrade, formatSwapSignedAnalyticsEventProperties } from 'lib/utils/analytics'
 import { useCallback } from 'react'
 import { ClassicTrade, TradeFillType } from 'state/routing/types'
@@ -50,6 +51,7 @@ export function useUniversalRouterSwapCallback(
 ) {
   const { account, chainId, provider } = useWeb3React()
   const analyticsContext = useTrace()
+  const blockNumber = useBlockNumber()
 
   return useCallback(async () => {
     return trace('swap.send', async ({ setTraceData, setTraceStatus, setTraceError }) => {
@@ -86,6 +88,7 @@ export function useUniversalRouterSwapCallback(
           sendAnalyticsEvent(SwapEventName.SWAP_ESTIMATE_GAS_CALL_FAILED, {
             ...formatCommonPropertiesForTrade(trade, options.slippageTolerance),
             ...analyticsContext,
+            client_block_number: blockNumber,
             tx,
             error: gasError,
           })

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -35,6 +35,7 @@ export function formatCommonPropertiesForTrade(trade: InterfaceTrade, allowedSli
     type: trade.tradeType,
     ura_quote_id: isUniswapXTrade(trade) ? trade.quoteId : undefined,
     ura_request_id: trade.requestId,
+    ura_quote_block_number: isClassicTrade(trade) ? trade.blockNumber : undefined,
     token_in_address: getTokenAddress(trade.inputAmount.currency),
     token_out_address: getTokenAddress(trade.outputAmount.currency),
     token_in_symbol: trade.inputAmount.currency.symbol,


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Adds amplitude logging for client side block number and router block number, to help diagnose whether potential mismatch between these two is causing price-movement swap failure.
