### PR TITLE
fix: do not re-init active locale

### DIFF
--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -10,6 +10,7 @@ i18n.load(DEFAULT_LOCALE, DEFAULT_MESSAGES)
 i18n.activate(DEFAULT_LOCALE)
 
 export async function dynamicActivate(locale: SupportedLocale) {
+  if (i18n.locale === locale) return
   try {
     const catalog = await import(`locales/${locale}.js`)
     // Bundlers will either export it as default or as a named export named default.

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -78,8 +78,10 @@ const userSlice = createSlice({
       state.selectedWallet = wallet
     },
     updateUserLocale(state, action) {
-      state.userLocale = action.payload.userLocale
-      state.timestamp = currentTimestamp()
+      if (action.payload.userLocale !== state.userLocale) {
+        state.userLocale = action.payload.userLocale
+        state.timestamp = currentTimestamp()
+      }
     },
     updateUserSlippageTolerance(state, action) {
       state.userSlippageTolerance = action.payload.userSlippageTolerance


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Does not re-load and re-activate the locale if it has already been loaded.
This prevents a re-render during initialization for en-US users, improving pageload time.