### PR TITLE
fix: ui fixes on the add liquidity flow

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -161,6 +161,10 @@ const StyledNumericalInput = styled(NumericalInput)<{ $loading: boolean }>`
   text-align: left;
 `
 
+const StyledPrefetchBalancesWrapper = styled(PrefetchBalancesWrapper)<{ $fullWidth: boolean }>`
+  width: ${({ $fullWidth }) => ($fullWidth ? '100%' : 'auto')};
+`
+
 interface CurrencyInputPanelProps {
   value: string
   onUserInput: (value: string) => void
@@ -231,7 +235,7 @@ export default function CurrencyInputPanel({
                 />
               )}
 
-              <PrefetchBalancesWrapper shouldFetchOnAccountUpdate={modalOpen}>
+              <StyledPrefetchBalancesWrapper shouldFetchOnAccountUpdate={modalOpen} $fullWidth={hideInput}>
                 <CurrencySelect
                   disabled={!chainAllowed}
                   visible={currency !== undefined}
@@ -274,7 +278,7 @@ export default function CurrencyInputPanel({
                     {onCurrencySelect && <StyledDropDown selected={!!currency} />}
                   </Aligner>
                 </CurrencySelect>
-              </PrefetchBalancesWrapper>
+              </StyledPrefetchBalancesWrapper>
             </InputRow>
             {Boolean(!hideInput && !hideBalance && currency) && (
               <FiatRow>

--- a/src/components/NavigationTabs/index.tsx
+++ b/src/components/NavigationTabs/index.tsx
@@ -21,6 +21,8 @@ const Tabs = styled.div`
 
 const StyledLink = styled(Link)<{ flex?: string }>`
   flex: ${({ flex }) => flex ?? 'none'};
+  display: flex;
+  align-items: center;
 
   ${({ theme }) => theme.deprecated_mediaWidth.deprecated_upToMedium`
     flex: none;
@@ -82,7 +84,7 @@ export function AddRemoveTabs({
 
   return (
     <Tabs>
-      <RowBetween style={{ padding: '1rem 1rem 0 1rem' }}>
+      <RowBetween style={{ padding: '1rem 1rem 0 1rem' }} align="center">
         <StyledLink
           to={poolLink}
           onClick={() => {

--- a/src/components/PrefetchBalancesWrapper/PrefetchBalancesWrapper.tsx
+++ b/src/components/PrefetchBalancesWrapper/PrefetchBalancesWrapper.tsx
@@ -30,7 +30,8 @@ const hasUnfetchedBalancesAtom = atom<boolean>(true)
 export default function PrefetchBalancesWrapper({
   children,
   shouldFetchOnAccountUpdate,
-}: PropsWithChildren<{ shouldFetchOnAccountUpdate: boolean }>) {
+  className,
+}: PropsWithChildren<{ shouldFetchOnAccountUpdate: boolean; className?: string }>) {
   const { account } = useWeb3React()
   const [prefetchPortfolioBalances] = usePortfolioBalancesLazyQuery()
 
@@ -64,5 +65,9 @@ export default function PrefetchBalancesWrapper({
     if (hasUnfetchedBalances) fetchBalances()
   }, [fetchBalances, hasUnfetchedBalances])
 
-  return <div onMouseEnter={onHover}>{children}</div>
+  return (
+    <div onMouseEnter={onHover} className={className}>
+      {children}
+    </div>
+  )
 }

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -65,15 +65,7 @@ import { currencyId } from '../../utils/currencyId'
 import { maxAmountSpend } from '../../utils/maxAmountSpend'
 import { Dots } from '../Pool/styled'
 import { Review } from './Review'
-import {
-  CurrencyDropdown,
-  DynamicSection,
-  MediumOnly,
-  ResponsiveTwoColumns,
-  ScrollablePage,
-  StyledInput,
-  Wrapper,
-} from './styled'
+import { DynamicSection, MediumOnly, ResponsiveTwoColumns, ScrollablePage, StyledInput, Wrapper } from './styled'
 
 const DEFAULT_ADD_IN_RANGE_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
@@ -631,11 +623,11 @@ function AddLiquidity() {
                           <Trans>Select Pair</Trans>
                         </ThemedText.DeprecatedLabel>
                       </RowBetween>
-                      <RowBetween>
-                        <CurrencyDropdown
+                      <RowBetween gap="md">
+                        <CurrencyInputPanel
                           value={formattedAmounts[Field.CURRENCY_A]}
                           onUserInput={onFieldAInput}
-                          hideInput={true}
+                          hideInput
                           onMax={() => {
                             onFieldAInput(maxAmounts[Field.CURRENCY_A]?.toExact() ?? '')
                           }}
@@ -646,11 +638,9 @@ function AddLiquidity() {
                           showCommonBases
                         />
 
-                        <div style={{ width: '12px' }} />
-
-                        <CurrencyDropdown
+                        <CurrencyInputPanel
                           value={formattedAmounts[Field.CURRENCY_B]}
-                          hideInput={true}
+                          hideInput
                           onUserInput={onFieldBInput}
                           onCurrencySelect={handleCurrencyBSelect}
                           onMax={() => {

--- a/src/pages/AddLiquidity/styled.tsx
+++ b/src/pages/AddLiquidity/styled.tsx
@@ -1,5 +1,4 @@
 import { AutoColumn } from 'components/Column'
-import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import { Input } from 'components/NumericalInput'
 import styled from 'styled-components'
 
@@ -30,10 +29,6 @@ export const ScrollablePage = styled.div`
 export const DynamicSection = styled(AutoColumn)<{ disabled?: boolean }>`
   opacity: ${({ disabled }) => (disabled ? '0.2' : '1')};
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'initial')};
-`
-
-export const CurrencyDropdown = styled(CurrencyInputPanel)`
-  width: 48.5%;
 `
 
 export const StyledInput = styled(Input)`


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
fixes some visual bugs in the LP flow:
- make the token select buttons fill their parent container
- align the items in the header
- removed an unnecessary div and used `gap` instead for spacing the token select elements

the bug described in the ticket isn't happening for me.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2803/clicking-preview-when-creating-an-lp-position-requires-two-clicks


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="727" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/7311b0c8-10dd-4615-87a2-adf8a127c11d">


### After

<img width="727" alt="Screenshot 2023-09-19 at 2 40 37 PM" src="https://github.com/Uniswap/interface/assets/66155195/0f55a7f6-54b7-4b93-af0b-2381ac0a19a9">



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. go through the add liquidity flow and use eyes

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] visual inspection

