### PR TITLE
feat: lazy-load safe only if iframed

### DIFF
--- a/patches/@web3-react+gnosis-safe+8.2.3.patch
+++ b/patches/@web3-react+gnosis-safe+8.2.3.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@web3-react/gnosis-safe/dist/index.js b/node_modules/@web3-react/gnosis-safe/dist/index.js
+index 015a33c..4cd7cde 100644
+--- a/node_modules/@web3-react/gnosis-safe/dist/index.js
++++ b/node_modules/@web3-react/gnosis-safe/dist/index.js
+@@ -68,8 +68,8 @@ class GnosisSafe extends types_1.Connector {
+             if (this.eagerConnection)
+                 return;
+             // kick off import early to minimize waterfalls
+-            const SafeAppProviderPromise = Promise.resolve().then(() => __importStar(require('@safe-global/safe-apps-provider'))).then(({ SafeAppProvider }) => SafeAppProvider);
+-            yield (this.eagerConnection = Promise.resolve().then(() => __importStar(require('@safe-global/safe-apps-sdk'))).then((m) => __awaiter(this, void 0, void 0, function* () {
++            const SafeAppProviderPromise = Promise.resolve().then(async () => __importStar(await import('@safe-global/safe-apps-provider'))).then(({ SafeAppProvider }) => SafeAppProvider);
++            yield (this.eagerConnection = Promise.resolve().then(async () => __importStar(await import('@safe-global/safe-apps-sdk'))).then((m) => __awaiter(this, void 0, void 0, function* () {
+                 this.sdk = new m.default(this.options);
+                 const safe = yield Promise.race([
+                     this.sdk.safe.getInfo(),

--- a/src/connection/eagerlyConnect.ts
+++ b/src/connection/eagerlyConnect.ts
@@ -20,8 +20,14 @@ async function connect(connector: Connector, type: ConnectionType) {
   }
 }
 
-connect(gnosisSafeConnection.connector, ConnectionType.GNOSIS_SAFE)
+// The Safe connector will only work from safe.global, which iframes;
+// it is only necessary to try (and to load all the deps) if we are in an iframe.
+if (window !== window.parent) {
+  connect(gnosisSafeConnection.connector, ConnectionType.GNOSIS_SAFE)
+}
+
 connect(networkConnection.connector, ConnectionType.NETWORK)
+
 const selectedWallet = toConnectionType(localStorage.getItem(selectedWalletKey) ?? undefined)
 if (selectedWallet) {
   const selectedConnection = getConnection(selectedWallet)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
Lazy-loads Gnosis Safe, and only does so if we are on an iframe. This allows us to defer loading viem (used by Safe) unless we need to, and reduces the main bundle by 10%.