### PR TITLE
chore: Remove Hardcoded Uni Wallet Supported Chains List

### DIFF
--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -7,12 +7,7 @@ import { getConnection } from 'connection'
 import { ConnectionType } from 'connection/types'
 import { WalletConnectV2 } from 'connection/WalletConnectV2'
 import { getChainInfo } from 'constants/chainInfo'
-import {
-  getChainPriority,
-  L1_CHAIN_IDS,
-  L2_CHAIN_IDS,
-  TESTNET_CHAIN_IDS,
-} from 'constants/chains'
+import { getChainPriority, L1_CHAIN_IDS, L2_CHAIN_IDS, TESTNET_CHAIN_IDS } from 'constants/chains'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import useSelectChain from 'hooks/useSelectChain'
 import useSyncChainQuery from 'hooks/useSyncChainQuery'

--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -38,11 +38,11 @@ interface ChainSelectorProps {
 
 function useWalletSupportedChains(): ChainId[] {
   const { connector } = useWeb3React()
-
   const connectionType = getConnection(connector).type
 
   switch (connectionType) {
-    case ConnectionType.WALLET_CONNECT_V2 || ConnectionType.UNISWAP_WALLET_V2:
+    case ConnectionType.WALLET_CONNECT_V2:
+    case ConnectionType.UNISWAP_WALLET_V2:
       return getSupportedChainIdsFromWalletConnectSession((connector as WalletConnectV2).provider?.session)
     default:
       return NETWORK_SELECTOR_CHAINS

--- a/src/components/NavBar/ChainSelector.tsx
+++ b/src/components/NavBar/ChainSelector.tsx
@@ -12,7 +12,6 @@ import {
   L1_CHAIN_IDS,
   L2_CHAIN_IDS,
   TESTNET_CHAIN_IDS,
-  UniWalletSupportedChains,
 } from 'constants/chains'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import useSelectChain from 'hooks/useSelectChain'
@@ -43,10 +42,8 @@ function useWalletSupportedChains(): ChainId[] {
   const connectionType = getConnection(connector).type
 
   switch (connectionType) {
-    case ConnectionType.WALLET_CONNECT_V2:
+    case ConnectionType.WALLET_CONNECT_V2 || ConnectionType.UNISWAP_WALLET_V2:
       return getSupportedChainIdsFromWalletConnectSession((connector as WalletConnectV2).provider?.session)
-    case ConnectionType.UNISWAP_WALLET_V2:
-      return UniWalletSupportedChains
     default:
       return NETWORK_SELECTOR_CHAINS
   }

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -1,13 +1,5 @@
 import { ChainId, SUPPORTED_CHAINS, SupportedChainsType } from '@uniswap/sdk-core'
 
-export const UniWalletSupportedChains = [
-  ChainId.MAINNET,
-  ChainId.ARBITRUM_ONE,
-  ChainId.OPTIMISM,
-  ChainId.POLYGON,
-  ChainId.BASE,
-]
-
 export const CHAIN_IDS_TO_NAMES = {
   [ChainId.MAINNET]: 'mainnet',
   [ChainId.GOERLI]: 'goerli',


### PR DESCRIPTION

## Description
Removes the hardcoded `UniWalletSupportedChains` config, and relies on supported chains from wallet connect 



### QA (ie manual testing)

- connect a uniswap wallet
- ensure that chains not currently supported by the uni wallet (bnb, celo) are not listed as chains you can connect to
- ensure the rest of the chains are able to be connected to 

