### PR TITLE
fix: Remove e2e test

### DIFF
--- a/cypress/e2e/token-details.test.ts
+++ b/cypress/e2e/token-details.test.ts
@@ -55,14 +55,6 @@ describe('Token details', () => {
     if (cy.get('[data-cy="chart-header"]').contains('Price Unavailable')) {
       cy.get('[data-cy="missing-chart"]').should('exist')
     }
-    // Stats should have: TVL, 24H Volume, 52W low, 52W high
-    cy.get(getTestSelector('token-details-stats')).should('exist')
-    cy.get(getTestSelector('token-details-stats')).within(() => {
-      cy.get('[data-cy="tvl"]').should('exist')
-      cy.get('[data-cy="volume-24h"]').should('exist')
-      cy.get('[data-cy="52w-low"]').should('exist')
-      cy.get('[data-cy="52w-high"]').should('exist')
-    })
 
     // About section should have description of token
     cy.get(getTestSelector('token-details-about-section')).should('exist')

--- a/cypress/e2e/token-details.test.ts
+++ b/cypress/e2e/token-details.test.ts
@@ -56,6 +56,9 @@ describe('Token details', () => {
       cy.get('[data-cy="missing-chart"]').should('exist')
     }
 
+    // Stats should not exist
+    cy.get(getTestSelector('token-details-stats')).should('not.exist')
+
     // About section should have description of token
     cy.get(getTestSelector('token-details-about-section')).should('exist')
     cy.contains('QOM is the Shiba Predator').should('exist')


### PR DESCRIPTION
It looks like backend stopped returning stats data for tokens with no prices, so this test is no longer true