### PR TITLE
feat: Move UniswapX signature expiry back to deadline

### DIFF
--- a/src/hooks/useUniswapXSwapCallback.ts
+++ b/src/hooks/useUniswapXSwapCallback.ts
@@ -90,7 +90,7 @@ export function useUniswapXSwapCallback({
             const { domain, types, values } = updatedOrder.permitData()
 
             const signature = await signTypedData(provider.getSigner(account), domain, types, values)
-            if (startTime < Math.floor(Date.now() / 1000)) {
+            if (deadline < Math.floor(Date.now() / 1000)) {
               throw new SignatureExpiredError()
             }
             return { signature, updatedOrder }


### PR DESCRIPTION
## Description
We just switched UniswapX signature deadlines to expire if the message gets signed past `startTime`, but it's a bit too strict, so move it back to `deadline`

## Screen capture
Showing that it still submits after waiting for ~30s:

https://github.com/Uniswap/interface/assets/59578595/eb2dfd64-bd41-41d1-9a59-6423bc1d6075



### QA (ie manual testing)
- Wait in the signature screen between 30s and 2 minutes, and the signature should still submit.
- If you wait over 2 minutes, you should see the regular expiration message.

