### PR TITLE
feat: lazy-load MiniPortfolio, avoid eager data fetching

### DIFF
--- a/src/components/AccountDrawer/AuthenticatedHeader.tsx
+++ b/src/components/AccountDrawer/AuthenticatedHeader.tsx
@@ -17,12 +17,12 @@ import useENSName from 'hooks/useENSName'
 import { useProfilePageState, useSellAsset, useWalletCollections } from 'nft/hooks'
 import { useIsNftClaimAvailable } from 'nft/hooks/useIsNftClaimAvailable'
 import { ProfilePageStateType } from 'nft/types'
-import { useCallback, useState } from 'react'
+import { lazy, Suspense, useCallback, useState } from 'react'
 import { CreditCard, Info } from 'react-feather'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from 'state/hooks'
 import { updateSelectedWallet } from 'state/user/reducer'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { CopyHelper, ExternalLink, ThemedText } from 'theme'
 import { shortenAddress } from 'utils'
 import { NumberType, useFormatter } from 'utils/formatNumbers'
@@ -33,9 +33,9 @@ import { useUserHasAvailableClaim, useUserUnclaimedAmount } from '../../state/cl
 import StatusIcon from '../Identicon/StatusIcon'
 import { useToggleAccountDrawer } from '.'
 import IconButton, { IconHoverText, IconWithConfirmTextButton } from './IconButton'
-import MiniPortfolio from './MiniPortfolio'
-import { portfolioFadeInAnimation } from './MiniPortfolio/PortfolioRow'
 import { useCachedPortfolioBalancesQuery } from './PrefetchBalancesWrapper'
+
+const MiniPortfolio = lazy(() => import('./MiniPortfolio'))
 
 const AuthenticatedHeaderWrapper = styled.div`
   padding: 20px 16px;
@@ -141,8 +141,13 @@ const CopyText = styled(CopyHelper).attrs({
   iconPosition: 'right',
 })``
 
+const fadeIn = keyframes`
+  from { opacity: .25 }
+  to { opacity: 1 }
+`
+
 const FadeInColumn = styled(Column)`
-  ${portfolioFadeInAnimation}
+  animation: ${fadeIn} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.in}`};
 `
 
 const PortfolioDrawerContainer = styled(Column)`
@@ -342,7 +347,9 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
             </Tooltip>
           </FiatOnrampNotAvailableText>
         )}
-        <MiniPortfolio account={account} />
+        <Suspense>
+          <MiniPortfolio account={account} />
+        </Suspense>
         {isUnclaimed && (
           <UNIButton onClick={openClaimModal} size={ButtonSize.medium} emphasis={ButtonEmphasis.medium}>
             <Trans>Claim</Trans> {unclaimedAmount?.toFixed(0, { groupSeparator: ',' } ?? '-')} <Trans>reward</Trans>

--- a/src/components/AccountDrawer/DefaultMenu.tsx
+++ b/src/components/AccountDrawer/DefaultMenu.tsx
@@ -43,6 +43,7 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
   }, [drawerOpen, menu, closeSettings])
 
   const SubMenu = useMemo(() => {
+    if (!drawerOpen) return null
     switch (menu) {
       case MenuState.DEFAULT:
         return isAuthenticated ? (
@@ -63,7 +64,16 @@ function DefaultMenu({ drawerOpen }: { drawerOpen: boolean }) {
       case MenuState.LOCAL_CURRENCY_SETTINGS:
         return <LocalCurrencyMenu onClose={openSettings} />
     }
-  }, [account, closeSettings, isAuthenticated, menu, openLanguageSettings, openLocalCurrencySettings, openSettings])
+  }, [
+    account,
+    closeSettings,
+    drawerOpen,
+    isAuthenticated,
+    menu,
+    openLanguageSettings,
+    openLocalCurrencySettings,
+    openSettings,
+  ])
 
   return <DefaultMenuWrap>{SubMenu}</DefaultMenuWrap>
 }

--- a/src/components/AccountDrawer/MiniPortfolio/PortfolioRow.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/PortfolioRow.tsx
@@ -1,7 +1,7 @@
 import Column, { AutoColumn } from 'components/Column'
 import Row from 'components/Row'
 import { LoadingBubble } from 'components/Tokens/loading'
-import styled, { css, keyframes } from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 export const PortfolioRowWrapper = styled(Row)<{ onClick?: any }>`
   gap: 12px;
@@ -85,10 +85,7 @@ const fadeIn = keyframes`
   from { opacity: .25 }
   to { opacity: 1 }
 `
-export const portfolioFadeInAnimation = css`
-  animation: ${fadeIn} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.in}`};
-`
 
 export const PortfolioTabWrapper = styled.div`
-  ${portfolioFadeInAnimation}
+  animation: ${fadeIn} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.in}`};
 `


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Does not render the AccountDrawer when it is not open, which avoids eagerly- and over- fetching data.
Lazy-loads the MiniPortfolio to improve pageload.

This will make the AccountDrawer populate slower, but should be a minor change, and will improve pageload and data usage overall. AccountDrawer uses skeleton loaders, so it will not appear broken.

## Testing

To test:
- Navigate to the preview url
- Open your devtools (F12)
- In the Network pane, set throttling to "Fast 3G"
- Open the AccountDrawer
  - Note that the MiniPortfolio takes a second to load, and then the data loads after you navigate to it
    This is in contrast to the current state, where data is pre-loaded even if you don't request it