### PR TITLE
fix: synchronously load first page

### DIFF
--- a/src/components/TopLevelModals/index.tsx
+++ b/src/components/TopLevelModals/index.tsx
@@ -1,18 +1,16 @@
 import { useWeb3React } from '@web3-react/core'
 import { OffchainActivityModal } from 'components/AccountDrawer/MiniPortfolio/Activity/OffchainActivityModal'
 import UniwalletModal from 'components/AccountDrawer/UniwalletModal'
+import AirdropModal from 'components/AirdropModal'
 import BaseAnnouncementBanner from 'components/Banner/BaseAnnouncementBanner'
 import AddressClaimModal from 'components/claim/AddressClaimModal'
 import ConnectedAccountBlocked from 'components/ConnectedAccountBlocked'
 import FiatOnrampModal from 'components/FiatOnrampModal'
 import useAccountRiskCheck from 'hooks/useAccountRiskCheck'
-import { lazy } from 'react'
+import Bag from 'nft/components/bag/Bag'
+import TransactionCompleteModal from 'nft/components/collection/TransactionCompleteModal'
 import { useModalIsOpen, useToggleModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
-
-const Bag = lazy(() => import('nft/components/bag/Bag'))
-const TransactionCompleteModal = lazy(() => import('nft/components/collection/TransactionCompleteModal'))
-const AirdropModal = lazy(() => import('components/AirdropModal'))
 
 export default function TopLevelModals() {
   const addressClaimOpen = useModalIsOpen(ApplicationModal.ADDRESS_CLAIM)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Loads top-level modals synchronously, as they block the first paint.
This prevents a waterfall, which - on my 500 Mbps connection - improves cold load time by 200ms.

In the following diagnostic screenshots, the red vertical line denotes Load, which correlates to Largest Contentful Paint (LCP).

| Before | After |
| - | - |
| <image src="https://github.com/Uniswap/interface/assets/5403956/5ea85d77-d9d9-41e0-8f6a-5addcfa22320"/> | <image src="https://github.com/Uniswap/interface/assets/5403956/b603db8d-7e03-45c2-a21d-9535a62b7a0a"/> |