### PR TITLE
fix: add v2 to lp importer link

### DIFF
--- a/src/pages/PoolFinder/index.tsx
+++ b/src/pages/PoolFinder/index.tsx
@@ -105,7 +105,7 @@ export default function PoolFinder() {
     <Trace page={InterfacePageName.POOL_PAGE} shouldLogImpression>
       <>
         <AppBody>
-          <FindPoolTabs origin={query.get('origin') ?? '/pools'} />
+          <FindPoolTabs origin={query.get('origin') ?? '/pools/v2'} />
           <AutoColumn style={{ padding: '1rem' }} gap="md">
             <BlueCard>
               <AutoColumn gap="10px">


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

v2 import liquidity back button will now correctly navigate back to v2 pool page

https://github.com/Uniswap/interface/assets/5773490/3a54b137-fe41-4aeb-98f5-f94eb006e64f



<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C047U65H422/p1692625017980549
