### PR TITLE
fix: fot ui bug in swap details dropdown

### DIFF
--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -191,6 +191,8 @@ function TokenTaxLineItem({
   type: 'input' | 'output'
   syncing: boolean
 }) {
+  if (syncing) return null
+
   const [currency, percentage] =
     type === 'input' ? [trade.inputAmount.currency, trade.inputTax] : [trade.outputAmount.currency, trade.outputTax]
 
@@ -213,9 +215,7 @@ function TokenTaxLineItem({
       >
         <ThemedText.BodySmall color="neutral2">{`${currency.symbol} fee`}</ThemedText.BodySmall>
       </MouseoverTooltip>
-      <TextWithLoadingPlaceholder syncing={syncing} width={50}>
-        <ThemedText.BodySmall>{formatPriceImpact(percentage)}</ThemedText.BodySmall>
-      </TextWithLoadingPlaceholder>
+      <ThemedText.BodySmall>{formatPriceImpact(percentage)}</ThemedText.BodySmall>
     </RowBetween>
   )
 }

--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -84,8 +84,8 @@ export function AdvancedSwapDetails({ trade, allowedSlippage, syncing = false }:
       )}
       {isClassicTrade(trade) && (
         <>
-          <TokenTaxLineItem trade={trade} type="input" />
-          <TokenTaxLineItem trade={trade} type="output" />
+          <TokenTaxLineItem trade={trade} type="input" syncing={syncing} />
+          <TokenTaxLineItem trade={trade} type="output" syncing={syncing} />
           <RowBetween>
             <MouseoverTooltip text={<Trans>The impact your trade has on the market price of this pool.</Trans>}>
               <ThemedText.BodySmall color="neutral2">
@@ -182,7 +182,15 @@ export function AdvancedSwapDetails({ trade, allowedSlippage, syncing = false }:
   )
 }
 
-function TokenTaxLineItem({ trade, type }: { trade: ClassicTrade; type: 'input' | 'output' }) {
+function TokenTaxLineItem({
+  trade,
+  type,
+  syncing,
+}: {
+  trade: ClassicTrade
+  type: 'input' | 'output'
+  syncing: boolean
+}) {
   const [currency, percentage] =
     type === 'input' ? [trade.inputAmount.currency, trade.inputTax] : [trade.outputAmount.currency, trade.outputTax]
 
@@ -203,9 +211,11 @@ function TokenTaxLineItem({ trade, type }: { trade: ClassicTrade; type: 'input' 
           </>
         }
       >
-        <ThemedText.BodySmall color="textSecondary">{`${currency.symbol} fee`}</ThemedText.BodySmall>
+        <ThemedText.BodySmall color="neutral2">{`${currency.symbol} fee`}</ThemedText.BodySmall>
       </MouseoverTooltip>
-      <ThemedText.BodySmall>{formatPriceImpact(percentage)}</ThemedText.BodySmall>
+      <TextWithLoadingPlaceholder syncing={syncing} width={50}>
+        <ThemedText.BodySmall>{formatPriceImpact(percentage)}</ThemedText.BodySmall>
+      </TextWithLoadingPlaceholder>
     </RowBetween>
   )
 }

--- a/src/components/swap/SwapDetailsDropdown.test.tsx
+++ b/src/components/swap/SwapDetailsDropdown.test.tsx
@@ -51,7 +51,7 @@ describe('SwapDetailsDropdown.tsx', () => {
     render(
       <SwapDetailsDropdown
         trade={TEST_TRADE_FEE_ON_SELL}
-        syncing={true}
+        syncing={false}
         loading={true}
         allowedSlippage={TEST_ALLOWED_SLIPPAGE}
       />
@@ -70,7 +70,7 @@ describe('SwapDetailsDropdown.tsx', () => {
     render(
       <SwapDetailsDropdown
         trade={TEST_TRADE_FEE_ON_BUY}
-        syncing={true}
+        syncing={false}
         loading={true}
         allowedSlippage={TEST_ALLOWED_SLIPPAGE}
       />


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Fixes visual bug where FOT details in swap dropdown were wrong color and lacked a loading state

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
https://github.com/Uniswap/interface/assets/39385577/278fa5e8-24c2-43eb-b79c-1180fa6a0fc4  

### After
https://github.com/Uniswap/interface/assets/39385577/0f1c1033-4fdd-406b-a81c-4baf64414fbe
