### PR TITLE
fix: remove sentry warnings for failed tax fetches

### DIFF
--- a/src/hooks/useSwapTaxes.ts
+++ b/src/hooks/useSwapTaxes.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react'
 import { InterfaceEventName } from '@uniswap/analytics-events'
 import { ChainId, Percent } from '@uniswap/sdk-core'
 import { WETH_ADDRESS as getWethAddress } from '@uniswap/universal-router-sdk'
@@ -61,11 +60,7 @@ async function getSwapTaxes(
       })
     }
   } catch (e) {
-    Sentry.withScope(function (scope) {
-      scope.setTag('method', 'getSwapTaxes')
-      scope.setLevel('warning')
-      Sentry.captureException(e)
-    })
+    console.warn('Failed to get swap taxes for token(s):', addresses, e)
   }
 
   const inputTax = (inputTokenAddress ? FEE_CACHE[inputTokenAddress]?.sellTax : ZERO_PERCENT) ?? ZERO_PERCENT


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Removes sentry logging in `getSwapTaxes` since we expect tax lookups to fail regularly for tokens that have insufficient v2 liquidity