### PR TITLE
feat: uniswapx deadline

### DIFF
--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -423,7 +423,7 @@ export default function ConfirmSwapModal({
     if (approvalError) return approvalError
     // SignatureExpiredError is a special case. The UI is shown in the PendingModalContent component.
     if (swapError instanceof SignatureExpiredError) return
-    if (swapError) return PendingModalError.CONFIRMATION_ERROR
+    if (swapError && !didUserReject(swapError)) return PendingModalError.CONFIRMATION_ERROR
     return
   }, [approvalError, swapError])
 

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -273,6 +273,7 @@ export default function ConfirmSwapModal({
   swapResult,
   fiatValueInput,
   fiatValueOutput,
+  onRetryUniswapXSignature,
 }: {
   trade: InterfaceTrade
   inputCurrency?: Currency
@@ -287,6 +288,10 @@ export default function ConfirmSwapModal({
   onCurrencySelection: (field: Field, currency: Currency) => void
   fiatValueInput: { data?: number; isLoading: boolean }
   fiatValueOutput: { data?: number; isLoading: boolean }
+  // onConfirm triggers the same callback, but it also clears other swap state.
+  // for the UniswapX signature expiration logic, we need a callback which only
+  // requests the signature without clearing swap state.
+  onRetryUniswapXSignature?: () => void
 }) {
   const { chainId } = useWeb3React()
   const doesTradeDiffer = originalTrade && tradeMeaningfullyDiffers(trade, originalTrade, allowedSlippage)
@@ -378,7 +383,7 @@ export default function ConfirmSwapModal({
         tokenApprovalPending={allowance.state === AllowanceState.REQUIRED && allowance.isApprovalPending}
         revocationPending={allowance.state === AllowanceState.REQUIRED && allowance.isRevocationPending}
         swapError={swapError}
-        onRetry={startSwapFlow}
+        onRetryUniswapXSignature={onRetryUniswapXSignature}
       />
     )
   }, [
@@ -396,6 +401,7 @@ export default function ConfirmSwapModal({
     fiatValueOutput,
     onAcceptChanges,
     swapFailed,
+    onRetryUniswapXSignature,
   ])
 
   const l2Badge = () => {

--- a/src/components/swap/PendingModalContent/TransitionText.tsx
+++ b/src/components/swap/PendingModalContent/TransitionText.tsx
@@ -1,0 +1,103 @@
+import { Trans } from '@lingui/macro'
+import { useUnmountingAnimation } from 'hooks/useUnmountingAnimation'
+import { ReactNode, useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+import { slideInAnimation, slideOutAnimation } from './animations'
+import { AnimationType } from './Logos'
+
+interface TransitionTextProps {
+  initialText: ReactNode
+  transitionText: ReactNode
+  transitionTimeMs?: number
+  onTransitionEnded?: () => void
+}
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+  min-height: 30px;
+`
+
+const InitialTextContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  transition: display ${({ theme }) => `${theme.transition.duration.fast} ${theme.transition.timing.inOut}`};
+  ${slideInAnimation}
+  &.${AnimationType.EXITING} {
+    ${slideOutAnimation}
+  }
+`
+
+const TransitionTextContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  transition: display ${({ theme }) => `${theme.transition.duration.fast} ${theme.transition.timing.inOut}`};
+  ${slideInAnimation}
+  &.${AnimationType.EXITING} {
+    ${slideOutAnimation}
+  }
+`
+
+export function TransitionText({
+  initialText,
+  transitionText,
+  transitionTimeMs = 1000,
+  onTransitionEnded,
+}: TransitionTextProps) {
+  const [transitioned, setTransitioned] = useState(false)
+  const [transitionEnded, setTransitionEnded] = useState(false)
+
+  useEffect(() => {
+    // Transition from initial text to transition text.
+    const timeout = setTimeout(() => {
+      setTransitioned(true)
+    }, transitionTimeMs)
+
+    return () => clearTimeout(timeout)
+  }, [transitionTimeMs])
+
+  useEffect(() => {
+    // Show the transition text for a bit before removing it.
+    if (transitioned) {
+      const timeout = setTimeout(() => {
+        setTransitionEnded(true)
+      }, transitionTimeMs)
+      return () => clearTimeout(timeout)
+    }
+    return
+  }, [transitionTimeMs, transitioned])
+
+  useEffect(() => {
+    // Delay the onTransitionEnded callback until the transition has ended.
+    if (transitioned && transitionEnded) {
+      const timeout = setTimeout(() => {
+        onTransitionEnded?.()
+      }, 125 /* theme.transition.duration.fast */)
+      return () => clearTimeout(timeout)
+    }
+    return
+  }, [onTransitionEnded, transitionEnded, transitionTimeMs, transitioned])
+
+  const initialTextRef = useRef<HTMLDivElement>(null)
+  const transitionTextRef = useRef<HTMLDivElement>(null)
+  useUnmountingAnimation(initialTextRef, () => AnimationType.EXITING)
+  useUnmountingAnimation(transitionTextRef, () => AnimationType.EXITING)
+
+  return (
+    <Container>
+      {!transitioned && (
+        <InitialTextContainer ref={initialTextRef}>
+          <Trans>{initialText}</Trans>
+        </InitialTextContainer>
+      )}
+      {transitioned && !transitionEnded && (
+        <TransitionTextContainer ref={transitionTextRef}>
+          <Trans>{transitionText}</Trans>
+        </TransitionTextContainer>
+      )}
+    </Container>
+  )
+}

--- a/src/components/swap/PendingModalContent/TransitionText.tsx
+++ b/src/components/swap/PendingModalContent/TransitionText.tsx
@@ -10,7 +10,7 @@ interface TransitionTextProps {
   initialText: ReactNode
   transitionText: ReactNode
   transitionTimeMs?: number
-  onTransitionEnded?: () => void
+  onTransition?: () => void
 }
 
 const Container = styled.div`
@@ -44,47 +44,25 @@ const TransitionTextContainer = styled.div`
 export function TransitionText({
   initialText,
   transitionText,
-  transitionTimeMs = 1000,
-  onTransitionEnded,
+  transitionTimeMs = 1500,
+  onTransition,
 }: TransitionTextProps) {
   const [transitioned, setTransitioned] = useState(false)
-  const [transitionEnded, setTransitionEnded] = useState(false)
 
   useEffect(() => {
     // Transition from initial text to transition text.
     const timeout = setTimeout(() => {
-      setTransitioned(true)
+      if (!transitioned) {
+        setTransitioned(true)
+        onTransition?.()
+      }
     }, transitionTimeMs)
 
     return () => clearTimeout(timeout)
-  }, [transitionTimeMs])
-
-  useEffect(() => {
-    // Show the transition text for a bit before removing it.
-    if (transitioned) {
-      const timeout = setTimeout(() => {
-        setTransitionEnded(true)
-      }, transitionTimeMs)
-      return () => clearTimeout(timeout)
-    }
-    return
-  }, [transitionTimeMs, transitioned])
-
-  useEffect(() => {
-    // Delay the onTransitionEnded callback until the transition has ended.
-    if (transitioned && transitionEnded) {
-      const timeout = setTimeout(() => {
-        onTransitionEnded?.()
-      }, 125 /* theme.transition.duration.fast */)
-      return () => clearTimeout(timeout)
-    }
-    return
-  }, [onTransitionEnded, transitionEnded, transitionTimeMs, transitioned])
+  }, [onTransition, transitionTimeMs, transitioned])
 
   const initialTextRef = useRef<HTMLDivElement>(null)
-  const transitionTextRef = useRef<HTMLDivElement>(null)
   useUnmountingAnimation(initialTextRef, () => AnimationType.EXITING)
-  useUnmountingAnimation(transitionTextRef, () => AnimationType.EXITING)
 
   return (
     <Container>
@@ -93,8 +71,8 @@ export function TransitionText({
           <Trans>{initialText}</Trans>
         </InitialTextContainer>
       )}
-      {transitioned && !transitionEnded && (
-        <TransitionTextContainer ref={transitionTextRef}>
+      {transitioned && (
+        <TransitionTextContainer>
           <Trans>{transitionText}</Trans>
         </TransitionTextContainer>
       )}

--- a/src/components/swap/PendingModalContent/animations.ts
+++ b/src/components/swap/PendingModalContent/animations.ts
@@ -1,0 +1,16 @@
+import { css, keyframes } from 'styled-components'
+
+const slideIn = keyframes`
+  from { opacity: 0; transform: translateX(40px) }
+  to { opacity: 1; transform: translateX(0px) }
+`
+export const slideInAnimation = css`
+  animation: ${slideIn} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
+`
+const slideOut = keyframes`
+  from { opacity: 1; transform: translateX(0px) }
+  to { opacity: 0; transform: translateX(-40px) }
+`
+export const slideOutAnimation = css`
+  animation: ${slideOut} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
+`

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -14,13 +14,15 @@ import { InterfaceTrade, TradeFillType } from 'state/routing/types'
 import { useOrder } from 'state/signatures/hooks'
 import { UniswapXOrderDetails } from 'state/signatures/types'
 import { useIsTransactionConfirmed, useSwapTransactionStatus } from 'state/transactions/hooks'
-import styled, { css, keyframes } from 'styled-components'
+import styled, { css } from 'styled-components'
 import { ExternalLink } from 'theme/components'
 import { ThemedText } from 'theme/components/text'
+import { SignatureExpiredError } from 'utils/errors'
 import { getExplorerLink } from 'utils/getExplorerLink'
 import { ExplorerDataType } from 'utils/getExplorerLink'
 
 import { ConfirmModalState } from '../ConfirmSwapModal'
+import { slideInAnimation, slideOutAnimation } from './animations'
 import {
   AnimatedEntranceConfirmationIcon,
   AnimatedEntranceSubmittedIcon,
@@ -31,6 +33,7 @@ import {
   PaperIcon,
 } from './Logos'
 import { TradeSummary } from './TradeSummary'
+import { TransitionText } from './TransitionText'
 
 export const PendingModalContainer = styled(ColumnCenter)`
   margin: 48px 0 8px;
@@ -51,21 +54,6 @@ const StepCircle = styled.div<{ active: boolean }>`
   transition: background-color ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
 `
 
-const slideIn = keyframes`
-  from { opacity: 0; transform: translateX(40px) }
-  to { opacity: 1; transform: translateX(0px) }
-`
-const slideInAnimation = css`
-  animation: ${slideIn} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
-`
-const slideOut = keyframes`
-  from { opacity: 1; transform: translateX(0px) }
-  to { opacity: 0; transform: translateX(-40px) }
-`
-const slideOutAnimation = css`
-  animation: ${slideOut} ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
-`
-
 const AnimationWrapper = styled.div`
   position: relative;
   width: 100%;
@@ -77,7 +65,10 @@ const AnimationWrapper = styled.div`
 const StepTitleAnimationContainer = styled(Column)<{ disableEntranceAnimation?: boolean }>`
   position: absolute;
   width: 100%;
+  height: 100%;
   align-items: center;
+  display: flex;
+  flex-direction: column;
   transition: display ${({ theme }) => `${theme.transition.duration.medium} ${theme.transition.timing.inOut}`};
   ${({ disableEntranceAnimation }) =>
     !disableEntranceAnimation &&
@@ -117,6 +108,8 @@ interface PendingModalContentProps {
   hideStepIndicators?: boolean
   tokenApprovalPending?: boolean
   revocationPending?: boolean
+  swapError?: Error | string
+  onRetry?: () => void
 }
 
 interface ContentArgs {
@@ -130,6 +123,8 @@ interface ContentArgs {
   swapResult?: SwapResult
   chainId?: number
   order?: UniswapXOrderDetails
+  swapError?: Error | string
+  onRetry?: () => void
 }
 
 function getPendingConfirmationContent({
@@ -138,7 +133,12 @@ function getPendingConfirmationContent({
   trade,
   chainId,
   swapResult,
-}: Pick<ContentArgs, 'swapConfirmed' | 'swapPending' | 'trade' | 'chainId' | 'swapResult'>): PendingModalStep {
+  swapError,
+  onRetry,
+}: Pick<
+  ContentArgs,
+  'swapConfirmed' | 'swapPending' | 'trade' | 'chainId' | 'swapResult' | 'swapError' | 'onRetry'
+>): PendingModalStep {
   const title = swapPending ? t`Swap submitted` : swapConfirmed ? t`Swap success!` : t`Confirm Swap`
   const tradeSummary = trade ? <TradeSummary trade={trade} /> : null
   if (swapPending && trade?.fillType === TradeFillType.UniswapX) {
@@ -174,6 +174,18 @@ function getPendingConfirmationContent({
         bottomLabel: null,
       }
     }
+  } else if (swapError instanceof SignatureExpiredError) {
+    return {
+      title: (
+        <TransitionText
+          initialText={<Trans>Time expired</Trans>}
+          transitionText={<Trans>Retry confirmation</Trans>}
+          onTransitionEnded={onRetry}
+        />
+      ),
+      subtitle: tradeSummary,
+      bottomLabel: t`Proceed in your wallet`,
+    }
   } else {
     return {
       title,
@@ -194,6 +206,8 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
     trade,
     swapResult,
     chainId,
+    swapError,
+    onRetry,
   } = args
 
   return useMemo(
@@ -236,6 +250,8 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
         swapPending,
         swapResult,
         trade,
+        swapError,
+        onRetry,
       }),
     }),
     [
@@ -248,6 +264,8 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
       tokenApprovalPending,
       trade,
       wrapPending,
+      swapError,
+      onRetry,
     ]
   )
 }
@@ -261,6 +279,8 @@ export function PendingModalContent({
   hideStepIndicators,
   tokenApprovalPending = false,
   revocationPending = false,
+  swapError,
+  onRetry,
 }: PendingModalContentProps) {
   const { chainId } = useWeb3React()
 
@@ -283,6 +303,8 @@ export function PendingModalContent({
     swapResult,
     trade,
     chainId,
+    swapError,
+    onRetry,
   })
 
   const currentStepContainerRef = useRef<HTMLDivElement>(null)
@@ -341,7 +363,7 @@ export function PendingModalContent({
                   key={step}
                   ref={step === currentStep ? currentStepContainerRef : undefined}
                 >
-                  <ThemedText.SubHeaderLarge textAlign="center" data-testid="pending-modal-content-title">
+                  <ThemedText.SubHeaderLarge width="100%" textAlign="center" data-testid="pending-modal-content-title">
                     {stepContents[step].title}
                   </ThemedText.SubHeaderLarge>
                   <ThemedText.LabelSmall textAlign="center">{stepContents[step].subtitle}</ThemedText.LabelSmall>

--- a/src/components/swap/PendingModalContent/index.tsx
+++ b/src/components/swap/PendingModalContent/index.tsx
@@ -109,7 +109,7 @@ interface PendingModalContentProps {
   tokenApprovalPending?: boolean
   revocationPending?: boolean
   swapError?: Error | string
-  onRetry?: () => void
+  onRetryUniswapXSignature?: () => void
 }
 
 interface ContentArgs {
@@ -124,7 +124,7 @@ interface ContentArgs {
   chainId?: number
   order?: UniswapXOrderDetails
   swapError?: Error | string
-  onRetry?: () => void
+  onRetryUniswapXSignature?: () => void
 }
 
 function getPendingConfirmationContent({
@@ -134,10 +134,10 @@ function getPendingConfirmationContent({
   chainId,
   swapResult,
   swapError,
-  onRetry,
+  onRetryUniswapXSignature,
 }: Pick<
   ContentArgs,
-  'swapConfirmed' | 'swapPending' | 'trade' | 'chainId' | 'swapResult' | 'swapError' | 'onRetry'
+  'swapConfirmed' | 'swapPending' | 'trade' | 'chainId' | 'swapResult' | 'swapError' | 'onRetryUniswapXSignature'
 >): PendingModalStep {
   const title = swapPending ? t`Swap submitted` : swapConfirmed ? t`Swap success!` : t`Confirm Swap`
   const tradeSummary = trade ? <TradeSummary trade={trade} /> : null
@@ -178,9 +178,10 @@ function getPendingConfirmationContent({
     return {
       title: (
         <TransitionText
+          key={swapError.id}
           initialText={<Trans>Time expired</Trans>}
           transitionText={<Trans>Retry confirmation</Trans>}
-          onTransitionEnded={onRetry}
+          onTransition={onRetryUniswapXSignature}
         />
       ),
       subtitle: tradeSummary,
@@ -207,7 +208,7 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
     swapResult,
     chainId,
     swapError,
-    onRetry,
+    onRetryUniswapXSignature,
   } = args
 
   return useMemo(
@@ -251,7 +252,7 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
         swapResult,
         trade,
         swapError,
-        onRetry,
+        onRetryUniswapXSignature,
       }),
     }),
     [
@@ -265,7 +266,7 @@ function useStepContents(args: ContentArgs): Record<PendingConfirmModalState, Pe
       trade,
       wrapPending,
       swapError,
-      onRetry,
+      onRetryUniswapXSignature,
     ]
   )
 }
@@ -280,7 +281,7 @@ export function PendingModalContent({
   tokenApprovalPending = false,
   revocationPending = false,
   swapError,
-  onRetry,
+  onRetryUniswapXSignature,
 }: PendingModalContentProps) {
   const { chainId } = useWeb3React()
 
@@ -304,7 +305,7 @@ export function PendingModalContent({
     trade,
     chainId,
     swapError,
-    onRetry,
+    onRetryUniswapXSignature,
   })
 
   const currentStepContainerRef = useRef<HTMLDivElement>(null)

--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -9,7 +9,7 @@ import { formatSwapSignedAnalyticsEventProperties } from 'lib/utils/analytics'
 import { useCallback } from 'react'
 import { DutchOrderTrade, TradeFillType } from 'state/routing/types'
 import { trace } from 'tracing/trace'
-import { UserRejectedRequestError } from 'utils/errors'
+import { SignatureExpiredError, UserRejectedRequestError } from 'utils/errors'
 import { signTypedData } from 'utils/signing'
 import { didUserReject, swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
 
@@ -90,11 +90,14 @@ export function useUniswapXSwapCallback({
             const { domain, types, values } = updatedOrder.permitData()
 
             const signature = await signTypedData(provider.getSigner(account), domain, types, values)
-            if (deadline < Math.floor(Date.now() / 1000)) {
-              return signDutchOrder()
+            if (startTime < Math.floor(Date.now() / 1000)) {
+              throw new SignatureExpiredError()
             }
             return { signature, updatedOrder }
           } catch (swapError) {
+            if (swapError instanceof SignatureExpiredError) {
+              throw swapError
+            }
             if (didUserReject(swapError)) {
               setTraceStatus('cancelled')
               throw new UserRejectedRequestError(swapErrorToUserReadableMessage(swapError))

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -484,6 +484,15 @@ export function Swap({
       })
   }, [swapCallback, preTaxStablecoinPriceImpact])
 
+  const handleRetryUniswapXSignature = useCallback(() => {
+    swapCallback?.().catch((error) => {
+      setSwapState((currentState) => ({
+        ...currentState,
+        swapError: error,
+      }))
+    })
+  }, [swapCallback])
+
   const handleOnWrap = useCallback(async () => {
     if (!onWrap) return
     try {
@@ -617,6 +626,7 @@ export function Swap({
           onDismiss={handleConfirmDismiss}
           fiatValueInput={fiatValueTradeInput}
           fiatValueOutput={fiatValueTradeOutput}
+          onRetryUniswapXSignature={handleRetryUniswapXSignature}
         />
       )}
       {showPriceImpactModal && showPriceImpactWarning && (

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -455,6 +455,14 @@ export function Swap({
     })
   }, [trade])
 
+  const clearSwapState = useCallback(() => {
+    setSwapState((currentState) => ({
+      ...currentState,
+      swapError: undefined,
+      swapResult: undefined,
+    }))
+  }, [])
+
   const handleSwap = useCallback(() => {
     if (!swapCallback) {
       return
@@ -462,11 +470,6 @@ export function Swap({
     if (preTaxStablecoinPriceImpact && !confirmPriceImpactWithoutFee(preTaxStablecoinPriceImpact)) {
       return
     }
-    setSwapState((currentState) => ({
-      ...currentState,
-      swapError: undefined,
-      swapResult: undefined,
-    }))
     swapCallback()
       .then((result) => {
         setSwapState((currentState) => ({
@@ -483,15 +486,6 @@ export function Swap({
         }))
       })
   }, [swapCallback, preTaxStablecoinPriceImpact])
-
-  const handleRetryUniswapXSignature = useCallback(() => {
-    swapCallback?.().catch((error) => {
-      setSwapState((currentState) => ({
-        ...currentState,
-        swapError: error,
-      }))
-    })
-  }, [swapCallback])
 
   const handleOnWrap = useCallback(async () => {
     if (!onWrap) return
@@ -620,13 +614,13 @@ export function Swap({
           onCurrencySelection={onCurrencySelection}
           swapResult={swapResult}
           allowedSlippage={allowedSlippage}
+          clearSwapState={clearSwapState}
           onConfirm={handleSwap}
           allowance={allowance}
           swapError={swapError}
           onDismiss={handleConfirmDismiss}
           fiatValueInput={fiatValueTradeInput}
           fiatValueOutput={fiatValueTradeOutput}
-          onRetryUniswapXSignature={handleRetryUniswapXSignature}
         />
       )}
       {showPriceImpactModal && showPriceImpactWarning && (

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro'
+import { v4 as uuid } from 'uuid'
 
 // You may throw an instance of this class when the user rejects a request in their wallet.
 // The benefit is that you can distinguish this error from other errors using didUserReject().
@@ -24,8 +25,14 @@ export class WrongChainError extends Error {
 }
 
 export class SignatureExpiredError extends Error {
+  private _id: string
   constructor() {
     super(t`Your signature has expired.`)
     this.name = 'SignatureExpiredError'
+    this._id = `SignatureExpiredError-${uuid()}`
+  }
+
+  get id(): string {
+    return this._id
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,7 +1,6 @@
-// You may throw an instance of this class when the user rejects a request in their wallet.
-
 import { t } from '@lingui/macro'
 
+// You may throw an instance of this class when the user rejects a request in their wallet.
 // The benefit is that you can distinguish this error from other errors using didUserReject().
 export class UserRejectedRequestError extends Error {
   constructor(message: string) {
@@ -21,5 +20,12 @@ export function toReadableError(errorText: string, error: unknown) {
 export class WrongChainError extends Error {
   constructor() {
     super(t`Your wallet is connected to the wrong network.`)
+  }
+}
+
+export class SignatureExpiredError extends Error {
+  constructor() {
+    super(t`Your signature has expired.`)
+    this.name = 'SignatureExpiredError'
   }
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

problem: right now, some fillers are receiving uniswapx orders after startTime has already passed so they no longer have an exclusivity window. we think it's because users are taking too long to sign the permit signature in their wallet. the interface currently only re-prompts a signature if the submission happens after deadline
solution: change the re-prompt logic to happen after startTime instead (so moving up the time requirement), and also add copy in the swap submission modal to say that their signature has expired 

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2898/uniswapx-change-time-to-sign
_Slack thread:_ https://uniswapteam.slack.com/archives/C053G2YEK5M/p1695663790335929


<!-- Delete this section if your change does not affect UI. -->
## Screen capture


https://github.com/Uniswap/interface/assets/66155195/18987195-1465-49cb-b287-4a43d0edce41


## Test plan


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manual testing - wait 30s before signing and ensure the new text appears, transitions, and re-requests the signature
- [x] make sure that this happens on subsequent timed-out signatures too (see video w/ two in a row)

