### PR TITLE
fix: lazy-load web3-react libs

### DIFF
--- a/patches/@web3-react+coinbase-wallet+8.2.2.patch
+++ b/patches/@web3-react+coinbase-wallet+8.2.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@web3-react/coinbase-wallet/dist/index.js b/node_modules/@web3-react/coinbase-wallet/dist/index.js
+index f38d06e..4f8fa19 100644
+--- a/node_modules/@web3-react/coinbase-wallet/dist/index.js
++++ b/node_modules/@web3-react/coinbase-wallet/dist/index.js
+@@ -62,7 +62,7 @@ class CoinbaseWallet extends types_1.Connector {
+         return __awaiter(this, void 0, void 0, function* () {
+             if (this.eagerConnection)
+                 return;
+-            yield (this.eagerConnection = Promise.resolve().then(() => __importStar(require('@coinbase/wallet-sdk'))).then((m) => {
++            yield (this.eagerConnection = Promise.resolve().then(async () => __importStar(await import('@coinbase/wallet-sdk'))).then((m) => {
+                 const _a = this.options, { url } = _a, options = __rest(_a, ["url"]);
+                 this.coinbaseWallet = new m.default(options);
+                 this.provider = this.coinbaseWallet.makeWeb3Provider(url);

--- a/patches/@web3-react+metamask+8.2.3.patch
+++ b/patches/@web3-react+metamask+8.2.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@web3-react/metamask/dist/index.js b/node_modules/@web3-react/metamask/dist/index.js
+index c8476dd..c0bfce7 100644
+--- a/node_modules/@web3-react/metamask/dist/index.js
++++ b/node_modules/@web3-react/metamask/dist/index.js
+@@ -54,7 +54,7 @@ class MetaMask extends types_1.Connector {
+         return __awaiter(this, void 0, void 0, function* () {
+             if (this.eagerConnection)
+                 return;
+-            return (this.eagerConnection = Promise.resolve().then(() => __importStar(require('@metamask/detect-provider'))).then((m) => __awaiter(this, void 0, void 0, function* () {
++            return (this.eagerConnection = Promise.resolve().then(async () => __importStar(await import('@metamask/detect-provider'))).then((m) => __awaiter(this, void 0, void 0, function* () {
+                 var _a, _b;
+                 const provider = yield m.default(this.options);
+                 if (provider) {

--- a/patches/@web3-react+walletconnect-v2+8.5.0.patch
+++ b/patches/@web3-react+walletconnect-v2+8.5.0.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/@web3-react/walletconnect-v2/dist/index.js b/node_modules/@web3-react/walletconnect-v2/dist/index.js
+index 1a36d14..908b8c5 100644
+--- a/node_modules/@web3-react/walletconnect-v2/dist/index.js
++++ b/node_modules/@web3-react/walletconnect-v2/dist/index.js
+@@ -84,7 +84,7 @@ class WalletConnect extends types_1.Connector {
+         return __awaiter(this, void 0, void 0, function* () {
+             const rpcMap = this.rpcMap ? (0, utils_1.getBestUrlMap)(this.rpcMap, this.timeout) : undefined;
+             const chainProps = this.getChainProps(this.chains, this.optionalChains, desiredChainId);
+-            const ethProviderModule = yield Promise.resolve().then(() => __importStar(require('@walletconnect/ethereum-provider')));
++            const ethProviderModule = yield Promise.resolve().then(async () => __importStar(await import('@walletconnect/ethereum-provider')));
+             this.provider = yield ethProviderModule.default.init(Object.assign(Object.assign(Object.assign({}, this.options), chainProps), { rpcMap: yield rpcMap }));
+             return this.provider
+                 .on('disconnect', this.disconnectListener)
+diff --git a/node_modules/@web3-react/walletconnect-v2/dist/utils.js b/node_modules/@web3-react/walletconnect-v2/dist/utils.js
+index 17539b6..9ea6371 100644
+--- a/node_modules/@web3-react/walletconnect-v2/dist/utils.js
++++ b/node_modules/@web3-react/walletconnect-v2/dist/utils.js
+@@ -62,8 +62,8 @@ function getBestUrl(urls, timeout) {
+         if (urls.length === 1)
+             return urls[0];
+         const [HttpConnection, JsonRpcProvider] = yield Promise.all([
+-            Promise.resolve().then(() => __importStar(require('@walletconnect/jsonrpc-http-connection'))).then(({ HttpConnection }) => HttpConnection),
+-            Promise.resolve().then(() => __importStar(require('@walletconnect/jsonrpc-provider'))).then(({ JsonRpcProvider }) => JsonRpcProvider),
++            Promise.resolve().then(async () => __importStar(await import('@walletconnect/jsonrpc-http-connection'))).then(({ HttpConnection }) => HttpConnection),
++            Promise.resolve().then(async () => __importStar(await import('@walletconnect/jsonrpc-provider'))).then(({ JsonRpcProvider }) => JsonRpcProvider),
+         ]);
+         // the below returns the first url for which there's been a successful call, prioritized by index
+         return new Promise((resolve) => {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Fixes web3-react so that large libs (especially coinbase) are lazy-loaded. This improves pageload, as coinbase is a ~500kb package.
This is an issue because cjs libs use `require`, which is not split into an async package by webpack (see https://webpack.js.org/api/module-methods/#requireensure).

Until a better fix is found - presumably either (a) re-compiling our own packages, or (b) adding a custom loader to translate `__importStar(require('package'))` to `__importStar(await import('package'))` - this is being done as a patch for web3-react, so that the *large* savings of not loading coinbase-wallet on pageload can be realized.