### PR TITLE
fix: should show slippage/deadline on LP flow settings

### DIFF
--- a/src/components/NavigationTabs/index.tsx
+++ b/src/components/NavigationTabs/index.tsx
@@ -1,4 +1,7 @@
 import { Trans } from '@lingui/macro'
+import { Percent } from '@uniswap/sdk-core'
+import { useWeb3React } from '@web3-react/core'
+import SettingsTab from 'components/Settings'
 import { ReactNode } from 'react'
 import { ArrowLeft } from 'react-feather'
 import { Link, useLocation } from 'react-router-dom'
@@ -61,15 +64,18 @@ const AddRemoveTitleText = styled(ThemedText.SubHeaderLarge)`
 export function AddRemoveTabs({
   adding,
   creating,
+  autoSlippage,
   positionID,
   children,
 }: {
   adding: boolean
   creating: boolean
+  autoSlippage: Percent
   positionID?: string
   showBackLink?: boolean
   children?: ReactNode
 }) {
+  const { chainId } = useWeb3React()
   const theme = useTheme()
   // reset states on back
   const dispatch = useAppDispatch()
@@ -106,6 +112,7 @@ export function AddRemoveTabs({
           )}
         </AddRemoveTitleText>
         {children && <Box style={{ marginRight: '.5rem' }}>{children}</Box>}
+        <SettingsTab autoSlippage={autoSlippage} chainId={chainId} showRoutingSettings={false} />
       </RowBetween>
     </Tabs>
   )

--- a/src/components/Settings/index.test.tsx
+++ b/src/components/Settings/index.test.tsx
@@ -1,0 +1,39 @@
+import { Percent } from '@uniswap/sdk-core'
+import { isSupportedChain } from 'constants/chains'
+import { mocked } from 'test-utils/mocked'
+import { fireEvent, render, screen, waitFor } from 'test-utils/render'
+
+import SettingsTab from './index'
+
+const slippage = new Percent(75, 10_000)
+jest.mock('constants/chains')
+
+describe('Settings Tab', () => {
+  describe('showRoutingSettings', () => {
+    beforeEach(() => {
+      mocked(isSupportedChain).mockReturnValue(true)
+    })
+
+    it('renders routing settings when showRoutingSettings is true', async () => {
+      render(<SettingsTab showRoutingSettings={true} chainId={1} autoSlippage={slippage} />)
+
+      const settingsButton = screen.getByTestId('open-settings-dialog-button')
+      fireEvent.click(settingsButton)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('toggle-local-routing-button')).toBeInTheDocument()
+      })
+    })
+
+    it('does not render routing settings when showRoutingSettings is false', async () => {
+      render(<SettingsTab showRoutingSettings={false} chainId={1} autoSlippage={slippage} />)
+
+      const settingsButton = screen.getByTestId('open-settings-dialog-button')
+      fireEvent.click(settingsButton)
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('toggle-local-routing-button')).not.toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -59,9 +59,9 @@ const MenuFlyout = styled(AutoColumn)`
   padding: 16px;
 `
 
-const ExpandColumn = styled(AutoColumn)`
+const ExpandColumn = styled(AutoColumn)<{ padTop: boolean }>`
   gap: 16px;
-  padding-top: 16px;
+  padding-top: ${({ padTop }) => (padTop ? '16px' : '0')};
 `
 
 const MobileMenuContainer = styled(Row)`
@@ -101,10 +101,12 @@ export default function SettingsTab({
   autoSlippage,
   chainId,
   trade,
+  showRoutingSettings = true,
 }: {
   autoSlippage: Percent
   chainId?: number
   trade?: InterfaceTrade
+  showRoutingSettings?: boolean
 }) {
   const { chainId: connectedChainId } = useWeb3React()
   const showDeadlineSettings = Boolean(chainId && !L2_CHAIN_IDS.includes(chainId))
@@ -123,16 +125,17 @@ export default function SettingsTab({
   useDisableScrolling(isOpen)
 
   const isChainSupported = isSupportedChain(chainId)
-
   const Settings = useMemo(
     () => (
       <>
-        <AutoColumn gap="16px">
-          <RouterPreferenceSettings />
-        </AutoColumn>
+        {showRoutingSettings && (
+          <AutoColumn gap="16px">
+            <RouterPreferenceSettings />
+          </AutoColumn>
+        )}
         <AnimatedDropdown open={!isUniswapXTrade(trade)}>
-          <ExpandColumn>
-            <Divider />
+          <ExpandColumn padTop={showRoutingSettings}>
+            {showRoutingSettings && <Divider />}
             <MaxSlippageSettings autoSlippage={autoSlippage} />
             {showDeadlineSettings && (
               <>
@@ -144,7 +147,7 @@ export default function SettingsTab({
         </AnimatedDropdown>
       </>
     ),
-    [autoSlippage, showDeadlineSettings, trade]
+    [autoSlippage, showDeadlineSettings, showRoutingSettings, trade]
   )
 
   return (

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -59,9 +59,9 @@ const MenuFlyout = styled(AutoColumn)`
   padding: 16px;
 `
 
-const ExpandColumn = styled(AutoColumn)<{ padTop: boolean }>`
+const ExpandColumn = styled(AutoColumn)<{ $padTop: boolean }>`
   gap: 16px;
-  padding-top: ${({ padTop }) => (padTop ? '16px' : '0')};
+  padding-top: ${({ $padTop }) => ($padTop ? '16px' : '0')};
 `
 
 const MobileMenuContainer = styled(Row)`
@@ -134,7 +134,7 @@ export default function SettingsTab({
           </AutoColumn>
         )}
         <AnimatedDropdown open={!isUniswapXTrade(trade)}>
-          <ExpandColumn padTop={showRoutingSettings}>
+          <ExpandColumn $padTop={showRoutingSettings}>
             {showRoutingSettings && <Divider />}
             <MaxSlippageSettings autoSlippage={autoSlippage} />
             {showDeadlineSettings && (

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -607,7 +607,13 @@ function AddLiquidity() {
           pendingText={pendingText}
         />
         <StyledBodyWrapper $hasExistingPosition={hasExistingPosition}>
-          <AddRemoveTabs creating={false} adding={true} positionID={tokenId} showBackLink={!hasExistingPosition}>
+          <AddRemoveTabs
+            creating={false}
+            adding={true}
+            positionID={tokenId}
+            autoSlippage={DEFAULT_ADD_IN_RANGE_SLIPPAGE_TOLERANCE}
+            showBackLink={!hasExistingPosition}
+          >
             {!hasExistingPosition && (
               <Row justifyContent="flex-end" style={{ width: 'fit-content', minWidth: 'fit-content' }}>
                 <MediumOnly>

--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -335,7 +335,7 @@ export default function AddLiquidity() {
   return (
     <>
       <AppBody>
-        <AddRemoveTabs creating={isCreate} adding={true} />
+        <AddRemoveTabs creating={isCreate} adding={true} autoSlippage={DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE} />
         <Wrapper>
           <TransactionConfirmationModal
             isOpen={showConfirm}

--- a/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -739,7 +739,11 @@ export default function MigrateV2Pair() {
           <ThemedText.DeprecatedMediumHeader>
             <Trans>Migrate V2 Liquidity</Trans>
           </ThemedText.DeprecatedMediumHeader>
-          <SettingsTab autoSlippage={DEFAULT_MIGRATE_SLIPPAGE_TOLERANCE} chainId={chainId} />
+          <SettingsTab
+            autoSlippage={DEFAULT_MIGRATE_SLIPPAGE_TOLERANCE}
+            chainId={chainId}
+            showRoutingSettings={false}
+          />
         </AutoRow>
 
         {!account ? (

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -300,7 +300,12 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
         pendingText={pendingText}
       />
       <AppBody $maxWidth="unset">
-        <AddRemoveTabs creating={false} adding={false} positionID={tokenId.toString()} />
+        <AddRemoveTabs
+          creating={false}
+          adding={false}
+          positionID={tokenId.toString()}
+          autoSlippage={DEFAULT_REMOVE_V3_LIQUIDITY_SLIPPAGE_TOLERANCE}
+        />
         <Wrapper>
           {position ? (
             <AutoColumn gap="lg">

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -451,7 +451,7 @@ function RemoveLiquidity() {
   return (
     <>
       <AppBody>
-        <AddRemoveTabs creating={false} adding={false} />
+        <AddRemoveTabs creating={false} adding={false} autoSlippage={DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE} />
         <Wrapper>
           <TransactionConfirmationModal
             isOpen={showConfirm}


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
* puts settings for slippage & transaction deadline back in LP flows
* SettingsTab should show routing settings only for trade/swaps

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C04D07TQBT4/p1695326833684059


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
* oopsie add/remove liquidity don't have settings

|    Swap    |   Add Liquidity    | Remove Liquidity |
| ------------ | ------------ | ------------ |
| <img width="250" alt="Screenshot 2023-09-21 at 5 15 31 PM" src="https://github.com/Uniswap/interface/assets/27475332/17d63b7f-2fe0-47ab-93ea-fb513a8f4792"> | <img width="250" alt="Screenshot 2023-09-21 at 5 19 09 PM" src="https://github.com/Uniswap/interface/assets/27475332/3660131d-0f12-49b5-8e4d-437d47532bd9"> | <img width="250" alt="Screenshot 2023-09-21 at 5 19 25 PM" src="https://github.com/Uniswap/interface/assets/27475332/1ad94b65-24ce-4ecb-94c0-35f0e26fdf8c"> |


### After
|    Swap    |   Add Liquidity    | Remove Liquidity |
| ------------ | ------------ | ------------ |
| <img width="250" alt="Screenshot 2023-09-21 at 5 15 31 PM" src="https://github.com/Uniswap/interface/assets/27475332/17d63b7f-2fe0-47ab-93ea-fb513a8f4792"> | <img width="250" alt="Screenshot 2023-09-21 at 5 13 39 PM" src="https://github.com/Uniswap/interface/assets/27475332/61a54acb-96d8-483a-b1fa-66d30528032a"> | <img width="250" alt="Screenshot 2023-09-21 at 5 13 54 PM" src="https://github.com/Uniswap/interface/assets/27475332/cace6be4-ff79-4b1f-98d1-dde8aabdf9f6"> |


### Testing
* unit test for showRoutingSettings