### PR TITLE
fix: defer popper style recalc until use

### DIFF
--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -112,7 +112,7 @@ export default function Popover({
     [placement, offsetX, offsetY, arrowElement]
   )
 
-  const { styles, update, attributes } = usePopper(referenceElement, popperElement, options)
+  const { styles, update, attributes } = usePopper(referenceElement, show ? popperElement : null, options)
 
   const updateCallback = useCallback(() => {
     update && update()


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Defers popper style recalculation until it is used. This prevents style recalculations during the initial render, which would otherwise force a repaint and delay largest contentful paint (LCP). Effectively, this improves pageload time.

This is necessary because popper uses CSSOM APIs (like `getBoundingClientRect`) to determine its bounds for painting elements, and invoking these APIs slow down the CSSOM and browsers' rendering engines.

## Test plan

Manually tested that popovers still worked, by hovering over the settings `?` icons.