### PR TITLE
feat: add sentry monitoring for NO_ROUTE error

### DIFF
--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
+import * as Sentry from '@sentry/react'
 import { Protocol } from '@uniswap/router-sdk'
 import { TradeType } from '@uniswap/sdk-core'
 import { isUniswapXSupportedChain } from 'constants/chains'
@@ -163,6 +164,11 @@ export const routingApi = createApi({
                   typeof errorData === 'object' &&
                   (errorData?.errorCode === 'NO_ROUTE' || errorData?.detail === 'No quotes available')
                 ) {
+                  Sentry.withScope((scope) => {
+                    scope.setExtra('requestBody', requestBody)
+                    scope.setExtra('response', response)
+                    Sentry.captureException(new Error("No routes found for user's quote request, alert Routing Team"))
+                  })
                   return {
                     data: { state: QuoteState.NOT_FOUND, latencyMs: getQuoteLatencyMeasure(quoteStartMark).duration },
                   }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Capture when UX receives a `NO_ROUTE` error from the routing API to help diagnose outages

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2727/add-no-route-error-logging
_Slack thread:_ https://uniswapteam.slack.com/archives/C05MPSE3WDQ
_Relevant docs:_ https://www.notion.so/uniswaplabs/V3-over-V2-routing-on-interface-e947a8e0f3f2486faca2490ee0ee8773
