### PR TITLE
feat: uniswapx start time buffer

### DIFF
--- a/cypress/fixtures/uniswapx/quote1.json
+++ b/cypress/fixtures/uniswapx/quote1.json
@@ -32,7 +32,7 @@
         "quoteId": "f9f47cd7-a62c-4622-9ac7-51d0e662245a",
         "requestId": "2d16f993-6429-4755-ba50-1383789459dc",
         "auctionPeriodSecs": 60,
-        "startTimeOffsetSecs": 30,
+        "startTimeBufferSecs": 30,
         "deadlineBufferSecs": 12,
         "slippageTolerance": "0.5",
         "permitData": {
@@ -253,7 +253,7 @@
                 "quoteId": "f9f47cd7-a62c-4622-9ac7-51d0e662245a",
                 "requestId": "2d16f993-6429-4755-ba50-1383789459dc",
                 "auctionPeriodSecs": 60,
-                "startTimeOffsetSecs": 30,
+                "startTimeBufferSecs": 30,
                 "deadlineBufferSecs": 12,
                 "slippageTolerance": "0.5",
                 "permitData": {

--- a/cypress/fixtures/uniswapx/quote1.json
+++ b/cypress/fixtures/uniswapx/quote1.json
@@ -32,6 +32,7 @@
         "quoteId": "f9f47cd7-a62c-4622-9ac7-51d0e662245a",
         "requestId": "2d16f993-6429-4755-ba50-1383789459dc",
         "auctionPeriodSecs": 60,
+        "startTimeOffsetSecs": 30,
         "deadlineBufferSecs": 12,
         "slippageTolerance": "0.5",
         "permitData": {
@@ -252,6 +253,7 @@
                 "quoteId": "f9f47cd7-a62c-4622-9ac7-51d0e662245a",
                 "requestId": "2d16f993-6429-4755-ba50-1383789459dc",
                 "auctionPeriodSecs": 60,
+                "startTimeOffsetSecs": 30,
                 "deadlineBufferSecs": 12,
                 "slippageTolerance": "0.5",
                 "permitData": {

--- a/cypress/fixtures/uniswapx/quote2.json
+++ b/cypress/fixtures/uniswapx/quote2.json
@@ -32,6 +32,7 @@
       "quoteId": "09ce28b7-1ddf-4317-a28d-d21092be9f84",
       "requestId": "f00535d4-461a-4363-afbe-7a5ab7061cd1",
       "auctionPeriodSecs": 60,
+      "startTimeOffsetSecs": 30,
       "deadlineBufferSecs": 12,
       "slippageTolerance": "0.5",
       "permitData": {
@@ -252,6 +253,7 @@
               "quoteId": "09ce28b7-1ddf-4317-a28d-d21092be9f84",
               "requestId": "f00535d4-461a-4363-afbe-7a5ab7061cd1",
               "auctionPeriodSecs": 60,
+              "startTimeOffsetSecs": 30,
               "deadlineBufferSecs": 12,
               "slippageTolerance": "0.5",
               "permitData": {

--- a/cypress/fixtures/uniswapx/quote2.json
+++ b/cypress/fixtures/uniswapx/quote2.json
@@ -32,7 +32,7 @@
       "quoteId": "09ce28b7-1ddf-4317-a28d-d21092be9f84",
       "requestId": "f00535d4-461a-4363-afbe-7a5ab7061cd1",
       "auctionPeriodSecs": 60,
-      "startTimeOffsetSecs": 30,
+      "startTimeBufferSecs": 30,
       "deadlineBufferSecs": 12,
       "slippageTolerance": "0.5",
       "permitData": {
@@ -253,7 +253,7 @@
               "quoteId": "09ce28b7-1ddf-4317-a28d-d21092be9f84",
               "requestId": "f00535d4-461a-4363-afbe-7a5ab7061cd1",
               "auctionPeriodSecs": 60,
-              "startTimeOffsetSecs": 30,
+              "startTimeBufferSecs": 30,
               "deadlineBufferSecs": 12,
               "slippageTolerance": "0.5",
               "permitData": {

--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -13,8 +13,6 @@ import { UserRejectedRequestError } from 'utils/errors'
 import { signTypedData } from 'utils/signing'
 import { didUserReject, swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
 
-const DEFAULT_START_TIME_PADDING_SECONDS = 30
-
 type DutchAuctionOrderError = { errorCode?: number; detail?: string }
 type DutchAuctionOrderSuccess = { hash: string }
 type DutchAuctionOrderResponse = DutchAuctionOrderError | DutchAuctionOrderSuccess
@@ -69,7 +67,7 @@ export function useUniswapXSwapCallback({
           try {
             const updatedNonce = await getUpdatedNonce(account, trade.order.chainId)
 
-            const startTime = Math.floor(Date.now() / 1000) + DEFAULT_START_TIME_PADDING_SECONDS
+            const startTime = Math.floor(Date.now() / 1000) + trade.startTimeOffsetSecs
             setTraceData('startTime', startTime)
 
             const endTime = startTime + trade.auctionPeriodSecs

--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -67,7 +67,7 @@ export function useUniswapXSwapCallback({
           try {
             const updatedNonce = await getUpdatedNonce(account, trade.order.chainId)
 
-            const startTime = Math.floor(Date.now() / 1000) + trade.startTimeOffsetSecs
+            const startTime = Math.floor(Date.now() / 1000) + trade.startTimeBufferSecs
             setTraceData('startTime', startTime)
 
             const endTime = startTime + trade.auctionPeriodSecs

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -114,6 +114,7 @@ type URADutchOrderQuoteResponse = {
   quote: {
     auctionPeriodSecs: number
     deadlineBufferSecs: number
+    startTimeOffsetSecs: number
     orderInfo: DutchOrderInfoJSON
     quoteId?: string
     requestId?: string
@@ -236,6 +237,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
   // The gas estimate of the reference classic trade, if there is one.
   classicGasUseEstimateUSD?: number
   auctionPeriodSecs: number
+  startTimeOffsetSecs: number
   deadlineBufferSecs: number
   slippageTolerance: Percent
 
@@ -250,6 +252,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
     approveInfo,
     classicGasUseEstimateUSD,
     auctionPeriodSecs,
+    startTimeOffsetSecs,
     deadlineBufferSecs,
     slippageTolerance,
   }: {
@@ -263,6 +266,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
     wrapInfo: WrapInfo
     classicGasUseEstimateUSD?: number
     auctionPeriodSecs: number
+    startTimeOffsetSecs: number
     deadlineBufferSecs: number
     slippageTolerance: Percent
   }) {
@@ -275,6 +279,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
     this.auctionPeriodSecs = auctionPeriodSecs
     this.deadlineBufferSecs = deadlineBufferSecs
     this.slippageTolerance = slippageTolerance
+    this.startTimeOffsetSecs = startTimeOffsetSecs
   }
 
   public get totalGasUseEstimateUSD(): number {
@@ -351,6 +356,7 @@ type UniswapXConfig = {
   swapper?: string
   exclusivityOverrideBps?: number
   auctionPeriodSecs?: number
+  startTimeOffsetSecs?: number
 }
 
 export type RoutingConfig = (UniswapXConfig | ClassicAPIConfig)[]

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -114,7 +114,7 @@ type URADutchOrderQuoteResponse = {
   quote: {
     auctionPeriodSecs: number
     deadlineBufferSecs: number
-    startTimeOffsetSecs: number
+    startTimeBufferSecs: number
     orderInfo: DutchOrderInfoJSON
     quoteId?: string
     requestId?: string
@@ -237,7 +237,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
   // The gas estimate of the reference classic trade, if there is one.
   classicGasUseEstimateUSD?: number
   auctionPeriodSecs: number
-  startTimeOffsetSecs: number
+  startTimeBufferSecs: number
   deadlineBufferSecs: number
   slippageTolerance: Percent
 
@@ -252,7 +252,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
     approveInfo,
     classicGasUseEstimateUSD,
     auctionPeriodSecs,
-    startTimeOffsetSecs,
+    startTimeBufferSecs,
     deadlineBufferSecs,
     slippageTolerance,
   }: {
@@ -266,7 +266,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
     wrapInfo: WrapInfo
     classicGasUseEstimateUSD?: number
     auctionPeriodSecs: number
-    startTimeOffsetSecs: number
+    startTimeBufferSecs: number
     deadlineBufferSecs: number
     slippageTolerance: Percent
   }) {
@@ -279,7 +279,7 @@ export class DutchOrderTrade extends IDutchOrderTrade<Currency, Currency, TradeT
     this.auctionPeriodSecs = auctionPeriodSecs
     this.deadlineBufferSecs = deadlineBufferSecs
     this.slippageTolerance = slippageTolerance
-    this.startTimeOffsetSecs = startTimeOffsetSecs
+    this.startTimeBufferSecs = startTimeBufferSecs
   }
 
   public get totalGasUseEstimateUSD(): number {
@@ -356,7 +356,7 @@ type UniswapXConfig = {
   swapper?: string
   exclusivityOverrideBps?: number
   auctionPeriodSecs?: number
-  startTimeOffsetSecs?: number
+  startTimeBufferSecs?: number
 }
 
 export type RoutingConfig = (UniswapXConfig | ClassicAPIConfig)[]

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -277,7 +277,7 @@ export async function transformRoutesToTrade(
       wrapInfo,
       approveInfo,
       auctionPeriodSecs: data.quote.auctionPeriodSecs,
-      startTimeOffsetSecs: data.quote.startTimeOffsetSecs,
+      startTimeBufferSecs: data.quote.startTimeBufferSecs,
       deadlineBufferSecs: data.quote.deadlineBufferSecs,
       slippageTolerance: toSlippagePercent(data.quote.slippageTolerance),
     })

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -277,6 +277,7 @@ export async function transformRoutesToTrade(
       wrapInfo,
       approveInfo,
       auctionPeriodSecs: data.quote.auctionPeriodSecs,
+      startTimeOffsetSecs: data.quote.startTimeOffsetSecs,
       deadlineBufferSecs: data.quote.deadlineBufferSecs,
       slippageTolerance: toSlippagePercent(data.quote.slippageTolerance),
     })

--- a/src/test-utils/constants.ts
+++ b/src/test-utils/constants.ts
@@ -121,7 +121,7 @@ export const TEST_DUTCH_TRADE_ETH_INPUT = new DutchOrderTrade({
   classicGasUseEstimateUSD: 7.87,
   auctionPeriodSecs: 120,
   deadlineBufferSecs: 30,
-  startTimeOffsetSecs: 30,
+  startTimeBufferSecs: 30,
   slippageTolerance: new Percent(5, 100),
 })
 

--- a/src/test-utils/constants.ts
+++ b/src/test-utils/constants.ts
@@ -121,6 +121,7 @@ export const TEST_DUTCH_TRADE_ETH_INPUT = new DutchOrderTrade({
   classicGasUseEstimateUSD: 7.87,
   auctionPeriodSecs: 120,
   deadlineBufferSecs: 30,
+  startTimeOffsetSecs: 30,
   slippageTolerance: new Percent(5, 100),
 })
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

we want to use a server-defined value for the start time offset, instead of a constant 30s.


- https://github.com/Uniswap/unified-routing-api/pull/259


## Test plan
### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] logged the value from the API response when signing a dutch order to verify it's actually used at the time of signing

<img width="883" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/8ca8a293-3c19-49dd-b327-70d3c2963c51">
