### PR TITLE
feat: track connected wallet provider calls to be replaced with BE/infura

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@sentry/types": "^7.45.0",
     "@types/react-window-infinite-loader": "^1.0.6",
     "@uniswap/analytics": "^1.4.0",
-    "@uniswap/analytics-events": "^2.17.0",
+    "@uniswap/analytics-events": "^2.18.0",
     "@uniswap/governance": "^1.0.2",
     "@uniswap/liquidity-staker": "^1.0.2",
     "@uniswap/merkle-distributor": "^1.0.1",

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -30,7 +30,7 @@ import WETH_ABI from 'abis/weth.json'
 import { sendAnalyticsEvent } from 'analytics'
 import { RPC_PROVIDERS } from 'constants/providers'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { NonfungiblePositionManager, TickLens, UniswapInterfaceMulticall } from 'types/v3'
 import { V3Migrator } from 'types/v3/V3Migrator'
 import { getContract } from 'utils'
@@ -147,12 +147,21 @@ export function useMainnetInterfaceMulticall() {
 }
 
 export function useV3NFTPositionManagerContract(withSignerIfPossible?: boolean): NonfungiblePositionManager | null {
-  sendAnalyticsEvent(InterfaceEventName.WALLET_PROVIDER_USED, { source: 'useV3NFTPositionManagerContract' })
-  return useContract<NonfungiblePositionManager>(
+  const { account } = useWeb3React()
+  const contract = useContract<NonfungiblePositionManager>(
     NONFUNGIBLE_POSITION_MANAGER_ADDRESSES,
     NFTPositionManagerABI,
     withSignerIfPossible
   )
+  useEffect(() => {
+    if (contract && withSignerIfPossible !== false && account) {
+      sendAnalyticsEvent(InterfaceEventName.WALLET_PROVIDER_USED, {
+        source: 'useV3NFTPositionManagerContract',
+        contract,
+      })
+    }
+  }, [account, contract, withSignerIfPossible])
+  return contract
 }
 
 export function useTickLens(): TickLens | null {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -154,13 +154,13 @@ export function useV3NFTPositionManagerContract(withSignerIfPossible?: boolean):
     withSignerIfPossible
   )
   useEffect(() => {
-    if (contract && withSignerIfPossible !== false && account) {
+    if (contract && account) {
       sendAnalyticsEvent(InterfaceEventName.WALLET_PROVIDER_USED, {
         source: 'useV3NFTPositionManagerContract',
         contract,
       })
     }
-  }, [account, contract, withSignerIfPossible])
+  }, [account, contract])
   return contract
 }
 

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -1,4 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
+import { InterfaceEventName } from '@uniswap/analytics-events'
 import {
   ARGENT_WALLET_DETECTOR_ADDRESS,
   ChainId,
@@ -26,6 +27,7 @@ import ERC721_ABI from 'abis/erc721.json'
 import ERC1155_ABI from 'abis/erc1155.json'
 import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Erc721, Erc1155, Weth } from 'abis/types'
 import WETH_ABI from 'abis/weth.json'
+import { sendAnalyticsEvent } from 'analytics'
 import { RPC_PROVIDERS } from 'constants/providers'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { useMemo } from 'react'
@@ -145,6 +147,7 @@ export function useMainnetInterfaceMulticall() {
 }
 
 export function useV3NFTPositionManagerContract(withSignerIfPossible?: boolean): NonfungiblePositionManager | null {
+  sendAnalyticsEvent(InterfaceEventName.WALLET_PROVIDER_USED, { source: 'useV3NFTPositionManagerContract' })
   return useContract<NonfungiblePositionManager>(
     NONFUNGIBLE_POSITION_MANAGER_ADDRESSES,
     NFTPositionManagerABI,

--- a/src/lib/hooks/useCurrency.ts
+++ b/src/lib/hooks/useCurrency.ts
@@ -1,7 +1,9 @@
 import { arrayify } from '@ethersproject/bytes'
 import { parseBytes32String } from '@ethersproject/strings'
+import { InterfaceEventName } from '@uniswap/analytics-events'
 import { ChainId, Currency, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
+import { sendAnalyticsEvent } from 'analytics'
 import { asSupportedChain, isSupportedChain } from 'constants/chains'
 import { useBytes32TokenContract, useTokenContract } from 'hooks/useContract'
 import { NEVER_RELOAD, useSingleCallResult } from 'lib/hooks/multicall'
@@ -46,6 +48,11 @@ export function useTokenFromActiveNetwork(tokenAddress: string | undefined): Tok
   const symbol = useSingleCallResult(tokenContract, 'symbol', undefined, NEVER_RELOAD)
   const symbolBytes32 = useSingleCallResult(tokenContractBytes32, 'symbol', undefined, NEVER_RELOAD)
   const decimals = useSingleCallResult(tokenContract, 'decimals', undefined, NEVER_RELOAD)
+  sendAnalyticsEvent(InterfaceEventName.WALLET_PROVIDER_USED, {
+    source: 'useTokenFromActiveNetwork',
+    tokenAddress: formattedAddress,
+    tokenName,
+  })
 
   const isLoading = useMemo(
     () => decimals.loading || symbol.loading || tokenName.loading,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6177,10 +6177,10 @@
     "@typescript-eslint/types" "5.59.1"
     eslint-visitor-keys "^3.3.0"
 
-"@uniswap/analytics-events@^2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.17.0.tgz#cc0fab2737a673b740ba6d303f04eab365b1876e"
-  integrity sha512-8obHdI+YjfuFCcPH7XOqIDxYVMl30GSUBMZjTx9Ik5vZAXNFJpyOjBcb0aZbL5L6y3vzqkCR8HUpAgd3NuOBFA==
+"@uniswap/analytics-events@^2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.18.0.tgz#22d38adcbe9c18aec7109e562fd005c0e4082edc"
+  integrity sha512-raJP1/xLnunxLwu6XyM4kRJuuIb4aHFR5X9fAovpR6gllpbHicwdjPnjKR5Z8DAnFe5ClFBT0T/foyE5SU5oQQ==
 
 "@uniswap/analytics@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Adds logging for calls to a user's connect wallet provider that will be replaced with calls to our Be/infura in the new multichain UX as noted in [this doc](https://www.notion.so/uniswaplabs/MultiChain-Web-UX-127bdec19777423abf12b7b7ad98a60f)
- This includes:
  - pool positions
  - multicall token address searches in the token selector
- Dependent on the addition of the new analytics event https://github.com/Uniswap/analytics-events/pull/52

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2723/add-amplitude-tracking-for-current-wallet-provider-calls
_Slack thread:_ https://uniswapteam.slack.com/archives/C047U65H422/p1692638017065729
