### PR TITLE
feat: change address screening service to Uniswap /screen API

### DIFF
--- a/src/hooks/useAccountRiskCheck.test.ts
+++ b/src/hooks/useAccountRiskCheck.test.ts
@@ -32,8 +32,8 @@ describe('useAccountRiskCheck', () => {
     })
   })
 
-  it('should handle unblocked account', async () => {
-    const account = 'unblocked-account'
+  it('should handle non-blocked account', async () => {
+    const account = 'non-blocked-account'
     const mockResponse = { block: false }
     const fetchMock = jest.spyOn(window, 'fetch').mockResolvedValueOnce({
       json: jest.fn().mockResolvedValueOnce(mockResponse),

--- a/src/hooks/useAccountRiskCheck.test.ts
+++ b/src/hooks/useAccountRiskCheck.test.ts
@@ -1,0 +1,56 @@
+import { ApplicationModal, setOpenModal } from 'state/application/reducer'
+import { renderHook, waitFor } from 'test-utils/render'
+
+import useAccountRiskCheck from './useAccountRiskCheck'
+
+// Mock the useAppDispatch hook
+const dispatchMock = jest.fn()
+jest.mock('state/hooks', () => ({
+  useAppDispatch: () => dispatchMock,
+}))
+
+describe('useAccountRiskCheck', () => {
+  it('should handle blocked account', async () => {
+    const account = 'blocked-account'
+    const mockResponse = { block: true }
+    const fetchMock = jest.spyOn(window, 'fetch').mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce(mockResponse),
+    } as any)
+
+    renderHook(() => useAccountRiskCheck(account))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('https://api.uniswap.org/v1/screen', {
+        method: 'POST',
+        headers: new Headers({
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ address: account }),
+      })
+
+      expect(dispatchMock).toHaveBeenCalledWith(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
+    })
+  })
+
+  it('should handle unblocked account', async () => {
+    const account = 'unblocked-account'
+    const mockResponse = { block: false }
+    const fetchMock = jest.spyOn(window, 'fetch').mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce(mockResponse),
+    } as any)
+
+    renderHook(() => useAccountRiskCheck(account))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('https://api.uniswap.org/v1/screen', {
+        method: 'POST',
+        headers: new Headers({
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ address: account }),
+      })
+
+      expect(dispatchMock).not.toHaveBeenCalledWith(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
+    })
+  })
+})

--- a/src/hooks/useAccountRiskCheck.ts
+++ b/src/hooks/useAccountRiskCheck.ts
@@ -8,29 +8,71 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
 
   useEffect(() => {
     if (account) {
+      // check local browser cache
       const riskCheckLocalStorageKey = `risk-check-${account}`
       const now = Date.now()
       try {
         const storedTime = localStorage.getItem(riskCheckLocalStorageKey)
         const checkExpirationTime = storedTime ? parseInt(storedTime) : now - 1
         if (checkExpirationTime < Date.now()) {
-          const headers = new Headers({ 'Content-Type': 'application/json' })
-          fetch('https://screening-worker.uniswap.workers.dev', {
+          // query API
+          const headers = new Headers({
+            'Content-Type': 'application/json',
+          })
+          fetch('https://api.uniswap.org/v1/screen', {
             method: 'POST',
             headers,
             body: JSON.stringify({ address: account }),
           })
             .then((res) => res.json())
             .then((data) => {
+              console.log('SUCCESSFUL DATA', data)
+              // if blocked, dispatch Blocked modal
               if (data.block) {
                 dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
               }
             })
-            .catch(() => dispatch(setOpenModal(null)))
+            .catch((err) => {
+              console.log('NOT SUCCESSFUL', err)
+              dispatch(setOpenModal(null))
+            })
         }
       } finally {
+        // Set item to have 1 day local cache storage
         localStorage.setItem(riskCheckLocalStorageKey, (now + ms(`1d`)).toString())
       }
     }
   }, [account, dispatch])
 }
+
+// export default function useAccountRiskCheck(account: string | null | undefined) {
+//   const dispatch = useAppDispatch()
+
+//   useEffect(() => {
+//     if (account) {
+//       const riskCheckLocalStorageKey = `risk-check-${account}`
+//       const now = Date.now()
+//       try {
+//         const storedTime = localStorage.getItem(riskCheckLocalStorageKey)
+//         const checkExpirationTime = storedTime ? parseInt(storedTime) : now - 1
+//         if (checkExpirationTime < Date.now()) {
+//           const headers = new Headers({ 'Content-Type': 'application/json' })
+//           fetch('https://screening-worker.uniswap.workers.dev', {
+//             method: 'POST',
+//             headers,
+//             body: JSON.stringify({ address: account }),
+//           })
+//             .then((res) => res.json())
+//             .then((data) => {
+//               if (data.block) {
+//                 dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
+//               }
+//             })
+//             .catch(() => dispatch(setOpenModal(null)))
+//         }
+//       } finally {
+//         localStorage.setItem(riskCheckLocalStorageKey, (now + ms(`1d`)).toString())
+//       }
+//     }
+//   }, [account, dispatch])
+// }

--- a/src/hooks/useAccountRiskCheck.ts
+++ b/src/hooks/useAccountRiskCheck.ts
@@ -15,9 +15,7 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
         const storedTime = localStorage.getItem(riskCheckLocalStorageKey)
         const checkExpirationTime = storedTime ? parseInt(storedTime) : now - 1
         if (checkExpirationTime < Date.now()) {
-          const headers = new Headers({
-            'Content-Type': 'application/json',
-          })
+          const headers = new Headers({ 'Content-Type': 'application/json' })
           fetch('https://api.uniswap.org/v1/screen', {
             method: 'POST',
             headers,
@@ -29,8 +27,7 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
                 dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
               }
             })
-            .catch((e) => {
-              console.error(e)
+            .catch(() => {
               dispatch(setOpenModal(null))
             })
         }

--- a/src/hooks/useAccountRiskCheck.ts
+++ b/src/hooks/useAccountRiskCheck.ts
@@ -8,14 +8,13 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
 
   useEffect(() => {
     if (account) {
-      // check local browser cache
       const riskCheckLocalStorageKey = `risk-check-${account}`
       const now = Date.now()
       try {
+        // Check local browser cache
         const storedTime = localStorage.getItem(riskCheckLocalStorageKey)
         const checkExpirationTime = storedTime ? parseInt(storedTime) : now - 1
         if (checkExpirationTime < Date.now()) {
-          // query API
           const headers = new Headers({
             'Content-Type': 'application/json',
           })
@@ -26,14 +25,12 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
           })
             .then((res) => res.json())
             .then((data) => {
-              console.log('SUCCESSFUL DATA', data)
-              // if blocked, dispatch Blocked modal
               if (data.block) {
                 dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
               }
             })
-            .catch((err) => {
-              console.log('NOT SUCCESSFUL', err)
+            .catch((e) => {
+              console.error(e)
               dispatch(setOpenModal(null))
             })
         }
@@ -44,35 +41,3 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
     }
   }, [account, dispatch])
 }
-
-// export default function useAccountRiskCheck(account: string | null | undefined) {
-//   const dispatch = useAppDispatch()
-
-//   useEffect(() => {
-//     if (account) {
-//       const riskCheckLocalStorageKey = `risk-check-${account}`
-//       const now = Date.now()
-//       try {
-//         const storedTime = localStorage.getItem(riskCheckLocalStorageKey)
-//         const checkExpirationTime = storedTime ? parseInt(storedTime) : now - 1
-//         if (checkExpirationTime < Date.now()) {
-//           const headers = new Headers({ 'Content-Type': 'application/json' })
-//           fetch('https://screening-worker.uniswap.workers.dev', {
-//             method: 'POST',
-//             headers,
-//             body: JSON.stringify({ address: account }),
-//           })
-//             .then((res) => res.json())
-//             .then((data) => {
-//               if (data.block) {
-//                 dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
-//               }
-//             })
-//             .catch(() => dispatch(setOpenModal(null)))
-//         }
-//       } finally {
-//         localStorage.setItem(riskCheckLocalStorageKey, (now + ms(`1d`)).toString())
-//       }
-//     }
-//   }, [account, dispatch])
-// }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
* Change our address screening service from current cloudflare worker ([wallet-screening-server](https://github.com/Uniswap/wallet-screening-server)) to Uniswap /screen API


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2587/move-web-app-trm-checking-to-use-same-backend-endpoint-as-the-mobile
_PR to API repo:_ https://github.com/Uniswap/api/pull/110

## Test plan
* unit tests in /interface repo

### QA (ie manual testing)
* replace UNISWAP_API_V1 in .env using my deployed AWS dev API (https://xtr344xw65.execute-api.us-east-1.amazonaws.com/prod/screen)
