### PR TITLE
fix: no stale trade when otherCurrency is missing

### DIFF
--- a/src/hooks/useDebouncedTrade.ts
+++ b/src/hooks/useDebouncedTrade.ts
@@ -96,6 +96,7 @@ export function useDebouncedTrade(
 
   const skipBothFetches = !autoRouterSupported || !isWindowVisible || isWrap
   const skipRoutingFetch = skipBothFetches || isDebouncing
+
   const skipPreviewTradeFetch =
     skipBothFetches || routerPreference === RouterPreference.CLIENT || isPreviewTradeDebouncing
 

--- a/src/state/routing/usePreviewTrade.ts
+++ b/src/state/routing/usePreviewTrade.ts
@@ -88,7 +88,7 @@ export function usePreviewTrade(
   const isFetching = currentData !== tradeResult || !currentData
 
   return useMemo(() => {
-    if (amountSpecified && queryArgs === skipToken) {
+    if (amountSpecified && otherCurrency && queryArgs === skipToken) {
       return {
         state: TradeState.STALE,
         trade: tradeResult?.trade,
@@ -124,5 +124,6 @@ export function usePreviewTrade(
     tradeResult?.state,
     tradeResult?.trade,
     currentData?.trade,
+    otherCurrency,
   ])
 }

--- a/src/state/routing/useRoutingAPITrade.ts
+++ b/src/state/routing/useRoutingAPITrade.ts
@@ -104,7 +104,7 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
   const isFetching = currentData !== tradeResult || !currentData
 
   return useMemo(() => {
-    if (amountSpecified && queryArgs === skipToken) {
+    if (amountSpecified && otherCurrency && queryArgs === skipToken) {
       return {
         state: TradeState.STALE,
         trade: tradeResult?.trade,
@@ -140,5 +140,6 @@ export function useRoutingAPITrade<TTradeType extends TradeType>(
     tradeResult?.state,
     tradeResult?.trade,
     currentData?.trade,
+    otherCurrency,
   ])
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes a bug where we incorrectly used a stale quote when the `otherCurrency` was not defined.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2885/swap-shows-incorrect-quote-after-changing-chains-with-no-output


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/66155195/b2d83e31-6c61-45a3-aaaf-c25410f65c66




### After



https://github.com/Uniswap/interface/assets/66155195/43b985a0-b8d3-4f98-9198-21ed42556d23




## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. on chain A, select output token (leave input as ETH), and enter an amount to load a quote
2. switch to chain B. verify that the swap inputs are cleared but ETH is still the input token.
3. enter an input amount for ETH - note that a quote is incorrectly shown

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] followed the above steps to verify the fix worked


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


