### PR TITLE
fix: TokenDetails block explorer links to token page instead of address page

### DIFF
--- a/src/components/Tokens/TokenDetails/About.tsx
+++ b/src/components/Tokens/TokenDetails/About.tsx
@@ -106,7 +106,7 @@ export function AboutSection({ address, chainId, description, homepageUrl, twitt
       <ResourcesContainer data-cy="resources-container">
         <Resource
           name={chainId === ChainId.MAINNET ? 'Etherscan' : 'Block Explorer'}
-          link={`${explorer}${address === 'NATIVE' ? '' : 'address/' + address}`}
+          link={`${explorer}${address === 'NATIVE' ? '' : 'token/' + address}`}
         />
         <Resource name="More analytics" link={`${infoLink}tokens/${address}`} />
         {homepageUrl && <Resource name="Website" link={homepageUrl} />}


### PR DESCRIPTION
fixes #6746 

### Description
Opening in a block explorer from the TokenDetails page should redirect to a Token Page but it redirects to the Address Page instead. This is fixed in this PR

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

|    Before    |   After    |
| ------------ | ------------ |
|<video src="https://github.com/Uniswap/interface/assets/89173284/46107dc0-e11a-467b-a1fa-417a550f85ff"> |<video src="https://github.com/Uniswap/interface/assets/89173284/97227dc1-ee0b-4b38-a254-64347eb73838">|


### Reproducing the error
1. Navigate to app.uniswap.org
2. Click "tokens" in navbar
3. Click on a token
4. Click on "etherscan" 
5. Should open to the "token page" in the block explorer bu tit opens to a 


