### PR TITLE
fix: detect refunds on exact_out native swaps

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
@@ -159,10 +159,16 @@ function parseSwap(changes: TransactionChanges) {
   }
   // Some swaps may have more than 2 transfers, e.g. swaps with fees on tranfer
   if (changes.TokenTransfer.length >= 2) {
-    const sent = changes.TokenTransfer.find((t) => t?.__typename === 'TokenTransfer' && t.direction === 'OUT')
-    const received = changes.TokenTransfer.find((t) => t?.__typename === 'TokenTransfer' && t.direction === 'IN')
+    const sent = changes.TokenTransfer.find((t) => t.direction === 'OUT')
+    // Any leftover native token is refunded on exact_out swaps where the output token is native
+    const refund = changes.TokenTransfer.find(
+      (t) => t.direction === 'IN' && t.asset.id === sent?.asset.id && t.asset.standard === 'NATIVE'
+    )
+    const received = changes.TokenTransfer.find((t) => t.direction === 'IN' && t !== refund)
+
     if (sent && received) {
-      const inputAmount = formatNumberOrString(sent.quantity, NumberType.TokenNonTx)
+      const adjustedInput = parseFloat(sent.quantity) - parseFloat(refund?.quantity ?? '0')
+      const inputAmount = formatNumberOrString(adjustedInput, NumberType.TokenNonTx)
       const outputAmount = formatNumberOrString(received.quantity, NumberType.TokenNonTx)
       return {
         title: getSwapTitle(sent, received),

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
@@ -160,7 +160,7 @@ function parseSwap(changes: TransactionChanges) {
   // Some swaps may have more than 2 transfers, e.g. swaps with fees on tranfer
   if (changes.TokenTransfer.length >= 2) {
     const sent = changes.TokenTransfer.find((t) => t.direction === 'OUT')
-    // Any leftover native token is refunded on exact_out swaps where the output token is native
+    // Any leftover native token is refunded on exact_out swaps where the input token is native
     const refund = changes.TokenTransfer.find(
       (t) => t.direction === 'IN' && t.asset.id === sent?.asset.id && t.asset.standard === 'NATIVE'
     )


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
fixes incorrect tx parsing for exact_out swaps where the input token is native. This issue was caused by the fact that there is a third TokenTransfer for these types of swaps, representing a refund of any leftover (estimated_amt - actual_amt) native token after the swap.

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

|    Before    |   After    |
| ------------ | ------------ |
| <img width="387" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/30dc82f0-0d84-4b69-8886-ccf9b71f4adb"> | <img width="392" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/6fb4307c-c569-40e4-a14e-ca27f2bc0cf0"> |
