### PR TITLE
feat: use cache while debouncing quotes

### DIFF
--- a/src/components/Loader/styled.tsx
+++ b/src/components/Loader/styled.tsx
@@ -35,7 +35,8 @@ export const LoadingRows = styled.div`
 export const loadingOpacityMixin = css<{ $loading: boolean }>`
   filter: ${({ $loading }) => ($loading ? 'grayscale(1)' : 'none')};
   opacity: ${({ $loading }) => ($loading ? '0.4' : '1')};
-  transition: opacity 0.2s ease-in-out;
+  transition: ${({ $loading, theme }) =>
+    $loading ? 'none' : `opacity ${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
 `
 
 export const LoadingOpacityContainer = styled.div<{ $loading: boolean }>`

--- a/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
@@ -110,8 +110,8 @@ exports[`SwapDetailsDropdown.tsx renders a trade 1`] = `
   -webkit-filter: none;
   filter: none;
   opacity: 1;
-  -webkit-transition: opacity 0.2s ease-in-out;
-  transition: opacity 0.2s ease-in-out;
+  -webkit-transition: opacity 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out;
 }
 
 .c10 {

--- a/src/hooks/useDebouncedTrade.ts
+++ b/src/hooks/useDebouncedTrade.ts
@@ -70,28 +70,27 @@ export function useDebouncedTrade(
     [amountSpecified, otherCurrency]
   )
   const debouncedSwapQuoteFlagEnabled = useDebounceSwapQuoteFlag() === DebounceSwapQuoteVariant.Enabled
-  const debouncedInputs = useDebounce(inputs, debouncedSwapQuoteFlagEnabled ? DEBOUNCE_TIME_INCREASED : DEBOUNCE_TIME)
-  const isDebouncing = debouncedInputs !== inputs
-  const [debouncedAmount, debouncedOtherCurrency] = debouncedInputs
+  const isDebouncing =
+    useDebounce(inputs, debouncedSwapQuoteFlagEnabled ? DEBOUNCE_TIME_INCREASED : DEBOUNCE_TIME) !== inputs
 
   const isWrap = useMemo(() => {
-    if (!chainId || !amountSpecified || !debouncedOtherCurrency) return false
+    if (!chainId || !amountSpecified || !otherCurrency) return false
     const weth = WRAPPED_NATIVE_CURRENCY[chainId]
     return (
-      (amountSpecified.currency.isNative && weth?.equals(debouncedOtherCurrency)) ||
-      (debouncedOtherCurrency.isNative && weth?.equals(amountSpecified.currency))
+      (amountSpecified.currency.isNative && weth?.equals(otherCurrency)) ||
+      (otherCurrency.isNative && weth?.equals(amountSpecified.currency))
     )
-  }, [amountSpecified, chainId, debouncedOtherCurrency])
+  }, [amountSpecified, chainId, otherCurrency])
 
   const shouldGetTrade = !isWrap && isWindowVisible
 
   const [routerPreference] = useRouterPreference()
   const routingAPITrade = useRoutingAPITrade(
     tradeType,
-    amountSpecified ? debouncedAmount : undefined,
-    debouncedOtherCurrency,
+    amountSpecified,
+    otherCurrency,
     routerPreferenceOverride ?? routerPreference,
-    !(autoRouterSupported && shouldGetTrade), // skip fetching
+    isDebouncing || !(autoRouterSupported && shouldGetTrade), // skip fetching
     account
   )
 

--- a/src/hooks/useDebouncedTrade.ts
+++ b/src/hooks/useDebouncedTrade.ts
@@ -82,26 +82,15 @@ export function useDebouncedTrade(
     )
   }, [amountSpecified, chainId, otherCurrency])
 
-  const shouldGetTrade = !isWrap && isWindowVisible
+  const skipFetch = isDebouncing || !autoRouterSupported || !isWindowVisible || isWrap
 
   const [routerPreference] = useRouterPreference()
-  const routingAPITrade = useRoutingAPITrade(
+  return useRoutingAPITrade(
     tradeType,
     amountSpecified,
     otherCurrency,
     routerPreferenceOverride ?? routerPreference,
-    isDebouncing || !(autoRouterSupported && shouldGetTrade), // skip fetching
+    skipFetch,
     account
-  )
-
-  // If the user is debouncing, we want to show the loading state until the debounce is complete.
-  const isLoading = (routingAPITrade.state === TradeState.LOADING || isDebouncing) && !isWrap
-
-  return useMemo(
-    () => ({
-      ...routingAPITrade,
-      ...(isLoading ? { state: TradeState.LOADING } : {}),
-    }),
-    [isLoading, routingAPITrade]
   )
 }

--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -1,3 +1,4 @@
+import { SkipToken, skipToken } from '@reduxjs/toolkit/query/react'
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { useForceUniswapXOn } from 'featureFlags/flags/forceUniswapXOn'
 import { useUniswapXEnabled } from 'featureFlags/flags/uniswapx'
@@ -27,7 +28,7 @@ export function useRoutingAPIArguments({
   amount?: CurrencyAmount<Currency>
   tradeType: TradeType
   routerPreference: RouterPreference | typeof INTERNAL_ROUTER_PREFERENCE_PRICE
-}): GetQuoteArgs | undefined {
+}): GetQuoteArgs | SkipToken {
   const uniswapXEnabled = useUniswapXEnabled()
   const uniswapXForceSyntheticQuotes = useUniswapXSyntheticQuoteEnabled()
   const forceUniswapXOn = useForceUniswapXOn()
@@ -37,7 +38,7 @@ export function useRoutingAPIArguments({
   return useMemo(
     () =>
       !tokenIn || !tokenOut || !amount || tokenIn.equals(tokenOut) || tokenIn.wrapped.equals(tokenOut.wrapped)
-        ? undefined
+        ? skipToken
         : {
             account,
             amount: amount.quotient.toString(),

--- a/src/pages/Landing/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Landing/__snapshots__/index.test.tsx.snap
@@ -753,8 +753,8 @@ exports[`disable nft on landing page does not render nft information and card 1`
   -webkit-filter: none;
   filter: none;
   opacity: 1;
-  -webkit-transition: opacity 0.2s ease-in-out;
-  transition: opacity 0.2s ease-in-out;
+  -webkit-transition: opacity 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out;
 }
 
 .c31 {
@@ -1063,8 +1063,8 @@ exports[`disable nft on landing page does not render nft information and card 1`
   -webkit-filter: none;
   filter: none;
   opacity: 1;
-  -webkit-transition: opacity 0.2s ease-in-out;
-  transition: opacity 0.2s ease-in-out;
+  -webkit-transition: opacity 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out;
   text-align: left;
   font-size: 36px;
   line-height: 44px;
@@ -3315,8 +3315,8 @@ exports[`disable nft on landing page renders nft information and card 1`] = `
   -webkit-filter: none;
   filter: none;
   opacity: 1;
-  -webkit-transition: opacity 0.2s ease-in-out;
-  transition: opacity 0.2s ease-in-out;
+  -webkit-transition: opacity 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out;
 }
 
 .c31 {
@@ -3625,8 +3625,8 @@ exports[`disable nft on landing page renders nft information and card 1`] = `
   -webkit-filter: none;
   filter: none;
   opacity: 1;
-  -webkit-transition: opacity 0.2s ease-in-out;
-  transition: opacity 0.2s ease-in-out;
+  -webkit-transition: opacity 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out;
   text-align: left;
   font-size: 36px;
   line-height: 44px;

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -209,3 +209,4 @@ export const routingApi = createApi({
 })
 
 export const { useGetQuoteQuery } = routingApi
+export const useGetQuoteQueryState = routingApi.endpoints.getQuote.useQueryState

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -93,7 +93,13 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
   const isFetching = currentData !== tradeResult || !currentData
 
   return useMemo(() => {
-    if (!amountSpecified || isError || queryArgs === skipToken) {
+    if (amountSpecified && queryArgs === skipToken) {
+      return {
+        state: TradeState.STALE,
+        trade: tradeResult?.trade,
+        swapQuoteLatency: tradeResult?.latencyMs,
+      }
+    } else if (!amountSpecified || isError || queryArgs === skipToken) {
       return {
         state: TradeState.INVALID,
         trade: undefined,

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -19,6 +19,7 @@ import {
 } from './types'
 
 const TRADE_NOT_FOUND = { state: TradeState.NO_ROUTE_FOUND, trade: undefined } as const
+const TRADE_LOADING = { state: TradeState.LOADING, trade: undefined } as const
 
 export function useRoutingAPITrade<TTradeType extends TradeType>(
   tradeType: TTradeType,
@@ -89,7 +90,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     // If latest quote from cache was fetched > 2m ago, instantly repoll for another instead of waiting for next poll period
     refetchOnMountOrArgChange: 2 * 60,
   })
-  const isFetching = currentData !== tradeResult
+  const isFetching = currentData !== tradeResult || !currentData
 
   return useMemo(() => {
     if (!amountSpecified || isError || !queryArgs) {
@@ -100,6 +101,8 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
       }
     } else if (tradeResult?.state === QuoteState.NOT_FOUND && !isFetching) {
       return TRADE_NOT_FOUND
+    } else if (!tradeResult?.trade) {
+      return TRADE_LOADING
     } else {
       return {
         state: isFetching ? TradeState.LOADING : TradeState.VALID,

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -83,8 +83,8 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     routerPreference,
   })
 
-  const { isError, data: tradeResult, error, currentData } = useGetQuoteQueryState(queryArgs ?? skipToken)
-  useGetQuoteQuery(skipFetch ? skipToken : queryArgs ?? skipToken, {
+  const { isError, data: tradeResult, error, currentData } = useGetQuoteQueryState(queryArgs)
+  useGetQuoteQuery(skipFetch ? skipToken : queryArgs, {
     // Price-fetching is informational and costly, so it's done less frequently.
     pollingInterval: routerPreference === INTERNAL_ROUTER_PREFERENCE_PRICE ? ms(`1m`) : AVERAGE_L1_BLOCK_TIME,
     // If latest quote from cache was fetched > 2m ago, instantly repoll for another instead of waiting for next poll period
@@ -93,7 +93,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
   const isFetching = currentData !== tradeResult || !currentData
 
   return useMemo(() => {
-    if (!amountSpecified || isError || !queryArgs) {
+    if (!amountSpecified || isError || queryArgs === skipToken) {
       return {
         state: TradeState.INVALID,
         trade: undefined,

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -7,7 +7,7 @@ import { useRoutingAPIArguments } from 'lib/hooks/routing/useRoutingAPIArguments
 import ms from 'ms'
 import { useMemo } from 'react'
 
-import { useGetQuoteQuery } from './slice'
+import { useGetQuoteQuery, useGetQuoteQueryState } from './slice'
 import {
   ClassicTrade,
   InterfaceTrade,
@@ -19,7 +19,6 @@ import {
 } from './types'
 
 const TRADE_NOT_FOUND = { state: TradeState.NO_ROUTE_FOUND, trade: undefined } as const
-const TRADE_LOADING = { state: TradeState.LOADING, trade: undefined } as const
 
 export function useRoutingAPITrade<TTradeType extends TradeType>(
   tradeType: TTradeType,
@@ -78,55 +77,44 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     account,
     tokenIn: currencyIn,
     tokenOut: currencyOut,
-    amount: skipFetch ? undefined : amountSpecified,
+    amount: amountSpecified,
     tradeType,
     routerPreference,
   })
 
-  const {
-    isError,
-    data: tradeResult,
-    error,
-    currentData: currentTradeResult,
-  } = useGetQuoteQuery(queryArgs ?? skipToken, {
+  const { isError, data: tradeResult, error, currentData } = useGetQuoteQueryState(queryArgs ?? skipToken)
+  useGetQuoteQuery(skipFetch ? skipToken : queryArgs ?? skipToken, {
     // Price-fetching is informational and costly, so it's done less frequently.
     pollingInterval: routerPreference === INTERNAL_ROUTER_PREFERENCE_PRICE ? ms(`1m`) : AVERAGE_L1_BLOCK_TIME,
     // If latest quote from cache was fetched > 2m ago, instantly repoll for another instead of waiting for next poll period
     refetchOnMountOrArgChange: 2 * 60,
   })
-  const isCurrent = currentTradeResult === tradeResult
+  const isFetching = currentData !== tradeResult
 
   return useMemo(() => {
-    if (skipFetch && amountSpecified) {
-      // If we don't want to fetch new trades, but have valid inputs, return the stale trade.
-      return { state: TradeState.STALE, trade: tradeResult?.trade, swapQuoteLatency: tradeResult?.latencyMs }
-    } else if (!amountSpecified || isError || !queryArgs) {
+    if (!amountSpecified || isError || !queryArgs) {
       return {
         state: TradeState.INVALID,
         trade: undefined,
         error: JSON.stringify(error),
       }
-    } else if (tradeResult?.state === QuoteState.NOT_FOUND && isCurrent) {
+    } else if (tradeResult?.state === QuoteState.NOT_FOUND && !isFetching) {
       return TRADE_NOT_FOUND
-    } else if (!tradeResult?.trade) {
-      // TODO(WEB-1985): use `isLoading` returned by rtk-query hook instead of checking for `trade` status
-      return TRADE_LOADING
     } else {
       return {
-        state: isCurrent ? TradeState.VALID : TradeState.LOADING,
-        trade: tradeResult.trade,
-        swapQuoteLatency: tradeResult.latencyMs,
+        state: isFetching ? TradeState.LOADING : TradeState.VALID,
+        trade: tradeResult?.trade,
+        swapQuoteLatency: tradeResult?.latencyMs,
       }
     }
   }, [
     amountSpecified,
     error,
-    isCurrent,
     isError,
+    isFetching,
     queryArgs,
-    skipFetch,
-    tradeResult?.state,
     tradeResult?.latencyMs,
+    tradeResult?.state,
     tradeResult?.trade,
   ])
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Returns cache entries (using rtk's `useQueryState`) when debouncing quotes, to provide _instant_ quotes for already-loaded data.

<!-- Delete inapplicable lines: -->
_Relevant docs:_ https://redux-toolkit.js.org/rtk-query/api/created-api/hooks#usequerystate


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

|    Before    |   After    |
| ------------ | ------------ |
| <video src="https://github.com/Uniswap/interface/assets/5403956/a12013f7-c87f-460e-804d-0f52859e4fe2" > | <video src="https://github.com/Uniswap/interface/assets/5403956/e3c5791e-4c39-49ca-8303-7639d9f26f42" > |