### PR TITLE
fix: quote price in SwapDetailsDropdown should match execution price

### DIFF
--- a/src/components/swap/TradePrice.tsx
+++ b/src/components/swap/TradePrice.tsx
@@ -32,8 +32,8 @@ export default function TradePrice({ price }: TradePriceProps) {
 
   const [showInverted, setShowInverted] = useState<boolean>(false)
 
-  const { baseCurrency, quoteCurrency } = price
-  const { data: usdPrice } = useUSDPrice(tryParseCurrencyAmount('1', showInverted ? baseCurrency : quoteCurrency))
+  const { quoteCurrency } = price
+  const { data: usdPrice } = useUSDPrice(tryParseCurrencyAmount('1', quoteCurrency))
 
   const formattedPrice = useMemo(() => {
     try {
@@ -63,7 +63,7 @@ export default function TradePrice({ price }: TradePriceProps) {
           <Trans>
             (
             {formatNumber({
-              input: usdPrice,
+              input: showInverted && formattedPrice ? Number(formattedPrice) * usdPrice : usdPrice,
               type: NumberType.FiatTokenPrice,
             })}
             )


### PR DESCRIPTION
fixes #2648 

## Description
The price in SwapDetailsDropdown should match the execution price.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

|    Before   |   After    |
| ------------ | ------------ |
|<img width="518" alt="Screenshot 2023-09-18 at 4 06 23 PM" src="https://github.com/Uniswap/interface/assets/89173284/8031c984-a9b9-4632-aee1-eb73e4da7edf">|<img width="518" alt="Screenshot 2023-09-18 at 4 04 51 PM" src="https://github.com/Uniswap/interface/assets/89173284/3cc4d543-2271-4649-a829-038b36b6c4eb">|



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1.  Navigate to [uniswap](app.uniswap.org/swap)
2. Enter in a huge number like 1000000
3. Select a output token
4. Look at the ETH to output token ratio