### PR TITLE
fix: Spore color fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -118,13 +118,13 @@
 
       @media (prefers-color-scheme: dark) {
         html {
-          background: linear-gradient(180deg, #202738 0%, #070816 100%);
+          background: linear-gradient(rgb(19, 19, 19) 0%, rgb(19, 19, 19) 100%);
         }
       }
 
       @media (prefers-color-scheme: light) {
         html {
-          background: radial-gradient(100% 100% at 50% 0%, rgba(255, 184, 226, 0.51) 0%, rgba(255, 255, 255, 0) 100%), #FFFFFF
+          background: radial-gradient(100% 100% at 50% 0%, rgba(255, 184, 226, 0) 0%, rgba(255, 255, 255, 0) 100%), rgb(255, 255, 255);
         }
       }
     </style>

--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -8,7 +8,7 @@ import { ExternalLink, HideSmall } from 'theme'
 import { colors } from 'theme/colors'
 import { useDarkModeManager } from 'theme/components/ThemeToggle'
 
-import { AutoRow } from '../Row'
+import Column from '../Column'
 
 const L2Icon = styled.img`
   width: 24px;
@@ -23,6 +23,7 @@ const BodyText = styled.div`
   justify-content: flex-start;
   margin: 8px;
   font-size: 14px;
+  line-height: 20px;
 `
 const RootWrapper = styled.div`
   margin-top: 16px;
@@ -188,14 +189,14 @@ export function NetworkAlert() {
         <LinkOutToBridge href={bridge}>
           <BodyText color={textColor}>
             <L2Icon src={logoUrl} />
-            <AutoRow>
+            <Column>
               <Header>
                 <Trans>{label} token bridge</Trans>
               </Header>
               <HideSmall>
                 <Trans>Deposit tokens to the {label} network.</Trans>
               </HideSmall>
-            </AutoRow>
+            </Column>
           </BodyText>
           <StyledArrowUpRight color={textColor} />
         </LinkOutToBridge>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After

Base chain selector now looks like on prod:

![CleanShot 2023-08-25 at 11 31 45](https://github.com/Uniswap/interface/assets/12100/029930f0-a38e-4abc-a294-fa8944f35c95)


Gradient now matches the initial ETH gradient (we change based on chain) for light and dark (very subtle):
![CleanShot 2023-08-25 at 11 32 47](https://github.com/Uniswap/interface/assets/12100/d35b7adc-ccc2-4a4d-b0ab-2a7f8b9ee706)

You can test this one ^ by setting a breakpoint at and checking it matches the react rendered bg:

![CleanShot 2023-08-25 at 11 33 11](https://github.com/Uniswap/interface/assets/12100/e53ab6ba-8a65-4c5d-8111-4167c9676757)





## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
