### PR TITLE
fix: broken Checkmark image for Mobile NFT Sort dropdown

### DIFF
--- a/src/nft/components/common/SortDropdown/FilterSortDropdown.tsx
+++ b/src/nft/components/common/SortDropdown/FilterSortDropdown.tsx
@@ -1,8 +1,15 @@
-import { Box } from 'nft/components/Box'
 import { FilterDropdown, FilterItem } from 'nft/components/collection/MarketplaceSelect'
 import { useCollectionFilters } from 'nft/hooks'
 import { DropDownOption } from 'nft/types'
 import { useState } from 'react'
+import { Check } from 'react-feather'
+import styled from 'styled-components'
+
+const CheckIcon = styled(Check)`
+  height: 20px;
+  width: 20px;
+  color: ${({ theme }) => theme.accent1};
+`
 
 export const FilterSortDropdown = ({ sortDropDownOptions }: { sortDropDownOptions: DropDownOption[] }) => {
   const [isOpen, setOpen] = useState(false)
@@ -24,19 +31,7 @@ const SortByItem = ({
   parentOnClick: React.MouseEventHandler<HTMLElement>
 }) => {
   const sortBy = useCollectionFilters((state) => state.sortBy)
-  const checkMark =
-    dropDownOption.sortBy !== undefined && sortBy === dropDownOption.sortBy ? (
-      <Box
-        as="img"
-        alt={dropDownOption.displayText}
-        width="20"
-        height="20"
-        objectFit="cover"
-        src="/nft/svgs/checkmark.svg"
-      />
-    ) : (
-      <></>
-    )
+  const checkMark = dropDownOption.sortBy !== undefined && sortBy === dropDownOption.sortBy ? <CheckIcon /> : <></>
   const onClick: React.MouseEventHandler<HTMLElement> = (e) => {
     e.preventDefault()
     parentOnClick(e)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- We removed the src for the checkmark svg used in the NFT Mobile Filter menu, this updates the component to use the React Feather component

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2921/[mweb][android][nft]-the-price-low-to-high-option-is-displayed-twice


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Mobile
|    Before    |   After   |
| ------------ | ----------- |
| <img width="404" alt="Screenshot 2023-10-02 at 4 28 24 PM" src="https://github.com/Uniswap/interface/assets/11512321/30bef388-6bc0-460d-95f0-47ed761e07e9">  | <img width="405" alt="Screenshot 2023-10-02 at 4 28 06 PM" src="https://github.com/Uniswap/interface/assets/11512321/418d05bb-9f96-4f4a-a4bc-6ff5a9dd1ff3"> |


## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] Need to test on an actual mobile device, web emulator does not trigger
