### PR TITLE
feat: polish blocked, nonexistent NFT collection page

### DIFF
--- a/src/constants/supportArticles.ts
+++ b/src/constants/supportArticles.ts
@@ -1,0 +1,3 @@
+export enum SupportArticleURL {
+  UNSUPPORTED_TOKEN_AND_NFT_POLICY = 'https://support.uniswap.org/hc/en-us/articles/18783694078989-Unsupported-Token-Policy',
+}

--- a/src/nft/components/collection/UnavailableCollectionPage.test.tsx
+++ b/src/nft/components/collection/UnavailableCollectionPage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from 'test-utils/render'
+
+import { UnavailableCollectionPage } from './UnavailableCollectionPage'
+
+describe('Nonexistent Collection', () => {
+  it('displays informative message', () => {
+    render(<UnavailableCollectionPage />)
+    expect(screen.getByText('No collection assets exist at this address')).toBeInTheDocument()
+  })
+
+  it('has a hyperlink back to the Explore page', () => {
+    render(<UnavailableCollectionPage />)
+    expect(screen.getByText('Return to NFT Explore')).toHaveAttribute('href', '/nfts')
+  })
+})
+
+describe('Blocked Collection', () => {
+  it('displays warning icon and informative message', () => {
+    render(<UnavailableCollectionPage isBlocked />)
+    expect(screen.getByTestId('alert-icon')).toBeInTheDocument()
+    expect(screen.getByText('This collection is blocked')).toBeInTheDocument()
+  })
+
+  it('has hyperlinks to learn more and return to the Explore page', () => {
+    render(<UnavailableCollectionPage isBlocked />)
+    expect(screen.getByText('Learn why')).toHaveAttribute(
+      'href',
+      'https://support.uniswap.org/hc/en-us/articles/18783694078989-Unsupported-Token-Policy'
+    )
+    expect(screen.getByText('Return to NFT Explore')).toHaveAttribute('href', '/nfts')
+  })
+})

--- a/src/nft/components/collection/UnavailableCollectionPage.tsx
+++ b/src/nft/components/collection/UnavailableCollectionPage.tsx
@@ -10,6 +10,8 @@ const Container = styled(Column)`
   height: 75vh;
   justify-content: center;
   align-items: center;
+  text-align: center;
+  padding: 48px;
   gap: 8px;
 `
 const LinkStyles = css`

--- a/src/nft/components/collection/UnavailableCollectionPage.tsx
+++ b/src/nft/components/collection/UnavailableCollectionPage.tsx
@@ -1,10 +1,9 @@
 import { Trans } from '@lingui/macro'
 import Column from 'components/Column'
-import { darken } from 'polished'
+import { SupportArticleURL } from 'constants/supportArticles'
 import { AlertTriangle } from 'react-feather'
-import { Link } from 'react-router-dom'
-import styled, { css, useTheme } from 'styled-components'
-import { ThemedText } from 'theme/components'
+import styled, { useTheme } from 'styled-components'
+import { ExternalLink, StyledInternalLink, ThemedText } from 'theme/components'
 
 const Container = styled(Column)`
   height: 75vh;
@@ -14,54 +13,44 @@ const Container = styled(Column)`
   padding: 48px;
   gap: 8px;
 `
-const LinkStyles = css`
-  color: ${({ theme }) => theme.accent1};
-  text-decoration: none;
-  &:hover,
-  &:focus {
-    color: ${({ theme }) => darken(0.1, theme.accent1)};
-  }
-`
-const InternalLink = styled(Link)`
-  ${LinkStyles};
-`
-const ExternalLink = styled.a`
-  ${LinkStyles};
+const StyledExternalLink = styled(ExternalLink)`
+  color: ${({ theme }) => theme.neutral2};
 `
 export function UnavailableCollectionPage({ isBlocked }: { isBlocked?: boolean }) {
   const theme = useTheme()
-  return isBlocked ? (
-    <Container>
-      <AlertTriangle
-        width="48px"
-        height="48px"
-        stroke={theme.background}
-        strokeWidth="1px"
-        fill={theme.critical}
-        data-testid="alert-icon"
-      />
-      <ThemedText.HeadlineMedium>
-        <Trans>This collection is blocked</Trans>
-      </ThemedText.HeadlineMedium>
-      <ExternalLink
-        href="https://support.uniswap.org/hc/en-us/articles/18783694078989-Unsupported-Token-Policy"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Trans>Learn why</Trans>
-      </ExternalLink>
-      <InternalLink to="/nfts">
-        <Trans>Return to NFT Explore</Trans>
-      </InternalLink>
-    </Container>
-  ) : (
+
+  if (isBlocked) {
+    return (
+      <Container>
+        <AlertTriangle
+          width="48px"
+          height="48px"
+          stroke={theme.background}
+          strokeWidth="1px"
+          fill={theme.critical}
+          data-testid="alert-icon"
+        />
+        <ThemedText.HeadlineMedium>
+          <Trans>This collection is blocked</Trans>
+        </ThemedText.HeadlineMedium>
+        <StyledInternalLink to="/nfts">
+          <Trans>Return to NFT Explore</Trans>
+        </StyledInternalLink>
+        <StyledExternalLink href={SupportArticleURL.UNSUPPORTED_TOKEN_AND_NFT_POLICY}>
+          <Trans>Learn why</Trans>
+        </StyledExternalLink>
+      </Container>
+    )
+  }
+
+  return (
     <Container>
       <ThemedText.HeadlineMedium>
         <Trans>No collection assets exist at this address</Trans>
       </ThemedText.HeadlineMedium>
-      <InternalLink to="/nfts">
+      <StyledInternalLink to="/nfts">
         <Trans>Return to NFT Explore</Trans>
-      </InternalLink>
+      </StyledInternalLink>
     </Container>
   )
 }

--- a/src/nft/components/collection/UnavailableCollectionPage.tsx
+++ b/src/nft/components/collection/UnavailableCollectionPage.tsx
@@ -1,0 +1,65 @@
+import { Trans } from '@lingui/macro'
+import Column from 'components/Column'
+import { darken } from 'polished'
+import { AlertTriangle } from 'react-feather'
+import { Link } from 'react-router-dom'
+import styled, { css, useTheme } from 'styled-components'
+import { ThemedText } from 'theme'
+
+const Container = styled(Column)`
+  height: 75vh;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+`
+const LinkStyles = css`
+  color: ${({ theme }) => theme.accent1};
+  text-decoration: none;
+  &:hover,
+  &:focus {
+    color: ${({ theme }) => darken(0.1, theme.accent1)};
+  }
+`
+const InternalLink = styled(Link)`
+  ${LinkStyles};
+`
+const ExternalLink = styled.a`
+  ${LinkStyles};
+`
+export function UnavailableCollectionPage({ isBlocked }: { isBlocked?: boolean }) {
+  const theme = useTheme()
+  return isBlocked ? (
+    <Container>
+      <AlertTriangle
+        width="48px"
+        height="48px"
+        stroke={theme.background}
+        strokeWidth="1px"
+        fill={theme.critical}
+        data-testid="alert-icon"
+      />
+      <ThemedText.HeadlineMedium>
+        <Trans>This collection is blocked</Trans>
+      </ThemedText.HeadlineMedium>
+      <ExternalLink
+        href="https://support.uniswap.org/hc/en-us/articles/18783694078989-Unsupported-Token-Policy"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Trans>Learn why</Trans>
+      </ExternalLink>
+      <InternalLink to="/nfts">
+        <Trans>Return to NFT Explore</Trans>
+      </InternalLink>
+    </Container>
+  ) : (
+    <Container>
+      <ThemedText.HeadlineMedium>
+        <Trans>No collection assets exist at this address</Trans>
+      </ThemedText.HeadlineMedium>
+      <InternalLink to="/nfts">
+        <Trans>Return to NFT Explore</Trans>
+      </InternalLink>
+    </Container>
+  )
+}

--- a/src/nft/components/collection/UnavailableCollectionPage.tsx
+++ b/src/nft/components/collection/UnavailableCollectionPage.tsx
@@ -4,7 +4,7 @@ import { darken } from 'polished'
 import { AlertTriangle } from 'react-feather'
 import { Link } from 'react-router-dom'
 import styled, { css, useTheme } from 'styled-components'
-import { ThemedText } from 'theme'
+import { ThemedText } from 'theme/components'
 
 const Container = styled(Column)`
   height: 75vh;

--- a/src/nft/pages/collection/index.tsx
+++ b/src/nft/pages/collection/index.tsx
@@ -12,6 +12,7 @@ import { MobileHoverBag } from 'nft/components/bag/MobileHoverBag'
 import { Activity, ActivitySwitcher, CollectionNfts, CollectionStats, Filters } from 'nft/components/collection'
 import { CollectionNftsAndMenuLoading } from 'nft/components/collection/CollectionNfts'
 import { CollectionPageSkeleton } from 'nft/components/collection/CollectionPageSkeleton'
+import { UnavailableCollectionPage } from 'nft/components/collection/UnavailableCollectionPage'
 import { BagCloseIcon } from 'nft/components/icons'
 import { useBag, useCollectionFilters, useFiltersExpanded, useIsMobile } from 'nft/hooks'
 import * as styles from 'nft/pages/collection/index.css'
@@ -170,6 +171,7 @@ const Collection = () => {
   }, [])
 
   if (loading) return <CollectionPageSkeleton />
+  if (!collectionStats.name) return <UnavailableCollectionPage />
 
   const toggleActivity = () => {
     isActivityToggled
@@ -256,7 +258,7 @@ const Collection = () => {
               </CollectionDisplaySection>
             </>
           ) : (
-            <div className={styles.noCollectionAssets}>No collection assets exist at this address</div>
+            <UnavailableCollectionPage isBlocked />
           )}
         </AnimatedCollectionContainer>
       </Trace>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
This PR refreshes the user experience when visiting the NFT collection page when no assets exist at the given contract address and when the address is blocked, sharing an informative message and helping the user continue navigating the application.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2726/blocked-collectionfalse-url-page-treatment

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile Valid Collection    |   Desktop Valid Collection    |
| ------------ | ------------ |
| <img width="1624" alt="valid collection mobile before" src="https://github.com/Uniswap/interface/assets/18626088/58c739a8-c3fa-4973-831c-0f5de3342aa4"> | <img width="1624" alt="valid collection desktop before" src="https://github.com/Uniswap/interface/assets/18626088/f4393563-97a2-4ff5-b9a2-1c9126642bb1"> |

|    Mobile Nonexistent Collection    |   Desktop Nonexistent Collection   |
| ------------ | ------------ |
| <img width="1624" alt="nonexistent collection mobile before" src="https://github.com/Uniswap/interface/assets/18626088/6970354a-e15c-4d09-a489-1bae91adcdc0"> | <img width="1624" alt="nonexistent collection desktop before" src="https://github.com/Uniswap/interface/assets/18626088/f00ff2f7-f504-4cb8-b447-857714f26cb5"> |

|    Mobile  Blocked Collection  |   Desktop Blocked Collection   |
| ------------ | ------------ |
| <img width="1624" alt="blocked collection mobile before" src="https://github.com/Uniswap/interface/assets/18626088/0afdcf12-6a21-4498-9107-c7573d891673"> | <img width="1624" alt="blocked collection desktop before" src="https://github.com/Uniswap/interface/assets/18626088/3a7b4622-37e2-486f-9287-8368cd7f9ef9"> |


### After
|    Mobile Valid Collection    |   Desktop Valid Collection    |
| ------------ | ------------ |
| <img width="1624" alt="Screenshot 2023-09-22 at 6 01 30 PM" src="https://github.com/Uniswap/interface/assets/18626088/4696b509-b40f-4cc4-b500-a24503324d30"> |  <img width="1624" alt="Screenshot 2023-09-22 at 6 01 23 PM" src="https://github.com/Uniswap/interface/assets/18626088/16ade9ac-18aa-4557-9b10-ce7c2431099a">|

|    Mobile Nonexistent Collection    |   Desktop Nonexistent Collection   |
| ------------ | ------------ |
| <img width="1624" alt="Screenshot 2023-09-22 at 6 03 11 PM" src="https://github.com/Uniswap/interface/assets/18626088/afcfbd0a-e6ac-4153-a01e-8f3cce287f44"> | <img width="1624" alt="Screenshot 2023-09-22 at 6 03 24 PM" src="https://github.com/Uniswap/interface/assets/18626088/b0d0733b-c53f-47a4-ad42-75617a9f5cfd"> |

|    Mobile  Blocked Collection  |   Desktop Blocked Collection   |
| ------------ | ------------ |
| <img width="1624" alt="Screenshot 2023-09-22 at 6 03 43 PM" src="https://github.com/Uniswap/interface/assets/18626088/d78efab5-a1a0-439d-87e1-b00e4a71dc22"> | <img width="1624" alt="Screenshot 2023-09-22 at 6 03 37 PM" src="https://github.com/Uniswap/interface/assets/18626088/1e6325a6-2973-4212-9926-998a6a892201"> |

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Visit any valid collection by navigating to the NFT tab of the Uniswap interface and selecting any collection, e.g. mfers: `/nfts/collection/0x79fcdef22feed20eddacbb2587640e45491b757f `
- [ ] VIsit any blocked collection, e.g. Stoner Cats: `/nfts/collection/0xd4d871419714b778ebec2e22c7c53572b573706e ` ([full list](https://github.com/Uniswap/interface/blob/main/src/nft/utils/blocklist.ts) of blocked contract addresses)
- [ ] Visit any nonexistent collection, e.g. `/nfts/collection/0x50ec05ade8280758e2077fcbc08d878d4aef79c3 ` 


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->
The same experience applies to Mobile and Desktop. Please try both to confirm consistency. 


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit tests