### PR TITLE
fix: Remove Minus Sign for FOT Display

### DIFF
--- a/src/components/swap/SwapLineItem.tsx
+++ b/src/components/swap/SwapLineItem.tsx
@@ -71,8 +71,8 @@ function ExchangeRateRow({ trade }: { trade: InterfaceTrade }) {
 }
 
 function ColoredPercentRow({ percent }: { percent: Percent }) {
-  const { formatPriceImpact } = useFormatter()
-  return <ColorWrapper textColor={getPriceImpactColor(percent)}>{formatPriceImpact(percent)}</ColorWrapper>
+  const { formatSlippage } = useFormatter()
+  return <ColorWrapper textColor={getPriceImpactColor(percent)}>{formatSlippage(percent)}</ColorWrapper>
 }
 
 function CurrencyAmountRow({ amount }: { amount: CurrencyAmount<Currency> }) {

--- a/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapDetailsDropdown.test.tsx.snap
@@ -316,7 +316,7 @@ exports[`SwapDetailsDropdown.tsx renders a trade 1`] = `
                   <span
                     class=""
                   >
-                    105566.373%
+                    -105566.373%
                   </span>
                 </div>
               </div>

--- a/src/components/swap/__snapshots__/SwapLineItem.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapLineItem.test.tsx.snap
@@ -1288,7 +1288,7 @@ exports[`SwapLineItem.tsx exact input 1`] = `
           <span
             class=""
           >
-            105566.373%
+            -105566.373%
           </span>
         </div>
       </div>
@@ -2627,7 +2627,7 @@ exports[`SwapLineItem.tsx exact input api 1`] = `
           <span
             class=""
           >
-            105566.373%
+            -105566.373%
           </span>
         </div>
       </div>
@@ -3966,7 +3966,7 @@ exports[`SwapLineItem.tsx exact output 1`] = `
           <span
             class=""
           >
-            105566.373%
+            -105566.373%
           </span>
         </div>
       </div>
@@ -5324,7 +5324,7 @@ exports[`SwapLineItem.tsx fee on buy 1`] = `
           <span
             class=""
           >
-            -3.000%
+            3.000%
           </span>
         </div>
       </div>
@@ -5511,7 +5511,7 @@ exports[`SwapLineItem.tsx fee on buy 1`] = `
           <span
             class=""
           >
-            105566.373%
+            -105566.373%
           </span>
         </div>
       </div>
@@ -6869,7 +6869,7 @@ exports[`SwapLineItem.tsx fee on sell 1`] = `
           <span
             class=""
           >
-            -3.000%
+            3.000%
           </span>
         </div>
       </div>
@@ -7056,7 +7056,7 @@ exports[`SwapLineItem.tsx fee on sell 1`] = `
           <span
             class=""
           >
-            105566.373%
+            -105566.373%
           </span>
         </div>
       </div>

--- a/src/components/swap/__snapshots__/SwapModalFooter.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapModalFooter.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`SwapModalFooter.tsx matches base snapshot, test trade exact input 1`] =
             <span
               class=""
             >
-              105566.373%
+              -105566.373%
             </span>
           </div>
         </div>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Removing the minus sign to come to parity with mobile

Ticket here: https://linear.app/uniswap/issue/WEB-2917/remove-in-front-of-fot-fee




<!-- Delete this section if your change does not affect UI. -->
<img width="518" alt="image" src="https://github.com/Uniswap/interface/assets/7286862/5787831b-7aac-463d-8de6-ed575a623b04">


### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| paste_after  | paste_after |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
