### PR TITLE
fix: use sentence case for text

### DIFF
--- a/cypress/e2e/token-details.test.ts
+++ b/cypress/e2e/token-details.test.ts
@@ -52,7 +52,7 @@ describe('Token details', () => {
     cy.visit('/tokens/ethereum/0xa71d0588EAf47f12B13cF8eC750430d21DF04974')
 
     // Should have missing price chart when price unavailable (expected for this token)
-    if (cy.get('[data-cy="chart-header"]').contains('Price Unavailable')) {
+    if (cy.get('[data-cy="chart-header"]').contains('Price unavailable')) {
       cy.get('[data-cy="missing-chart"]').should('exist')
     }
 

--- a/cypress/e2e/wallet-connection/connect.test.ts
+++ b/cypress/e2e/wallet-connection/connect.test.ts
@@ -19,7 +19,7 @@ describe('disconnect wallet', () => {
     // Verify wallet has disconnected
     cy.contains('Connect a wallet').should('exist')
     cy.get(getTestSelector('navbar-connect-wallet')).contains('Connect')
-    cy.contains('Connect Wallet')
+    cy.contains('Connect wallet')
 
     // Verify swap input is cleared
     cy.get('#swap-currency-input .token-amount-input').should('have.value', '1')

--- a/src/components/Badge/RangeBadge.tsx
+++ b/src/components/Badge/RangeBadge.tsx
@@ -55,7 +55,7 @@ export default function RangeBadge({ removed, inRange }: { removed?: boolean; in
         >
           <LabelText color={theme.success}>
             <BadgeText>
-              <Trans>In Range</Trans>
+              <Trans>In range</Trans>
             </BadgeText>
             <ActiveDot />
           </LabelText>

--- a/src/components/Charts/PriceChart/__snapshots__/index.test.tsx.snap
+++ b/src/components/Charts/PriceChart/__snapshots__/index.test.tsx.snap
@@ -366,7 +366,7 @@ exports[`PriceChart renders correctly with empty price array 1`] = `
     <div
       class="c1 css-slqfkh"
     >
-      Price Unavailable
+      Price unavailable
     </div>
     <div
       class="c1 css-142zc9n"
@@ -799,7 +799,7 @@ exports[`PriceChart renders correctly with undefined prices 1`] = `
     <div
       class="c1 css-slqfkh"
     >
-      Price Unavailable
+      Price unavailable
     </div>
     <div
       class="c1 css-142zc9n"

--- a/src/components/Charts/PriceChart/index.test.tsx
+++ b/src/components/Charts/PriceChart/index.test.tsx
@@ -42,7 +42,7 @@ describe('PriceChart', () => {
   it('renders correctly with empty price array', () => {
     const { asFragment } = render(<PriceChart prices={[]} width={780} height={392} timePeriod={TimePeriod.HOUR} />)
     expect(asFragment()).toMatchSnapshot()
-    expect(asFragment().textContent).toContain('Price Unavailable')
+    expect(asFragment().textContent).toContain('Price unavailable')
     expect(asFragment().textContent).toContain('Missing price data due to recently low trading volume on Uniswap v3')
   })
   it('renders correctly with undefined prices', () => {
@@ -50,7 +50,7 @@ describe('PriceChart', () => {
       <PriceChart prices={undefined} width={780} height={392} timePeriod={TimePeriod.HOUR} />
     )
     expect(asFragment()).toMatchSnapshot()
-    expect(asFragment().textContent).toContain('Price Unavailable')
+    expect(asFragment().textContent).toContain('Price unavailable')
     expect(asFragment().textContent).toContain('Missing chart data')
   })
   it('renders stale UI', () => {

--- a/src/components/Charts/PriceChart/index.tsx
+++ b/src/components/Charts/PriceChart/index.tsx
@@ -248,7 +248,7 @@ function ChartBody({ chart, timePeriod }: { chart: ChartModel; timePeriod: TimeP
 const CHART_ERROR_MESSAGES: Record<ChartErrorType, ReactNode> = {
   [ChartErrorType.NO_DATA_AVAILABLE]: <Trans>Missing chart data</Trans>,
   [ChartErrorType.NO_RECENT_VOLUME]: <Trans>Missing price data due to recently low trading volume on Uniswap v3</Trans>,
-  [ChartErrorType.INVALID_CHART]: <Trans>Invalid Chart</Trans>,
+  [ChartErrorType.INVALID_CHART]: <Trans>Invalid chart</Trans>,
 }
 
 function MissingPriceChart({ chart }: { chart: ErroredChartModel }) {
@@ -259,7 +259,7 @@ function MissingPriceChart({ chart }: { chart: ErroredChartModel }) {
     <>
       <ChartHeaderWrapper data-cy="chart-header">
         <ThemedText.HeadlineLarge fontSize={24} color="neutral3">
-          Price Unavailable
+          Price unavailable
         </ThemedText.HeadlineLarge>
         <ThemedText.BodySmall color="neutral3">{CHART_ERROR_MESSAGES[chart.error]}</ThemedText.BodySmall>
       </ChartHeaderWrapper>

--- a/src/components/ConnectedAccountBlocked/index.tsx
+++ b/src/components/ConnectedAccountBlocked/index.tsx
@@ -25,7 +25,7 @@ export default function ConnectedAccountBlocked(props: ConnectedAccountBlockedPr
       <ContentWrapper>
         <BlockedIcon size="22px" />
         <ThemedText.DeprecatedLargeHeader lineHeight={2} marginBottom={1} marginTop={1}>
-          <Trans>Blocked Address</Trans>
+          <Trans>Blocked address</Trans>
         </ThemedText.DeprecatedLargeHeader>
         <ThemedText.DeprecatedDarkGray fontSize={12} marginBottom={12}>
           {props.account}

--- a/src/components/FiatOnrampModal/index.tsx
+++ b/src/components/FiatOnrampModal/index.tsx
@@ -133,7 +133,7 @@ export default function FiatOnrampModal() {
         {error ? (
           <>
             <ThemedText.MediumHeader>
-              <Trans>Moonpay Fiat On-ramp iframe</Trans>
+              <Trans>MoonPay fiat on-ramp iframe</Trans>
             </ThemedText.MediumHeader>
             <ErrorText>
               <Trans>Something went wrong!</Trans>

--- a/src/components/FiatOnrampModal/index.tsx
+++ b/src/components/FiatOnrampModal/index.tsx
@@ -136,7 +136,7 @@ export default function FiatOnrampModal() {
               <Trans>Moonpay Fiat On-ramp iframe</Trans>
             </ThemedText.MediumHeader>
             <ErrorText>
-              <Trans>something went wrong!</Trans>
+              <Trans>Something went wrong!</Trans>
               <br />
               {error}
             </ErrorText>

--- a/src/components/NavBar/SearchBarDropdown.tsx
+++ b/src/components/NavBar/SearchBarDropdown.tsx
@@ -284,7 +284,7 @@ function SearchBarDropdownContents({
           suggestion_type: NavBarSearchTypes.COLLECTION_SUGGESTION,
           ...eventProperties,
         }}
-        header={<Trans>NFT Collections</Trans>}
+        header={<Trans>NFT collections</Trans>}
       />
     ) : (
       <Box className={styles.notFoundContainer}>No NFT collections found.</Box>

--- a/src/components/NavigationTabs/index.tsx
+++ b/src/components/NavigationTabs/index.tsx
@@ -51,7 +51,7 @@ export function FindPoolTabs({ origin }: { origin: string }) {
           <StyledArrowLeft />
         </Link>
         <FindPoolTabsText>
-          <Trans>Import V2 Pool</Trans>
+          <Trans>Import V2 pool</Trans>
         </FindPoolTabsText>
       </RowBetween>
     </Tabs>
@@ -108,9 +108,9 @@ export function AddRemoveTabs({
           {creating ? (
             <Trans>Create a pair</Trans>
           ) : adding ? (
-            <Trans>Add Liquidity</Trans>
+            <Trans>Add liquidity</Trans>
           ) : (
-            <Trans>Remove Liquidity</Trans>
+            <Trans>Remove liquidity</Trans>
           )}
         </AddRemoveTitleText>
         {children && <Box style={{ marginRight: '.5rem' }}>{children}</Box>}

--- a/src/components/Polling/ChainConnectivityWarning.tsx
+++ b/src/components/Polling/ChainConnectivityWarning.tsx
@@ -59,7 +59,7 @@ export function ChainConnectivityWarning() {
       <TitleRow>
         <CautionTriangle />
         <TitleText>
-          <Trans>Network Warning</Trans>
+          <Trans>Network warning</Trans>
         </TitleText>
       </TitleRow>
       <BodyRow>

--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -346,7 +346,7 @@ export default function FullPositionCard({ pair, border, stakedBalance }: Positi
                 to={`/uni/${currencyId(currency0)}/${currencyId(currency1)}`}
                 width="100%"
               >
-                <Trans>Manage Liquidity in Rewards Pool</Trans>
+                <Trans>Manage liquidity in rewards pool</Trans>
               </ButtonPrimary>
             )}
           </AutoColumn>

--- a/src/components/PositionPreview/index.tsx
+++ b/src/components/PositionPreview/index.tsx
@@ -101,7 +101,7 @@ export const PositionPreview = ({
           <Break />
           <RowBetween>
             <ThemedText.DeprecatedLabel>
-              <Trans>Fee Tier</Trans>
+              <Trans>Fee tier</Trans>
             </ThemedText.DeprecatedLabel>
             <ThemedText.DeprecatedLabel>
               <Trans>{position?.pool?.fee / 10000}%</Trans>
@@ -124,7 +124,7 @@ export const PositionPreview = ({
           <LightCard width="48%" padding="8px">
             <AutoColumn gap="4px" justify="center">
               <ThemedText.DeprecatedMain fontSize="12px">
-                <Trans>Min Price</Trans>
+                <Trans>Min price</Trans>
               </ThemedText.DeprecatedMain>
               <ThemedText.DeprecatedMediumHeader textAlign="center">
                 {formatTickPrice({
@@ -147,7 +147,7 @@ export const PositionPreview = ({
           <LightCard width="48%" padding="8px">
             <AutoColumn gap="4px" justify="center">
               <ThemedText.DeprecatedMain fontSize="12px">
-                <Trans>Max Price</Trans>
+                <Trans>Max price</Trans>
               </ThemedText.DeprecatedMain>
               <ThemedText.DeprecatedMediumHeader textAlign="center">
                 {formatTickPrice({

--- a/src/components/RangeSelector/PresetsButtons.tsx
+++ b/src/components/RangeSelector/PresetsButtons.tsx
@@ -21,7 +21,7 @@ export default function PresetsButtons({ onSetFullRange }: PresetsButtonsProps) 
     <AutoRow gap="4px" width="auto">
       <Button data-testid="set-full-range" onClick={onSetFullRange}>
         <ThemedText.DeprecatedBody fontSize={12}>
-          <Trans>Full Range</Trans>
+          <Trans>Full range</Trans>
         </ThemedText.DeprecatedBody>
       </Button>
     </AutoRow>

--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -256,7 +256,7 @@ function L2Content({
             {!hash ? (
               <Trans>Confirm transaction in wallet</Trans>
             ) : !confirmed ? (
-              <Trans>Transaction Submitted</Trans>
+              <Trans>Transaction submitted</Trans>
             ) : transactionSuccess ? (
               <Trans>Success</Trans>
             ) : (

--- a/src/components/WalletModal/ConnectionErrorView.tsx
+++ b/src/components/WalletModal/ConnectionErrorView.tsx
@@ -43,7 +43,7 @@ export default function ConnectionErrorView() {
         </Trans>
       </ThemedText.BodyPrimary>
       <ButtonPrimary $borderRadius="16px" onClick={retry}>
-        <Trans>Try Again</Trans>
+        <Trans>Try again</Trans>
       </ButtonPrimary>
       <ButtonEmpty width="fit-content" padding="0" marginTop={20}>
         <ThemedText.Link onClick={cancelActivation} marginBottom={12}>

--- a/src/components/WalletModal/PrivacyPolicyNotice.tsx
+++ b/src/components/WalletModal/PrivacyPolicyNotice.tsx
@@ -26,7 +26,7 @@ export default function PrivacyPolicyNotice() {
       </StyledLink>
       <LastUpdatedText>
         {' ('}
-        <Trans>Last Updated</Trans>
+        <Trans>Last updated</Trans>
         {` ${LAST_UPDATED_DATE})`}
       </LastUpdatedText>
     </ThemedText.BodySmall>

--- a/src/components/claim/AddressClaimModal.tsx
+++ b/src/components/claim/AddressClaimModal.tsx
@@ -104,7 +104,7 @@ export default function AddressClaimModal({ isOpen, onDismiss }: { isOpen: boole
             <CardSection gap="md">
               <RowBetween>
                 <ThemedText.DeprecatedWhite fontWeight={535}>
-                  <Trans>Claim UNI Token</Trans>
+                  <Trans>Claim UNI token</Trans>
                 </ThemedText.DeprecatedWhite>
                 <CloseIcon onClick={wrappedOnDismiss} style={{ zIndex: 99 }} stroke="white" />
               </RowBetween>

--- a/src/components/swap/UnsupportedCurrencyFooter.test.tsx
+++ b/src/components/swap/UnsupportedCurrencyFooter.test.tsx
@@ -29,7 +29,7 @@ describe('UnsupportedCurrencyFooter.tsx with unsupported tokens', () => {
   it('works as expected when one unsupported token exists', async () => {
     const rendered = render(<UnsupportedCurrencyFooter show={true} currencies={[unsupportedToken]} />)
     await act(() => userEvent.click(screen.getByTestId('read-more-button')))
-    expect(screen.getByText('Unsupported Assets')).toBeInTheDocument()
+    expect(screen.getByText('Unsupported assets')).toBeInTheDocument()
     expect(
       screen.getByText((content) => content.startsWith('Some assets are not available through this interface'))
     ).toBeInTheDocument()
@@ -58,14 +58,14 @@ describe('UnsupportedCurrencyFooter.tsx with no unsupported tokens', () => {
   it('works as expected when no unsupported tokens exist', async () => {
     const rendered = render(<UnsupportedCurrencyFooter show={true} currencies={[unsupportedToken]} />)
     await act(() => userEvent.click(screen.getByTestId('read-more-button')))
-    expect(screen.getByText('Unsupported Assets')).toBeInTheDocument()
+    expect(screen.getByText('Unsupported assets')).toBeInTheDocument()
     expect(
       screen.getByText((content) => content.startsWith('Some assets are not available through this interface'))
     ).toBeInTheDocument()
     expect(rendered.queryByTestId('unsupported-token-card')).toBeNull()
     await act(() => userEvent.click(screen.getByTestId('close-icon')))
-    await waitForElementToBeRemoved(screen.getByText('Unsupported Assets'))
-    expect(rendered.queryByText('Unsupported Assets')).toBeNull()
+    await waitForElementToBeRemoved(screen.getByText('Unsupported assets'))
+    expect(rendered.queryByText('Unsupported assets')).toBeNull()
     expect(
       rendered.queryByText((content) => content.startsWith('Some assets are not available through this interface'))
     ).toBeNull()

--- a/src/components/swap/UnsupportedCurrencyFooter.tsx
+++ b/src/components/swap/UnsupportedCurrencyFooter.tsx
@@ -72,7 +72,7 @@ export default function UnsupportedCurrencyFooter({
           <AutoColumn gap="lg">
             <RowBetween>
               <ThemedText.DeprecatedMediumHeader>
-                <Trans>Unsupported Assets</Trans>
+                <Trans>Unsupported assets</Trans>
               </ThemedText.DeprecatedMediumHeader>
               <CloseIcon onClick={() => setShowDetails(false)} data-testid="close-icon" />
             </RowBetween>

--- a/src/components/vote/DelegateModal.tsx
+++ b/src/components/vote/DelegateModal.tsx
@@ -107,12 +107,12 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
             {usingDelegate && <AddressInputPanel value={typed} onChange={handleRecipientType} />}
             <ButtonPrimary disabled={!isAddress(parsedAddress ?? '')} onClick={onDelegate}>
               <ThemedText.DeprecatedMediumHeader color="white">
-                {usingDelegate ? <Trans>Delegate Votes</Trans> : <Trans>Self Delegate</Trans>}
+                {usingDelegate ? <Trans>Delegate votes</Trans> : <Trans>Self-delegate</Trans>}
               </ThemedText.DeprecatedMediumHeader>
             </ButtonPrimary>
             <TextButton onClick={() => setUsingDelegate(!usingDelegate)}>
               <ThemedText.DeprecatedBlue>
-                {usingDelegate ? <Trans>Remove Delegate</Trans> : <Trans>Add Delegate +</Trans>}
+                {usingDelegate ? <Trans>Remove delegate</Trans> : <Trans>Add delegate +</Trans>}
               </ThemedText.DeprecatedBlue>
             </TextButton>
           </AutoColumn>
@@ -122,7 +122,7 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
         <LoadingView onDismiss={wrappedOnDismiss}>
           <AutoColumn gap="md" justify="center">
             <ThemedText.DeprecatedLargeHeader>
-              {usingDelegate ? <Trans>Delegating votes</Trans> : <Trans>Unlocking Votes</Trans>}
+              {usingDelegate ? <Trans>Delegating votes</Trans> : <Trans>Unlocking votes</Trans>}
             </ThemedText.DeprecatedLargeHeader>
             <ThemedText.DeprecatedMain fontSize={36}> {formatCurrencyAmount(uniBalance, 4)}</ThemedText.DeprecatedMain>
           </AutoColumn>
@@ -132,7 +132,7 @@ export default function DelegateModal({ isOpen, onDismiss, title }: VoteModalPro
         <SubmittedView onDismiss={wrappedOnDismiss} hash={hash}>
           <AutoColumn gap="md" justify="center">
             <ThemedText.DeprecatedLargeHeader>
-              <Trans>Transaction Submitted</Trans>
+              <Trans>Transaction submitted</Trans>
             </ThemedText.DeprecatedLargeHeader>
             <ThemedText.DeprecatedMain fontSize={36}>{formatCurrencyAmount(uniBalance, 4)}</ThemedText.DeprecatedMain>
           </AutoColumn>

--- a/src/components/vote/ExecuteModal.tsx
+++ b/src/components/vote/ExecuteModal.tsx
@@ -82,7 +82,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
           <AutoColumn gap="lg" justify="center">
             <RowBetween>
               <ThemedText.DeprecatedMediumHeader fontWeight={535}>
-                <Trans>Execute Proposal {proposalId}</Trans>
+                <Trans>Execute proposal {proposalId}</Trans>
               </ThemedText.DeprecatedMediumHeader>
               <StyledClosed onClick={wrappedOnDismiss} />
             </RowBetween>
@@ -132,7 +132,7 @@ export default function ExecuteModal({ isOpen, onDismiss, proposalId }: ExecuteM
           <AutoColumn gap="100px" justify="center">
             <AutoColumn gap="md" justify="center">
               <ThemedText.DeprecatedLargeHeader>
-                <Trans>Execution Submitted</Trans>
+                <Trans>Execution submitted</Trans>
               </ThemedText.DeprecatedLargeHeader>
             </AutoColumn>
             {chainId && (

--- a/src/components/vote/QueueModal.tsx
+++ b/src/components/vote/QueueModal.tsx
@@ -82,7 +82,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
           <AutoColumn gap="lg" justify="center">
             <RowBetween>
               <ThemedText.DeprecatedMediumHeader fontWeight={535}>
-                <Trans>Queue Proposal {proposalId}</Trans>
+                <Trans>Queue proposal {proposalId}</Trans>
               </ThemedText.DeprecatedMediumHeader>
               <StyledClosed onClick={wrappedOnDismiss} />
             </RowBetween>
@@ -132,7 +132,7 @@ export default function QueueModal({ isOpen, onDismiss, proposalId }: QueueModal
           <AutoColumn gap="100px" justify="center">
             <AutoColumn gap="md" justify="center">
               <ThemedText.DeprecatedLargeHeader>
-                <Trans>Transaction Submitted</Trans>
+                <Trans>Transaction submitted</Trans>
               </ThemedText.DeprecatedLargeHeader>
             </AutoColumn>
             {chainId && (

--- a/src/components/vote/VoteModal.tsx
+++ b/src/components/vote/VoteModal.tsx
@@ -125,7 +125,7 @@ export default function VoteModal({ isOpen, onDismiss, proposalId, voteOption }:
           <AutoColumn gap="100px" justify="center">
             <AutoColumn gap="md" justify="center">
               <ThemedText.DeprecatedLargeHeader>
-                <Trans>Submitting Vote</Trans>
+                <Trans>Submitting vote</Trans>
               </ThemedText.DeprecatedLargeHeader>
             </AutoColumn>
             <ThemedText.DeprecatedSubHeader>

--- a/src/constants/tokenSafety.tsx
+++ b/src/constants/tokenSafety.tsx
@@ -74,7 +74,7 @@ const StrongWarning: Warning = {
 
 const BlockedWarning: Warning = {
   level: WARNING_LEVEL.BLOCKED,
-  message: <Trans>Not Available</Trans>,
+  message: <Trans>Not available</Trans>,
   canProceed: false,
 }
 

--- a/src/nft/components/bag/BagFooter.test.tsx
+++ b/src/nft/components/bag/BagFooter.test.tsx
@@ -301,7 +301,7 @@ describe('BagFooter.tsx', () => {
 
     renderBagFooter()
     const buyButton = getBuyButton()
-    expect(buyButton.textContent).toBe('Fetching Route')
+    expect(buyButton.textContent).toBe('Fetching route')
     expect(buyButton).toBeDisabled()
   })
 
@@ -329,7 +329,7 @@ describe('BagFooter.tsx', () => {
     renderBagFooter()
     const buyButton = getBuyButton()
 
-    expect(buyButton.textContent).toBe('Loading Allowance')
+    expect(buyButton.textContent).toBe('Loading allowance')
     expect(buyButton).toBeDisabled()
   })
 

--- a/src/nft/components/bag/ButtonStates.tsx
+++ b/src/nft/components/bag/ButtonStates.tsx
@@ -86,7 +86,7 @@ export function getBuyButtonStateData(
     },
     [BuyButtonStates.FETCHING_TOKEN_ROUTE]: {
       ...defaultBuyButtonState,
-      buttonText: <Trans>Fetching Route</Trans>,
+      buttonText: <Trans>Fetching route</Trans>,
     },
     [BuyButtonStates.INVALID_TOKEN_ROUTE]: {
       ...defaultBuyButtonState,
@@ -101,7 +101,7 @@ export function getBuyButtonStateData(
     },
     [BuyButtonStates.LOADING_ALLOWANCE]: {
       ...defaultBuyButtonState,
-      buttonText: <Trans>Loading Allowance</Trans>,
+      buttonText: <Trans>Loading allowance</Trans>,
     },
     [BuyButtonStates.IN_WALLET_ALLOWANCE_APPROVAL]: {
       ...defaultBuyButtonState,

--- a/src/nft/components/profile/list/NFTListingsGrid.tsx
+++ b/src/nft/components/profile/list/NFTListingsGrid.tsx
@@ -199,10 +199,10 @@ export const NFTListingsGrid = ({ selectedMarkets }: { selectedMarkets: ListingM
       prompt = <Trans>Floor price</Trans>
       break
     case SetPriceMethod.LAST_PRICE:
-      prompt = <Trans>Last Price</Trans>
+      prompt = <Trans>Last price</Trans>
       break
     case SetPriceMethod.SAME_PRICE:
-      prompt = <Trans>Same Price</Trans>
+      prompt = <Trans>Same price</Trans>
       break
     default:
       break

--- a/src/nft/pages/profile/index.tsx
+++ b/src/nft/pages/profile/index.tsx
@@ -94,7 +94,7 @@ export default function Profile() {
             </ThemedText.HeadlineMedium>
             <ConnectWalletButton onClick={toggleWalletDrawer}>
               <ThemedText.SubHeader color="white" lineHeight="20px">
-                <Trans>Connect Wallet</Trans>
+                <Trans>Connect wallet</Trans>
               </ThemedText.SubHeader>
             </ConnectWalletButton>
           </Center>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -483,7 +483,7 @@ function AddLiquidity() {
         element={InterfaceElementName.CONNECT_WALLET_BUTTON}
       >
         <ButtonLight onClick={toggleWalletDrawer} $borderRadius="12px" padding="12px">
-          <Trans>Connect Wallet</Trans>
+          <Trans>Connect wallet</Trans>
         </ButtonLight>
       </TraceEvent>
     ) : (
@@ -611,7 +611,7 @@ function AddLiquidity() {
                 <MediumOnly>
                   <ButtonText onClick={clearAll}>
                     <ThemedText.DeprecatedBlue fontSize="12px">
-                      <Trans>Clear All</Trans>
+                      <Trans>Clear all</Trans>
                     </ThemedText.DeprecatedBlue>
                   </ButtonText>
                 </MediumOnly>
@@ -626,7 +626,7 @@ function AddLiquidity() {
                     <AutoColumn gap="md">
                       <RowBetween paddingBottom="20px">
                         <ThemedText.DeprecatedLabel>
-                          <Trans>Select Pair</Trans>
+                          <Trans>Select pair</Trans>
                         </ThemedText.DeprecatedLabel>
                       </RowBetween>
                       <RowBetween gap="md">
@@ -672,7 +672,7 @@ function AddLiquidity() {
                 {hasExistingPosition && existingPosition && (
                   <PositionPreview
                     position={existingPosition}
-                    title={<Trans>Selected Range</Trans>}
+                    title={<Trans>Selected range</Trans>}
                     inRange={!outOfRange}
                     ticksAtLimit={ticksAtLimit}
                   />
@@ -684,7 +684,7 @@ function AddLiquidity() {
                   <DynamicSection gap="md" disabled={!feeAmount || invalidPool}>
                     <RowBetween>
                       <ThemedText.DeprecatedLabel>
-                        <Trans>Set Price Range</Trans>
+                        <Trans>Set price range</Trans>
                       </ThemedText.DeprecatedLabel>
 
                       {Boolean(baseCurrency && quoteCurrency) && (
@@ -864,7 +864,7 @@ function AddLiquidity() {
                 <DynamicSection disabled={invalidPool || invalidRange || (noLiquidity && !startPriceTypedValue)}>
                   <AutoColumn gap="md">
                     <ThemedText.DeprecatedLabel>
-                      {hasExistingPosition ? <Trans>Add more liquidity</Trans> : <Trans>Deposit Amounts</Trans>}
+                      {hasExistingPosition ? <Trans>Add more liquidity</Trans> : <Trans>Deposit amounts</Trans>}
                     </ThemedText.DeprecatedLabel>
 
                     <CurrencyInputPanel

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -762,7 +762,7 @@ function AddLiquidity() {
                           <AutoColumn gap="2px" style={{ marginTop: '0.5rem' }}>
                             <Trans>
                               <ThemedText.DeprecatedMain fontWeight={535} fontSize={12} color="text1">
-                                Current Price:
+                                Current price:
                               </ThemedText.DeprecatedMain>
                               <ThemedText.DeprecatedBody fontWeight={535} fontSize={20} color="text1">
                                 {price && (

--- a/src/pages/AddLiquidityV2/ConfirmAddModalBottom.tsx
+++ b/src/pages/AddLiquidityV2/ConfirmAddModalBottom.tsx
@@ -70,7 +70,7 @@ export function ConfirmAddModalBottom({
       </RowBetween>
       <ButtonPrimary style={{ margin: '20px 0 0 0' }} onClick={onAdd}>
         <Text fontWeight={535} fontSize={20}>
-          {noLiquidity ? <Trans>Create Pool & Supply</Trans> : <Trans>Confirm Supply</Trans>}
+          {noLiquidity ? <Trans>Create pool & supply</Trans> : <Trans>Confirm supply</Trans>}
         </Text>
       </ButtonPrimary>
     </>

--- a/src/pages/AddLiquidityV2/PoolPriceBar.tsx
+++ b/src/pages/AddLiquidityV2/PoolPriceBar.tsx
@@ -58,7 +58,7 @@ export function PoolPriceBar({
             %
           </ThemedText.DeprecatedBlack>
           <Text fontWeight={535} fontSize={14} color={theme.neutral2} pt={1}>
-            <Trans>Share of Pool</Trans>
+            <Trans>Share of pool</Trans>
           </Text>
         </AutoColumn>
       </AutoRow>

--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -443,7 +443,7 @@ export default function AddLiquidity() {
             {addIsUnsupported ? (
               <ButtonPrimary disabled={true}>
                 <ThemedText.DeprecatedMain mb="4px">
-                  <Trans>Unsupported Asset</Trans>
+                  <Trans>Unsupported asset</Trans>
                 </ThemedText.DeprecatedMain>
               </ButtonPrimary>
             ) : !account ? (
@@ -454,7 +454,7 @@ export default function AddLiquidity() {
                 element={InterfaceElementName.CONNECT_WALLET_BUTTON}
               >
                 <ButtonLight onClick={toggleWalletDrawer}>
-                  <Trans>Connect Wallet</Trans>
+                  <Trans>Connect wallet</Trans>
                 </ButtonLight>
               </TraceEvent>
             ) : (

--- a/src/pages/CreateProposal/ProposalActionSelector.tsx
+++ b/src/pages/CreateProposal/ProposalActionSelector.tsx
@@ -77,7 +77,7 @@ export const ProposalActionSelector = ({
     <ProposalActionSelectorFlex>
       <ProposalActionSelectorContainer className={className}>
         <ActionSelectorHeader>
-          <Trans>Proposed Action</Trans>
+          <Trans>Proposed action</Trans>
         </ActionSelectorHeader>
         <ActionDropdown onClick={onClick}>{proposalAction}</ActionDropdown>
       </ProposalActionSelectorContainer>
@@ -113,14 +113,14 @@ export function ProposalActionSelectorModal({
         <MenuItem onClick={() => handleProposalActionSelect(ProposalAction.TRANSFER_TOKEN)}>
           <Column>
             <Text fontWeight={535}>
-              <Trans>Transfer Token</Trans>
+              <Trans>Transfer token</Trans>
             </Text>
           </Column>
         </MenuItem>
         <MenuItem onClick={() => handleProposalActionSelect(ProposalAction.APPROVE_TOKEN)}>
           <Column>
             <Text fontWeight={535}>
-              <Trans>Approve Token</Trans>
+              <Trans>Approve token</Trans>
             </Text>
           </Column>
         </MenuItem>

--- a/src/pages/CreateProposal/ProposalSubmissionModal.tsx
+++ b/src/pages/CreateProposal/ProposalSubmissionModal.tsx
@@ -26,7 +26,7 @@ export const ProposalSubmissionModal = ({
         <LoadingView onDismiss={onDismiss}>
           <AutoColumn gap="md" justify="center">
             <ThemedText.DeprecatedLargeHeader>
-              <Trans>Submitting Proposal</Trans>
+              <Trans>Submitting proposal</Trans>
             </ThemedText.DeprecatedLargeHeader>
           </AutoColumn>
         </LoadingView>
@@ -34,7 +34,7 @@ export const ProposalSubmissionModal = ({
         <SubmittedView onDismiss={onDismiss} hash={hash}>
           <AutoColumn gap="md" justify="center">
             <Text fontWeight={535} fontSize={20} textAlign="center">
-              <Trans>Proposal Submitted</Trans>
+              <Trans>Proposal submitted</Trans>
             </Text>
             {hash && (
               <ExternalLink href={getExplorerLink(1, hash, ExplorerDataType.TRANSACTION)}>

--- a/src/pages/CreateProposal/index.tsx
+++ b/src/pages/CreateProposal/index.tsx
@@ -101,7 +101,7 @@ const CreateProposalButton = ({
           )}
         </>
       ) : (
-        <Trans>Create Proposal</Trans>
+        <Trans>Create proposal</Trans>
       )}
     </ButtonError>
   )

--- a/src/pages/Landing/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Landing/__snapshots__/index.test.tsx.snap
@@ -2116,7 +2116,7 @@ exports[`disable nft on landing page does not render nft information and card 1`
                     <div
                       class="c52 c53"
                     />
-                    Connect Wallet
+                    Connect wallet
                   </button>
                 </div>
               </div>
@@ -4815,7 +4815,7 @@ exports[`disable nft on landing page renders nft information and card 1`] = `
                     <div
                       class="c52 c53"
                     />
-                    Connect Wallet
+                    Connect wallet
                   </button>
                 </div>
               </div>

--- a/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -512,7 +512,7 @@ function V2PairMigration({
 
                 <RowBetween>
                   <ThemedText.DeprecatedBody fontSize={14} color="inherit">
-                    <Trans>Price Difference:</Trans>
+                    <Trans>Price difference:</Trans>
                   </ThemedText.DeprecatedBody>
                   <ThemedText.DeprecatedBlack fontSize={14} color="inherit">
                     <Trans>{priceDifferenceFraction?.toSignificant(4)}%</Trans>
@@ -542,7 +542,7 @@ function V2PairMigration({
 
           <RowBetween>
             <ThemedText.DeprecatedLabel>
-              <Trans>Set Price Range</Trans>
+              <Trans>Set price range</Trans>
             </ThemedText.DeprecatedLabel>
             <RateToggle
               currencyA={invertPrice ? currency1 : currency0}
@@ -737,7 +737,7 @@ export default function MigrateV2Pair() {
         <AutoRow style={{ alignItems: 'center', justifyContent: 'space-between' }} gap="8px">
           <BackArrowLink to="/migrate/v2" />
           <ThemedText.DeprecatedMediumHeader>
-            <Trans>Migrate V2 Liquidity</Trans>
+            <Trans>Migrate V2 liquidity</Trans>
           </ThemedText.DeprecatedMediumHeader>
           <SettingsTab
             autoSlippage={DEFAULT_MIGRATE_SLIPPAGE_TOLERANCE}

--- a/src/pages/MigrateV2/index.tsx
+++ b/src/pages/MigrateV2/index.tsx
@@ -122,7 +122,7 @@ export default function MigrateV2() {
           <AutoRow style={{ alignItems: 'center', justifyContent: 'space-between' }} gap="8px">
             <BackArrowLink to="/pools" />
             <ThemedText.DeprecatedMediumHeader>
-              <Trans>Migrate V2 Liquidity</Trans>
+              <Trans>Migrate V2 liquidity</Trans>
             </ThemedText.DeprecatedMediumHeader>
             <div>
               <QuestionHelper text={<Trans>Migrate your liquidity tokens from Uniswap V2 to Uniswap V3.</Trans>} />
@@ -170,7 +170,7 @@ export default function MigrateV2() {
               })}
             </>
           ) : (
-            <EmptyState message={<Trans>No V2 Liquidity found.</Trans>} />
+            <EmptyState message={<Trans>No V2 liquidity found.</Trans>} />
           )}
 
           <AutoColumn justify="center" gap="md">

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -704,7 +704,7 @@ function PositionPageContent() {
                         $borderRadius="12px"
                         style={{ marginRight: '8px' }}
                       >
-                        <Trans>Increase Liquidity</Trans>
+                        <Trans>Increase liquidity</Trans>
                       </ButtonGray>
                     ) : null}
                     {tokenId && !removed ? (
@@ -715,7 +715,7 @@ function PositionPageContent() {
                         width="fit-content"
                         $borderRadius="12px"
                       >
-                        <Trans>Remove Liquidity</Trans>
+                        <Trans>Remove liquidity</Trans>
                       </SmallButtonPrimary>
                     ) : null}
                   </ActionButtonResponsiveRow>

--- a/src/pages/Pool/v2.tsx
+++ b/src/pages/Pool/v2.tsx
@@ -193,12 +193,12 @@ export default function Pool() {
                     </ResponsiveButtonSecondary>
                     <ResponsiveButtonPrimary id="find-pool-button" as={Link} to="/pools/v2/find" padding="6px 8px">
                       <Text fontWeight={535} fontSize={16}>
-                        <Trans>Import Pool</Trans>
+                        <Trans>Import pool</Trans>
                       </Text>
                     </ResponsiveButtonPrimary>
                     <ResponsiveButtonPrimary id="join-pool-button" as={Link} to="/add/v2/ETH" padding="6px 8px">
                       <Text fontWeight={535} fontSize={16}>
-                        <Trans>Add V2 Liquidity</Trans>
+                        <Trans>Add V2 liquidity</Trans>
                       </Text>
                     </ResponsiveButtonPrimary>
                   </ButtonRow>
@@ -257,7 +257,7 @@ export default function Pool() {
                         }}
                       >
                         <ChevronsRight size={16} style={{ marginRight: '8px' }} />
-                        <Trans>Migrate Liquidity to V3</Trans>
+                        <Trans>Migrate liquidity to V3</Trans>
                       </ButtonOutlined>
                     </RowFixed>
                   </>

--- a/src/pages/PoolFinder/index.tsx
+++ b/src/pages/PoolFinder/index.tsx
@@ -165,7 +165,7 @@ export default function PoolFinder() {
                 style={{ justifyItems: 'center', backgroundColor: '', padding: '12px 0px', borderRadius: '12px' }}
               >
                 <Text textAlign="center" fontWeight={535}>
-                  <Trans>Pool Found!</Trans>
+                  <Trans>Pool found!</Trans>
                 </Text>
                 <StyledInternalLink to="pools/v2">
                   <Text textAlign="center">

--- a/src/pages/RemoveLiquidity/V3.tsx
+++ b/src/pages/RemoveLiquidity/V3.tsx
@@ -292,7 +292,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
         hash={txnHash ?? ''}
         reviewContent={() => (
           <ConfirmationModalContent
-            title={<Trans>Remove Liquidity</Trans>}
+            title={<Trans>Remove liquidity</Trans>}
             onDismiss={handleDismissConfirmation}
             topContent={modalHeader}
           />

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -483,7 +483,7 @@ function RemoveLiquidity() {
               <AutoColumn gap="20px">
                 <RowBetween>
                   <Text fontWeight={535}>
-                    <Trans>Remove Amount</Trans>
+                    <Trans>Remove amount</Trans>
                   </Text>
                   <ClickableText
                     fontWeight={535}
@@ -651,7 +651,7 @@ function RemoveLiquidity() {
                   element={InterfaceElementName.CONNECT_WALLET_BUTTON}
                 >
                   <ButtonLight onClick={toggleWalletDrawer}>
-                    <Trans>Connect Wallet</Trans>
+                    <Trans>Connect wallet</Trans>
                   </ButtonLight>
                 </TraceEvent>
               ) : (

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -727,7 +727,7 @@ export function Swap({
           {swapIsUnsupported ? (
             <ButtonPrimary $borderRadius="16px" disabled={true}>
               <ThemedText.DeprecatedMain mb="4px">
-                <Trans>Unsupported Asset</Trans>
+                <Trans>Unsupported asset</Trans>
               </ThemedText.DeprecatedMain>
             </ButtonPrimary>
           ) : switchingChain ? (
@@ -742,7 +742,7 @@ export function Swap({
               element={InterfaceElementName.CONNECT_WALLET_BUTTON}
             >
               <ButtonLight onClick={toggleWalletDrawer} fontWeight={535} $borderRadius="16px">
-                <Trans>Connect Wallet</Trans>
+                <Trans>Connect wallet</Trans>
               </ButtonLight>
             </TraceEvent>
           ) : chainId && chainId !== connectedChainId ? (
@@ -806,7 +806,7 @@ export function Swap({
                   ) : routeIsSyncing || routeIsLoading ? (
                     <Trans>Swap</Trans>
                   ) : priceImpactSeverity > 2 ? (
-                    <Trans>Swap Anyway</Trans>
+                    <Trans>Swap anyway</Trans>
                   ) : (
                     <Trans>Swap</Trans>
                   )}

--- a/src/pages/Vote/Landing.tsx
+++ b/src/pages/Vote/Landing.tsx
@@ -150,7 +150,7 @@ export default function Landing() {
           <DelegateModal
             isOpen={showDelegateModal}
             onDismiss={toggleDelegateModal}
-            title={showUnlockVoting ? <Trans>Unlock Votes</Trans> : <Trans>Update Delegation</Trans>}
+            title={showUnlockVoting ? <Trans>Unlock votes</Trans> : <Trans>Update delegation</Trans>}
           />
           <TopSection gap="md">
             <VoteCard>
@@ -160,7 +160,7 @@ export default function Landing() {
                 <AutoColumn gap="md">
                   <RowBetween>
                     <ThemedText.DeprecatedWhite fontWeight={535}>
-                      <Trans>Uniswap Governance</Trans>
+                      <Trans>Uniswap governance</Trans>
                     </ThemedText.DeprecatedWhite>
                   </RowBetween>
                   <RowBetween>
@@ -203,7 +203,7 @@ export default function Landing() {
                     $borderRadius="8px"
                     onClick={toggleDelegateModal}
                   >
-                    <Trans>Unlock Voting</Trans>
+                    <Trans>Unlock voting</Trans>
                   </ButtonPrimary>
                 ) : availableVotes && JSBI.notEqual(JSBI.BigInt(0), availableVotes?.quotient) ? (
                   <ThemedText.DeprecatedBody fontWeight={535} mr="6px">
@@ -229,7 +229,7 @@ export default function Landing() {
                   style={{ width: 'fit-content', borderRadius: '8px', height: '40px' }}
                   padding="8px"
                 >
-                  <Trans>Create Proposal</Trans>
+                  <Trans>Create proposal</Trans>
                 </ButtonPrimary>
               </AutoRow>
             </WrapSmall>
@@ -266,7 +266,7 @@ export default function Landing() {
                 <RowBetween></RowBetween>
                 <RowBetween>
                   <ThemedText.DeprecatedMain>
-                    <Trans>Show Cancelled</Trans>
+                    <Trans>Show cancelled</Trans>
                   </ThemedText.DeprecatedMain>
                   <Toggle
                     isActive={!hideCancelled}

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -283,7 +283,7 @@ export default function VotePage() {
           <DelegateModal
             isOpen={showDelegateModal}
             onDismiss={toggleDelegateModal}
-            title={<Trans>Unlock Votes</Trans>}
+            title={<Trans>Unlock votes</Trans>}
           />
           <QueueModal isOpen={showQueueModal} onDismiss={toggleQueueModal} proposalId={proposalData?.id} />
           <ExecuteModal isOpen={showExecuteModal} onDismiss={toggleExecuteModal} proposalId={proposalData?.id} />
@@ -346,7 +346,7 @@ export default function VotePage() {
                     toggleVoteModal()
                   }}
                 >
-                  <Trans>Vote For</Trans>
+                  <Trans>Vote for</Trans>
                 </ButtonPrimary>
                 <ButtonPrimary
                   padding="8px"
@@ -356,7 +356,7 @@ export default function VotePage() {
                     toggleVoteModal()
                   }}
                 >
-                  <Trans>Vote Against</Trans>
+                  <Trans>Vote against</Trans>
                 </ButtonPrimary>
               </RowFixed>
             )}

--- a/src/state/burn/hooks.tsx
+++ b/src/state/burn/hooks.tsx
@@ -124,7 +124,7 @@ export function useDerivedBurnInfo(
 
   let error: ReactNode | undefined
   if (!account) {
-    error = <Trans>Connect Wallet</Trans>
+    error = <Trans>Connect wallet</Trans>
   }
 
   if (!parsedAmounts[Field.LIQUIDITY] || !parsedAmounts[Field.CURRENCY_A] || !parsedAmounts[Field.CURRENCY_B]) {

--- a/src/state/burn/v3/hooks.tsx
+++ b/src/state/burn/v3/hooks.tsx
@@ -76,7 +76,7 @@ export function useDerivedV3BurnInfo(
 
   let error: ReactNode | undefined
   if (!account) {
-    error = <Trans>Connect Wallet</Trans>
+    error = <Trans>Connect wallet</Trans>
   }
   if (percent === 0) {
     error = error ?? <Trans>Enter a percent</Trans>

--- a/src/state/mint/hooks.tsx
+++ b/src/state/mint/hooks.tsx
@@ -178,7 +178,7 @@ export function useDerivedMintInfo(
 
   let error: ReactNode | undefined
   if (!account) {
-    error = <Trans>Connect Wallet</Trans>
+    error = <Trans>Connect wallet</Trans>
   }
 
   if (pairState === PairState.INVALID) {

--- a/src/state/mint/v3/hooks.tsx
+++ b/src/state/mint/v3/hooks.tsx
@@ -444,7 +444,7 @@ export function useV3DerivedMintInfo(
 
   let errorMessage: ReactNode | undefined
   if (!account) {
-    errorMessage = <Trans>Connect Wallet</Trans>
+    errorMessage = <Trans>Connect wallet</Trans>
   }
 
   if (poolState === PoolState.INVALID) {

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -174,7 +174,7 @@ export function useDerivedSwapInfo(state: SwapState, chainId: ChainId | undefine
     let inputError: ReactNode | undefined
 
     if (!account) {
-      inputError = connectionReady ? <Trans>Connect Wallet</Trans> : <Trans>Connecting Wallet...</Trans>
+      inputError = connectionReady ? <Trans>Connect wallet</Trans> : <Trans>Connecting wallet...</Trans>
     }
 
     if (!currencies[Field.INPUT] || !currencies[Field.OUTPUT]) {


### PR DESCRIPTION
For titles and button labels, the styling we use is "sentence-casing" with the exception of proper nouns (e.g. ETH). For example "Connect Wallet" should be "Connect wallet".

Linear ticket: https://linear.app/uniswap/issue/WEB-2313/update-all-swap-box-button-labels-and-headings-to-be-sentence-case

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Before    |   After    |
| ------------ | ------------ |
| <img width="400" alt="Screenshot 2023-09-26 at 12 08 06 PM" src="https://github.com/Uniswap/interface/assets/27475332/588b1fd6-4057-494c-958a-228fa4a01a41"> | <img width="400" alt="Screenshot 2023-09-26 at 12 08 03 PM" src="https://github.com/Uniswap/interface/assets/27475332/8762f8b8-7cb1-4ab2-8ed0-af8ea5fead94"> |
| <img width="400" alt="Screenshot 2023-09-26 at 12 08 28 PM" src="https://github.com/Uniswap/interface/assets/27475332/20f62219-3ded-4f61-b592-707afdc64b20"> | <img width="400" alt="Screenshot 2023-09-26 at 12 54 24 PM" src="https://github.com/Uniswap/interface/assets/27475332/2957cf3a-9311-4892-8086-6463d12a5b5f"> |
| and more | and more |


