### PR TITLE
feat: remove sitemap script from prepare step

### DIFF
--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -67,6 +67,12 @@ jobs:
           echo '* @uniswap/web-admins' > CODEOWNERS
           git add CODEOWNERS
           git commit -m 'ci: add global CODEOWNERS'
+      
+      - name: Update sitemap
+        run: |
+          yarn sitemap:generate
+          git add public/sitemap.xml
+          git commit -m 'ci: update sitemap'
 
       - name: Git push
         run: |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "i18n:extract": "lingui extract --locale en-US",
     "i18n:compile": "lingui compile",
     "i18n": "yarn i18n:extract --clean && yarn i18n:compile",
-    "prepare": "concurrently \"npm:ajv\" \"npm:contracts\" \"npm:graphql\" \"npm:i18n\" \"npm:sitemap:generate\"",
+    "prepare": "concurrently \"npm:ajv\" \"npm:contracts\" \"npm:graphql\" \"npm:i18n\"",
     "start": "craco start",
     "start:cloud": "NODE_OPTIONS=--dns-result-order=ipv4first PORT=3001 npx wrangler pages dev --compatibility-flags=nodejs_compat --compatibility-date=2023-08-01 --proxy=3001 --port=3000 -- yarn start",
     "build": "craco build",


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

we don't want the sitemap script to run every time someone runs `yarn install` - this removes it from the `prepare` script and adds it as a step to the main -> staging pipeline

