### PR TITLE
fix: un-nest translation on AddLiquidityV2 page

### DIFF
--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -367,10 +367,10 @@ export default function AddLiquidity() {
                   <BlueCard>
                     <AutoColumn gap="10px">
                       <ThemedText.DeprecatedLink fontWeight={485} color="accent1">
+                        <b>
+                          <Trans>Tip:</Trans>
+                        </b>{' '}
                         <Trans>
-                          <b>
-                            <Trans>Tip:</Trans>
-                          </b>{' '}
                           When you add liquidity, you will receive pool tokens representing your position. These tokens
                           automatically earn fees proportional to your share of the pool, and can be redeemed at any
                           time.


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
The information message on the AddLiquidityV2 page is not being translated correctly. Instead of the actual message, users are seeing a random string (likely an internal lingui hash). The root cause is the use of a `Trans` component inside of another `Trans` component. Un-nesting them resolves the issue and allows the intended message to be shown.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2783/weird-text-string-on-the-add-v2-liquidity-page-here
_Slack thread:_ https://uniswapteam.slack.com/archives/C047U65H422/p1693507380586379

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| <img width="405" alt="Screenshot 2023-08-31 at 6 08 51 PM" src="https://github.com/Uniswap/interface/assets/18626088/a0c01820-d062-400b-aae9-78be9b0ebd2f"> | <img width="487" alt="Screenshot 2023-08-31 at 6 08 34 PM" src="https://github.com/Uniswap/interface/assets/18626088/7767bc32-8f1b-4cac-b8a9-43135cb7dadf"> |

### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| <img width="425" alt="Screenshot 2023-08-31 at 6 08 12 PM" src="https://github.com/Uniswap/interface/assets/18626088/1b3a947a-6cbc-4025-b005-b3426a01dca4">  | <img width="475" alt="Screenshot 2023-08-31 at 6 07 32 PM" src="https://github.com/Uniswap/interface/assets/18626088/673be59f-2645-4f75-b1c0-e9ed4bea2983"> |

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Go to the V2 AddLiquidity page
2. Information message appearing at the top of the page is a random hash

### QA (ie manual testing)
Replace the "Tip" call to action and following information message with another valid, previously translated string, e.g. "Pool." Running a production build locally, you will see that, when the strings are nested, the message is incorrect. When they are un-nested, the message is correct.

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
- [x] Integration/E2E test
