### PR TITLE
fix: userHideClosedPositions persist between browser refreshes

### DIFF
--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -138,6 +138,7 @@ export function useUserHideClosedPositions(): [boolean, (newHideClosedPositions:
 
   const setHideClosedPositions = useCallback(
     (newHideClosedPositions: boolean) => {
+      sessionStorage.setItem('userHideClosedPositions', JSON.stringify(newHideClosedPositions))
       dispatch(updateHideClosedPositions({ userHideClosedPositions: newHideClosedPositions }))
     },
     [dispatch]

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -60,7 +60,7 @@ export const initialState: UserState = {
   selectedWallet: undefined,
   userLocale: null,
   userRouterPreference: RouterPreference.API,
-  userHideClosedPositions: false,
+  userHideClosedPositions: JSON.parse(sessionStorage.getItem('userHideClosedPositions') || 'false'),
   userSlippageTolerance: SlippageTolerance.Auto,
   userSlippageToleranceHasBeenMigratedToAuto: true,
   userDeadline: DEFAULT_DEADLINE_FROM_NOW,


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Fixes #2356 

## Screen capture

|    Before    |   After    |
| ------------ | ------------ |
| <video src="https://github.com/Uniswap/interface/assets/89173284/f492b74d-c299-4acd-b8bf-70631d1fc5ea" /> | <video src="https://github.com/Uniswap/interface/assets/89173284/3809049b-fa27-4a34-986f-455b96c90bda" /> 
 |





## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. navigate tp http://app.uniswap.org/pools
2. Click on "Show closed positions"
3. Refresh the page


