### PR TITLE
fix: network connector fix and lists fix

### DIFF
--- a/cypress/e2e/swap/unconnected.test.ts
+++ b/cypress/e2e/swap/unconnected.test.ts
@@ -1,0 +1,27 @@
+import { SwapEventName } from '@uniswap/analytics-events'
+import { USDC_MAINNET } from 'constants/tokens'
+
+import { getTestSelector } from '../../utils'
+
+describe('Swap inputs with no wallet connected', () => {
+  it('can input and load a quote with no wallet connected', () => {
+    cy.visit(`/swap?inputCurrency=ETH&outputCurrency=${USDC_MAINNET.address}`)
+
+    cy.get(getTestSelector('web3-status-connected')).click()
+    // click twice, first time to show confirmation, second to confirm
+    cy.get(getTestSelector('wallet-disconnect')).click()
+    cy.get(getTestSelector('wallet-disconnect')).should('contain', 'Disconnect')
+    cy.get(getTestSelector('wallet-disconnect')).click()
+    cy.get(getTestSelector('close-account-drawer')).click()
+
+    // Enter amount to swap
+    cy.get('#swap-currency-output .token-amount-input').type('1').should('have.value', '1')
+    cy.get('#swap-currency-input .token-amount-input').should('not.have.value', '')
+    // Verify logging
+    cy.waitForAmplitudeEvent(SwapEventName.SWAP_QUOTE_RECEIVED).then((event: any) => {
+      cy.wrap(event.event_properties).should('have.property', 'quote_latency_milliseconds')
+      cy.wrap(event.event_properties.quote_latency_milliseconds).should('be.a', 'number')
+      cy.wrap(event.event_properties.quote_latency_milliseconds).should('be.gte', 0)
+    })
+  })
+})

--- a/src/hooks/useEagerlyConnect.ts
+++ b/src/hooks/useEagerlyConnect.ts
@@ -24,11 +24,12 @@ export default function useEagerlyConnect() {
   const rehydrated = useAppSelector((state) => state._persist.rehydrated)
 
   useEffect(() => {
-    if (!selectedWallet) return
     try {
-      const selectedConnection = getConnection(selectedWallet)
       connect(gnosisSafeConnection.connector)
       connect(networkConnection.connector)
+
+      if (!selectedWallet) return
+      const selectedConnection = getConnection(selectedWallet)
 
       if (selectedConnection) {
         connect(selectedConnection.connector)

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -1,10 +1,11 @@
 import { getVersionUpgrade, VersionUpgrade } from '@uniswap/token-lists'
 import { useWeb3React } from '@web3-react/core'
 import { DEFAULT_LIST_OF_LISTS, UNSUPPORTED_LIST_URLS } from 'constants/lists'
+import TokenSafetyLookupTable from 'constants/tokenSafetyLookup'
 import useInterval from 'lib/hooks/useInterval'
 import ms from 'ms'
 import { useCallback, useEffect } from 'react'
-import { useAppDispatch } from 'state/hooks'
+import { useAppDispatch, useAppSelector } from 'state/hooks'
 import { useAllLists } from 'state/lists/hooks'
 
 import { useFetchListCallback } from '../../hooks/useFetchListCallback'
@@ -19,6 +20,11 @@ export default function Updater(): null {
 
   // get all loaded lists, and the active urls
   const lists = useAllLists()
+  const listsState = useAppSelector((state) => state.lists)
+
+  useEffect(() => {
+    TokenSafetyLookupTable.update(listsState)
+  }, [listsState])
 
   const fetchList = useFetchListCallback()
   const fetchAllListsCallback = useCallback(() => {


### PR DESCRIPTION
follow up fixes to #6830 :

1. properly default to the network connector so we can still load quotes with no wallet
2. make sure to update the token safety lookup table once lists are rehydrated