### PR TITLE
fix: null check on elapsedTime for some browsers

### DIFF
--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -2,7 +2,8 @@
  * Returns the time elapsed between page load and now.
  * @param markName the identifier for the performance mark to be created and measured.
  */
-export function calculateElapsedTimeWithPerformanceMark(markName: string): number {
+export function calculateElapsedTimeWithPerformanceMark(markName: string): number | undefined {
   const elapsedTime = performance.mark(markName)
+  if (!elapsedTime) return undefined
   return elapsedTime.startTime
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

sentry issue: https://linear.app/uniswap/issue/WEB-2733/elapsedtime-is-undefined-occasionally

on iOS webviews (not safari, embedded browsers in other apps), `performance.mark` does not return  a `PerformanceEntry` object. as a quick fix we should just fail gracefully and not log performance metrics for these browsers.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2733/elapsedtime-is-undefined-occasionally


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. load the app in an embedded browser on iOS (e.g. ...)

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] hard-coded `elapsedTime` to be undefined and ensured the app fails gracefully and doesn't log the perf metrics


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->
- Mobile Safari UI/WKWebView