### PR TITLE
feat: support redirects for a list of header paths

### DIFF
--- a/cypress/e2e/token-details.test.ts
+++ b/cypress/e2e/token-details.test.ts
@@ -57,7 +57,7 @@ describe('Token details', () => {
     }
 
     // Stats should not exist - need to find another token with no stats
-    // cy.get(getTestSelector('token-details-stats')).should('not.exist')
+    cy.get(getTestSelector('token-details-stats')).should('not.exist')
 
     // About section should have description of token
     cy.get(getTestSelector('token-details-about-section')).should('exist')

--- a/cypress/e2e/token-details.test.ts
+++ b/cypress/e2e/token-details.test.ts
@@ -56,7 +56,7 @@ describe('Token details', () => {
       cy.get('[data-cy="missing-chart"]').should('exist')
     }
 
-    // Stats should not exist - need to find another token with no stats
+    // Stats should not exist
     cy.get(getTestSelector('token-details-stats')).should('not.exist')
 
     // About section should have description of token

--- a/cypress/e2e/token-details.test.ts
+++ b/cypress/e2e/token-details.test.ts
@@ -56,8 +56,8 @@ describe('Token details', () => {
       cy.get('[data-cy="missing-chart"]').should('exist')
     }
 
-    // Stats should not exist
-    cy.get(getTestSelector('token-details-stats')).should('not.exist')
+    // Stats should not exist - need to find another token with no stats
+    // cy.get(getTestSelector('token-details-stats')).should('not.exist')
 
     // About section should have description of token
     cy.get(getTestSelector('token-details-about-section')).should('exist')

--- a/functions/[[index]].ts
+++ b/functions/[[index]].ts
@@ -8,11 +8,10 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
     image: imageUri,
     url: request.url,
     description: 'Swap or provide liquidity on the Uniswap Protocol',
-    country: request.headers.get('cf-ipcountry'),
   }
   const res = next()
   try {
-    return new HTMLRewriter().on('head', new MetaTagInjector(data)).transform(await res)
+    return new HTMLRewriter().on('head', new MetaTagInjector(data, request)).transform(await res)
   } catch (e) {
     return res
   }

--- a/functions/[[index]].ts
+++ b/functions/[[index]].ts
@@ -8,6 +8,7 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
     image: imageUri,
     url: request.url,
     description: 'Swap or provide liquidity on the Uniswap Protocol',
+    country: request.headers.get('cf-ipcountry'),
   }
   const res = next()
   try {

--- a/functions/components/metaTagInjector.test.ts
+++ b/functions/components/metaTagInjector.test.ts
@@ -6,12 +6,15 @@ test('should append meta tag to element', () => {
   } as unknown as Element
   const property = 'property'
   const content = 'content'
-  const injector = new MetaTagInjector({
-    title: 'test',
-    url: 'testUrl',
-    image: 'testImage',
-    description: 'testDescription',
-  })
+  const injector = new MetaTagInjector(
+    {
+      title: 'test',
+      url: 'testUrl',
+      image: 'testImage',
+      description: 'testDescription',
+    },
+    new Request('http://localhost')
+  )
   injector.append(element, property, content)
   expect(element.append).toHaveBeenCalledWith(`<meta property="${property}" content="${content}"/>`, { html: true })
 

--- a/functions/components/metaTagInjector.test.ts
+++ b/functions/components/metaTagInjector.test.ts
@@ -45,7 +45,7 @@ test('should pass through header blocked paths', () => {
     append: jest.fn(),
   } as unknown as Element
   const request = new Request('http://localhost')
-  request.headers.set('cf-blocked-paths-list', '/')
+  request.headers.set('x-blocked-paths', '/')
   const injector = new MetaTagInjector(
     {
       title: 'test',
@@ -56,5 +56,5 @@ test('should pass through header blocked paths', () => {
     request
   )
   injector.element(element)
-  expect(element.append).toHaveBeenCalledWith(`<meta property="cf:blockedpaths" content="/"/>`, { html: true })
+  expect(element.append).toHaveBeenCalledWith(`<meta property="x:blocked-paths" content="/"/>`, { html: true })
 })

--- a/functions/components/metaTagInjector.test.ts
+++ b/functions/components/metaTagInjector.test.ts
@@ -39,3 +39,22 @@ test('should append meta tag to element', () => {
 
   expect(element.append).toHaveBeenCalledTimes(13)
 })
+
+test('should pass through header blocked paths', () => {
+  const element = {
+    append: jest.fn(),
+  } as unknown as Element
+  const request = new Request('http://localhost')
+  request.headers.set('cf-blocked-paths-list', '/')
+  const injector = new MetaTagInjector(
+    {
+      title: 'test',
+      url: 'testUrl',
+      image: 'testImage',
+      description: 'testDescription',
+    },
+    request
+  )
+  injector.element(element)
+  expect(element.append).toHaveBeenCalledWith(`<meta property="cf:blockedpaths" content="/"/>`, { html: true })
+})

--- a/functions/components/metaTagInjector.ts
+++ b/functions/components/metaTagInjector.ts
@@ -39,7 +39,7 @@ export class MetaTagInjector implements HTMLRewriterElementContentHandlers {
       this.append(element, 'twitter:image:alt', this.input.title)
     }
 
-    const blockedPaths = request.headers.get('x-blocked-paths-list')
+    const blockedPaths = this.request.headers.get('x-blocked-paths')
     if (blockedPaths) {
       this.append(element, 'x:blocked-paths', blockedPaths)
     }

--- a/functions/components/metaTagInjector.ts
+++ b/functions/components/metaTagInjector.ts
@@ -39,8 +39,9 @@ export class MetaTagInjector implements HTMLRewriterElementContentHandlers {
       this.append(element, 'twitter:image:alt', this.input.title)
     }
 
-    if (this.blockedPathsList) {
-      this.append(element, 'cf:blockedpaths', this.blockedPathsList)
+    const blockedPaths = request.headers.get('x-blocked-paths-list')
+    if (blockedPaths) {
+      this.append(element, 'x:blocked-paths', blockedPaths)
     }
   }
 }

--- a/functions/components/metaTagInjector.ts
+++ b/functions/components/metaTagInjector.ts
@@ -3,6 +3,7 @@ type MetaTagInjectorInput = {
   image?: string
   url: string
   description?: string
+  country: string | null
 }
 
 /**
@@ -37,6 +38,10 @@ export class MetaTagInjector implements HTMLRewriterElementContentHandlers {
     if (this.input.image) {
       this.append(element, 'twitter:image', this.input.image)
       this.append(element, 'twitter:image:alt', this.input.title)
+    }
+
+    if (this.input.country) {
+      this.append(element, 'cf:country', this.input.country)
     }
   }
 }

--- a/functions/components/metaTagInjector.ts
+++ b/functions/components/metaTagInjector.ts
@@ -3,7 +3,6 @@ type MetaTagInjectorInput = {
   image?: string
   url: string
   description?: string
-  country: string | null
 }
 
 /**
@@ -11,7 +10,11 @@ type MetaTagInjectorInput = {
  * to inject meta tags into the <head> of an HTML document.
  */
 export class MetaTagInjector implements HTMLRewriterElementContentHandlers {
-  constructor(private input: MetaTagInjectorInput) {}
+  blockedPathsList: string | null
+
+  constructor(private input: MetaTagInjectorInput, request: Request) {
+    this.blockedPathsList = request.headers.get('cf-blocked-paths-list')
+  }
 
   append(element: Element, property: string, content: string) {
     element.append(`<meta property="${property}" content="${content}"/>`, { html: true })
@@ -40,8 +43,8 @@ export class MetaTagInjector implements HTMLRewriterElementContentHandlers {
       this.append(element, 'twitter:image:alt', this.input.title)
     }
 
-    if (this.input.country) {
-      this.append(element, 'cf:country', this.input.country)
+    if (this.blockedPathsList) {
+      this.append(element, 'cf:blockedpaths', this.blockedPathsList)
     }
   }
 }

--- a/functions/components/metaTagInjector.ts
+++ b/functions/components/metaTagInjector.ts
@@ -10,11 +10,7 @@ type MetaTagInjectorInput = {
  * to inject meta tags into the <head> of an HTML document.
  */
 export class MetaTagInjector implements HTMLRewriterElementContentHandlers {
-  blockedPathsList: string | null
-
-  constructor(private input: MetaTagInjectorInput, request: Request) {
-    this.blockedPathsList = request.headers.get('cf-blocked-paths-list')
-  }
+  constructor(private input: MetaTagInjectorInput, private request: Request) {}
 
   append(element: Element, property: string, content: string) {
     element.append(`<meta property="${property}" content="${content}"/>`, { html: true })

--- a/functions/nfts/asset/[[index]].ts
+++ b/functions/nfts/asset/[[index]].ts
@@ -8,7 +8,7 @@ export const onRequest: PagesFunction = async ({ params, request, next }) => {
     const { index } = params
     const collectionAddress = index[0]?.toString()
     const tokenId = index[1]?.toString()
-    return getMetadataRequest(res, request.url, () => getAsset(collectionAddress, tokenId, request.url))
+    return getMetadataRequest(res, request, () => getAsset(collectionAddress, tokenId, request.url))
   } catch (e) {
     return res
   }

--- a/functions/nfts/collection/[index].ts
+++ b/functions/nfts/collection/[index].ts
@@ -7,7 +7,7 @@ export const onRequest: PagesFunction = async ({ params, request, next }) => {
   try {
     const { index } = params
     const collectionAddress = index?.toString()
-    return getMetadataRequest(res, request.url, () => getCollection(collectionAddress, request.url))
+    return getMetadataRequest(res, request, () => getCollection(collectionAddress, request.url))
   } catch (e) {
     return res
   }

--- a/functions/tokens/[[index]].ts
+++ b/functions/tokens/[[index]].ts
@@ -11,7 +11,7 @@ export const onRequest: PagesFunction = async ({ params, request, next }) => {
     if (!tokenAddress) {
       return res
     }
-    return getMetadataRequest(res, request.url, () => getToken(networkName, tokenAddress, request.url))
+    return getMetadataRequest(res, request, () => getToken(networkName, tokenAddress, request.url))
   } catch (e) {
     return res
   }

--- a/functions/utils/getRequest.ts
+++ b/functions/utils/getRequest.ts
@@ -4,13 +4,13 @@ import { Data } from './cache'
 
 export async function getMetadataRequest(
   res: Promise<Response>,
-  url: string,
+  request: Request,
   getData: () => Promise<Data | undefined>
 ) {
   try {
-    const cachedData = await getRequest(url, getData, (data): data is Data => true)
+    const cachedData = await getRequest(request.url, getData, (data): data is Data => true)
     if (cachedData) {
-      return new HTMLRewriter().on('head', new MetaTagInjector(cachedData)).transform(await res)
+      return new HTMLRewriter().on('head', new MetaTagInjector(cachedData, request)).transform(await res)
     } else {
       return res
     }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -200,6 +200,12 @@ export default function App() {
     return null
   }
 
+  // redirect from blocked pages if needed
+  const blockedPathsList = document.querySelector('meta[name="cf:blockedpaths"]')?.getAttribute('content')?.split(',')
+  if (blockedPathsList && blockedPathsList?.includes(pathname)) {
+    return <Navigate to="/swap" replace />
+  }
+
   return (
     <ErrorBoundary>
       <DarkModeQueryParamReader />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -202,6 +202,10 @@ export default function App() {
 
   const blockedPaths = document.querySelector('meta[name="x:blocked-paths"]')?.getAttribute('content')?.split(',')
   const shouldBlockPath = blockedPaths?.includes(pathname) ?? false
+  if (shouldBlockPath && pathname !== '/swap') {
+    return <Navigate to="/swap" replace />
+  }
+
   return (
     <ErrorBoundary>
       <DarkModeQueryParamReader />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -200,12 +200,8 @@ export default function App() {
     return null
   }
 
-  // redirect from blocked pages if needed
-  const blockedPathsList = document.querySelector('meta[name="cf:blockedpaths"]')?.getAttribute('content')?.split(',')
-  if (blockedPathsList && blockedPathsList?.includes(pathname)) {
-    return <Navigate to="/swap" replace />
-  }
-
+  const blockedPaths = document.querySelector('meta[name="x:blocked-paths"]')?.getAttribute('content')?.split(',')
+  const shouldBlockPath = blockedPaths?.includes(pathname) ?? false
   return (
     <ErrorBoundary>
       <DarkModeQueryParamReader />


### PR DESCRIPTION
## Description
Support adding a list of blocked paths in cloudflare headers

### QA (ie manual testing)

Add a meta tag `<meta name="x:blocked-paths" content="/,/nfts" />` and see that the pages redirect

### Automated testing
- [X] Unit test
- [ ] Integration/E2E test
