### PR TITLE
feat: uniswapX opt-out update

### DIFF
--- a/src/components/Settings/RouterPreferenceSettings/index.tsx
+++ b/src/components/Settings/RouterPreferenceSettings/index.tsx
@@ -8,8 +8,8 @@ import { isUniswapXSupportedChain } from 'constants/chains'
 import { useUniswapXDefaultEnabled } from 'featureFlags/flags/uniswapXDefault'
 import { useAppDispatch } from 'state/hooks'
 import { RouterPreference } from 'state/routing/types'
-import { useRouterPreference, useUserDisabledUniswapX } from 'state/user/hooks'
-import { updateDisabledUniswapX } from 'state/user/reducer'
+import { useRouterPreference, useUserOptedOutOfUniswapX } from 'state/user/hooks'
+import { updateDisabledUniswapX, updateOptedOutOfUniswapX } from 'state/user/reducer'
 import styled from 'styled-components'
 import { Divider, ExternalLink, ThemedText } from 'theme'
 
@@ -27,9 +27,9 @@ export default function RouterPreferenceSettings() {
   const [routerPreference, setRouterPreference] = useRouterPreference()
   const uniswapXEnabled = chainId && isUniswapXSupportedChain(chainId)
   const dispatch = useAppDispatch()
-  const userDisabledUniswapX = useUserDisabledUniswapX()
+  const userOptedOutOfUniswapX = useUserOptedOutOfUniswapX()
   const isUniswapXDefaultEnabled = useUniswapXDefaultEnabled()
-  const isUniswapXOverrideEnabled = isUniswapXDefaultEnabled && !userDisabledUniswapX
+  const isUniswapXOverrideEnabled = isUniswapXDefaultEnabled && !userOptedOutOfUniswapX
 
   const uniswapXInEffect =
     routerPreference === RouterPreference.X ||
@@ -61,8 +61,13 @@ export default function RouterPreferenceSettings() {
               isActive={uniswapXInEffect}
               toggle={() => {
                 if (uniswapXInEffect) {
-                  // We need to remember if a user disables Uniswap X, so we don't show the opt-in flow again.
-                  dispatch(updateDisabledUniswapX({ disabledUniswapX: true }))
+                  if (isUniswapXDefaultEnabled) {
+                    // We need to remember if a opts out of UniswapX, so we don't request UniswapX quotes.
+                    dispatch(updateOptedOutOfUniswapX({ optedOutOfUniswapX: true }))
+                  } else {
+                    // We need to remember if a user disables Uniswap X, so we don't show the opt-in flow again.
+                    dispatch(updateDisabledUniswapX({ disabledUniswapX: true }))
+                  }
                 }
                 setRouterPreference(uniswapXInEffect ? RouterPreference.API : RouterPreference.X)
               }}

--- a/src/lib/hooks/routing/useRoutingAPIArguments.ts
+++ b/src/lib/hooks/routing/useRoutingAPIArguments.ts
@@ -7,7 +7,7 @@ import { useUniswapXSyntheticQuoteEnabled } from 'featureFlags/flags/uniswapXUse
 import { useMemo } from 'react'
 import { GetQuoteArgs, INTERNAL_ROUTER_PREFERENCE_PRICE, RouterPreference } from 'state/routing/types'
 import { currencyAddressForSwapQuote } from 'state/routing/utils'
-import { useUserDisabledUniswapX } from 'state/user/hooks'
+import { useUserDisabledUniswapX, useUserOptedOutOfUniswapX } from 'state/user/hooks'
 
 /**
  * Returns query arguments for the Routing API query or undefined if the
@@ -35,6 +35,7 @@ export function useRoutingAPIArguments({
 }): GetQuoteArgs | SkipToken {
   const uniswapXForceSyntheticQuotes = useUniswapXSyntheticQuoteEnabled()
   const userDisabledUniswapX = useUserDisabledUniswapX()
+  const userOptedOutOfUniswapX = useUserOptedOutOfUniswapX()
   const uniswapXEthOutputEnabled = useUniswapXEthOutputEnabled()
   const uniswapXExactOutputEnabled = useUniswapXExactOutputEnabled()
   const isUniswapXDefaultEnabled = useUniswapXDefaultEnabled()
@@ -59,6 +60,7 @@ export function useRoutingAPIArguments({
             needsWrapIfUniswapX: tokenIn.isNative,
             uniswapXForceSyntheticQuotes,
             userDisabledUniswapX,
+            userOptedOutOfUniswapX,
             uniswapXEthOutputEnabled,
             uniswapXExactOutputEnabled,
             isUniswapXDefaultEnabled,
@@ -75,6 +77,7 @@ export function useRoutingAPIArguments({
       uniswapXExactOutputEnabled,
       uniswapXForceSyntheticQuotes,
       userDisabledUniswapX,
+      userOptedOutOfUniswapX,
       uniswapXEthOutputEnabled,
       isUniswapXDefaultEnabled,
       inputTax,

--- a/src/state/reducerTypeTest.ts
+++ b/src/state/reducerTypeTest.ts
@@ -88,6 +88,7 @@ interface ExpectedUserState {
   hideBaseWalletBanner: boolean
   showSurveyPopup?: boolean
   disabledUniswapX?: boolean
+  optedOutOfUniswapX?: boolean
 }
 
 assert<Equals<UserState, ExpectedUserState>>()

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -73,7 +73,8 @@ function getRoutingAPIConfig(args: GetQuoteArgs): RoutingConfig {
   // UniswapX doesn't support native out, exact-out, or non-mainnet trades (yet),
   // so even if the user has selected UniswapX as their router preference, force them to receive a Classic quote.
   if (
-    (args.userDisabledUniswapX && routerPreference !== RouterPreference.X) ||
+    // If the user has opted out of UniswapX during the opt-out transition period, we should respect that preference and only request classic quotes.
+    (args.userOptedOutOfUniswapX && routerPreference !== RouterPreference.X) ||
     (tokenOutIsNative && !uniswapXEthOutputEnabled) ||
     (!uniswapXExactOutputEnabled && tradeType === TradeType.EXACT_OUTPUT) ||
     !isUniswapXSupportedChain(tokenInChainId) ||

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -45,7 +45,10 @@ export interface GetQuoteArgs {
   uniswapXForceSyntheticQuotes: boolean
   uniswapXEthOutputEnabled: boolean
   uniswapXExactOutputEnabled: boolean
+  // legacy field indicating the user disabled UniswapX during the opt-in period, or dismissed the UniswapX opt-in modal.
   userDisabledUniswapX: boolean
+  // temporary field indicating the user disabled UniswapX during the transition to the opt-out model
+  userOptedOutOfUniswapX: boolean
   isUniswapXDefaultEnabled: boolean
   inputTax: Percent
   outputTax: Percent

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -221,6 +221,10 @@ export function useUserDisabledUniswapX(): boolean {
   return useAppSelector((state) => state.user.disabledUniswapX) ?? false
 }
 
+export function useUserOptedOutOfUniswapX(): boolean {
+  return useAppSelector((state) => state.user.optedOutOfUniswapX) ?? false
+}
+
 /**
  * Given two tokens return the liquidity token that represents its liquidity shares
  * @param tokenA one of the two tokens

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -47,7 +47,10 @@ export interface UserState {
 
   timestamp: number
   hideBaseWalletBanner: boolean
+  // legacy field indicating the user disabled UniswapX during the opt-in period, or dismissed the UniswapX opt-in modal.
   disabledUniswapX?: boolean
+  // temporary field indicating the user disabled UniswapX during the transition to the opt-out model
+  optedOutOfUniswapX?: boolean
   // undefined means has not gone through A/B split yet
   showSurveyPopup?: boolean
 }
@@ -105,6 +108,9 @@ const userSlice = createSlice({
     updateDisabledUniswapX(state, action) {
       state.disabledUniswapX = action.payload.disabledUniswapX
     },
+    updateOptedOutOfUniswapX(state, action) {
+      state.optedOutOfUniswapX = action.payload.optedOutOfUniswapX
+    },
     addSerializedToken(state, { payload: { serializedToken } }) {
       if (!state.tokens) {
         state.tokens = {}
@@ -138,5 +144,6 @@ export const {
   updateUserSlippageTolerance,
   updateHideBaseWalletBanner,
   updateDisabledUniswapX,
+  updateOptedOutOfUniswapX,
 } = userSlice.actions
 export default userSlice.reducer


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

updates the code for transitioning to UniswapX by default, or opt-out, phase. This change is needed because we want to opt-in users who only saw but dismissed the opt-in flow, but unfortunately right now we're treating them the same as users who actually tried uniswapX and then disabled it - both types of users would have `user.disabledUniswapX=true`. since we can't differentiate between those two groups of users, we are deciding to opt-in both groups when we roll out the on-by-default change.

now, when we flip on `isUniswapXDefaultEnabled`, we want to treat all users the same and opt them into uniswapX until they explicitly opt out again. 

as a reminder (and see the linked doc for more details), we are rolling this out gradually via the feature flag which is why we need these temporary flags. after the transition we'll be able to migrate all users to the proper RouterPreference setting via a redux migration and delete all these boolean flags

why add a new user state field? we could implement a small redux migration now to reset all users' `disabledUniswapX` values to false, but migrations only run once per user and happen in the first session after the release. this would force the timing of the rollout, and it's not compatible with a gradual rollout. using a new field decouples the app release from the feature rollout in this case.

here are the important places in code implementing the transition

- Router Preference toggle
  - This needs to *appear* enabled even if the user's routerPreference is `API` 
  - if the user disables the toggle again, after the on-by-default period has started, then it should be disabled.
  - we use the new field, `user.optedOutOfUniswapX`, to track if it's been disabled
  - we now disregard the old field, `user.disabledUniswapX` since it was too general to be useful here
- Quote request - [slice.ts](https://github.com/Uniswap/interface/blob/main/src/state/routing/slice.ts#L76)
  - this is where we actually implement whether a user has turned OFF uniswapX during this period.
  - using the new field, if the user has disabled the toggle in settings and has not re-enabled it, then we'll just request classic quotes
- Quote response - [transformRoutesToTrade](https://github.com/Uniswap/interface/blob/main/src/state/routing/utils.ts#L187)
  - this is where we decide to show the UniswapX quote instead of classic, if the price is better.
  - no changes here in this PR - we still check the featureFlag and, if true, show the better X quote to all users regardless of persisted RouterPreference.



<!-- Delete inapplicable lines: -->
_Relevant docs:_ https://www.notion.so/uniswaplabs/Web-UniswapX-Opt-Out-d7d5d33b3e2c447ab43d40cc92e427ae


## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] verified that the toggle is working as expected, and updating the persisted fields correctly


