### PR TITLE
fix: ignore large slices in immutable check

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -15,6 +15,9 @@ export function createDefaultStore() {
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         thunk: true,
+        immutableCheck: {
+          ignoredPaths: [routingApi.reducerPath, 'logs', 'lists'],
+        },
         serializableCheck: {
           // meta.arg and meta.baseQueryMeta are defaults. payload.trade is a nonserializable return value, but that's ok
           // because we are not adding it into any persisted store that requires serialization (e.g. localStorage)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

our large redux slices are causing console warnings (and unit test failures) in the immutable check middleware, so we should ignore them in this check.

these checks don't happen in prod, so this won't have any effect on users
