### PR TITLE
feat: [info] update color extract default and have PDP fallback

### DIFF
--- a/src/hooks/useColor.ts
+++ b/src/hooks/useColor.ts
@@ -62,13 +62,13 @@ export function useColor(token?: Token) {
   useEffect(() => {
     let stale = false
 
-    // if (token) {
-    //   getColorFromToken(token, src).then((tokenColor) => {
-    //     if (!stale && tokenColor !== null) {
-    //       setColor(tokenColor)
-    //     }
-    //   })
-    // }
+    if (token) {
+      getColorFromToken(token, src).then((tokenColor) => {
+        if (!stale && tokenColor !== null) {
+          setColor(tokenColor)
+        }
+      })
+    }
 
     return () => {
       stale = true

--- a/src/hooks/useColor.ts
+++ b/src/hooks/useColor.ts
@@ -4,6 +4,7 @@ import useTokenLogoSource from 'hooks/useAssetLogoSource'
 import { rgb } from 'polished'
 import { useEffect, useState } from 'react'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
+import { useTheme } from 'styled-components'
 import { getColor } from 'utils/getColor'
 
 function URIForEthToken(address: string) {
@@ -54,25 +55,26 @@ function convertColorArrayToString([red, green, blue]: number[]): string {
 }
 
 export function useColor(token?: Token) {
-  const [color, setColor] = useState('#2172E5')
+  const theme = useTheme()
+  const [color, setColor] = useState(theme.accent1)
   const [src] = useTokenLogoSource(token?.address, token?.chainId, token?.isNative)
 
   useEffect(() => {
     let stale = false
 
-    if (token) {
-      getColorFromToken(token, src).then((tokenColor) => {
-        if (!stale && tokenColor !== null) {
-          setColor(tokenColor)
-        }
-      })
-    }
+    // if (token) {
+    //   getColorFromToken(token, src).then((tokenColor) => {
+    //     if (!stale && tokenColor !== null) {
+    //       setColor(tokenColor)
+    //     }
+    //   })
+    // }
 
     return () => {
       stale = true
-      setColor('#2172E5')
+      setColor(theme.accent1)
     }
-  }, [src, token])
+  }, [src, theme.accent1, token])
 
   return color
 }

--- a/src/pages/PoolDetails/PoolDetailsStats.tsx
+++ b/src/pages/PoolDetails/PoolDetailsStats.tsx
@@ -9,8 +9,9 @@ import { useColor } from 'hooks/useColor'
 import { useScreenSize } from 'hooks/useScreenSize'
 import { ReactNode, useMemo } from 'react'
 import { Text } from 'rebass'
-import styled, { css } from 'styled-components'
+import styled, { css, useTheme } from 'styled-components'
 import { BREAKPOINTS } from 'theme'
+import { colors } from 'theme/colors'
 import { ThemedText } from 'theme/components'
 import { NumberType, useFormatter } from 'utils/formatNumbers'
 
@@ -99,12 +100,16 @@ export function PoolDetailsStats({ poolData, isReversed, chainId }: PoolDetailsS
   const isScreenSize = useScreenSize()
   const screenIsNotLarge = isScreenSize['lg']
   const { formatNumber } = useFormatter()
+  const theme = useTheme()
 
   const currency0 = useCurrency(poolData?.token0?.id, chainId) ?? undefined
   const currency1 = useCurrency(poolData?.token1?.id, chainId) ?? undefined
 
   const color0 = useColor(currency0?.wrapped)
-  const color1 = useColor(currency1?.wrapped)
+  let color1 = useColor(currency1?.wrapped)
+  if (color0 === color1 && color0 === theme.accent1) {
+    color1 = colors.blue400
+  }
 
   const [token0, token1] = useMemo(() => {
     const fullWidth = poolData?.tvlToken0 / poolData?.token0Price + poolData?.tvlToken1

--- a/src/pages/PoolDetails/__snapshots__/PoolDetailsStats.test.tsx.snap
+++ b/src/pages/PoolDetails/__snapshots__/PoolDetailsStats.test.tsx.snap
@@ -506,7 +506,7 @@ exports[`PoolDetailsStats renders stats text correctly 1`] = `
 .c9 {
   height: 8px;
   width: 40.698463777008904%;
-  background: #2172E5;
+  background: #FC72FF;
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
   border-right: 1px solid #F9F9F9;
@@ -515,7 +515,7 @@ exports[`PoolDetailsStats renders stats text correctly 1`] = `
 .c10 {
   height: 8px;
   width: 59.3015362229911%;
-  background: #2172E5;
+  background: #4C82FB;
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;
   border-left: 1px solid #F9F9F9;

--- a/src/pages/PoolDetails/__snapshots__/index.test.tsx.snap
+++ b/src/pages/PoolDetails/__snapshots__/index.test.tsx.snap
@@ -324,7 +324,7 @@ exports[`PoolDetailsPage pool header is displayed when data is received from the
 .c27 {
   height: 8px;
   width: 40.698463777008904%;
-  background: #2172E5;
+  background: #FC72FF;
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
   border-right: 1px solid #F9F9F9;
@@ -333,7 +333,7 @@ exports[`PoolDetailsPage pool header is displayed when data is received from the
 .c28 {
   height: 8px;
   width: 59.3015362229911%;
-  background: #2172E5;
+  background: #4C82FB;
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;
   border-left: 1px solid #F9F9F9;


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- Updates the color extract default to be accent1 to fit with spore
- In the PoolDetailsStats graph, fallback to blue for the second token in the case that both colors default to accent1

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C05NXMASXNZ/p1696614227484049?thread_ts=1696355275.788919&cid=C05NXMASXNZ


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
![Screenshot 2023-10-06 at 10 34 35 AM](https://github.com/Uniswap/interface/assets/11512321/e1e3bfce-3959-4b38-87bf-120281fbd2ee)



### After
<img width="391" alt="Screenshot 2023-10-06 at 10 52 10 AM" src="https://github.com/Uniswap/interface/assets/11512321/f61684ef-6705-4751-b93b-a735b798cdcf">



## Test plan

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually cause color extraction to fallback to default and show new pink and blue fallback

