### PR TITLE
Patch for CVE-2023-39027 (Insecure Permissions Vulnerability in Uniswap Interface)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,9 +18,9 @@
     <meta
       http-equiv="Content-Security-Policy"
       <% if (process.env.REACT_APP_CSP_ALLOW_UNSAFE_EVAL) { %>
-        content="script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+        content="script-src 'self' 'unsafe-eval'"
       <% } else { %>
-        content="script-src 'self' 'unsafe-inline'"
+        content="script-src 'self'"
       <% } %>
     />
 


### PR DESCRIPTION
Hey Everyone👋

A bit of mixed news here.  On a pentest for an (unnamed) exchange - multiple exploitable XSS vulnerabilities were uncovered.  Browser-based XSS mitigations didn’t come into play because it was DOM-Based (document.write()) and pXSS.   The Exchange had a restrictive CSP header, however the issue was tracked down to a bug in this repo, and even though the HTTP CSP header was secure, the Unsiwap Interface project adds an insecure permission which allowed for code execution to occur.

The vulnerability was tracked back to these lines of code:
https://github.com/Uniswap/interface/blob/bcc57e4612fb9e498cecdad6d38f0b25a04a49b6/public/index.html#L20-L24

According to the OWASP top 10; **unsafe-inline** is not to be used in a production application, and the use of **unsafe-inline** is scenario #4 of a5 in the OWASP top 10. (https://owasp.org/Top10/A05_2021-Security_Misconfiguration/).  If an application feature relies upon unsafe operations to function - then that feature must be changed to support a secure CSP and comply with OWASP. 

Here is more information on the unsafe misconfiguration from the CSP cheat sheet: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#3-restricting-unsafe-javascript. 

To demonstrate why this OWASP top 10 vulnerability is a problem for the community, I have written the following python code, which shows how problems can occur when you accidentally adopt an insecure CSP ruleset:
 
```
import http.server
import socketserver

class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
    def end_headers(self):
        if self.path == '/':
            self.send_header("Content-Security-Policy", "default-src 'self';")
        super().end_headers()

    def do_GET(self):
        if True:
            self.send_response(200)
            self.send_header('Content-type', 'text/html')
            self.end_headers()

            # Minified HTML content without external library
            html_content = """<!DOCTYPE html><html><head><title>CSP Example</title><meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline';"></head><body><h1>Content Security Policy Example</h1><p>This is an example page with a CSP allowing unsafe inline scripts.</p><script>alert('This is an alert box from an inline script!');</script></body></html>"""

            self.wfile.write(html_content.encode())

PORT = 8000

with socketserver.TCPServer(("", PORT), CustomHTTPRequestHandler) as httpd:
    print(f"Serving at port {PORT}")
    httpd.serve_forever()

```

The code above shows how the exchange in question was affected.  You can see this interaction by going to http://localhost:8000/ and then to http://localhost:8000/a to show both combinations.

The following javascript can be used to test for CSP-related OWASP a5 misconfigurations. Good security engineering is about planning on failure, and the following test demonstrates what can happen if an attacker had knowledge of a DOM-based XSS vulnerability: 

`    document.write('<script>alert(/this is an unsafe-inline script/)</script>')`

An example domain that is vulnerable is `https://app.uniswap.org/#/swap` - by visiting this domain in a browser and opening the console, the following alert box shows that untrusted JavaScript was executed in a trusted domain:

https://i.imgur.com/J0FmVKd.png

More value has passed through the Uniswap javascript widget than many banks, XSS in this context is far more serious than in other applications. Not naming any names here, but this was a P0 for someone in the community. It was determined that if this insecure CSP wasn’t introduced by the Uniswap codebase that the XSS would not have been exploitable.  Fixing all of the XSS in an application is a bit of a whack-a-mole, it is better to have mitigating factors in place such as a CSP to know that any potential XSS would be unexploitable.  Which is why the CSP is in the OWASP top 10, this is a bit like having seatbelts in your car - you never know who might be at the wheel.

Needless to say - a user could hand out a web3 grant which completely clears out their assets, we have seen this happen.  XSS in the context of web3 is far more serious than in web2, because you only need a single signature interaction in order to fully compromise a target.  The CSP was created to prevent inline injections with XSS, and this is a vulnerability class that is worth locking out completely with a secure CSP ruleset.

As a security professional and as a Uniswap user, the CSP is very important, and it would be great to see Uniswap lead the way in secure coding standards and adherence to The OWASP best practices. 

