### PR TITLE
fix: reset USDT logic

### DIFF
--- a/cypress/e2e/permit2.test.ts
+++ b/cypress/e2e/permit2.test.ts
@@ -146,6 +146,26 @@ describe('Permit2', () => {
       cy.contains('Swap success!')
       cy.get(getTestSelector('popups')).contains('Swapped')
     })
+
+    it('swaps USDT with existing permit, and existing and sufficient token approval', () => {
+      cy.hardhat().then(async (hardhat) => {
+        await hardhat.fund(hardhat.wallet, CurrencyAmount.fromRawAmount(USDT, 2e6))
+        await hardhat.mine()
+        await hardhat.approval.setTokenAllowanceForPermit2({ owner: hardhat.wallet, token: USDT }, 1e6)
+        await hardhat.mine()
+        await hardhat.approval.setPermit2Allowance({ owner: hardhat.wallet, token: USDT })
+        await hardhat.mine()
+      })
+      setupInputs(USDT, USDC_MAINNET)
+      cy.get('#swap-currency-input .token-amount-input').clear().type('1')
+      initiateSwap()
+
+      // Verify transaction
+      cy.wait('@eth_sendRawTransaction')
+      cy.hardhat().then((hardhat) => hardhat.mine())
+      cy.contains('Swap success!')
+      cy.get(getTestSelector('popups')).contains('Swapped')
+    })
   })
 
   it('swaps when user has already approved token and permit2', () => {

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -97,6 +97,7 @@ function useConfirmModalState({
     // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
     if (
       allowance.state === AllowanceState.REQUIRED &&
+      allowance.needsSetupApproval &&
       allowance.token.equals(USDT_MAINNET) &&
       allowance.allowedAmount.greaterThan(0)
     ) {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes a bug in the Resetting USDT logic - we only want to force the USDT approval if the setup approval step is needed in the first place. In other words, if the USDT setup approval is already large enough, we don't need to reset. 

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2620/investigate-permit2-bug-with-tether-reapproval-after-inactivity

issue #7083 


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/66155195/23450fad-5f45-4d7f-86c1-63db2f14048e




### After


https://github.com/Uniswap/interface/assets/66155195/00b77d57-71c6-4e8c-8a4a-5c9470166df5




## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. for USDT mainnet, set up your token approval to X
2. try to swap USDT to another token, with input amount <= X
3. notice that the reset step occurs even though you're swapping X or less USDT

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] repeat steps 1-2 above
- [x] ensure that the reset step is skipped



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test n/a
- [x] Integration/E2E test - added
