### PR TITLE
fix: use Date as a performance tracker fallback

### DIFF
--- a/src/tracing/SwapEventTimestampTracker.test.ts
+++ b/src/tracing/SwapEventTimestampTracker.test.ts
@@ -1,7 +1,7 @@
 import { SwapEventTimestampTracker, SwapEventType } from './SwapEventTimestampTracker'
 
 jest.mock('./utils', () => ({
-  calculateElapsedTimeWithPerformanceMark: (mark: string) => {
+  calculateElapsedTimeWithPerformanceMarkMs: (mark: string) => {
     switch (mark) {
       case SwapEventType.FIRST_SWAP_ACTION:
         return 100

--- a/src/tracing/SwapEventTimestampTracker.ts
+++ b/src/tracing/SwapEventTimestampTracker.ts
@@ -1,4 +1,4 @@
-import { calculateElapsedTimeWithPerformanceMark } from './utils'
+import { calculateElapsedTimeWithPerformanceMarkMs } from './utils'
 
 // These events should happen in this order.
 export enum SwapEventType {
@@ -18,6 +18,7 @@ export enum SwapEventType {
 
 export class SwapEventTimestampTracker {
   private static _instance: SwapEventTimestampTracker
+  private createdAt = Date.now()
   private constructor() {
     // Private constructor to prevent direct construction calls with the `new` operator.
   }
@@ -36,7 +37,7 @@ export class SwapEventTimestampTracker {
 
   public setElapsedTime(eventType: SwapEventType): number | undefined {
     if (this.timestamps.has(eventType)) return undefined
-    const elapsedTime = calculateElapsedTimeWithPerformanceMark(eventType)
+    const elapsedTime = calculateElapsedTimeWithPerformanceMarkMs(eventType, this.createdAt)
     if (elapsedTime) {
       this.timestamps.set(eventType, elapsedTime)
     }

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -1,9 +1,18 @@
 /**
- * Returns the time elapsed between page load and now.
+ * Returns the time elapsed between page load and now in milliseconds.
  * @param markName the identifier for the performance mark to be created and measured.
  */
-export function calculateElapsedTimeWithPerformanceMark(markName: string): number | undefined {
+export function calculateElapsedTimeWithPerformanceMarkMs(
+  markName: string,
+  fallbackStartTime?: number
+): number | undefined {
   const elapsedTime = performance.mark(markName)
-  if (!elapsedTime) return undefined
-  return elapsedTime.startTime
+  if (elapsedTime) {
+    return elapsedTime.startTime
+  }
+  if (fallbackStartTime) {
+    // On some browsers like iOS WebViews, performance.mark is not supported.
+    return Date.now() - fallbackStartTime
+  }
+  return undefined
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

on some browsers like iOS webviews , `performance.mark` doesn't actually return the expected value. 

in this case a good approximate fallback is just measuring from the creation of the `SwapEventTimestampTracker` singleton.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2733/elapsedtime-is-undefined-on-ios-webview


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/66155195/7eb4e656-63f0-40c0-9e2f-ac5e250627ce


## Test plan
### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually removed the `performance.mark` to ensure that the "time_to_first_x" values are still populated with the fallback

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
- [x] Integration/E2E test
