### PR TITLE
feat: remove overlay cutoff

### DIFF
--- a/src/nft/components/profile/list/ListPage.tsx
+++ b/src/nft/components/profile/list/ListPage.tsx
@@ -139,6 +139,7 @@ const FloatingConfirmationBar = styled(Row)<{ issues: boolean }>`
 const Overlay = styled.div`
   position: fixed;
   bottom: 0px;
+  left: 0px;
   height: 158px;
   width: 100vw;
   background: ${({ theme }) => `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, ${theme.surface2} 100%)`};

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -26,6 +26,7 @@ const TableHeader = styled.div`
   font-size: 14px;
   font-weight: normal;
   line-height: 20px;
+  border-radius: 12px;
 
   @media screen and (min-width: ${BREAKPOINTS.sm}px) {
     padding-left: 48px;


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Overlay behind listing page confirmation would cutoff on the left now it's the full length of the page
- The table header was also missing border-radius so I added it back

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C04D07TQBT4/p1694730206799959


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
![image (1)](https://github.com/Uniswap/interface/assets/11512321/e062c317-1068-4160-9680-1fdbe3c5bdf9)
![IMG_2959](https://github.com/Uniswap/interface/assets/11512321/6395697f-ed8e-4d12-a752-61ab8021af55)



### After
![Screenshot 2023-09-15 at 5 08 31 PM](https://github.com/Uniswap/interface/assets/11512321/cd9aad03-4a6a-4463-90f1-7e80baf7ff8a)


