### PR TITLE
fix: update description truncation from TokenDescription

### DIFF
--- a/src/components/Tokens/TokenDetails/TokenDescription.test.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDescription.test.tsx
@@ -46,18 +46,16 @@ describe('TokenDescription', () => {
   })
 
   it('truncates description and shows more', async () => {
-    const shortDescription = 'USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...'
-    const longDescription =
-      'USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges.'
-    render(<TokenDescription tokenAddress={tokenAddress} />)
-    const descriptionContainer = screen.getByText(shortDescription)
+    const { asFragment } = render(<TokenDescription tokenAddress={tokenAddress} />)
 
-    expect(descriptionContainer).toHaveTextContent(shortDescription)
-    expect(descriptionContainer).not.toHaveTextContent(longDescription)
+    expect(asFragment()).toMatchSnapshot()
+    const shortWrapper = screen.getByTestId('desc-short-wrapper')
+    const longWrapper = screen.getByTestId('desc-long-wrapper')
+    // verify that both descriptions are in the DOM for SEO crawling
+    expect(shortWrapper).toBeVisible()
+    expect(longWrapper).toBeVisible()
 
     await act(() => userEvent.click(screen.getByText('Show more')))
-    expect(descriptionContainer).toHaveTextContent(longDescription)
-    expect(descriptionContainer).not.toHaveTextContent(shortDescription)
     expect(screen.getByText('Hide')).toBeVisible()
   })
 

--- a/src/components/Tokens/TokenDetails/TokenDescription.test.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDescription.test.tsx
@@ -49,13 +49,15 @@ describe('TokenDescription', () => {
     const { asFragment } = render(<TokenDescription tokenAddress={tokenAddress} />)
 
     expect(asFragment()).toMatchSnapshot()
-    const shortWrapper = screen.getByTestId('desc-short-wrapper')
-    const longWrapper = screen.getByTestId('desc-long-wrapper')
-    // verify that both descriptions are in the DOM for SEO crawling
-    expect(shortWrapper).toBeVisible()
-    expect(longWrapper).toBeVisible()
+    const truncatedDescription = screen.getByTestId('token-description-truncated')
+    const fullDescription = screen.getByTestId('token-description-full')
+
+    expect(truncatedDescription).toHaveStyleRule('display', 'inline')
+    expect(fullDescription).toHaveStyleRule('display', 'none')
 
     await act(() => userEvent.click(screen.getByText('Show more')))
+    expect(truncatedDescription).toHaveStyleRule('display', 'none')
+    expect(fullDescription).toHaveStyleRule('display', 'inline')
     expect(screen.getByText('Hide')).toBeVisible()
   })
 

--- a/src/components/Tokens/TokenDetails/TokenDescription.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDescription.tsx
@@ -64,6 +64,10 @@ const TokenDescriptionContainer = styled(ThemedText.BodyPrimary)`
   white-space: pre-wrap;
 `
 
+const DescriptionVisibilityWrapper = styled.span<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? 'inline' : 'none')};
+`
+
 const TRUNCATE_CHARACTER_COUNT = 75
 
 export function TokenDescription({
@@ -94,9 +98,9 @@ export function TokenDescription({
   }, [tokenAddress, setCopied])
 
   const [isDescriptionTruncated, toggleIsDescriptionTruncated] = useReducer((x) => !x, true)
+  const truncatedDescription = truncateDescription(description ?? '', TRUNCATE_CHARACTER_COUNT)
   const shouldTruncate = !!description && description.length > TRUNCATE_CHARACTER_COUNT
-  const tokenDescription =
-    shouldTruncate && isDescriptionTruncated ? truncateDescription(description, TRUNCATE_CHARACTER_COUNT) : description
+  const showTruncatedDescription = shouldTruncate && isDescriptionTruncated
 
   return (
     <TokenInfoSection>
@@ -141,7 +145,16 @@ export function TokenDescription({
             <Trans>No token information available</Trans>
           </NoInfoAvailable>
         )}
-        {tokenDescription}
+        {description && (
+          <>
+            <DescriptionVisibilityWrapper data-testid="desc-long-wrapper" isVisible={!showTruncatedDescription}>
+              {description}
+            </DescriptionVisibilityWrapper>
+            <DescriptionVisibilityWrapper data-testid="desc-short-wrapper" isVisible={showTruncatedDescription}>
+              {truncatedDescription}
+            </DescriptionVisibilityWrapper>
+          </>
+        )}
         {shouldTruncate && (
           <TruncateDescriptionButton
             onClick={toggleIsDescriptionTruncated}

--- a/src/components/Tokens/TokenDetails/TokenDescription.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDescription.tsx
@@ -64,8 +64,8 @@ const TokenDescriptionContainer = styled(ThemedText.BodyPrimary)`
   white-space: pre-wrap;
 `
 
-const DescriptionVisibilityWrapper = styled.span<{ isVisible: boolean }>`
-  display: ${({ isVisible }) => (isVisible ? 'inline' : 'none')};
+const DescriptionVisibilityWrapper = styled.span<{ $visible: boolean }>`
+  display: ${({ $visible }) => ($visible ? 'inline' : 'none')};
 `
 
 const TRUNCATE_CHARACTER_COUNT = 75
@@ -147,10 +147,10 @@ export function TokenDescription({
         )}
         {description && (
           <>
-            <DescriptionVisibilityWrapper data-testid="desc-long-wrapper" isVisible={!showTruncatedDescription}>
+            <DescriptionVisibilityWrapper data-testid="desc-long-wrapper" $visible={!showTruncatedDescription}>
               {description}
             </DescriptionVisibilityWrapper>
-            <DescriptionVisibilityWrapper data-testid="desc-short-wrapper" isVisible={showTruncatedDescription}>
+            <DescriptionVisibilityWrapper data-testid="desc-short-wrapper" $visible={showTruncatedDescription}>
               {truncatedDescription}
             </DescriptionVisibilityWrapper>
           </>

--- a/src/components/Tokens/TokenDetails/TokenDescription.tsx
+++ b/src/components/Tokens/TokenDetails/TokenDescription.tsx
@@ -147,10 +147,10 @@ export function TokenDescription({
         )}
         {description && (
           <>
-            <DescriptionVisibilityWrapper data-testid="desc-long-wrapper" $visible={!showTruncatedDescription}>
+            <DescriptionVisibilityWrapper data-testid="token-description-full" $visible={!showTruncatedDescription}>
               {description}
             </DescriptionVisibilityWrapper>
-            <DescriptionVisibilityWrapper data-testid="desc-short-wrapper" $visible={showTruncatedDescription}>
+            <DescriptionVisibilityWrapper data-testid="token-description-truncated" $visible={showTruncatedDescription}>
               {truncatedDescription}
             </DescriptionVisibilityWrapper>
           </>

--- a/src/components/Tokens/TokenDetails/__snapshots__/TokenDescription.test.tsx.snap
+++ b/src/components/Tokens/TokenDetails/__snapshots__/TokenDescription.test.tsx.snap
@@ -99,15 +99,15 @@ exports[`TokenDescription copy address button hidden when flagged 1`] = `
   display: flex;
 }
 
-.c14 {
+.c16 {
   color: #7D7D7D;
   font-weight: 485;
   font-size: 0.85em;
   padding-top: 0.5em;
 }
 
-.c14:hover,
-.c14:focus {
+.c16:hover,
+.c16:focus {
   color: #636363;
   cursor: pointer;
 }
@@ -171,6 +171,14 @@ exports[`TokenDescription copy address button hidden when flagged 1`] = `
   max-height: fit-content;
   line-height: 24px;
   white-space: pre-wrap;
+}
+
+.c14 {
+  display: none;
+}
+
+.c15 {
+  display: inline;
 }
 
 @media (max-width:1023px) and (min-width:640px) {
@@ -292,9 +300,20 @@ exports[`TokenDescription copy address button hidden when flagged 1`] = `
     <div
       class="c7 c13 css-1urox24"
     >
-      USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
-      <div
+      <span
         class="c14"
+        data-testid="desc-long-wrapper"
+      >
+        USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy.
+      </span>
+      <span
+        class="c15"
+        data-testid="desc-short-wrapper"
+      >
+        USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
+      </span>
+      <div
+        class="c16"
         data-testid="token-description-show-more-button"
       >
         Show more
@@ -676,15 +695,15 @@ exports[`TokenDescription renders token information correctly with defaults 1`] 
   display: flex;
 }
 
-.c14 {
+.c16 {
   color: #7D7D7D;
   font-weight: 485;
   font-size: 0.85em;
   padding-top: 0.5em;
 }
 
-.c14:hover,
-.c14:focus {
+.c16:hover,
+.c16:focus {
   color: #636363;
   cursor: pointer;
 }
@@ -748,6 +767,14 @@ exports[`TokenDescription renders token information correctly with defaults 1`] 
   max-height: fit-content;
   line-height: 24px;
   white-space: pre-wrap;
+}
+
+.c14 {
+  display: none;
+}
+
+.c15 {
+  display: inline;
 }
 
 @media (max-width:1023px) and (min-width:640px) {
@@ -897,9 +924,371 @@ exports[`TokenDescription renders token information correctly with defaults 1`] 
     <div
       class="c7 c13 css-1urox24"
     >
-      USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
-      <div
+      <span
         class="c14"
+        data-testid="desc-long-wrapper"
+      >
+        USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy.
+      </span>
+      <span
+        class="c15"
+        data-testid="desc-short-wrapper"
+      >
+        USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
+      </span>
+      <div
+        class="c16"
+        data-testid="token-description-show-more-button"
+      >
+        Show more
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TokenDescription truncates description and shows more 1`] = `
+<DocumentFragment>
+  .c2 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+}
+
+.c3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c7 {
+  color: #222222;
+}
+
+.c9 {
+  color: #7D7D7D;
+}
+
+.c12 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+  color: #FC72FF;
+  stroke: #FC72FF;
+  font-weight: 500;
+}
+
+.c12:hover {
+  opacity: 0.6;
+}
+
+.c12:active {
+  opacity: 0.4;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c6 {
+  --size: 20px;
+  border-radius: 100px;
+  color: #222222;
+  background-color: #22222212;
+  font-size: calc(var(--size) / 3);
+  font-weight: 535;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  width: 20px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c16 {
+  color: #7D7D7D;
+  font-weight: 485;
+  font-size: 0.85em;
+  padding-top: 0.5em;
+}
+
+.c16:hover,
+.c16:focus {
+  color: #636363;
+  cursor: pointer;
+}
+
+.c1 {
+  gap: 12px;
+  width: 100%;
+}
+
+.c4 {
+  gap: 8px;
+  width: 100%;
+}
+
+.c8 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c10 {
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c11 {
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 20px;
+  color: #2172E5;
+  background-color: #2172E51f;
+  font-size: 14px;
+  font-weight: 535;
+  line-height: 16px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-transition-duration: 125ms;
+  transition-duration: 125ms;
+}
+
+.c11:hover {
+  opacity: 0.6;
+}
+
+.c11:active {
+  opacity: 0.4;
+}
+
+.c13 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  max-height: -webkit-fit-content;
+  max-height: -moz-fit-content;
+  max-height: fit-content;
+  line-height: 24px;
+  white-space: pre-wrap;
+}
+
+.c14 {
+  display: none;
+}
+
+.c15 {
+  display: inline;
+}
+
+@media (max-width:1023px) and (min-width:640px) {
+  .c1 {
+    max-width: 45%;
+  }
+}
+
+<div
+    class="c0 c1"
+  >
+    <div
+      class="c2 c3 c4"
+    >
+      <div
+        class="c5"
+        style="height: 20px; width: 20px;"
+      >
+        <div
+          class="c6"
+        >
+          USD
+        </div>
+      </div>
+      <div
+        class="c7 c8 css-1urox24"
+      >
+        USDCoin
+      </div>
+      <div
+        class="c9 css-1urox24"
+      >
+        USDC
+      </div>
+    </div>
+    <div
+      class="c2 c3 c4 c10"
+    >
+      <div
+        class="c2 c3 c11"
+      >
+        <svg
+          fill="none"
+          height="18px"
+          stroke="#2172E5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="18px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="13"
+            rx="2"
+            ry="2"
+            width="13"
+            x="9"
+            y="9"
+          />
+          <path
+            d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+          />
+        </svg>
+        0xA0b8...eB48
+      </div>
+      <a
+        class="c12"
+        href="https://etherscan.io/token/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <div
+          class="c2 c3 c11"
+        >
+          <svg
+            fill="#2172E5"
+            height="18px"
+            stroke="transparent"
+            viewBox="0 0 18 18"
+            width="18px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.08042 8.66148C5.08043 8.58693 5.09517 8.51313 5.12378 8.44429C5.1524 8.37546 5.19432 8.31297 5.24716 8.26038C5.30001 8.2078 5.3627 8.16617 5.43167 8.13788C5.50064 8.1096 5.57452 8.09522 5.64907 8.09557L6.59187 8.09865C6.74218 8.09865 6.88635 8.15836 6.99263 8.26465C7.09893 8.37094 7.15865 8.5151 7.15865 8.66543V12.2303C7.26478 12.1988 7.4011 12.1652 7.55026 12.1301C7.65387 12.1058 7.74621 12.0471 7.8123 11.9637C7.87839 11.8803 7.91434 11.777 7.91432 11.6705V7.24848C7.91432 7.09814 7.97403 6.95397 8.08032 6.84766C8.1866 6.74135 8.33077 6.68162 8.4811 6.68158H9.42577C9.57609 6.68162 9.72026 6.74135 9.82655 6.84766C9.93284 6.95397 9.99255 7.09814 9.99255 7.24848V11.3526C9.99255 11.3526 10.2291 11.2569 10.4595 11.1596C10.545 11.1234 10.6181 11.0629 10.6694 10.9854C10.7208 10.908 10.7482 10.8172 10.7483 10.7242V5.83152C10.7483 5.68122 10.808 5.53707 10.9143 5.43078C11.0206 5.32449 11.1647 5.26478 11.315 5.26474H12.2597C12.41 5.26474 12.5542 5.32445 12.6604 5.43075C12.7667 5.53704 12.8265 5.6812 12.8265 5.83152V9.86056C13.6455 9.267 14.4754 8.55315 15.1341 7.69474C15.2297 7.57015 15.2929 7.42383 15.3181 7.26887C15.3434 7.1139 15.3299 6.95509 15.2788 6.8066C14.9739 5.9294 14.4894 5.12551 13.856 4.44636C13.2226 3.76722 12.4544 3.22777 11.6005 2.86256C10.7467 2.49734 9.82602 2.31439 8.89742 2.32542C7.96882 2.33645 7.05275 2.54121 6.20783 2.9266C5.36291 3.31199 4.60774 3.86952 3.99066 4.56352C3.37358 5.25751 2.90817 6.07269 2.62422 6.95689C2.34027 7.84107 2.24403 8.7748 2.34166 9.69832C2.43929 10.6218 2.72863 11.5148 3.19118 12.3201C3.27176 12.459 3.39031 12.572 3.53289 12.6459C3.67548 12.7198 3.83618 12.7514 3.99614 12.7372C4.17482 12.7215 4.3973 12.6992 4.66181 12.6681C4.77695 12.655 4.88326 12.6001 4.96048 12.5137C5.0377 12.4273 5.08043 12.3155 5.08053 12.1996L5.08042 8.66148Z"
+              fill="#2172E5"
+            />
+            <path
+              d="M5.05957 14.3792C6.05531 15.1036 7.23206 15.5384 8.45961 15.6356C9.68716 15.7326 10.9176 15.4883 12.0149 14.9294C13.1122 14.3705 14.0334 13.519 14.6768 12.4691C15.3201 11.4191 15.6605 10.2116 15.6601 8.98024C15.6601 8.82658 15.653 8.67457 15.6428 8.52344C13.2041 12.1605 8.70139 13.8609 5.05978 14.3786"
+              fill="#2172E5"
+            />
+          </svg>
+          Etherscan
+        </div>
+      </a>
+      <a
+        class="c12"
+        href="https://www.circle.com/en/usdc"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <div
+          class="c2 c3 c11"
+        >
+          <svg
+            fill="#2172E5"
+            height="18px"
+            stroke="transparent"
+            viewBox="0 0 18 18"
+            width="18px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.12245 9.5625C5.23495 11.8725 6.01495 14.2275 7.37245 16.32C4.19245 15.615 1.76996 12.8925 1.52246 9.5625H5.12245ZM7.37245 1.67999C4.19245 2.38499 1.76996 5.1075 1.52246 8.4375H5.12245C5.23495 6.1275 6.01495 3.77249 7.37245 1.67999ZM9.14997 1.5H8.84995L8.62496 1.82249C7.19996 3.84749 6.36745 6.1725 6.24745 8.4375H11.7525C11.6325 6.1725 10.8 3.84749 9.37496 1.82249L9.14997 1.5ZM6.24745 9.5625C6.36745 11.8275 7.19996 14.1525 8.62496 16.1775L8.84995 16.5H9.14997L9.37496 16.1775C10.8 14.1525 11.6325 11.8275 11.7525 9.5625H6.24745ZM12.8775 9.5625C12.765 11.8725 11.985 14.2275 10.6275 16.32C13.8075 15.615 16.23 12.8925 16.4775 9.5625H12.8775ZM16.4775 8.4375C16.23 5.1075 13.8075 2.38499 10.6275 1.67999C11.985 3.77249 12.765 6.1275 12.8775 8.4375H16.4775Z"
+              fill="#2172E5"
+            />
+          </svg>
+          Website
+        </div>
+      </a>
+      <a
+        class="c12"
+        href="https://x.com/circle"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <div
+          class="c2 c3 c11"
+        >
+          <svg
+            fill="#2172E5"
+            height="18px"
+            stroke="transparent"
+            viewBox="0 0 18 18"
+            width="18px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.8761 3H14.9451L10.4251 8.16609L15.7425 15.196H11.579L8.31797 10.9324L4.58662 15.196H2.51644L7.35104 9.67026L2.25 3H6.51922L9.46689 6.89708L12.8761 3ZM12.15 13.9576H13.2964L5.89628 4.17332H4.66605L12.15 13.9576Z"
+              fill="#2172E5"
+            />
+          </svg>
+          Twitter
+        </div>
+      </a>
+    </div>
+    <div
+      class="c7 c13 css-1urox24"
+    >
+      <span
+        class="c14"
+        data-testid="desc-long-wrapper"
+      >
+        USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy.
+      </span>
+      <span
+        class="c15"
+        data-testid="desc-short-wrapper"
+      >
+        USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
+      </span>
+      <div
+        class="c16"
         data-testid="token-description-show-more-button"
       >
         Show more

--- a/src/components/Tokens/TokenDetails/__snapshots__/TokenDescription.test.tsx.snap
+++ b/src/components/Tokens/TokenDetails/__snapshots__/TokenDescription.test.tsx.snap
@@ -302,13 +302,13 @@ exports[`TokenDescription copy address button hidden when flagged 1`] = `
     >
       <span
         class="c14"
-        data-testid="desc-long-wrapper"
+        data-testid="token-description-full"
       >
         USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy.
       </span>
       <span
         class="c15"
-        data-testid="desc-short-wrapper"
+        data-testid="token-description-truncated"
       >
         USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
       </span>
@@ -926,13 +926,13 @@ exports[`TokenDescription renders token information correctly with defaults 1`] 
     >
       <span
         class="c14"
-        data-testid="desc-long-wrapper"
+        data-testid="token-description-full"
       >
         USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy.
       </span>
       <span
         class="c15"
-        data-testid="desc-short-wrapper"
+        data-testid="token-description-truncated"
       >
         USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
       </span>
@@ -1277,13 +1277,13 @@ exports[`TokenDescription truncates description and shows more 1`] = `
     >
       <span
         class="c14"
-        data-testid="desc-long-wrapper"
+        data-testid="token-description-full"
       >
         USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy.
       </span>
       <span
         class="c15"
-        data-testid="desc-short-wrapper"
+        data-testid="token-description-truncated"
       >
         USDC is a fully collateralized US dollar stablecoin. USDC is the bridge...
       </span>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

to improve SEO , we should not hide any content behind a user interaction (like a click). web crawlers don't click so they don't see this content. the new solution keeps both strings in the DOM all the time, and just updates the CSS display property to toggle between them

<!-- Delete inapplicable lines: -->
_Relevant docs:_ https://www.notion.so/uniswaplabs/Web-SEO-Improvements-1de35e2d684648efac0ca36055a6f8ad#6aba3250e8d140cbbfac0ba4731c6a29



## Test plan

verified that truncation is still working on the pools page

![image](https://github.com/Uniswap/interface/assets/66155195/8eebcf8e-ef65-4dd3-b74f-616b2e443c8e)

