### PR TITLE
fix: move off deprecated gql fields

### DIFF
--- a/cypress/fixtures/mini-portfolio/full_activity.json
+++ b/cypress/fixtures/mini-portfolio/full_activity.json
@@ -7,2486 +7,568 @@
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnM09EQm1NamcwTURSak1qRXpPRGd6TVRVM00yRXdOakJtTVRaaE1UQTNaV0ZtTW1Jd01qazFZbUZqTmpjNU5tUm1ZamN5TW1WbVl6VmpPVE5tTmpRM1h6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEQXdNREF3TURBek1HWTBPV0ptTW1Vd01ESmxOakJqTm1Wa01UWTJNV1ppTWpNME5tUTRPREk9",
             "timestamp": 1684364195,
-            "type": "UNKNOWN",
             "chain": "ETHEREUM",
             "details": {
               "__typename": "TransactionDetails",
               "id": "VHJhbnNhY3Rpb246MHg3ODBmMjg0MDRjMjEzODgzMTU3M2EwNjBmMTZhMTA3ZWFmMmIwMjk1YmFjNjc5NmRmYjcyMmVmYzVjOTNmNjQ3XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDAwMDAwMDAzMGY0OWJmMmUwMDJlNjBjNmVkMTY2MWZiMjM0NmQ4ODI=",
+              "type": "UNKNOWN",
               "blockNumber": 17282434,
               "hash": "0x780f28404c2138831573a060f16a107eaf2b0295bac6796dfb722efc5c93f647",
               "status": "CONFIRMED",
               "to": "0x000000030f49bf2e002e60c6ed1661fb2346d882",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 465
+              "nonce": 465,
+              "assetChanges": []
             },
-            "assetChanges": [],
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhobFl6QTROMkpoTjJJMk4yUTFPVEEwTVdNMU5XTXdObU16TkdNNVlXVmhPVEUxTkRreVpUYzRNRFl4WldRd016TTBNMlprWmprMU1qa3dPR1U0WTJSa1h6QjRaR0psWmpNM05HWmtaamhrTnpNMVpUYzFPRGxoT1dFNVpUSmpOV0V3T1RGbFlqSmtZbVUxTjE4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
             "timestamp": 1684364135,
-            "type": "RECEIVE",
             "chain": "ETHEREUM",
             "details": {
               "__typename": "TransactionDetails",
               "id": "VHJhbnNhY3Rpb246MHhlYzA4N2JhN2I2N2Q1OTA0MWM1NWMwNmMzNGM5YWVhOTE1NDkyZTc4MDYxZWQwMzM0M2ZkZjk1MjkwOGU4Y2RkXzB4ZGJlZjM3NGZkZjhkNzM1ZTc1ODlhOWE5ZTJjNWEwOTFlYjJkYmU1N18weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
+              "type": "RECEIVE",
               "blockNumber": 17282429,
               "hash": "0xec087ba7b67d59041c55c06c34c9aea915492e78061ed03343fdf952908e8cdd",
               "status": "CONFIRMED",
               "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "from": "0xdbef374fdf8d735e7589a9a9e2c5a091eb2dbe57",
-              "nonce": 66
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGRiZWYzNzRmZGY4ZDczNWU3NTg5YTlhOWUyYzVhMDkxZWIyZGJlNTdfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ZWMwODdiYTdiNjdkNTkwNDFjNTVjMDZjMzRjOWFlYTkxNTQ5MmU3ODA2MWVkMDMzNDNmZGY5NTI5MDhlOGNkZA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "nonce": 66,
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGRiZWYzNzRmZGY4ZDczNWU3NTg5YTlhOWUyYzVhMDkxZWIyZGJlNTdfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ZWMwODdiYTdiNjdkNTkwNDFjNTVjMDZjMzRjOWFlYTkxNTQ5MmU3ODA2MWVkMDMzNDNmZGY5NTI5MDhlOGNkZA==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.001",
-                "sender": "0xdbef374fdf8d735e7589a9a9e2c5a091eb2dbe57",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjEuODI5NjcwMDAwMDAwMDAwMV9VU0Q=",
-                  "currency": "USD",
-                  "value": 1.8296700000000001,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.001",
+                  "sender": "0xdbef374fdf8d735e7589a9a9e2c5a091eb2dbe57",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "direction": "IN",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjEuODI5NjcwMDAwMDAwMDAwMV9VU0Q=",
+                    "currency": "USD",
+                    "value": 1.8296700000000001,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaE9URXdPVFEwT1Rka01UVmpNelpsWWprd1pXUXpZVEkwWW1Wa09ESTBOalpqWmpKaU9URXpNV1l4WkRVMk1EUmlNelppWW1aallqRTBOMkUzTURnNFh6QjRaV1JoTldVeE9ERXhORFppTVdZNVlUZG1OREJtT0RWak1HUmhNek0wT1RNNE5ESXdaRFV4TkY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
             "timestamp": 1684319903,
-            "type": "RECEIVE",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHhhOTEwOTQ0OTdkMTVjMzZlYjkwZWQzYTI0YmVkODI0NjZjZjJiOTEzMWYxZDU2MDRiMzZiYmZjYjE0N2E3MDg4XzB4ZWRhNWUxODExNDZiMWY5YTdmNDBmODVjMGRhMzM0OTM4NDIwZDUxNF8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
+              "type": "RECEIVE",
               "blockNumber": 17278819,
               "hash": "0xa91094497d15c36eb90ed3a24bed82466cf2b9131f1d5604b36bbfcb147a7088",
               "status": "CONFIRMED",
               "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "from": "0xeda5e181146b1f9a7f40f85c0da334938420d514",
               "nonce": 5,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGVkYTVlMTgxMTQ2YjFmOWE3ZjQwZjg1YzBkYTMzNDkzODQyMGQ1MTRfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4YTkxMDk0NDk3ZDE1YzM2ZWI5MGVkM2EyNGJlZDgyNDY2Y2YyYjkxMzFmMWQ1NjA0YjM2YmJmY2IxNDdhNzA4OA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGVkYTVlMTgxMTQ2YjFmOWE3ZjQwZjg1YzBkYTMzNDkzODQyMGQ1MTRfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4YTkxMDk0NDk3ZDE1YzM2ZWI5MGVkM2EyNGJlZDgyNDY2Y2YyYjkxMzFmMWQ1NjA0YjM2YmJmY2IxNDdhNzA4OA==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.15",
-                "sender": "0xeda5e181146b1f9a7f40f85c0da334938420d514",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjI3NC40NTA1X1VTRA==",
-                  "currency": "USD",
-                  "value": 274.4505,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.15",
+                  "sender": "0xeda5e181146b1f9a7f40f85c0da334938420d514",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "direction": "IN",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjI3NC40NTA1X1VTRA==",
+                    "currency": "USD",
+                    "value": 274.4505,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMFkyUm1Nell6T0dRME1ERXdOV1U1WkRZMVlUZGxObUV6WVdFMlpHTXpNREZpWVRNNVpHTXlNV1ppT0dGaE5USTBNVFppT1ROaE5tWXhOVEUwTWpReVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHUmxOR1F6WVRJME5XUXlZall4WW1WaE1tTmlaREl4TmpVNE1XVXlaR1ZrTmpWbFl6azFNRFE9",
             "timestamp": 1684319903,
-            "type": "SEND",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg0Y2RmMzYzOGQ0MDEwNWU5ZDY1YTdlNmEzYWE2ZGMzMDFiYTM5ZGMyMWZiOGFhNTI0MTZiOTNhNmYxNTE0MjQyXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGRlNGQzYTI0NWQyYjYxYmVhMmNiZDIxNjU4MWUyZGVkNjVlYzk1MDQ=",
+              "type": "SEND",
               "blockNumber": 17278819,
               "hash": "0x4cdf3638d40105e9d65a7e6a3aa6dc301ba39dc21fb8aa52416b93a6f1514242",
               "status": "CONFIRMED",
               "to": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "nonce": 464,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhkZTRkM2EyNDVkMmI2MWJlYTJjYmQyMTY1ODFlMmRlZDY1ZWM5NTA0XzB4NGNkZjM2MzhkNDAxMDVlOWQ2NWE3ZTZhM2FhNmRjMzAxYmEzOWRjMjFmYjhhYTUyNDE2YjkzYTZmMTUxNDI0Mg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhkZTRkM2EyNDVkMmI2MWJlYTJjYmQyMTY1ODFlMmRlZDY1ZWM5NTA0XzB4NGNkZjM2MzhkNDAxMDVlOWQ2NWE3ZTZhM2FhNmRjMzAxYmEzOWRjMjFmYjhhYTUyNDE2YjkzYTZmMTUxNDI0Mg==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00134999999999999",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuNDcwMDU0NDk5OTk5OTgyX1VTRA==",
-                  "currency": "USD",
-                  "value": 2.470054499999982,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.00134999999999999",
+                  "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "recipient": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
+                  "direction": "OUT",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjIuNDcwMDU0NDk5OTk5OTgyX1VTRA==",
+                    "currency": "USD",
+                    "value": 2.470054499999982,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnM04yRXhPVGRoWmpjek9EUXpNRFk0WVRCaVlqUmlaV1V6WWpabFptWmxaakpsTkdZMFptTXlNR1UxWVRGbVltSTBOak14WXpoak1UQTROMk15WWpjM1h6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWTFZekZoTnpCbU5qY3pPV0k1TW1ZNU4yTmtOVE5qTXpFMk1ETTJNbU14TXpBMVpUa3hZVGc9",
             "timestamp": 1684202579,
-            "type": "SEND",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg3N2ExOTdhZjczODQzMDY4YTBiYjRiZWUzYjZlZmZlZjJlNGY0ZmMyMGU1YTFmYmI0NjMxYzhjMTA4N2MyYjc3XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGY1YzFhNzBmNjczOWI5MmY5N2NkNTNjMzE2MDM2MmMxMzA1ZTkxYTg=",
+              "type": "SEND",
               "blockNumber": 17269191,
               "hash": "0x77a197af73843068a0bb4bee3b6effef2e4f4fc20e5a1fbb4631c8c1087c2b77",
               "status": "CONFIRMED",
               "to": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "nonce": 463,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmNWMxYTcwZjY3MzliOTJmOTdjZDUzYzMxNjAzNjJjMTMwNWU5MWE4XzB4NzdhMTk3YWY3Mzg0MzA2OGEwYmI0YmVlM2I2ZWZmZWYyZTRmNGZjMjBlNWExZmJiNDYzMWM4YzEwODdjMmI3Nw==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmNWMxYTcwZjY3MzliOTJmOTdjZDUzYzMxNjAzNjJjMTMwNWU5MWE4XzB4NzdhMTk3YWY3Mzg0MzA2OGEwYmI0YmVlM2I2ZWZmZWYyZTRmNGZjMjBlNWExZmJiNDYzMWM4YzEwODdjMmI3Nw==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.001216034894406018",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuMjI0OTQyNTY1MjQ3ODU5X1VTRA==",
-                  "currency": "USD",
-                  "value": 2.224942565247859,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.001216034894406018",
+                  "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "recipient": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
+                  "direction": "OUT",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjIuMjI0OTQyNTY1MjQ3ODU5X1VTRA==",
+                    "currency": "USD",
+                    "value": 2.224942565247859,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMlpXSmtZbVJrTVRZMk0yVmxNV1ZrT0RVeE16TXlZelUyWmpkall6YzJaV1ZqTVROaE5qTm1PVEkxTldOa1ltWXlZVEUxWWpReFl6azBPVGhrWW1Wa1h6QjROREZpTXpBNU1qTTJZemczWWpGaVl6Wm1ZVGhsWWpnMk5UZ3pNMlUwTkRFMU9HWmhPVGt4WVY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
             "timestamp": 1684202579,
-            "type": "RECEIVE",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg2ZWJkYmRkMTY2M2VlMWVkODUxMzMyYzU2ZjdjYzc2ZWVjMTNhNjNmOTI1NWNkYmYyYTE1YjQxYzk0OThkYmVkXzB4NDFiMzA5MjM2Yzg3YjFiYzZmYThlYjg2NTgzM2U0NDE1OGZhOTkxYV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
+              "type": "RECEIVE",
               "blockNumber": 17269191,
               "hash": "0x6ebdbdd1663ee1ed851332c56f7cc76eec13a63f9255cdbf2a15b41c9498dbed",
               "status": "CONFIRMED",
               "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "from": "0x41b309236c87b1bc6fa8eb865833e44158fa991a",
               "nonce": 111266,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDQxYjMwOTIzNmM4N2IxYmM2ZmE4ZWI4NjU4MzNlNDQxNThmYTk5MWFfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4NmViZGJkZDE2NjNlZTFlZDg1MTMzMmM1NmY3Y2M3NmVlYzEzYTYzZjkyNTVjZGJmMmExNWI0MWM5NDk4ZGJlZA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweDQxYjMwOTIzNmM4N2IxYmM2ZmE4ZWI4NjU4MzNlNDQxNThmYTk5MWFfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4NmViZGJkZDE2NjNlZTFlZDg1MTMzMmM1NmY3Y2M3NmVlYzEzYTYzZjkyNTVjZGJmMmExNWI0MWM5NDk4ZGJlZA==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00275365",
-                "sender": "0x41b309236c87b1bc6fa8eb865833e44158fa991a",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjUuMDM4MjcwNzk1NV9VU0Q=",
-                  "currency": "USD",
-                  "value": 5.0382707955,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.00275365",
+                  "sender": "0x41b309236c87b1bc6fa8eb865833e44158fa991a",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "direction": "IN",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjUuMDM4MjcwNzk1NV9VU0Q=",
+                    "currency": "USD",
+                    "value": 5.0382707955,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNU5EUmlNR00wTVROa1l6QmpNekU0TUdFelkyTTNZakUyT1RCbVlqZzBNRFExWm1FME9UTXpObUV5WmprNE16VmpORFpqTURsak1UY3lObUUzTm1aalh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEWXlNakJsTURoak9XUTJNMkZpTjJKaE1tVTFOalk0TXpsbU5ESTVaV1ZsWm1VeE9UbGlOMlU9",
             "timestamp": 1684171943,
-            "type": "SEND",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg5NDRiMGM0MTNkYzBjMzE4MGEzY2M3YjE2OTBmYjg0MDQ1ZmE0OTMzNmEyZjk4MzVjNDZjMDljMTcyNmE3NmZjXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDYyMjBlMDhjOWQ2M2FiN2JhMmU1NjY4MzlmNDI5ZWVlZmUxOTliN2U=",
+              "type": "SEND",
               "blockNumber": 17266680,
               "hash": "0x944b0c413dc0c3180a3cc7b1690fb84045fa49336a2f9835c46c09c1726a76fc",
               "status": "CONFIRMED",
               "to": "0x6220e08c9d63ab7ba2e566839f429eeefe199b7e",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "nonce": 462,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHg2MjIwZTA4YzlkNjNhYjdiYTJlNTY2ODM5ZjQyOWVlZWZlMTk5YjdlXzB4OTQ0YjBjNDEzZGMwYzMxODBhM2NjN2IxNjkwZmI4NDA0NWZhNDkzMzZhMmY5ODM1YzQ2YzA5YzE3MjZhNzZmYw==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHg2MjIwZTA4YzlkNjNhYjdiYTJlNTY2ODM5ZjQyOWVlZWZlMTk5YjdlXzB4OTQ0YjBjNDEzZGMwYzMxODBhM2NjN2IxNjkwZmI4NDA0NWZhNDkzMzZhMmY5ODM1YzQ2YzA5YzE3MjZhNzZmYw==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.003476850926189204",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x6220e08c9d63ab7ba2e566839f429eeefe199b7e",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjYuMzYxNDg5ODM0MTIwNjAxX1VTRA==",
-                  "currency": "USD",
-                  "value": 6.361489834120601,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.003476850926189204",
+                  "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "recipient": "0x6220e08c9d63ab7ba2e566839f429eeefe199b7e",
+                  "direction": "OUT",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjYuMzYxNDg5ODM0MTIwNjAxX1VTRA==",
+                    "currency": "USD",
+                    "value": 6.361489834120601,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhneE0yRTRNRGxsT1RZd05USmhOVGxrWlRjNU56WXhObVZrTlRjME1qTTVNakV3WkRJMVpUY3hNRGhqTkRjek9EbG1NbVJoTnpjeU5qTXhZbVZpTUdZMlh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEWXlNakJsTURoak9XUTJNMkZpTjJKaE1tVTFOalk0TXpsbU5ESTVaV1ZsWm1VeE9UbGlOMlU9",
             "timestamp": 1684171943,
-            "type": "SEND",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHgxM2E4MDllOTYwNTJhNTlkZTc5NzYxNmVkNTc0MjM5MjEwZDI1ZTcxMDhjNDczODlmMmRhNzcyNjMxYmViMGY2XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDYyMjBlMDhjOWQ2M2FiN2JhMmU1NjY4MzlmNDI5ZWVlZmUxOTliN2U=",
+              "type": "SEND",
               "blockNumber": 17266680,
               "hash": "0x13a809e96052a59de797616ed574239210d25e7108c47389f2da772631beb0f6",
               "status": "CONFIRMED",
               "to": "0x6220e08c9d63ab7ba2e566839f429eeefe199b7e",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "nonce": 461,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHg2MjIwZTA4YzlkNjNhYjdiYTJlNTY2ODM5ZjQyOWVlZWZlMTk5YjdlXzB4MTNhODA5ZTk2MDUyYTU5ZGU3OTc2MTZlZDU3NDIzOTIxMGQyNWU3MTA4YzQ3Mzg5ZjJkYTc3MjYzMWJlYjBmNg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHg2MjIwZTA4YzlkNjNhYjdiYTJlNTY2ODM5ZjQyOWVlZWZlMTk5YjdlXzB4MTNhODA5ZTk2MDUyYTU5ZGU3OTc2MTZlZDU3NDIzOTIxMGQyNWU3MTA4YzQ3Mzg5ZjJkYTc3MjYzMWJlYjBmNg==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000900000000000318",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x6220e08c9d63ab7ba2e566839f429eeefe199b7e",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjEuNjQ2NzAzMDAwMDAwNTgxOF9VU0Q=",
-                  "currency": "USD",
-                  "value": 1.6467030000005818,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.000900000000000318",
+                  "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "recipient": "0x6220e08c9d63ab7ba2e566839f429eeefe199b7e",
+                  "direction": "OUT",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjEuNjQ2NzAzMDAwMDAwNTgxOF9VU0Q=",
+                    "currency": "USD",
+                    "value": 1.6467030000005818,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhobFkyRTJNVEZrTlRVME1EZGxPVGt6WlRFM1lqWmtaVGhpWVRJMFlqWXlOREpqWVRSbFlXWTBORGN3TkRKbFpHRmtNRFE0TTJNNFptSTJabUU0WkRJNVh6QjROekU0WVRVeE5ESXhNR0kwTnpWaU9USXhOVGd6WldGaU5ERXlaV0ptTUdaaVlXUm1NMkl6T1Y4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
             "timestamp": 1684171931,
-            "type": "RECEIVE",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHhlY2E2MTFkNTU0MDdlOTkzZTE3YjZkZThiYTI0YjYyNDJjYTRlYWY0NDcwNDJlZGFkMDQ4M2M4ZmI2ZmE4ZDI5XzB4NzE4YTUxNDIxMGI0NzViOTIxNTgzZWFiNDEyZWJmMGZiYWRmM2IzOV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
+              "type": "RECEIVE",
               "blockNumber": 17266679,
               "hash": "0xeca611d55407e993e17b6de8ba24b6242ca4eaf447042edad0483c8fb6fa8d29",
               "status": "CONFIRMED",
               "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "from": "0x718a514210b475b921583eab412ebf0fbadf3b39",
               "nonce": 92,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDcxOGE1MTQyMTBiNDc1YjkyMTU4M2VhYjQxMmViZjBmYmFkZjNiMzlfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ZWNhNjExZDU1NDA3ZTk5M2UxN2I2ZGU4YmEyNGI2MjQyY2E0ZWFmNDQ3MDQyZWRhZDA0ODNjOGZiNmZhOGQyOQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweDcxOGE1MTQyMTBiNDc1YjkyMTU4M2VhYjQxMmViZjBmYmFkZjNiMzlfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ZWNhNjExZDU1NDA3ZTk5M2UxN2I2ZGU4YmEyNGI2MjQyY2E0ZWFmNDQ3MDQyZWRhZDA0ODNjOGZiNmZhOGQyOQ==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.01",
-                "sender": "0x718a514210b475b921583eab412ebf0fbadf3b39",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjE4LjI5NjdfVVNE",
-                  "currency": "USD",
-                  "value": 18.2967,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.01",
+                  "sender": "0x718a514210b475b921583eab412ebf0fbadf3b39",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "direction": "IN",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjE4LjI5NjdfVVNE",
+                    "currency": "USD",
+                    "value": 18.2967,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMllqTTJNelEwT1daaU1HWTROems0TkRnM1pqWmlOREkwTkRjMFkySXdNbVF5WlRVNE1EZ3dPVEpoWVRneE1EVm1ObUU0T1dOalpHTTBORGRsTURSa1h6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEQXdNREF3TURBek1HWTBPV0ptTW1Vd01ESmxOakJqTm1Wa01UWTJNV1ppTWpNME5tUTRPREk9",
             "timestamp": 1684085063,
-            "type": "UNKNOWN",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg2YjM2MzQ0OWZiMGY4Nzk4NDg3ZjZiNDI0NDc0Y2IwMmQyZTU4MDgwOTJhYTgxMDVmNmE4OWNjZGM0NDdlMDRkXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDAwMDAwMDAzMGY0OWJmMmUwMDJlNjBjNmVkMTY2MWZiMjM0NmQ4ODI=",
+              "type": "UNKNOWN",
               "blockNumber": 17259555,
               "hash": "0x6b363449fb0f8798487f6b424474cb02d2e5808092aa8105f6a89ccdc447e04d",
               "status": "CONFIRMED",
               "to": "0x000000030f49bf2e002e60c6ed1661fb2346d882",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "nonce": 460,
-              "__typename": "TransactionDetails"
+              "__typename": "TransactionDetails",
+              "assetChanges": []
             },
-            "assetChanges": [],
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNFlXRTVNVFJqTkRjeU5qWTNNVGxqWkRFeE1EYzNOMkprTnpZek0yVTFOV1kyWkdWbVpXRmpPVEV4TlRjd09EZzNZVEEyWXpNNE5UTmxaV0kyTldZeVh6QjRaR0V4TTJRMk5HVmpPVFZqWkRZM056VXlPVEZpTVdNek1qRXdNamN4TWpGaVpUSXdPV1JtTUY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
             "timestamp": 1684085051,
-            "type": "RECEIVE",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg4YWE5MTRjNDcyNjY3MTljZDExMDc3N2JkNzYzM2U1NWY2ZGVmZWFjOTExNTcwODg3YTA2YzM4NTNlZWI2NWYyXzB4ZGExM2Q2NGVjOTVjZDY3NzUyOTFiMWMzMjEwMjcxMjFiZTIwOWRmMF8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
+              "type": "RECEIVE",
               "blockNumber": 17259554,
               "hash": "0x8aa914c47266719cd110777bd7633e55f6defeac911570887a06c3853eeb65f2",
               "status": "CONFIRMED",
               "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "from": "0xda13d64ec95cd6775291b1c321027121be209df0",
               "nonce": 832,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGRhMTNkNjRlYzk1Y2Q2Nzc1MjkxYjFjMzIxMDI3MTIxYmUyMDlkZjBfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4OGFhOTE0YzQ3MjY2NzE5Y2QxMTA3NzdiZDc2MzNlNTVmNmRlZmVhYzkxMTU3MDg4N2EwNmMzODUzZWViNjVmMg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGRhMTNkNjRlYzk1Y2Q2Nzc1MjkxYjFjMzIxMDI3MTIxYmUyMDlkZjBfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4OGFhOTE0YzQ3MjY2NzE5Y2QxMTA3NzdiZDc2MzNlNTVmNmRlZmVhYzkxMTU3MDg4N2EwNmMzODUzZWViNjVmMg==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
+                    "name": "Ether",
+                    "symbol": "ETH",
+                    "address": null,
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
+                      "isSpam": false,
+                      "logo": {
+                        "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
+                        "url": "https://token-icons.s3.amazonaws.com/eth.png",
+                        "__typename": "Image"
+                      },
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00129866",
-                "sender": "0xda13d64ec95cd6775291b1c321027121be209df0",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuMzc2MTE5MjQyMl9VU0Q=",
-                  "currency": "USD",
-                  "value": 2.3761192422,
-                  "__typename": "Amount"
+                  "tokenStandard": "NATIVE",
+                  "quantity": "0.00129866",
+                  "sender": "0xda13d64ec95cd6775291b1c321027121be209df0",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "direction": "IN",
+                  "transactedValue": {
+                    "id": "QW1vdW50OjIuMzc2MTE5MjQyMl9VU0Q=",
+                    "currency": "USD",
+                    "value": 2.3761192422,
+                    "__typename": "Amount"
+                  }
                 }
-              }
-            ],
+              ]
+            },
             "__typename": "AssetActivity"
           },
           {
             "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnM00yTXdZMlJpTnpReU9UVTJZVFUxWXpZd016YzBOemd6TkRRNVpUSmpNbVZtTURnM1lqUTVPRFl4TVdGak5EZ3dZalJrTVRFMU1UbGhZemRpTXpZNVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHUXpaR1UwTkRneE5qTXlNakl5TURVME9UazJZVE0yTlRsaE5UTXlNR0k1TWpWbU5qUXhNR1k9",
             "timestamp": 1684006019,
-            "type": "SEND",
             "chain": "ETHEREUM",
             "details": {
               "id": "VHJhbnNhY3Rpb246MHg3M2MwY2RiNzQyOTU2YTU1YzYwMzc0NzgzNDQ5ZTJjMmVmMDg3YjQ5ODYxMWFjNDgwYjRkMTE1MTlhYzdiMzY5XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGQzZGU0NDgxNjMyMjIyMDU0OTk2YTM2NTlhNTMyMGI5MjVmNjQxMGY=",
+              "type": "SEND",
               "blockNumber": 17253116,
               "hash": "0x73c0cdb742956a55c60374783449e2c2ef087b498611ac480b4d11519ac7b369",
               "status": "CONFIRMED",
               "to": "0xd3de4481632222054996a3659a5320b925f6410f",
               "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
               "nonce": 459,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhiZTgyODI1NjRlYzJiNzAwMDlmMmQ2ODk1NDAxMmViMDlmNDhiYzhkXzB4NzNjMGNkYjc0Mjk1NmE1NWM2MDM3NDc4MzQ0OWUyYzJlZjA4N2I0OTg2MTFhYzQ4MGI0ZDExNTE5YWM3YjM2OQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fMHhkM2RlNDQ4MTYzMjIyMjA1NDk5NmEzNjU5YTUzMjBiOTI1ZjY0MTBm",
-                  "name": "EL CHAPO",
-                  "symbol": "CHAPO",
-                  "address": "0xd3de4481632222054996a3659a5320b925f6410f",
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4ZDNkZTQ0ODE2MzIyMjIwNTQ5OTZhMzY1OWE1MzIwYjkyNWY2NDEwZg==",
-                    "isSpam": true,
-                    "logo": null,
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "ERC20",
-                "quantity": "50000000000000.002683081102196736",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xbe8282564ec2b70009f2d68954012eb09f48bc8d",
-                "direction": "OUT",
-                "transactedValue": null
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMVlURXhZV05rTjJJMU5UWTBOems1TXpRM01ESXhNVEJsTlRrM1kyRTVOalUxWkdFeE0yTmlPRGd6T1dJNVpqTTNObVV4WWpobE56RXdORFk0TkRWbVh6QjRZbVU0TWpneU5UWTBaV015WWpjd01EQTVaakprTmpnNU5UUXdNVEpsWWpBNVpqUTRZbU00WkY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1684006019,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg1YTExYWNkN2I1NTY0Nzk5MzQ3MDIxMTBlNTk3Y2E5NjU1ZGExM2NiODgzOWI5ZjM3NmUxYjhlNzEwNDY4NDVmXzB4YmU4MjgyNTY0ZWMyYjcwMDA5ZjJkNjg5NTQwMTJlYjA5ZjQ4YmM4ZF8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17253116,
-              "hash": "0x5a11acd7b556479934702110e597ca9655da13cb8839b9f376e1b8e71046845f",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0xbe8282564ec2b70009f2d68954012eb09f48bc8d",
-              "nonce": 16,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGJlODI4MjU2NGVjMmI3MDAwOWYyZDY4OTU0MDEyZWIwOWY0OGJjOGRfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4NWExMWFjZDdiNTU2NDc5OTM0NzAyMTEwZTU5N2NhOTY1NWRhMTNjYjg4MzliOWYzNzZlMWI4ZTcxMDQ2ODQ1Zg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
+              "__typename": "TransactionDetails",
+              "assetChanges": [
+                {
+                  "__typename": "TokenTransfer",
+                  "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhiZTgyODI1NjRlYzJiNzAwMDlmMmQ2ODk1NDAxMmViMDlmNDhiYzhkXzB4NzNjMGNkYjc0Mjk1NmE1NWM2MDM3NDc4MzQ0OWUyYzJlZjA4N2I0OTg2MTFhYzQ4MGI0ZDExNTE5YWM3YjM2OQ==",
+                  "asset": {
+                    "id": "VG9rZW46RVRIRVJFVU1fMHhkM2RlNDQ4MTYzMjIyMjA1NDk5NmEzNjU5YTUzMjBiOTI1ZjY0MTBm",
+                    "name": "EL CHAPO",
+                    "symbol": "CHAPO",
+                    "address": "0xd3de4481632222054996a3659a5320b925f6410f",
+                    "decimals": 18,
+                    "chain": "ETHEREUM",
+                    "standard": null,
+                    "project": {
+                      "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4ZDNkZTQ0ODE2MzIyMjIwNTQ5OTZhMzY1OWE1MzIwYjkyNWY2NDEwZg==",
+                      "isSpam": true,
+                      "logo": null,
+                      "__typename": "TokenProject"
                     },
-                    "__typename": "TokenProject"
+                    "__typename": "Token"
                   },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00255212",
-                "sender": "0xbe8282564ec2b70009f2d68954012eb09f48bc8d",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjQuNjY5NTM3NDAwNF9VU0Q=",
-                  "currency": "USD",
-                  "value": 4.6695374004,
-                  "__typename": "Amount"
+                  "tokenStandard": "ERC20",
+                  "quantity": "50000000000000.002683081102196736",
+                  "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "recipient": "0xbe8282564ec2b70009f2d68954012eb09f48bc8d",
+                  "direction": "OUT",
+                  "transactedValue": null
                 }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoa05USmxOR1JqTW1Rd09UTm1ZMkZoTVRNd05qQTFZemM0WVRCak1XVTNNREZoWTJWbVlUWXdaakl3TkdObU56QmxOVEprTkRRek5UQTRZV1ZrTURNNFh6QjRaVEEzT0dRMllUSTJOVEE1WVdZNVl6RTNaRGMyWkdKak1tVm1PR1JrTURVNU16QTVOR0UxTlY4d2VESm1aalZoT0dKbVpETTBaalV5Tm1NNE5HUm1NVEV6T0RrM1kyTmlOelppTURVNU1qY3laRGM9",
-            "timestamp": 1683944327,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhkNTJlNGRjMmQwOTNmY2FhMTMwNjA1Yzc4YTBjMWU3MDFhY2VmYTYwZjIwNGNmNzBlNTJkNDQzNTA4YWVkMDM4XzB4ZTA3OGQ2YTI2NTA5YWY5YzE3ZDc2ZGJjMmVmOGRkMDU5MzA5NGE1NV8weDJmZjVhOGJmZDM0ZjUyNmM4NGRmMTEzODk3Y2NiNzZiMDU5MjcyZDc=",
-              "blockNumber": 17248056,
-              "hash": "0xd52e4dc2d093fcaa130605c78a0c1e701acefa60f204cf70e52d443508aed038",
-              "status": "CONFIRMED",
-              "to": "0x2ff5a8bfd34f526c84df113897ccb76b059272d7",
-              "from": "0xe078d6a26509af9c17d76dbc2ef8dd0593094a55",
-              "nonce": 90,
-              "__typename": "TransactionDetails"
+              ]
             },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDJmZjVhOGJmZDM0ZjUyNmM4NGRmMTEzODk3Y2NiNzZiMDU5MjcyZDdfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ZDUyZTRkYzJkMDkzZmNhYTEzMDYwNWM3OGEwYzFlNzAxYWNlZmE2MGYyMDRjZjcwZTUyZDQ0MzUwOGFlZDAzOA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fMHhkM2RlNDQ4MTYzMjIyMjA1NDk5NmEzNjU5YTUzMjBiOTI1ZjY0MTBm",
-                  "name": "EL CHAPO",
-                  "symbol": "CHAPO",
-                  "address": "0xd3de4481632222054996a3659a5320b925f6410f",
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4ZDNkZTQ0ODE2MzIyMjIwNTQ5OTZhMzY1OWE1MzIwYjkyNWY2NDEwZg==",
-                    "isSpam": true,
-                    "logo": null,
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "ERC20",
-                "quantity": "50000000000000.002683081102196736",
-                "sender": "0x2ff5a8bfd34f526c84df113897ccb76b059272d7",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": null
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhobFltRm1NRFk0TmpCa09HSXlaakprWVRWbU5HWTRaV1ZrTVRjeVlqbGpZelZoT0RSaE9HUmlORFl4TXpKak5UWTJZekZtT1RrMFl6WXdZVFF5TTJNMVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHSmpPVGN3TURCaVpqRXdOakpqWmpjelpqbG1ZelV3WTJGak1ESTJNamcxTWpNM09UUTNOVFk9",
-            "timestamp": 1683891431,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhlYmFmMDY4NjBkOGIyZjJkYTVmNGY4ZWVkMTcyYjljYzVhODRhOGRiNDYxMzJjNTY2YzFmOTk0YzYwYTQyM2M1XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGJjOTcwMDBiZjEwNjJjZjczZjlmYzUwY2FjMDI2Mjg1MjM3OTQ3NTY=",
-              "blockNumber": 17243877,
-              "hash": "0xebaf06860d8b2f2da5f4f8eed172b9cc5a84a8db46132c566c1f994c60a423c5",
-              "status": "CONFIRMED",
-              "to": "0xbc97000bf1062cf73f9fc50cac02628523794756",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 458,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhiYzk3MDAwYmYxMDYyY2Y3M2Y5ZmM1MGNhYzAyNjI4NTIzNzk0NzU2XzB4ZWJhZjA2ODYwZDhiMmYyZGE1ZjRmOGVlZDE3MmI5Y2M1YTg0YThkYjQ2MTMyYzU2NmMxZjk5NGM2MGE0MjNjNQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00252224199999847",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xbc97000bf1062cf73f9fc50cac02628523794756",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjQuNjE0ODcwNTIwMTM3MjAxX1VTRA==",
-                  "currency": "USD",
-                  "value": 4.614870520137201,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNE1EUXlZbVZpWlRSbU1URmhZV1l4T0RFNE5XSTVZamxqT0dGbFpUTXpOVFJtTlRnd01tTTFNamhsTnpFek9HTXpOVFl6T1dJeE1Ua3lNVGt5TW1JNVh6QjROelZsT0Rsa05UazNPV1UwWmpabVltRTVaamszWXpFd05HTXlaakJoWm1JelpqRmtZMkk0T0Y4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1683891431,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg4MDQyYmViZTRmMTFhYWYxODE4NWI5YjljOGFlZTMzNTRmNTgwMmM1MjhlNzEzOGMzNTYzOWIxMTkyMTkyMmI5XzB4NzVlODlkNTk3OWU0ZjZmYmE5Zjk3YzEwNGMyZjBhZmIzZjFkY2I4OF8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17243877,
-              "hash": "0x8042bebe4f11aaf18185b9b9c8aee3354f5802c528e7138c35639b11921922b9",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x75e89d5979e4f6fba9f97c104c2f0afb3f1dcb88",
-              "nonce": 3240290,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDc1ZTg5ZDU5NzllNGY2ZmJhOWY5N2MxMDRjMmYwYWZiM2YxZGNiODhfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ODA0MmJlYmU0ZjExYWFmMTgxODViOWI5YzhhZWUzMzU0ZjU4MDJjNTI4ZTcxMzhjMzU2MzliMTE5MjE5MjJiOQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.01261121",
-                "sender": "0x75e89d5979e4f6fba9f97c104c2f0afb3f1dcb88",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIzLjA3NDM1MjYwMDdfVVNE",
-                  "currency": "USD",
-                  "value": 23.0743526007,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNU56RTROR0V5WkRZNE5EZ3habVExTTJRNU1ERTNNR0UyTXpreU16UXhNekE0WkRaall6TTJZV1kwT1Rnd01XRTJZVEV3WldVeE5qSmlPRGt3T1Rnd1h6QjROVFpsWkdSaU4yRmhPRGMxTXpaak1EbGpZMk15Tnprek5EY3pOVGs1Wm1ReU1XRTRZakUzWmw4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1683658811,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg5NzE4NGEyZDY4NDgxZmQ1M2Q5MDE3MGE2MzkyMzQxMzA4ZDZjYzM2YWY0OTgwMWE2YTEwZWUxNjJiODkwOTgwXzB4NTZlZGRiN2FhODc1MzZjMDljY2MyNzkzNDczNTk5ZmQyMWE4YjE3Zl8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17224823,
-              "hash": "0x97184a2d68481fd53d90170a6392341308d6cc36af49801a6a10ee162b890980",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x56eddb7aa87536c09ccc2793473599fd21a8b17f",
-              "nonce": 4817368,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDU2ZWRkYjdhYTg3NTM2YzA5Y2NjMjc5MzQ3MzU5OWZkMjFhOGIxN2ZfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4OTcxODRhMmQ2ODQ4MWZkNTNkOTAxNzBhNjM5MjM0MTMwOGQ2Y2MzNmFmNDk4MDFhNmExMGVlMTYyYjg5MDk4MA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.0236",
-                "sender": "0x56eddb7aa87536c09ccc2793473599fd21a8b17f",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjQzLjE4MDIxMl9VU0Q=",
-                  "currency": "USD",
-                  "value": 43.180212,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnME1tUm1NekF6WmpnMFpHSTRZbVZoTm1GaU9ERXhOV0k1T1RrM05UQmxaVEkzT0dZeE9HWmpZalV4T1RBek5tUmhPV1EzT0RnNU16Y3lZek01TldSa1h6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHUmxOR1F6WVRJME5XUXlZall4WW1WaE1tTmlaREl4TmpVNE1XVXlaR1ZrTmpWbFl6azFNRFE9",
-            "timestamp": 1683658811,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg0MmRmMzAzZjg0ZGI4YmVhNmFiODExNWI5OTk3NTBlZTI3OGYxOGZjYjUxOTAzNmRhOWQ3ODg5MzcyYzM5NWRkXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGRlNGQzYTI0NWQyYjYxYmVhMmNiZDIxNjU4MWUyZGVkNjVlYzk1MDQ=",
-              "blockNumber": 17224823,
-              "hash": "0x42df303f84db8bea6ab8115b999750ee278f18fcb519036da9d7889372c395dd",
-              "status": "CONFIRMED",
-              "to": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 457,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhkZTRkM2EyNDVkMmI2MWJlYTJjYmQyMTY1ODFlMmRlZDY1ZWM5NTA0XzB4NDJkZjMwM2Y4NGRiOGJlYTZhYjgxMTViOTk5NzUwZWUyNzhmMThmY2I1MTkwMzZkYTlkNzg4OTM3MmMzOTVkZA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00021239999999999",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuMzg4NjIxOTA3OTk5OTgxNzVfVVNE",
-                  "currency": "USD",
-                  "value": 0.38862190799998175,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnM05UTXpOalF5WWpFME4yUTJZelF4Wm1aaU1UVmpPVFk1TkdOaE0yVXhORFV6Tm1FMFlUazBOelZrWW1GaE5qVmtZekptTkRnd09UUXpPR0l3TkdVM1h6QjRaVEpoWkRFeE1tVTFNV1kzT0dRd05USTBPR0l5TW1JeE0ySTNNVEptTXpKa04yVTFNelV3TVY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1683455399,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg3NTMzNjQyYjE0N2Q2YzQxZmZiMTVjOTY5NGNhM2UxNDUzNmE0YTk0NzVkYmFhNjVkYzJmNDgwOTQzOGIwNGU3XzB4ZTJhZDExMmU1MWY3OGQwNTI0OGIyMmIxM2I3MTJmMzJkN2U1MzUwMV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17208080,
-              "hash": "0x7533642b147d6c41ffb15c9694ca3e14536a4a9475dbaa65dc2f4809438b04e7",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0xe2ad112e51f78d05248b22b13b712f32d7e53501",
-              "nonce": 26,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGUyYWQxMTJlNTFmNzhkMDUyNDhiMjJiMTNiNzEyZjMyZDdlNTM1MDFfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4NzUzMzY0MmIxNDdkNmM0MWZmYjE1Yzk2OTRjYTNlMTQ1MzZhNGE5NDc1ZGJhYTY1ZGMyZjQ4MDk0MzhiMDRlNw==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.18",
-                "sender": "0xe2ad112e51f78d05248b22b13b712f32d7e53501",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjMyOS4zNDA2X1VTRA==",
-                  "currency": "USD",
-                  "value": 329.3406,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhneU5EQTNNekZtWm1WbU5EUmtNR1ZqT0RBNE1XRXpabVprWTJRM1ptWTNNalZsWXpBMU9EVmlNekl5T1RkbVlqUTJNREJqTmpsaFltSTRZbVF3WkdVMVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWTFZekZoTnpCbU5qY3pPV0k1TW1ZNU4yTmtOVE5qTXpFMk1ETTJNbU14TXpBMVpUa3hZVGc9",
-            "timestamp": 1683455399,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgyNDA3MzFmZmVmNDRkMGVjODA4MWEzZmZkY2Q3ZmY3MjVlYzA1ODViMzIyOTdmYjQ2MDBjNjlhYmI4YmQwZGU1XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGY1YzFhNzBmNjczOWI5MmY5N2NkNTNjMzE2MDM2MmMxMzA1ZTkxYTg=",
-              "blockNumber": 17208080,
-              "hash": "0x240731ffef44d0ec8081a3ffdcd7ff725ec0585b32297fb4600c69abb8bd0de5",
-              "status": "CONFIRMED",
-              "to": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 456,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmNWMxYTcwZjY3MzliOTJmOTdjZDUzYzMxNjAzNjJjMTMwNWU5MWE4XzB4MjQwNzMxZmZlZjQ0ZDBlYzgwODFhM2ZmZGNkN2ZmNzI1ZWMwNTg1YjMyMjk3ZmI0NjAwYzY5YWJiOGJkMGRlNQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.002700000000019696",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjQuOTQwMTA5MDAwMDM2MDM3NV9VU0Q=",
-                  "currency": "USD",
-                  "value": 4.9401090000360375,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaE56VmlNakl3T0RrM01HRmxZalV6WVRabE9HUTBaVFF4WWpsbU9XSXlOV1JsWVRRMk9XVmxObVUwTXpnNE56azRNemczTVRRNVltVTNOV1JsWWpSbVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHUmxOR1F6WVRJME5XUXlZall4WW1WaE1tTmlaREl4TmpVNE1XVXlaR1ZrTmpWbFl6azFNRFE9",
-            "timestamp": 1683195179,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhhNzViMjIwODk3MGFlYjUzYTZlOGQ0ZTQxYjlmOWIyNWRlYTQ2OWVlNmU0Mzg4Nzk4Mzg3MTQ5YmU3NWRlYjRmXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGRlNGQzYTI0NWQyYjYxYmVhMmNiZDIxNjU4MWUyZGVkNjVlYzk1MDQ=",
-              "blockNumber": 17186637,
-              "hash": "0xa75b2208970aeb53a6e8d4e41b9f9b25dea469ee6e4388798387149be75deb4f",
-              "status": "CONFIRMED",
-              "to": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 455,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhkZTRkM2EyNDVkMmI2MWJlYTJjYmQyMTY1ODFlMmRlZDY1ZWM5NTA0XzB4YTc1YjIyMDg5NzBhZWI1M2E2ZThkNGU0MWI5ZjliMjVkZWE0NjllZTZlNDM4ODc5ODM4NzE0OWJlNzVkZWI0Zg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000501491629081394",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuOTE3NTY0MTg4OTgxMzU0M19VU0Q=",
-                  "currency": "USD",
-                  "value": 0.9175641889813543,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnek1UTTNORGt3WlRnek1URmhOVGsxTkRNMll6bGhOemcyWXprMk5UVmhNemN6TkRnM01EVXdNVFEyTVdSbFpHSXpOamd4T0dVME9XWmlOamd4T0RabVh6QjRPR000WkRkak5EWXlNVGxrT1RJd05XWXdOVFptTWpobVpXVTFPVFV3WVdRMU5qUmtOelEyTlY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1683195179,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgzMTM3NDkwZTgzMTFhNTk1NDM2YzlhNzg2Yzk2NTVhMzczNDg3MDUwMTQ2MWRlZGIzNjgxOGU0OWZiNjgxODZmXzB4OGM4ZDdjNDYyMTlkOTIwNWYwNTZmMjhmZWU1OTUwYWQ1NjRkNzQ2NV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17186637,
-              "hash": "0x3137490e8311a595436c9a786c9655a3734870501461dedb36818e49fb68186f",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x8c8d7c46219d9205f056f28fee5950ad564d7465",
-              "nonce": 321141,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDhjOGQ3YzQ2MjE5ZDkyMDVmMDU2ZjI4ZmVlNTk1MGFkNTY0ZDc0NjVfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4MzEzNzQ5MGU4MzExYTU5NTQzNmM5YTc4NmM5NjU1YTM3MzQ4NzA1MDE0NjFkZWRiMzY4MThlNDlmYjY4MTg2Zg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.055721292120156088",
-                "sender": "0x8c8d7c46219d9205f056f28fee5950ad564d7465",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjEwMS45NTE1NzY1NTM0ODU5OV9VU0Q=",
-                  "currency": "USD",
-                  "value": 101.95157655348599,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNFpETTVZVFE0TVRaallXVTJNVEF5TkdKaU9Ea3pPR0k1WWpKaFlqWmtPRFkyWVRFM09HWTVZV0ptWXpBMU0yWmxOemszTjJSaE5EWTJNbUU0TVRJNVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWTFZekZoTnpCbU5qY3pPV0k1TW1ZNU4yTmtOVE5qTXpFMk1ETTJNbU14TXpBMVpUa3hZVGc9",
-            "timestamp": 1681944875,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg4ZDM5YTQ4MTZjYWU2MTAyNGJiODkzOGI5YjJhYjZkODY2YTE3OGY5YWJmYzA1M2ZlNzk3N2RhNDY2MmE4MTI5XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGY1YzFhNzBmNjczOWI5MmY5N2NkNTNjMzE2MDM2MmMxMzA1ZTkxYTg=",
-              "blockNumber": 17083726,
-              "hash": "0x8d39a4816cae61024bb8938b9b2ab6d866a178f9abfc053fe7977da4662a8129",
-              "status": "CONFIRMED",
-              "to": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 454,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmNWMxYTcwZjY3MzliOTJmOTdjZDUzYzMxNjAzNjJjMTMwNWU5MWE4XzB4OGQzOWE0ODE2Y2FlNjEwMjRiYjg5MzhiOWIyYWI2ZDg2NmExNzhmOWFiZmMwNTNmZTc5NzdkYTQ2NjJhODEyOQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000052571933376091",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuMDk2MTg5Mjg5MzQwMjMyNDJfVVNE",
-                  "currency": "USD",
-                  "value": 0.09618928934023242,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMk1qVXpPVGxqT0RSaVpqVmtOVFptT1RZNVpEVTJObUZsWkdNeVpHUmhPV0ZpWTJZM01qZGpNamN5WVdKbVkyUmhPRGt3WlRKbE16STBNRE0wTkRSbVh6QjRNbVZoWm1OaFpEWmlNbU0zWkRFNVpXVmlabU14WVdaa016RTRZbUUwT0RFM01EWmpObVEzTkY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681944875,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg2MjUzOTljODRiZjVkNTZmOTY5ZDU2NmFlZGMyZGRhOWFiY2Y3MjdjMjcyYWJmY2RhODkwZTJlMzI0MDM0NDRmXzB4MmVhZmNhZDZiMmM3ZDE5ZWViZmMxYWZkMzE4YmE0ODE3MDZjNmQ3NF8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17083726,
-              "hash": "0x625399c84bf5d56f969d566aedc2dda9abcf727c272abfcda890e2e32403444f",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x2eafcad6b2c7d19eebfc1afd318ba481706c6d74",
-              "nonce": 7,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDJlYWZjYWQ2YjJjN2QxOWVlYmZjMWFmZDMxOGJhNDgxNzA2YzZkNzRfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4NjI1Mzk5Yzg0YmY1ZDU2Zjk2OWQ1NjZhZWRjMmRkYTlhYmNmNzI3YzI3MmFiZmNkYTg5MGUyZTMyNDAzNDQ0Zg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.003",
-                "sender": "0x2eafcad6b2c7d19eebfc1afd318ba481706c6d74",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjUuNDg5MDFfVVNE",
-                  "currency": "USD",
-                  "value": 5.48901,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhneE5HRXlZamsyTVRFM05UWmpZMll3WkdFeFlUQTNaR1E0TTJFeU9XTTNObVF6TXpWaVpXWmxaVFpqTlRKa1pEZzVOVE00TnpNNVlXVm1aV000TURZd1h6QjROelU1WTJaa01ERXdaak0xT1dWbFpqQTRNelZoTURsaE5UZzBOVEl4TkdFME4yUTBNRFkwWWw4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681928591,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgxNGEyYjk2MTE3NTZjY2YwZGExYTA3ZGQ4M2EyOWM3NmQzMzViZWZlZTZjNTJkZDg5NTM4NzM5YWVmZWM4MDYwXzB4NzU5Y2ZkMDEwZjM1OWVlZjA4MzVhMDlhNTg0NTIxNGE0N2Q0MDY0Yl8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17082396,
-              "hash": "0x14a2b9611756ccf0da1a07dd83a29c76d335befee6c52dd89538739aefec8060",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x759cfd010f359eef0835a09a5845214a47d4064b",
-              "nonce": 7,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDc1OWNmZDAxMGYzNTllZWYwODM1YTA5YTU4NDUyMTRhNDdkNDA2NGJfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4MTRhMmI5NjExNzU2Y2NmMGRhMWEwN2RkODNhMjljNzZkMzM1YmVmZWU2YzUyZGQ4OTUzODczOWFlZmVjODA2MA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000504795557799091",
-                "sender": "0x759cfd010f359eef0835a09a5845214a47d4064b",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuOTIzNjA5Mjg4MjM4MjYyOV9VU0Q=",
-                  "currency": "USD",
-                  "value": 0.9236092882382629,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnell6VTROamcxWW1Oak5qY3dOV0l5TmpRMk1HRmpOVFV4Wm1RMk5UZG1PRGhpWVRZd05EYzNObVJtTUdZNU16TTBZVFJrWVRNellUTXdOR1E1WW1VNVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWTFZekZoTnpCbU5qY3pPV0k1TW1ZNU4yTmtOVE5qTXpFMk1ETTJNbU14TXpBMVpUa3hZVGc9",
-            "timestamp": 1681848887,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgzYzU4Njg1YmNjNjcwNWIyNjQ2MGFjNTUxZmQ2NTdmODhiYTYwNDc3NmRmMGY5MzM0YTRkYTMzYTMwNGQ5YmU5XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGY1YzFhNzBmNjczOWI5MmY5N2NkNTNjMzE2MDM2MmMxMzA1ZTkxYTg=",
-              "blockNumber": 17075856,
-              "hash": "0x3c58685bcc6705b26460ac551fd657f88ba604776df0f9334a4da33a304d9be9",
-              "status": "CONFIRMED",
-              "to": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 453,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmNWMxYTcwZjY3MzliOTJmOTdjZDUzYzMxNjAzNjJjMTMwNWU5MWE4XzB4M2M1ODY4NWJjYzY3MDViMjY0NjBhYzU1MWZkNjU3Zjg4YmE2MDQ3NzZkZjBmOTMzNGE0ZGEzM2EzMDRkOWJlOQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.001500000000003999",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuNzQ0NTA1MDAwMDA3MzE3X1VTRA==",
-                  "currency": "USD",
-                  "value": 2.744505000007317,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnek9HVmpObUprTUdSbVpUUXhOell5T0dWak9USTBNVEU1TVRZMk9UQTJZbVUzWXpoaE9UUm1NV1UwTXpSaFkyWmtZbUptTURneE9EVm1aall5TTJZMVh6QjROMkl4TmpVeU5tSTFPV1ptWXpKa05qVmlOREUxTlRFME9USTFNV1pqWXpNMVptUXlaVE0yTmw4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681848887,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgzOGVjNmJkMGRmZTQxNzYyOGVjOTI0MTE5MTY2OTA2YmU3YzhhOTRmMWU0MzRhY2ZkYmJmMDgxODVmZjYyM2Y1XzB4N2IxNjUyNmI1OWZmYzJkNjViNDE1NTE0OTI1MWZjYzM1ZmQyZTM2Nl8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17075856,
-              "hash": "0x38ec6bd0dfe417628ec924119166906be7c8a94f1e434acfdbbf08185ff623f5",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x7b16526b59ffc2d65b4155149251fcc35fd2e366",
-              "nonce": 56,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDdiMTY1MjZiNTlmZmMyZDY1YjQxNTUxNDkyNTFmY2MzNWZkMmUzNjZfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4MzhlYzZiZDBkZmU0MTc2MjhlYzkyNDExOTE2NjkwNmJlN2M4YTk0ZjFlNDM0YWNmZGJiZjA4MTg1ZmY2MjNmNQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.1",
-                "sender": "0x7b16526b59ffc2d65b4155149251fcc35fd2e366",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjE4Mi45NjdfVVNE",
-                  "currency": "USD",
-                  "value": 182.967,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNU9EUTRNekptTTJaaVpqRmpNamMwT0Rrd1lqYzBPR0V3WkdFd05EQTVNVFZtTWprd016ZzRZamcyTnpWbE9UQm1ZVEF6TmpVelpqQTFaVEJpWVdGbFh6QjRZbUV4TjJWbFlqTm1NRFF4TTJJM05qRTROR0poT0dWa056TXdOamN3TmpObVltRTJaVEpsWWw4d2VHUXhOVEptTlRRNU5UUTFNRGt6TXpRM1lURTJNbVJqWlRJeE1HVTNNamt6WmpFME5USXhOVEE9",
-            "timestamp": 1681834523,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg5ODQ4MzJmM2ZiZjFjMjc0ODkwYjc0OGEwZGEwNDA5MTVmMjkwMzg4Yjg2NzVlOTBmYTAzNjUzZjA1ZTBiYWFlXzB4YmExN2VlYjNmMDQxM2I3NjE4NGJhOGVkNzMwNjcwNjNmYmE2ZTJlYl8weGQxNTJmNTQ5NTQ1MDkzMzQ3YTE2MmRjZTIxMGU3MjkzZjE0NTIxNTA=",
-              "blockNumber": 17074676,
-              "hash": "0x984832f3fbf1c274890b748a0da040915f290388b8675e90fa03653f05e0baae",
-              "status": "CONFIRMED",
-              "to": "0xd152f549545093347a162dce210e7293f1452150",
-              "from": "0xba17eeb3f0413b76184ba8ed73067063fba6e2eb",
-              "nonce": 171,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGQxNTJmNTQ5NTQ1MDkzMzQ3YTE2MmRjZTIxMGU3MjkzZjE0NTIxNTBfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4OTg0ODMyZjNmYmYxYzI3NDg5MGI3NDhhMGRhMDQwOTE1ZjI5MDM4OGI4Njc1ZTkwZmEwMzY1M2YwNWUwYmFhZQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.005",
-                "sender": "0xd152f549545093347a162dce210e7293f1452150",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjkuMTQ4MzVfVVNE",
-                  "currency": "USD",
-                  "value": 9.14835,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNE1ERXpOMk0wTW1VM05tRXlNakEyWVRoak5EZzVZalppT0RRMFl6VTVOREl5TkRSak4yVmhOems1T1RneE1USTVabUprWkRjd1lXUTJZMlZpTURnMVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VERTNaamM1WlRjd1lXVTRPV00yWlRNeVlUa3lORFJrTTJRMU4ySTNZV0UyTkRneU5EWTBOamc9",
-            "timestamp": 1681834523,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg4MDEzN2M0MmU3NmEyMjA2YThjNDg5YjZiODQ0YzU5NDIyNDRjN2VhNzk5OTgxMTI5ZmJkZDcwYWQ2Y2ViMDg1XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDE3Zjc5ZTcwYWU4OWM2ZTMyYTkyNDRkM2Q1N2I3YWE2NDgyNDY0Njg=",
-              "blockNumber": 17074676,
-              "hash": "0x80137c42e76a2206a8c489b6b844c5942244c7ea799981129fbdd70ad6ceb085",
-              "status": "CONFIRMED",
-              "to": "0x17f79e70ae89c6e32a9244d3d57b7aa648246468",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 452,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHgxN2Y3OWU3MGFlODljNmUzMmE5MjQ0ZDNkNTdiN2FhNjQ4MjQ2NDY4XzB4ODAxMzdjNDJlNzZhMjIwNmE4YzQ4OWI2Yjg0NGM1OTQyMjQ0YzdlYTc5OTk4MTEyOWZiZGQ3MGFkNmNlYjA4NQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.001480000000018959",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x17f79e70ae89c6e32a9244d3d57b7aa648246468",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuNzA3OTExNjAwMDM0Njg5X1VTRA==",
-                  "currency": "USD",
-                  "value": 2.707911600034689,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoak9URmlZVFl4TW1KaFkyVTROalExTmpZeE9UQTBaRFkzTVRreVl6WTJZV1EzTW1KaU5tTmhOR0ZtTlRsaE5HSmtZMll5WkRNeFptSmxNVFZpTlRjeVh6QjROVFpsWkdSaU4yRmhPRGMxTXpaak1EbGpZMk15Tnprek5EY3pOVGs1Wm1ReU1XRTRZakUzWmw4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681807523,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhjOTFiYTYxMmJhY2U4NjQ1NjYxOTA0ZDY3MTkyYzY2YWQ3MmJiNmNhNGFmNTlhNGJkY2YyZDMxZmJlMTViNTcyXzB4NTZlZGRiN2FhODc1MzZjMDljY2MyNzkzNDczNTk5ZmQyMWE4YjE3Zl8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17072474,
-              "hash": "0xc91ba612bace8645661904d67192c66ad72bb6ca4af59a4bdcf2d31fbe15b572",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x56eddb7aa87536c09ccc2793473599fd21a8b17f",
-              "nonce": 4681363,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDU2ZWRkYjdhYTg3NTM2YzA5Y2NjMjc5MzQ3MzU5OWZkMjFhOGIxN2ZfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4YzkxYmE2MTJiYWNlODY0NTY2MTkwNGQ2NzE5MmM2NmFkNzJiYjZjYTRhZjU5YTRiZGNmMmQzMWZiZTE1YjU3Mg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.0093824",
-                "sender": "0x56eddb7aa87536c09ccc2793473599fd21a8b17f",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjE3LjE2NjY5NTgwODAwMDAwNF9VU0Q=",
-                  "currency": "USD",
-                  "value": 17.166695808000004,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaU1ERmhaVEk1TmpZeU16UTFNek5sTUdFNE5XWmhOalk0TVRBMVpEY3hPV0V6T0dVeVpHUm1OalEyT0RsaU5USm1PR1V5TXpnNE16RmlNMlpsT1Rsalh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHUmxOR1F6WVRJME5XUXlZall4WW1WaE1tTmlaREl4TmpVNE1XVXlaR1ZrTmpWbFl6azFNRFE9",
-            "timestamp": 1681807523,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhiMDFhZTI5NjYyMzQ1MzNlMGE4NWZhNjY4MTA1ZDcxOWEzOGUyZGRmNjQ2ODliNTJmOGUyMzg4MzFiM2ZlOTljXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGRlNGQzYTI0NWQyYjYxYmVhMmNiZDIxNjU4MWUyZGVkNjVlYzk1MDQ=",
-              "blockNumber": 17072474,
-              "hash": "0xb01ae2966234533e0a85fa668105d719a38e2ddf64689b52f8e238831b3fe99c",
-              "status": "CONFIRMED",
-              "to": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 451,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhkZTRkM2EyNDVkMmI2MWJlYTJjYmQyMTY1ODFlMmRlZDY1ZWM5NTA0XzB4YjAxYWUyOTY2MjM0NTMzZTBhODVmYTY2ODEwNWQ3MTlhMzhlMmRkZjY0Njg5YjUyZjhlMjM4ODMxYjNmZTk5Yw==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00008444159999999",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xde4d3a245d2b61bea2cbd216581e2ded65ec9504",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuMTU0NTAwMjYyMjcxOTgxNzFfVVNE",
-                  "currency": "USD",
-                  "value": 0.15450026227198171,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMVpUWXhZMlkwWVRkbU56QXdNekU1TkdNeE9HWTJPV1V6WVRBeVpEZ3pZMkV5TnpFelpHRTJabU00WXpObVlXRmpPVEZsWVRjNVpqbGxNMlF5WTJNelh6QjRaR0poWkRaaFpqQmtNVEptWVdNMk1tRXhNV1kxTm1VMVpUZzBPRGcxWWpoaVpUSXlOR1ppWkY4d2VHRXdZamcyT1RreFl6WXlNVGhpTXpaak1XUXhPV1EwWVRKbE9XVmlNR05sTXpZd05tVmlORGc9",
-            "timestamp": 1681715519,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg1ZTYxY2Y0YTdmNzAwMzE5NGMxOGY2OWUzYTAyZDgzY2EyNzEzZGE2ZmM4YzNmYWFjOTFlYTc5ZjllM2QyY2MzXzB4ZGJhZDZhZjBkMTJmYWM2MmExMWY1NmU1ZTg0ODg1YjhiZTIyNGZiZF8weGEwYjg2OTkxYzYyMThiMzZjMWQxOWQ0YTJlOWViMGNlMzYwNmViNDg=",
-              "blockNumber": 17064946,
-              "hash": "0x5e61cf4a7f7003194c18f69e3a02d83ca2713da6fc8c3faac91ea79f9e3d2cc3",
-              "status": "CONFIRMED",
-              "to": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-              "from": "0xdbad6af0d12fac62a11f56e5e84885b8be224fbd",
-              "nonce": 28,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhlMjkwYzVmZWRlODMyNDgzNDAwMzMzNWJmNjc1NDQ5ODQyZDVhZjc4XzB4NWU2MWNmNGE3ZjcwMDMxOTRjMThmNjllM2EwMmQ4M2NhMjcxM2RhNmZjOGMzZmFhYzkxZWE3OWY5ZTNkMmNjMw==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fMHhhMGI4Njk5MWM2MjE4YjM2YzFkMTlkNGEyZTllYjBjZTM2MDZlYjQ4",
-                  "name": "USD Coin",
-                  "symbol": "USDC",
-                  "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-                  "decimals": 6,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4YTBiODY5OTFjNjIxOGIzNmMxZDE5ZDRhMmU5ZWIwY2UzNjA2ZWI0OA==",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL1VuaXN3YXAvYXNzZXRzL21hc3Rlci9ibG9ja2NoYWlucy9ldGhlcmV1bS9hc3NldHMvMHhBMGI4Njk5MWM2MjE4YjM2YzFkMTlENGEyZTlFYjBjRTM2MDZlQjQ4L2xvZ28ucG5n",
-                      "url": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "ERC20",
-                "quantity": "7.2",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xe290c5fede8324834003335bf675449842d5af78",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjcuMjA0OTY1OTQxODQ2NjdfVVNE",
-                  "currency": "USD",
-                  "value": 7.20496594184667,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhneE1UUm1NR1k0TjJSaE9HTTBOR1UyT1RFeFptWTRZekEwT1dRelltTTRNRFUyTlRFNFpHWmlOV1JqWm1JM01qVTVZekkzT1Rnd09UbGpZVEl3TjJSalh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681714535,
-            "type": "UNKNOWN",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgxMTRmMGY4N2RhOGM0NGU2OTExZmY4YzA0OWQzYmM4MDU2NTE4ZGZiNWRjZmI3MjU5YzI3OTgwOTljYTIwN2RjXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17064865,
-              "hash": "0x114f0f87da8c44e6911ff8c049d3bc8056518dfb5dcfb7259c2798099ca207dc",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 450,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhobU1EQXlPVEl3TWpRd1ptUTNaV05sTldNMk5tTXpZakJsTnpZME4yWTRZVFEzTXpnME4yTTROVGd5TlRoaE9UUTNZV0kyWlRFNU1XUXlNVGt3TVdNd1h6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHRXdZamcyT1RreFl6WXlNVGhpTXpaak1XUXhPV1EwWVRKbE9XVmlNR05sTXpZd05tVmlORGc9",
-            "timestamp": 1681714523,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhmMDAyOTIwMjQwZmQ3ZWNlNWM2NmMzYjBlNzY0N2Y4YTQ3Mzg0N2M4NTgyNThhOTQ3YWI2ZTE5MWQyMTkwMWMwXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGEwYjg2OTkxYzYyMThiMzZjMWQxOWQ0YTJlOWViMGNlMzYwNmViNDg=",
-              "blockNumber": 17064864,
-              "hash": "0xf002920240fd7ece5c66c3b0e7647f8a473847c858258a947ab6e191d21901c0",
-              "status": "CONFIRMED",
-              "to": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 449,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHgwMDYwMDBlMDAwNzMwMGVmYjFmZDg1MDAwZDAwNDY5NTY0MDBmODhjXzB4ZjAwMjkyMDI0MGZkN2VjZTVjNjZjM2IwZTc2NDdmOGE0NzM4NDdjODU4MjU4YTk0N2FiNmUxOTFkMjE5MDFjMA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fMHhhMGI4Njk5MWM2MjE4YjM2YzFkMTlkNGEyZTllYjBjZTM2MDZlYjQ4",
-                  "name": "USD Coin",
-                  "symbol": "USDC",
-                  "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-                  "decimals": 6,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4YTBiODY5OTFjNjIxOGIzNmMxZDE5ZDRhMmU5ZWIwY2UzNjA2ZWI0OA==",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL1VuaXN3YXAvYXNzZXRzL21hc3Rlci9ibG9ja2NoYWlucy9ldGhlcmV1bS9hc3NldHMvMHhBMGI4Njk5MWM2MjE4YjM2YzFkMTlENGEyZTlFYjBjRTM2MDZlQjQ4L2xvZ28ucG5n",
-                      "url": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "ERC20",
-                "quantity": "27.25",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x006000e0007300efb1fd85000d0046956400f88c",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjI3LjI2ODc5NDcxMDQ2MTM1NF9VU0Q=",
-                  "currency": "USD",
-                  "value": 27.268794710461354,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhobE16SmxOMkV3T0ROa05XRXpaVFkwTXpSbE9HUmpNMkpqWlRFeE1qUmlNekpoTVRkaVpUTmxNVEV3T0RGak56WXlNRGhpT1RsaVlUYzBNbUZtTlRFeVh6QjROakF5Tm1aaU1qSTJaakl3TlRRNFpEWTRZVGRoWXpCa1ptUTFPRFJtWXpBMU1URXhNMlJoTlY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681714523,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhlMzJlN2EwODNkNWEzZTY0MzRlOGRjM2JjZTExMjRiMzJhMTdiZTNlMTEwODFjNzYyMDhiOTliYTc0MmFmNTEyXzB4NjAyNmZiMjI2ZjIwNTQ4ZDY4YTdhYzBkZmQ1ODRmYzA1MTExM2RhNV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17064864,
-              "hash": "0xe32e7a083d5a3e6434e8dc3bce1124b32a17be3e11081c76208b99ba742af512",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x6026fb226f20548d68a7ac0dfd584fc051113da5",
-              "nonce": 251,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDYwMjZmYjIyNmYyMDU0OGQ2OGE3YWMwZGZkNTg0ZmMwNTExMTNkYTVfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4ZTMyZTdhMDgzZDVhM2U2NDM0ZThkYzNiY2UxMTI0YjMyYTE3YmUzZTExMDgxYzc2MjA4Yjk5YmE3NDJhZjUxMg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00233796419336",
-                "sender": "0x6026fb226f20548d68a7ac0dfd584fc051113da5",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjQuMjc3NzAyOTQ1NjY0OTkxX1VTRA==",
-                  "currency": "USD",
-                  "value": 4.277702945664991,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaE5URmhZVFk1WVdOa1pUTmlOR1EyWVRVME1ERXpNbUl3T0daaVl6RTFZVEkwWTJabE9XRm1ObVJqWTJabVlUWmtNbVZoTjJVNU1qTXpObVU0TkRFeVh6QjRaVGs1TXpRNE5tSXlOVGRqWkRFME9ERmhaV1kzTkdJellqa3dPV0V5TmpJM1ptTTRaRE13TlY4d2VHUXhOVEptTlRRNU5UUTFNRGt6TXpRM1lURTJNbVJqWlRJeE1HVTNNamt6WmpFME5USXhOVEE9",
-            "timestamp": 1681714523,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhhNTFhYTY5YWNkZTNiNGQ2YTU0MDEzMmIwOGZiYzE1YTI0Y2ZlOWFmNmRjY2ZmYTZkMmVhN2U5MjMzNmU4NDEyXzB4ZTk5MzQ4NmIyNTdjZDE0ODFhZWY3NGIzYjkwOWEyNjI3ZmM4ZDMwNV8weGQxNTJmNTQ5NTQ1MDkzMzQ3YTE2MmRjZTIxMGU3MjkzZjE0NTIxNTA=",
-              "blockNumber": 17064864,
-              "hash": "0xa51aa69acde3b4d6a540132b08fbc15a24cfe9af6dccffa6d2ea7e92336e8412",
-              "status": "CONFIRMED",
-              "to": "0xd152f549545093347a162dce210e7293f1452150",
-              "from": "0xe993486b257cd1481aef74b3b909a2627fc8d305",
-              "nonce": 420,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGQxNTJmNTQ5NTQ1MDkzMzQ3YTE2MmRjZTIxMGU3MjkzZjE0NTIxNTBfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4YTUxYWE2OWFjZGUzYjRkNmE1NDAxMzJiMDhmYmMxNWEyNGNmZTlhZjZkY2NmZmE2ZDJlYTdlOTIzMzZlODQxMg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fMHhhMGI4Njk5MWM2MjE4YjM2YzFkMTlkNGEyZTllYjBjZTM2MDZlYjQ4",
-                  "name": "USD Coin",
-                  "symbol": "USDC",
-                  "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-                  "decimals": 6,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4YTBiODY5OTFjNjIxOGIzNmMxZDE5ZDRhMmU5ZWIwY2UzNjA2ZWI0OA==",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL1VuaXN3YXAvYXNzZXRzL21hc3Rlci9ibG9ja2NoYWlucy9ldGhlcmV1bS9hc3NldHMvMHhBMGI4Njk5MWM2MjE4YjM2YzFkMTlENGEyZTlFYjBjRTM2MDZlQjQ4L2xvZ28ucG5n",
-                      "url": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "ERC20",
-                "quantity": "34.45",
-                "sender": "0xd152f549545093347a162dce210e7293f1452150",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjM0LjQ3Mzc2MDY1MjMwODAyX1VTRA==",
-                  "currency": "USD",
-                  "value": 34.47376065230802,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhobE0yWXhOMk0yTmpJd05HSmhaV0UyT1dZeU9UTTJNemMxTnpVeE1EVmlNemxrTkdaallqZ3lOVFptTVRZMk5qaGtNREpqT1RVMU4yUTNaRFEyTm1WbVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEUXlZemszWW1SallXTTFZakJqTlRkbFpEUmtNV05qTWpneFltWXpNalkyTWpZM1kyUm1aV0U9",
-            "timestamp": 1681396271,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhlM2YxN2M2NjIwNGJhZWE2OWYyOTM2Mzc1NzUxMDViMzlkNGZjYjgyNTZmMTY2NjhkMDJjOTU1N2Q3ZDQ2NmVmXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDQyYzk3YmRjYWM1YjBjNTdlZDRkMWNjMjgxYmYzMjY2MjY3Y2RmZWE=",
-              "blockNumber": 17039093,
-              "hash": "0xe3f17c66204baea69f293637575105b39d4fcb8256f16668d02c9557d7d466ef",
-              "status": "CONFIRMED",
-              "to": "0x42c97bdcac5b0c57ed4d1cc281bf3266267cdfea",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 448,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHg0MmM5N2JkY2FjNWIwYzU3ZWQ0ZDFjYzI4MWJmMzI2NjI2N2NkZmVhXzB4ZTNmMTdjNjYyMDRiYWVhNjlmMjkzNjM3NTc1MTA1YjM5ZDRmY2I4MjU2ZjE2NjY4ZDAyYzk1NTdkN2Q0NjZlZg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000000000000000195",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x42c97bdcac5b0c57ed4d1cc281bf3266267cdfea",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjMuNTY3ODU2NWUtMTNfVVNE",
-                  "currency": "USD",
-                  "value": 3.5678565E-13,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaE1HUTVPV05sWmpBM05UQTJOR0ZsTjJFMVpXWTNPR0V4WkRZeU1HUTROR1ZqTTJKaVpUQTJNVFE1TkRKak5HRmtNMkUyTkRreU1ERTVPV0l6TURGbVh6QjROREpqT1RkaVpHTmhZelZpTUdNMU4yVmtOR1F4WTJNeU9ERmlaak15TmpZeU5qZGpaR1psWVY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681396259,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhhMGQ5OWNlZjA3NTA2NGFlN2E1ZWY3OGExZDYyMGQ4NGVjM2JiZTA2MTQ5NDJjNGFkM2E2NDkyMDE5OWIzMDFmXzB4NDJjOTdiZGNhYzViMGM1N2VkNGQxY2MyODFiZjMyNjYyNjdjZGZlYV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17039092,
-              "hash": "0xa0d99cef075064ae7a5ef78a1d620d84ec3bbe0614942c4ad3a64920199b301f",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x42c97bdcac5b0c57ed4d1cc281bf3266267cdfea",
-              "nonce": 6,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDQyYzk3YmRjYWM1YjBjNTdlZDRkMWNjMjgxYmYzMjY2MjY3Y2RmZWFfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4YTBkOTljZWYwNzUwNjRhZTdhNWVmNzhhMWQ2MjBkODRlYzNiYmUwNjE0OTQyYzRhZDNhNjQ5MjAxOTliMzAxZg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.001",
-                "sender": "0x42c97bdcac5b0c57ed4d1cc281bf3266267cdfea",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjEuODI5NjcwMDAwMDAwMDAwMV9VU0Q=",
-                  "currency": "USD",
-                  "value": 1.8296700000000001,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnd09ETTBaRE13TXpnMU5EQmpPR1JtWVdKaFpUTmpabU5tWldOaFlXUmpPVEZoTm1JeU9URmxOemt6T1RRelpXRXhOV1ZqTW1SaE5XTTROamRtWldaalh6QjRNakZoTXpGbFpURmhabU0xTVdRNU5HTXlaV1pqWTJGaE1qQTVNbUZrTVRBeU9ESTROVFUwT1Y4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681364843,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgwODM0ZDMwMzg1NDBjOGRmYWJhZTNjZmNmZWNhYWRjOTFhNmIyOTFlNzkzOTQzZWExNWVjMmRhNWM4NjdmZWZjXzB4MjFhMzFlZTFhZmM1MWQ5NGMyZWZjY2FhMjA5MmFkMTAyODI4NTU0OV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17036754,
-              "hash": "0x0834d3038540c8dfabae3cfcfecaadc91a6b291e793943ea15ec2da5c867fefc",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x21a31ee1afc51d94c2efccaa2092ad1028285549",
-              "nonce": 6173944,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDIxYTMxZWUxYWZjNTFkOTRjMmVmY2NhYTIwOTJhZDEwMjgyODU1NDlfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4MDgzNGQzMDM4NTQwYzhkZmFiYWUzY2ZjZmVjYWFkYzkxYTZiMjkxZTc5Mzk0M2VhMTVlYzJkYTVjODY3ZmVmYw==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.0122865",
-                "sender": "0x21a31ee1afc51d94c2efccaa2092ad1028285549",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIyLjQ4MDI0MDQ1NV9VU0Q=",
-                  "currency": "USD",
-                  "value": 22.480240455,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnd05URXdNRGN5TlRFd1pHRmtOV1JrWldGaU5XWXhNamxrWW1ReE1tWXlOell6T0RVd1pEY3hOakExTkRobU5tVmtOREkyTVRjNVl6Y3haREF3Tm1NMVh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWTFZekZoTnpCbU5qY3pPV0k1TW1ZNU4yTmtOVE5qTXpFMk1ETTJNbU14TXpBMVpUa3hZVGc9",
-            "timestamp": 1681364843,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgwNTEwMDcyNTEwZGFkNWRkZWFiNWYxMjlkYmQxMmYyNzYzODUwZDcxNjA1NDhmNmVkNDI2MTc5YzcxZDAwNmM1XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGY1YzFhNzBmNjczOWI5MmY5N2NkNTNjMzE2MDM2MmMxMzA1ZTkxYTg=",
-              "blockNumber": 17036754,
-              "hash": "0x0510072510dad5ddeab5f129dbd12f2763850d7160548f6ed426179c71d006c5",
-              "status": "CONFIRMED",
-              "to": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 447,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmNWMxYTcwZjY3MzliOTJmOTdjZDUzYzMxNjAzNjJjMTMwNWU5MWE4XzB4MDUxMDA3MjUxMGRhZDVkZGVhYjVmMTI5ZGJkMTJmMjc2Mzg1MGQ3MTYwNTQ4ZjZlZDQyNjE3OWM3MWQwMDZjNQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000188437715080199",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xf5c1a70f6739b92f97cd53c3160362c1305e91a8",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuMzQ0Nzc4ODM0MTUwNzg3NzVfVVNE",
-                  "currency": "USD",
-                  "value": 0.34477883415078775,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnelpEZ3pOR05oTXpRMVlUUTBZMlU1TUdVNVpXUmxZVEkyT1RZNE9HRXhOREUzTWpsaU9HSTBOVE13T1dZeU1Ea3haRE5tWW1ZNE1HUmxOakV6TUdWbFh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEYzFZV1EwWXpVd05XVTFZalJpWWpZMVlqZ3pNbU01TVdWaU56WTFNamxqWlRBM01qSXdaakU9",
-            "timestamp": 1681051355,
-            "type": "UNKNOWN",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgzZDgzNGNhMzQ1YTQ0Y2U5MGU5ZWRlYTI2OTY4OGExNDE3MjliOGI0NTMwOWYyMDkxZDNmYmY4MGRlNjEzMGVlXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDc1YWQ0YzUwNWU1YjRiYjY1YjgzMmM5MWViNzY1MjljZTA3MjIwZjE=",
-              "blockNumber": 17011398,
-              "hash": "0x3d834ca345a44ce90e9edea269688a141729b8b45309f2091d3fbf80de6130ee",
-              "status": "CONFIRMED",
-              "to": "0x75ad4c505e5b4bb65b832c91eb76529ce07220f1",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 446,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhneU9EYzFORFJsTlRNNU0yVXdPREJrWkRjd1lXWmxZalJrTldObFpHWTNNalJqWmpWa1lURmtPV1UxWkdNd01qUXpaalF4TURKbVlUQXpOVE00TWpJeVh6QjROak0xTmpBNE5HTmpNemt5WmpZMVpUUmpaV0UxWkRrNU1UaGxZalppTkdabE56UmpPREE0TTE4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1681051355,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgyODc1NDRlNTM5M2UwODBkZDcwYWZlYjRkNWNlZGY3MjRjZjVkYTFkOWU1ZGMwMjQzZjQxMDJmYTAzNTM4MjIyXzB4NjM1NjA4NGNjMzkyZjY1ZTRjZWE1ZDk5MThlYjZiNGZlNzRjODA4M18weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 17011398,
-              "hash": "0x287544e5393e080dd70afeb4d5cedf724cf5da1d9e5dc0243f4102fa03538222",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x6356084cc392f65e4cea5d9918eb6b4fe74c8083",
-              "nonce": 28,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDYzNTYwODRjYzM5MmY2NWU0Y2VhNWQ5OTE4ZWI2YjRmZTc0YzgwODNfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4Mjg3NTQ0ZTUzOTNlMDgwZGQ3MGFmZWI0ZDVjZWRmNzI0Y2Y1ZGExZDllNWRjMDI0M2Y0MTAyZmEwMzUzODIyMg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.003221777364824592",
-                "sender": "0x6356084cc392f65e4cea5d9918eb6b4fe74c8083",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjUuODk0Nzg5MzkxMDk4NjExNl9VU0Q=",
-                  "currency": "USD",
-                  "value": 5.8947893910986116,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaFpXUXpPR0prWkRReE1XSXpPVEkyTnpWak9UWTJZVEpoWVRjeFpqRXhOekJsTm1Jek9HTmhaV000T1RZNFl6QXhObVUyT1RKbFlXTXlaRGxpWmpjMFh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VHWmtNbVprWkRaaVpUQTFaVFF5Wm1NNE9XVXdOekZpTW1ZMVpEUTBObUppTVdGa1pEVm1ORFE9",
-            "timestamp": 1680897971,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhhZWQzOGJkZDQxMWIzOTI2NzVjOTY2YTJhYTcxZjExNzBlNmIzOGNhZWM4OTY4YzAxNmU2OTJlYWMyZDliZjc0XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weGZkMmZkZDZiZTA1ZTQyZmM4OWUwNzFiMmY1ZDQ0NmJiMWFkZDVmNDQ=",
-              "blockNumber": 16998855,
-              "hash": "0xaed38bdd411b392675c966a2aa71f1170e6b38caec8968c016e692eac2d9bf74",
-              "status": "CONFIRMED",
-              "to": "0xfd2fdd6be05e42fc89e071b2f5d446bb1add5f44",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 445,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHhmZDJmZGQ2YmUwNWU0MmZjODllMDcxYjJmNWQ0NDZiYjFhZGQ1ZjQ0XzB4YWVkMzhiZGQ0MTFiMzkyNjc1Yzk2NmEyYWE3MWYxMTcwZTZiMzhjYWVjODk2OGMwMTZlNjkyZWFjMmQ5YmY3NA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.00000000000001579",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0xfd2fdd6be05e42fc89e071b2f5d446bb1add5f44",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuODg5MDQ4OTMwMDAwMDAwNGUtMTFfVVNE",
-                  "currency": "USD",
-                  "value": 2.8890489300000004E-11,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoaFlUYzRaakUwTVRJNE9HUmhNVGRrT0RNNE5qbGxPVEk0TVRWbFpEQmhPREU1TWpjeU16ZzNOVGt5TldZeE1EZ3dZVFZsTWpOa09HSXdOekJsTXpVMlh6QjRNREF3TURCbE9HTTNPR1UwTmpFMk56aGxORFUxWWpGbU5qZzNPR0ppTUdObE5UQmpaVFU0TjE4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1680897959,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhhYTc4ZjE0MTI4OGRhMTdkODM4NjllOTI4MTVlZDBhODE5MjcyMzg3NTkyNWYxMDgwYTVlMjNkOGIwNzBlMzU2XzB4MDAwMDBlOGM3OGU0NjE2NzhlNDU1YjFmNjg3OGJiMGNlNTBjZTU4N18weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 16998854,
-              "hash": "0xaa78f141288da17d83869e92815ed0a8192723875925f1080a5e23d8b070e356",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x00000e8c78e461678e455b1f6878bb0ce50ce587",
-              "nonce": 28,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDAwMDAwZThjNzhlNDYxNjc4ZTQ1NWIxZjY4NzhiYjBjZTUwY2U1ODdfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4YWE3OGYxNDEyODhkYTE3ZDgzODY5ZTkyODE1ZWQwYTgxOTI3MjM4NzU5MjVmMTA4MGE1ZTIzZDhiMDcwZTM1Ng==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.004106843748088",
-                "sender": "0x00000e8c78e461678e455b1f6878bb0ce50ce587",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjcuNTE0MTY4ODAwNTY0MTcyX1VTRA==",
-                  "currency": "USD",
-                  "value": 7.514168800564172,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          null,
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhoalpEaG1OV0UxT0dGa01EQm1OVGczT0dZeU0yTTJNVEl4WVRSbFpqRXdOVGhtT1dJM1pEZGxNMlEyWTJZNFl6YzBZVEpoTVdGbE4ySmtNREptTW1WbFh6QjROV0UzWldNelpXSXhZakkyTkRRMllqaGhNelEyTXprM016TmlNRGRsTUdZd1pEQmpOamxoWTE4d2VERTBPVFkyTkRNNVptWXpZVE0yTUdZeU5XTXlOamd5WWpJME5qSmpOR1prWlRrelpUUmxOMlU9",
-            "timestamp": 1680445487,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHhjZDhmNWE1OGFkMDBmNTg3OGYyM2M2MTIxYTRlZjEwNThmOWI3ZDdlM2Q2Y2Y4Yzc0YTJhMWFlN2JkMDJmMmVlXzB4NWE3ZWMzZWIxYjI2NDQ2YjhhMzQ2Mzk3MzNiMDdlMGYwZDBjNjlhY18weDE0OTY2NDM5ZmYzYTM2MGYyNWMyNjgyYjI0NjJjNGZkZTkzZTRlN2U=",
-              "blockNumber": 16961984,
-              "hash": "0xcd8f5a58ad00f5878f23c6121a4ef1058f9b7d7e3d6cf8c74a2a1ae7bd02f2ee",
-              "status": "CONFIRMED",
-              "to": "0x14966439ff3a360f25c2682b2462c4fde93e4e7e",
-              "from": "0x5a7ec3eb1b26446b8a34639733b07e0f0d0c69ac",
-              "nonce": 3,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDE0OTY2NDM5ZmYzYTM2MGYyNWMyNjgyYjI0NjJjNGZkZTkzZTRlN2VfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4Y2Q4ZjVhNThhZDAwZjU4NzhmMjNjNjEyMWE0ZWYxMDU4ZjliN2Q3ZTNkNmNmOGM3NGEyYTFhZTdiZDAyZjJlZQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fMHg4YWY1ZmVkYzBmMjYzODQxYzE4ZjMxZDlkYmNjOTdhNDdlMWFiNDYy",
-                  "name": "MESSIER",
-                  "symbol": "M87",
-                  "address": "0x8af5fedc0f263841c18f31d9dbcc97a47e1ab462",
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNXzB4OGFmNWZlZGMwZjI2Mzg0MWMxOGYzMWQ5ZGJjYzk3YTQ3ZTFhYjQ2Mg==",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly9hc3NldHMuY29pbmdlY2tvLmNvbS9jb2lucy9pbWFnZXMvMjU5NTcvbGFyZ2UvTUVTU0lFUmxvZ29uZXdfJTI4MSUyOS5wbmc/MTY2Njc3Mzg0OA==",
-                      "url": "https://assets.coingecko.com/coins/images/25957/large/MESSIERlogonew_%281%29.png?1666773848",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "ERC20",
-                "quantity": "1500.0",
-                "sender": "0x14966439ff3a360f25c2682b2462c4fde93e4e7e",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjAuMDAxMjI3NDMzNzg5NDgxODY4OF9VU0Q=",
-                  "currency": "USD",
-                  "value": 0.0012274337894818688,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnM01XWmtNREppTXpsbFpUZ3dPR0ZrWlRnd01XVmlNRGRtTjJaa1pqZzBNVFU0TkRFM1lUUmhOemRtTm1ReVlUUTBaVEV4TmpObU9HUmlabUV4TkdZMlh6QjRPV05tTldJMVl6RTFZVGhoTkRFNE4yUmtaV1F5WmpVek5ESmpPVEU0TkRrelltRTRORGs0TUY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1680383399,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg3MWZkMDJiMzllZTgwOGFkZTgwMWViMDdmN2ZkZjg0MTU4NDE3YTRhNzdmNmQyYTQ0ZTExNjNmOGRiZmExNGY2XzB4OWNmNWI1YzE1YThhNDE4N2RkZWQyZjUzNDJjOTE4NDkzYmE4NDk4MF8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 16956876,
-              "hash": "0x71fd02b39ee808ade801eb07f7fdf84158417a4a77f6d2a44e1163f8dbfa14f6",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x9cf5b5c15a8a4187dded2f5342c918493ba84980",
-              "nonce": 28,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDljZjViNWMxNWE4YTQxODdkZGVkMmY1MzQyYzkxODQ5M2JhODQ5ODBfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4NzFmZDAyYjM5ZWU4MDhhZGU4MDFlYjA3ZjdmZGY4NDE1ODQxN2E0YTc3ZjZkMmE0NGUxMTYzZjhkYmZhMTRmNg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.002747222557993868",
-                "sender": "0x9cf5b5c15a8a4187dded2f5342c918493ba84980",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjUuMDI2NTEwNjk3Njg0NjRfVVNE",
-                  "currency": "USD",
-                  "value": 5.02651069768464,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnMVkyVTVNREEyTURnek1tTTJPR1l6TW1Wak1UUmpNams1WVRVd01UTmxaR1l3WXpVd09ESTJOVFptTWpRNVlXRTVaRFV6TjJZek1EQTFNak14WlROa1h6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEQXlOVGN3T1RCbFlqTmlNamd6WVdSak9XWXpOVGswTlRBeFltVTJNalEwTm1SbVpqWXhPRE09",
-            "timestamp": 1680383399,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg1Y2U5MDA2MDgzMmM2OGYzMmVjMTRjMjk5YTUwMTNlZGYwYzUwODI2NTZmMjQ5YWE5ZDUzN2YzMDA1MjMxZTNkXzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDAyNTcwOTBlYjNiMjgzYWRjOWYzNTk0NTAxYmU2MjQ0NmRmZjYxODM=",
-              "blockNumber": 16956876,
-              "hash": "0x5ce90060832c68f32ec14c299a5013edf0c5082656f249aa9d537f3005231e3d",
-              "status": "CONFIRMED",
-              "to": "0x0257090eb3b283adc9f3594501be62446dff6183",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 443,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHgwMjU3MDkwZWIzYjI4M2FkYzlmMzU5NDUwMWJlNjI0NDZkZmY2MTgzXzB4NWNlOTAwNjA4MzJjNjhmMzJlYzE0YzI5OWE1MDEzZWRmMGM1MDgyNjU2ZjI0OWFhOWQ1MzdmMzAwNTIzMWUzZA==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000000000000011743",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x0257090eb3b283adc9f3594501be62446dff6183",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjIuMTQ4NTgxNDgxMDAwMDAwMmUtMTFfVVNE",
-                  "currency": "USD",
-                  "value": 2.1485814810000002E-11,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhnNFptWTRNemxoTVRneFpHVmtZV0ppT0dNNU9USmtPREkyTVRJNU0yTTFZV1ZqTlRsbE9UVmpORFV3TWpFNE9URmlOVEl6WWpKbE5HWTFOamN3TVRJMlh6QjRaak01Wm1RMlpUVXhZV0ZrT0RobU5tWTBZMlUyWVdJNE9ESTNNamM1WTJabVptSTVNakkyTmw4d2VEUmpOREZsTWpJMk5EZ3dPV0ptWWpFd1pqVXdZVFZtT0ROaVlqRTJPVFJqTnpWa1lqa3pPVFU9",
-            "timestamp": 1680332735,
-            "type": "SEND",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHg4ZmY4MzlhMTgxZGVkYWJiOGM5OTJkODI2MTI5M2M1YWVjNTllOTVjNDUwMjE4OTFiNTIzYjJlNGY1NjcwMTI2XzB4ZjM5ZmQ2ZTUxYWFkODhmNmY0Y2U2YWI4ODI3Mjc5Y2ZmZmI5MjI2Nl8weDRjNDFlMjI2NDgwOWJmYjEwZjUwYTVmODNiYjE2OTRjNzVkYjkzOTU=",
-              "blockNumber": 16952706,
-              "hash": "0x8ff839a181dedabb8c992d8261293c5aec59e95c45021891b523b2e4f5670126",
-              "status": "CONFIRMED",
-              "to": "0x4c41e2264809bfb10f50a5f83bb1694c75db9395",
-              "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "nonce": 442,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjZfMHg0YzQxZTIyNjQ4MDliZmIxMGY1MGE1ZjgzYmIxNjk0Yzc1ZGI5Mzk1XzB4OGZmODM5YTE4MWRlZGFiYjhjOTkyZDgyNjEyOTNjNWFlYzU5ZTk1YzQ1MDIxODkxYjUyM2IyZTRmNTY3MDEyNg==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.000000000000000237",
-                "sender": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "recipient": "0x4c41e2264809bfb10f50a5f83bb1694c75db9395",
-                "direction": "OUT",
-                "transactedValue": {
-                  "id": "QW1vdW50OjQuMzM2MzE3OTAwMDAwMDAwM2UtMTNfVVNE",
-                  "currency": "USD",
-                  "value": 4.3363179000000003E-13,
-                  "__typename": "Amount"
-                }
-              }
-            ],
-            "__typename": "AssetActivity"
-          },
-          {
-            "id": "QXNzZXRBY3Rpdml0eTpWSEpoYm5OaFkzUnBiMjQ2TUhneU1Ea3lObVl4TnpoaE16VTNZekF4TUdJeE9HSmpOalV5TldabE9EUTRNakEzTXpnMU1HWm1PVGMzTVRFd1pUazVOek5sWm1WaVlUQXlPVGc0WldNeFh6QjROR00wTVdVeU1qWTBPREE1WW1aaU1UQm1OVEJoTldZNE0ySmlNVFk1TkdNM05XUmlPVE01TlY4d2VHWXpPV1prTm1VMU1XRmhaRGc0WmpabU5HTmxObUZpT0RneU56STNPV05tWm1aaU9USXlOalk9",
-            "timestamp": 1680332735,
-            "type": "RECEIVE",
-            "chain": "ETHEREUM",
-            "details": {
-              "id": "VHJhbnNhY3Rpb246MHgyMDkyNmYxNzhhMzU3YzAxMGIxOGJjNjUyNWZlODQ4MjA3Mzg1MGZmOTc3MTEwZTk5NzNlZmViYTAyOTg4ZWMxXzB4NGM0MWUyMjY0ODA5YmZiMTBmNTBhNWY4M2JiMTY5NGM3NWRiOTM5NV8weGYzOWZkNmU1MWFhZDg4ZjZmNGNlNmFiODgyNzI3OWNmZmZiOTIyNjY=",
-              "blockNumber": 16952706,
-              "hash": "0x20926f178a357c010b18bc6525fe8482073850ff977110e9973efeba02988ec1",
-              "status": "CONFIRMED",
-              "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-              "from": "0x4c41e2264809bfb10f50a5f83bb1694c75db9395",
-              "nonce": 9445,
-              "__typename": "TransactionDetails"
-            },
-            "assetChanges": [
-              {
-                "__typename": "TokenTransfer",
-                "id": "VG9rZW5UcmFuc2ZlcjoweDRjNDFlMjI2NDgwOWJmYjEwZjUwYTVmODNiYjE2OTRjNzVkYjkzOTVfMHhmMzlmZDZlNTFhYWQ4OGY2ZjRjZTZhYjg4MjcyNzljZmZmYjkyMjY2XzB4MjA5MjZmMTc4YTM1N2MwMTBiMThiYzY1MjVmZTg0ODIwNzM4NTBmZjk3NzExMGU5OTczZWZlYmEwMjk4OGVjMQ==",
-                "asset": {
-                  "id": "VG9rZW46RVRIRVJFVU1fbnVsbA==",
-                  "name": "Ether",
-                  "symbol": "ETH",
-                  "address": null,
-                  "decimals": 18,
-                  "chain": "ETHEREUM",
-                  "standard": null,
-                  "project": {
-                    "id": "VG9rZW5Qcm9qZWN0OkVUSEVSRVVNX251bGw=",
-                    "isSpam": false,
-                    "logo": {
-                      "id": "SW1hZ2U6aHR0cHM6Ly90b2tlbi1pY29ucy5zMy5hbWF6b25hd3MuY29tL2V0aC5wbmc=",
-                      "url": "https://token-icons.s3.amazonaws.com/eth.png",
-                      "__typename": "Image"
-                    },
-                    "__typename": "TokenProject"
-                  },
-                  "__typename": "Token"
-                },
-                "tokenStandard": "NATIVE",
-                "quantity": "0.02",
-                "sender": "0x4c41e2264809bfb10f50a5f83bb1694c75db9395",
-                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-                "direction": "IN",
-                "transactedValue": {
-                  "id": "QW1vdW50OjM2LjU5MzRfVVNE",
-                  "currency": "USD",
-                  "value": 36.5934,
-                  "__typename": "Amount"
-                }
-              }
-            ],
             "__typename": "AssetActivity"
           }
         ],

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
@@ -351,7 +351,7 @@ function parseRemoteActivity(assetActivity: AssetActivityPartsFragment): Activit
       return parseUniswapXOrder(assetActivity as OrderActivity)
     }
 
-    const changes = assetActivity.assetChanges.reduce(
+    const changes = assetActivity.details.assetChanges.reduce(
       (acc: TransactionChanges, assetChange) => {
         if (assetChange.__typename === 'NftApproval') acc.NftApproval.push(assetChange)
         else if (assetChange.__typename === 'NftApproveForAll') acc.NftApproveForAll.push(assetChange)
@@ -377,13 +377,16 @@ function parseRemoteActivity(assetActivity: AssetActivityPartsFragment): Activit
       status: assetActivity.details.status,
       timestamp: assetActivity.timestamp,
       logos: getLogoSrcs(changes),
-      title: assetActivity.type,
+      title: assetActivity.details.type,
       descriptor: assetActivity.details.to,
       from: assetActivity.details.from,
       nonce: assetActivity.details.nonce,
     }
 
-    const parsedFields = ActivityParserByType[assetActivity.type]?.(changes, assetActivity as TransactionActivity)
+    const parsedFields = ActivityParserByType[assetActivity.details.type]?.(
+      changes,
+      assetActivity as TransactionActivity
+    )
     return { ...defaultFields, ...parsedFields }
   } catch (e) {
     console.error('Failed to parse activity', e, assetActivity)

--- a/src/graphql/data/activity.graphql
+++ b/src/graphql/data/activity.graphql
@@ -110,6 +110,24 @@ fragment TransactionDetailsParts on TransactionDetails {
   hash
   nonce
   status
+  assetChanges {
+    __typename
+    ... on TokenTransfer {
+      ...TokenTransferParts
+    }
+    ... on NftTransfer {
+      ...NFTTransferParts
+    }
+    ... on TokenApproval {
+      ...TokenApprovalParts
+    }
+    ... on NftApproval {
+      ...NFTApprovalParts
+    }
+    ... on NftApproveForAll {
+      ...NFTApproveForAllParts
+    }
+  }
 }
 
 fragment SwapOrderDetailsParts on SwapOrderDetails {
@@ -130,7 +148,6 @@ fragment SwapOrderDetailsParts on SwapOrderDetails {
 fragment AssetActivityParts on AssetActivity {
   id
   timestamp
-  type
   chain
   details {
     __typename
@@ -139,24 +156,6 @@ fragment AssetActivityParts on AssetActivity {
     }
     ... on SwapOrderDetails {
       ...SwapOrderDetailsParts
-    }
-  }
-  assetChanges {
-    __typename
-    ... on TokenTransfer {
-      ...TokenTransferParts
-    }
-    ... on NftTransfer {
-      ...NFTTransferParts
-    }
-    ... on TokenApproval {
-      ...TokenApprovalParts
-    }
-    ... on NftApproval {
-      ...NFTApprovalParts
-    }
-    ... on NftApproveForAll {
-      ...NFTApproveForAllParts
     }
   }
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Updates AssetActivity queries to move off of deprecated fields, as these fields were made optional (by the schema) and so would lose type safety. Also: they are deprecated.


<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C052ARNFZGU/p1694021868796429
_Relevant docs:_ https://github.com/Uniswap/data-api-graphql/pull/1116/files#diff-5424116e8713d835fc94a4a0b222638eebf7c61231381c46bee66d6e549855f4R279-R283