### PR TITLE
fix: make line height bigger for token preview

### DIFF
--- a/functions/api/image/tokens/[[index]].tsx
+++ b/functions/api/image/tokens/[[index]].tsx
@@ -145,9 +145,13 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
                     fontSize: '168px',
                     lineHeight: '133px',
                     marginLeft: '-13px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    width: '100%',
                   }}
                 >
-                  {data.symbol.slice(0, 6)}
+                  {data.symbol}
                 </div>
                 <img src={WATERMARK_URL} alt="Uniswap" height="72px" width="324px" />
               </div>

--- a/functions/api/image/tokens/[[index]].tsx
+++ b/functions/api/image/tokens/[[index]].tsx
@@ -123,7 +123,7 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
                 style={{
                   fontFamily: 'Inter',
                   fontSize: '72px',
-                  lineHeight: '58px',
+                  lineHeight: '72px',
                   marginLeft: '-5px',
                   marginTop: '24px',
                 }}
@@ -147,7 +147,7 @@ export const onRequest: PagesFunction = async ({ params, request }) => {
                     marginLeft: '-13px',
                   }}
                 >
-                  {data.symbol}
+                  {data.symbol.slice(0, 6)}
                 </div>
                 <img src={WATERMARK_URL} alt="Uniswap" height="72px" width="324px" />
               </div>


### PR DESCRIPTION
Increased line height for token preview with long names and slices symbol for some tokens to prevent symbol for crossing to 2 lines. 

Before:
![0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0-1](https://github.com/Uniswap/interface/assets/35351983/5516e9f8-adad-4417-9bc3-04a5cbe0e3e4)
![0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd-1](https://github.com/Uniswap/interface/assets/35351983/d71707c3-8c69-49fe-adf1-cb6184aebd6e)

After:
![0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0](https://github.com/Uniswap/interface/assets/35351983/753ca4b5-dce3-4204-8893-2fa3419e5dea)

![0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd](https://github.com/Uniswap/interface/assets/35351983/d3f91924-f51a-4f2f-9c26-a8ab0f97adae)


