### PR TITLE
fix: reset LDO approvals

### DIFF
--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -12,7 +12,7 @@ import Badge from 'components/Badge'
 import Modal, { MODAL_TRANSITION_DURATION } from 'components/Modal'
 import { RowFixed } from 'components/Row'
 import { getChainInfo } from 'constants/chainInfo'
-import { USDT as USDT_MAINNET } from 'constants/tokens'
+import { LDO, USDT as USDT_MAINNET } from 'constants/tokens'
 import { TransactionStatus } from 'graphql/data/__generated__/types-and-hooks'
 import { useMaxAmountIn } from 'hooks/useMaxAmountIn'
 import { Allowance, AllowanceState } from 'hooks/usePermit2Allowance'
@@ -43,7 +43,7 @@ import SwapModalHeader from './SwapModalHeader'
 export enum ConfirmModalState {
   REVIEWING,
   WRAPPING,
-  RESETTING_USDT,
+  RESETTING_TOKEN,
   APPROVING_TOKEN,
   PERMITTING,
   PENDING_CONFIRMATION,
@@ -58,9 +58,13 @@ const StyledL2Logo = styled.img`
   width: 16px;
 `
 
+// Any existing USDT or LDO allowance needs to be reset before we can approve the new amount (mainnet only).
+// See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
+const RESET_APPROVAL_TOKENS = [USDT_MAINNET, LDO]
+
 function isInApprovalPhase(confirmModalState: ConfirmModalState) {
   return (
-    confirmModalState === ConfirmModalState.RESETTING_USDT ||
+    confirmModalState === ConfirmModalState.RESETTING_TOKEN ||
     confirmModalState === ConfirmModalState.APPROVING_TOKEN ||
     confirmModalState === ConfirmModalState.PERMITTING
   )
@@ -94,15 +98,13 @@ function useConfirmModalState({
     if (trade.fillType === TradeFillType.UniswapX && trade.wrapInfo.needsWrap) {
       steps.push(ConfirmModalState.WRAPPING)
     }
-    // Any existing USDT allowance needs to be reset before we can approve the new amount (mainnet only).
-    // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
     if (
       allowance.state === AllowanceState.REQUIRED &&
       allowance.needsSetupApproval &&
-      allowance.token.equals(USDT_MAINNET) &&
+      RESET_APPROVAL_TOKENS.some((token) => token.equals(allowance.token)) &&
       allowance.allowedAmount.greaterThan(0)
     ) {
-      steps.push(ConfirmModalState.RESETTING_USDT)
+      steps.push(ConfirmModalState.RESETTING_TOKEN)
     }
     if (allowance.state === AllowanceState.REQUIRED && allowance.needsSetupApproval) {
       steps.push(ConfirmModalState.APPROVING_TOKEN)
@@ -159,8 +161,8 @@ function useConfirmModalState({
             })
             .catch((e) => catchUserReject(e, PendingModalError.WRAP_ERROR))
           break
-        case ConfirmModalState.RESETTING_USDT:
-          setConfirmModalState(ConfirmModalState.RESETTING_USDT)
+        case ConfirmModalState.RESETTING_TOKEN:
+          setConfirmModalState(ConfirmModalState.RESETTING_TOKEN)
           invariant(allowance.state === AllowanceState.REQUIRED, 'Allowance should be required')
           allowance.revoke().catch((e) => catchUserReject(e, PendingModalError.TOKEN_APPROVAL_ERROR))
           break

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -97,7 +97,7 @@ export type PendingConfirmModalState = Extract<
   | ConfirmModalState.PERMITTING
   | ConfirmModalState.PENDING_CONFIRMATION
   | ConfirmModalState.WRAPPING
-  | ConfirmModalState.RESETTING_TOKEN
+  | ConfirmModalState.RESETTING_TOKEN_ALLOWANCE
 >
 
 interface PendingModalStep {
@@ -207,7 +207,7 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
         ),
         bottomLabel: wrapPending ? t`Pending...` : t`Proceed in your wallet`,
       },
-      [ConfirmModalState.RESETTING_TOKEN]: {
+      [ConfirmModalState.RESETTING_TOKEN_ALLOWANCE]: {
         title: t`Reset ${approvalCurrency?.symbol}`,
         subtitle: t`${approvalCurrency?.symbol} requires resetting approval when spending limits are too low.`,
         bottomLabel: revocationPending ? t`Pending...` : t`Proceed in your wallet`,

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -97,7 +97,7 @@ export type PendingConfirmModalState = Extract<
   | ConfirmModalState.PERMITTING
   | ConfirmModalState.PENDING_CONFIRMATION
   | ConfirmModalState.WRAPPING
-  | ConfirmModalState.RESETTING_USDT
+  | ConfirmModalState.RESETTING_TOKEN
 >
 
 interface PendingModalStep {
@@ -207,9 +207,9 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
         ),
         bottomLabel: wrapPending ? t`Pending...` : t`Proceed in your wallet`,
       },
-      [ConfirmModalState.RESETTING_USDT]: {
-        title: t`Reset USDT`,
-        subtitle: t`USDT requires resetting approval when spending limits are too low.`,
+      [ConfirmModalState.RESETTING_TOKEN]: {
+        title: t`Reset ${approvalCurrency?.symbol}`,
+        subtitle: t`${approvalCurrency?.symbol} requires resetting approval when spending limits are too low.`,
         bottomLabel: revocationPending ? t`Pending...` : t`Proceed in your wallet`,
       },
       [ConfirmModalState.APPROVING_TOKEN]: {

--- a/src/components/swap/constants.ts
+++ b/src/components/swap/constants.ts
@@ -1,0 +1,5 @@
+import { LDO, USDT as USDT_MAINNET } from 'constants/tokens'
+
+// Any existing USDT or LDO allowance needs to be reset before we can approve the new amount (mainnet only).
+// See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
+export const RESET_APPROVAL_TOKENS = [USDT_MAINNET, LDO]

--- a/src/components/swap/constants.ts
+++ b/src/components/swap/constants.ts
@@ -1,5 +1,5 @@
 import { LDO, USDT as USDT_MAINNET } from 'constants/tokens'
 
-// Any existing USDT or LDO allowance needs to be reset before we can approve the new amount (mainnet only).
+// List of tokens that require existing allowance to be reset before approving the new amount (mainnet only).
 // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
 export const RESET_APPROVAL_TOKENS = [USDT_MAINNET, LDO]

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -260,6 +260,8 @@ export const ARB = new Token(ChainId.ARBITRUM_ONE, '0x912CE59144191C1204E64559FE
 
 export const OP = new Token(ChainId.OPTIMISM, '0x4200000000000000000000000000000000000042', 18, 'OP', 'Optimism')
 
+export const LDO = new Token(ChainId.MAINNET, '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32', 18, 'LDO', 'Lido DAO Token')
+
 export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } = {
   ...(WETH9 as Record<ChainId, Token>),
   [ChainId.OPTIMISM]: new Token(


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

LDO token has the same `approve` logic as USDT on mainnet which requires you to reset the allowance to zero before increasing the amount.


see the contract source code [here](https://etherscan.io/token/0x5a98fcbea516cf06857215779fd812ca3bef1b32#code)

```
function approve(address _spender, uint256 _amount) public returns (bool success) {
// ........
        // To change the approve amount you first have to reduce the addresses`
        //  allowance to zero by calling `approve(_spender,0)` if it is not
        //  already 0 to mitigate the race condition described here:
        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
        require((_amount == 0) || (allowed[msg.sender][_spender] == 0));
// ........
}
```


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2857/generalize-reset-usdt-approval-step-to-work-for-ldo-too


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

https://github.com/Uniswap/interface/assets/66155195/a77a1dbf-5f1c-4d3f-8700-44bfa3046fe1



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1.  set your LDO token allowance to some amount greater than zero, but smaller than the amount you want to trade.
2. try to trade the higher amount and notice that the approval step fails.

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Integration/E2E test - existing tests for the USDT flow
