### PR TITLE
build: improve tree-shaking

### DIFF
--- a/craco.config.cjs
+++ b/craco.config.cjs
@@ -5,7 +5,6 @@ const { execSync } = require('child_process')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const path = require('path')
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin')
-const TerserPlugin = require('terser-webpack-plugin')
 const { IgnorePlugin, ProvidePlugin } = require('webpack')
 const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin')
 
@@ -140,18 +139,20 @@ module.exports = {
         return rule
       })
 
+      // Run terser compression on node_modules before tree-shaking, so that tree-shaking is more effective.
+      // This works by eliminating dead code, so that webpack can identify unused imports and tree-shake them;
+      // it is only necessary for node_modules - it is done through linting for our own source code -
+      // see https://medium.com/engineering-housing/dead-code-elimination-and-tree-shaking-at-housing-part-1-307a94b30f23#7e03:
+      webpackConfig.module.rules.push({
+        enforce: 'post',
+        test: /node_modules.*\.(js)$/,
+        loader: path.join(__dirname, 'scripts/terser-loader.js'),
+        options: { compress: true, mangle: false },
+      })
+
       // Configure webpack optimization:
       webpackConfig.optimization = Object.assign(
         webpackConfig.optimization,
-        {
-          minimize: isProduction,
-          minimizer: [
-            new TerserPlugin({
-              minify: TerserPlugin.swcMinify,
-              parallel: require('os').cpus().length,
-            }),
-          ],
-        },
         isProduction
           ? {
               splitChunks: {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "source-map-explorer": "^2.5.3",
     "start-server-and-test": "^2.0.0",
     "swc-loader": "^0.2.3",
+    "terser": "^5.19.4",
     "terser-webpack-plugin": "^5.3.9",
     "ts-jest": "^29.1.1",
     "ts-transform-graphql-tag": "^0.2.1",

--- a/scripts/terser-loader.js
+++ b/scripts/terser-loader.js
@@ -1,0 +1,15 @@
+/* eslint-env node */
+
+const { minify } = require('terser')
+
+module.exports = async function terserLoader(source, map, meta) {
+  const callback = this.async()
+  const options = this.getOptions()
+  try {
+    const data = await minify(source, options)
+    const { code } = data || {}
+    callback(null, code, map, meta)
+  } catch (e) {
+    callback(e)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19504,6 +19504,16 @@ terser@^5.0.0, terser@^5.10.0, terser@^5.16.8:
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
+terser@^5.19.4:
+  version "5.19.4"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.4.tgz#941426fa482bf9b40a0308ab2b3cd0cf7c775ebd"
+  integrity sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Reduces the initial payload size by eliminating 0.1 MiB of dead code and, more importantly, delivers the payload in 3 assets (node_modules, source, and css). Currently, the payload is delivered in 8 assets, as node_modules is split amongst 6 files. This improves pageload time by allowing all of the node_modules scripts to be parsed/evaluated at once, shaving off 100ms in local testing.

This is done by compressing the code (using `terser`) before tree-shaking, so that dead code is exposed by the compression (which will remove unused usages of imports), as described in [Extreme Dead Code Elimination](https://medium.com/engineering-housing/dead-code-elimination-and-tree-shaking-at-housing-part-1-307a94b30f23#7e03).

Also adds back CSS compression by removing the custom minimizers and using those provided by create-react-app.


<!-- Delete this section if your change does not affect UI. -->
## Tree maps

|    Current   |   With improved tree-shaking    |
| ------------ | ------------ |
| <img src="https://github.com/Uniswap/interface/assets/5403956/ff325332-561e-4222-8fa8-d237cae9a834" /> | <img src="https://github.com/Uniswap/interface/assets/5403956/19d3fe92-5de6-4244-8a05-716460e2888b" /> |
