### PR TITLE
feat: add real paths to app site association

### DIFF
--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -22,6 +22,22 @@
           {
             "#": "/address/*",
             "comment": "Wallet address"
+          },
+          {
+            "/": "/nfts/asset/*",
+            "comment": "NFT Item"
+          },
+          {
+            "/": "/nfts/collection/*",
+            "comment": "NFT Collection"
+          },
+          {
+            "/": "/tokens/*",
+            "comment": "Token address"
+          },
+          {
+            "/": "/address/*",
+            "comment": "Wallet address"
           }
         ]
       }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Adds real (not hash-based) paths to app site association, as described in https://developer.apple.com/documentation/xcode/supporting-associated-domains. This should enable deep-linking into the Uniswap Mobile Wallet when using path-based routing.

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C02T729PMQE/p1692222996293519?thread_ts=1692219376.681979&cid=C02T729PMQE