### PR TITLE
fix: smart contract wallets unsupported

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -117,7 +117,7 @@ export function useUniversalRouterSwapCallback(
               }),
               ...analyticsContext,
             })
-            if (tx.data !== response.data) {
+            if (!response.data || response.data.length === 0 || response.data === '0x') {
               sendAnalyticsEvent(SwapEventName.SWAP_MODIFIED_IN_WALLET, {
                 txHash: response.hash,
                 ...analyticsContext,

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -127,6 +127,7 @@ export function useUniversalRouterSwapCallback(
                 throw new ModifiedSwapError()
               }
             }
+            return response
           })
         return {
           type: TradeFillType.Classic as const,

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -117,14 +117,16 @@ export function useUniversalRouterSwapCallback(
               }),
               ...analyticsContext,
             })
-            if (!response.data || response.data.length === 0 || response.data === '0x') {
+            if (tx.data !== response.data) {
               sendAnalyticsEvent(SwapEventName.SWAP_MODIFIED_IN_WALLET, {
                 txHash: response.hash,
                 ...analyticsContext,
               })
-              throw new ModifiedSwapError()
+
+              if (!response.data || response.data.length === 0 || response.data === '0x') {
+                throw new ModifiedSwapError()
+              }
             }
-            return response
           })
         return {
           type: TradeFillType.Classic as const,


### PR DESCRIPTION
* fixes a bug that causes smart contract wallets to fail

linear: https://linear.app/uniswap/issue/WEB-2613/smart-contract-wallets-are-unsupported-investigative
slack: https://uniswapteam.slack.com/archives/C047U65H422/p1692894402092459

* smart contracts alter the calldata so checking if they are the same is not correct - better to check if it exists