### PR TITLE
chore: remove extra blocknumber from dep array

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -165,6 +165,5 @@ export function useUniversalRouterSwapCallback(
     provider,
     trade,
     isAutoSlippage,
-    blockNumber,
   ])
 }


### PR DESCRIPTION
* `blocknumber` was added twice to the dep array due to merge of #7231 