### PR TITLE
fix: only log swap success for swap txs

### DIFF
--- a/src/state/transactions/updater.tsx
+++ b/src/state/transactions/updater.tsx
@@ -12,7 +12,7 @@ import { L2_CHAIN_IDS } from '../../constants/chains'
 import { useAddPopup } from '../application/hooks'
 import { isPendingTx } from './hooks'
 import { checkedTransaction, finalizeTransaction } from './reducer'
-import { SerializableTransactionReceipt, TransactionDetails } from './types'
+import { SerializableTransactionReceipt, TransactionDetails, TransactionType } from './types'
 
 export function toSerializableReceipt(receipt: TransactionReceipt): SerializableTransactionReceipt {
   return {
@@ -58,7 +58,9 @@ export default function Updater() {
         })
       )
 
-      logSwapSuccess(hash, chainId, analyticsContext)
+      if (pendingTransactions[hash] && pendingTransactions[hash].info?.type === TransactionType.SWAP) {
+        logSwapSuccess(hash, chainId, analyticsContext)
+      }
 
       addPopup(
         {
@@ -69,7 +71,7 @@ export default function Updater() {
         isL2 ? L2_TXN_DISMISS_MS : DEFAULT_TXN_DISMISS_MS
       )
     },
-    [addPopup, analyticsContext, dispatch, isL2]
+    [addPopup, analyticsContext, dispatch, isL2, pendingTransactions]
   )
 
   return <LibUpdater pendingTransactions={pendingTransactions} onCheck={onCheck} onReceipt={onReceipt} />


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
we were incorrectly logging Swap Transaction Completed for all transaction types. this checks the transaction type before logging.


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. start a swap where the input token is an erc20 that doesn't have a setup approval
2. sign the setup approval transaction and notice that Swap Transaction Completed is logged when that transaction confirms

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] follow the above steps and verify that the event is not logged for the setup approval
- [x] continue the flow and verify the event is still logged for the actual swap

