### PR TITLE
fix: wrap/unwrap activity parsing

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/__snapshots__/parseRemote.test.tsx.snap
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/__snapshots__/parseRemote.test.tsx.snap
@@ -101,6 +101,42 @@ Object {
 }
 `;
 
+exports[`parseRemote parseRemoteActivities should parse eth wrap 1`] = `
+Object {
+  "chainId": 1,
+  "currencies": Array [
+    ExtendedEther {
+      "chainId": 1,
+      "decimals": 18,
+      "isNative": true,
+      "isToken": false,
+      "name": "Ether",
+      "symbol": "ETH",
+    },
+    Token {
+      "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "chainId": 1,
+      "decimals": 18,
+      "isNative": false,
+      "isToken": true,
+      "name": "Wrapped Ether",
+      "symbol": "WETH",
+    },
+  ],
+  "descriptor": "100 ETH for 100 WETH",
+  "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
+  "hash": "someHash",
+  "logos": Array [
+    "https://token-icons.s3.amazonaws.com/eth.png",
+    "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+  ],
+  "nonce": 12345,
+  "status": "CONFIRMED",
+  "timestamp": 10000,
+  "title": "Wrapped",
+}
+`;
+
 exports[`parseRemote parseRemoteActivities should parse moonpay purchase 1`] = `
 Object {
   "chainId": 1,

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/fixtures/activity.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/fixtures/activity.ts
@@ -222,6 +222,78 @@ const mockTokenTransferOutPartsFragment = {
   },
 }
 
+const mockNativeTokenTransferOutPartsFragment = {
+  __typename: 'TokenTransfer',
+  id: 'tokenTransferId',
+  asset: {
+    __typename: 'Token',
+    id: 'ETH',
+    name: 'Ether',
+    symbol: 'ETH',
+    address: null,
+    decimals: 18,
+    chain: 'ETHEREUM',
+    standard: null,
+    project: {
+      __typename: 'TokenProject',
+      id: 'Ethereum',
+      isSpam: false,
+      logo: {
+        __typename: 'Image',
+        id: 'ETH_logo',
+        url: 'https://token-icons.s3.amazonaws.com/eth.png',
+      },
+    },
+  },
+  tokenStandard: 'NATIVE',
+  quantity: '0.25',
+  sender: MockSenderAddress,
+  recipient: MockRecipientAddress,
+  direction: 'OUT',
+  transactedValue: {
+    __typename: 'Amount',
+    id: 'ETH_amount',
+    currency: 'USD',
+    value: 399.0225,
+  },
+}
+
+const mockWrappedEthTransferInPartsFragment = {
+  __typename: 'TokenTransfer',
+  id: 'tokenTransferId',
+  asset: {
+    __typename: 'Token',
+    id: 'WETH',
+    name: 'Wrapped Ether',
+    symbol: 'WETH',
+    address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    decimals: 18,
+    chain: 'ETHEREUM',
+    standard: 'ERC20',
+    project: {
+      __typename: 'TokenProject',
+      id: 'weth_project_id',
+      isSpam: false,
+      logo: {
+        __typename: 'Image',
+        id: 'weth_image',
+        url: 'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png',
+      },
+    },
+  },
+  tokenStandard: 'ERC20',
+  quantity: '0.25',
+  sender: MockSenderAddress,
+  recipient: MockRecipientAddress,
+  direction: 'IN',
+  transactedValue: {
+    __typename: 'Amount',
+    id: 'mockWethAmountId',
+    currency: 'USD',
+    value: 399.1334007875,
+  },
+}
+
 const mockTokenTransferInPartsFragment = {
   __typename: 'TokenTransfer',
   id: 'tokenTransferId',
@@ -437,5 +509,14 @@ export const MockNFTPurchase = {
         direction: TransactionDirection.In,
       },
     ],
+  },
+} as AssetActivityPartsFragment
+
+export const MockWrap = {
+  ...mockAssetActivityPartsFragment,
+  details: {
+    ...commonTransactionDetailsFields,
+    type: TransactionType.Lend,
+    assetChanges: [mockNativeTokenTransferOutPartsFragment, mockWrappedEthTransferInPartsFragment],
   },
 } as AssetActivityPartsFragment

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.test.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.test.tsx
@@ -16,6 +16,7 @@ import {
   MockTokenReceive,
   MockTokenSend,
   MockTokenTransfer,
+  MockWrap,
 } from './fixtures/activity'
 import { parseRemoteActivities, useTimeSince } from './parseRemote'
 
@@ -78,6 +79,10 @@ describe('parseRemote', () => {
     })
     it('should parse swap order', () => {
       const result = parseRemoteActivities(jest.fn().mockReturnValue('100'), [MockSwapOrder])
+      expect(result?.['someHash']).toMatchSnapshot()
+    })
+    it('should parse eth wrap', () => {
+      const result = parseRemoteActivities(jest.fn().mockReturnValue('100'), [MockWrap])
       expect(result?.['someHash']).toMatchSnapshot()
     })
   })

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/parseRemote.tsx
@@ -182,6 +182,45 @@ function parseSwap(changes: TransactionChanges, formatNumberOrString: FormatNumb
   return { title: t`Unknown Swap` }
 }
 
+/**
+ * Wrap/unwrap transactions are labelled as lend transactions on the backend.
+ * This function parses the transaction changes to determine if the transaction is a wrap/unwrap transaction.
+ */
+function parseLend(changes: TransactionChanges, formatNumberOrString: FormatNumberOrStringFunctionType) {
+  const received = changes.TokenTransfer.find((t) => t.direction === 'IN')
+  const sent = changes.TokenTransfer.find((t) => t.direction === 'OUT')
+  if (!received || !sent) {
+    return {}
+  }
+  const supportedSentChain = supportedChainIdFromGQLChain(sent?.asset.chain)
+  const supportedReceivedChain = supportedChainIdFromGQLChain(received?.asset.chain)
+  if (!supportedSentChain || !supportedReceivedChain) {
+    return {}
+  }
+  const inputAmount = formatNumberOrString({ input: sent.quantity, type: NumberType.TokenNonTx })
+  const outputAmount = formatNumberOrString({ input: received.quantity, type: NumberType.TokenNonTx })
+  if (
+    sent?.tokenStandard === 'NATIVE' &&
+    isSameAddress(nativeOnChain(supportedSentChain).wrapped.address, received.asset.address)
+  ) {
+    return {
+      title: getSwapTitle(sent, received),
+      descriptor: getSwapDescriptor({ tokenIn: sent.asset, inputAmount, tokenOut: received.asset, outputAmount }),
+      currencies: [gqlToCurrency(sent.asset), gqlToCurrency(received.asset)],
+    }
+  } else if (
+    received?.tokenStandard === 'NATIVE' &&
+    isSameAddress(nativeOnChain(supportedReceivedChain).wrapped.address, received.asset.address)
+  ) {
+    return {
+      title: getSwapTitle(sent, received),
+      descriptor: getSwapDescriptor({ tokenIn: sent.asset, inputAmount, tokenOut: received.asset, outputAmount }),
+      currencies: [gqlToCurrency(sent.asset), gqlToCurrency(received.asset)],
+    }
+  }
+  return {} // Not a wrap/unwrap transaction, so don't overwrite the default "Lend" title
+}
+
 function parseSwapOrder(changes: TransactionChanges, formatNumberOrString: FormatNumberOrStringFunctionType) {
   return { ...parseSwap(changes, formatNumberOrString), prefixIconSrc: UniswapXBolt }
 }
@@ -305,6 +344,7 @@ type ActivityTypeParser = (
 ) => Partial<Activity>
 const ActivityParserByType: { [key: string]: ActivityTypeParser | undefined } = {
   [ActivityType.Swap]: parseSwap,
+  [ActivityType.Lend]: parseLend,
   [ActivityType.SwapOrder]: parseSwapOrder,
   [ActivityType.Approve]: parseApprove,
   [ActivityType.Send]: parseSendReceive,
@@ -395,6 +435,7 @@ function parseRemoteActivity(
       })
       return undefined
     }
+
     const defaultFields = {
       hash: assetActivity.details.hash,
       chainId: supportedChain,


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fix activity parsing for wrap/unwrap transactions that are labelled as "LEND" by zerion

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2721/[web][metamask]-inaccurate-title-and-transaction-hash-paragraph-in


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before

<img width="559" alt="Screenshot 2023-09-27 at 3 39 09 PM" src="https://github.com/Uniswap/interface/assets/66155195/3902698c-f8c6-4382-951a-e7302e07b137">


### After

<img width="559" alt="Screenshot 2023-09-27 at 3 38 47 PM" src="https://github.com/Uniswap/interface/assets/66155195/a573ce28-d804-4149-9a1b-cd3d84ffe41e">


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. wrap ETH or unwrap WETH, let the transaction confirm, then open the Mini Portfolio activity history and see "LEND"

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] repeat above process, verify that "wrapped" or "unwrapped" is shown instead w/ amounts



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
