### PR TITLE
fix: hide slippage warning when trade is x

### DIFF
--- a/src/components/Settings/MenuButton/index.tsx
+++ b/src/components/Settings/MenuButton/index.tsx
@@ -1,6 +1,8 @@
 import { t, Trans } from '@lingui/macro'
 import { Settings } from 'components/Icons/Settings'
 import Row from 'components/Row'
+import { InterfaceTrade } from 'state/routing/types'
+import { isUniswapXTrade } from 'state/routing/utils'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { SlippageTolerance } from 'state/user/types'
 import styled from 'styled-components'
@@ -45,11 +47,11 @@ const IconContainerWithSlippage = styled(IconContainer)<{ displayWarning?: boole
     displayWarning ? theme.deprecated_accentWarningSoft : theme.surface2};
 `
 
-const ButtonContent = () => {
+const ButtonContent = ({ trade }: { trade?: InterfaceTrade }) => {
   const [userSlippageTolerance] = useUserSlippageTolerance()
   const { formatSlippage } = useFormatter()
 
-  if (userSlippageTolerance === SlippageTolerance.Auto) {
+  if (userSlippageTolerance === SlippageTolerance.Auto || isUniswapXTrade(trade)) {
     return (
       <IconContainer>
         <Icon />
@@ -73,10 +75,12 @@ export default function MenuButton({
   disabled,
   onClick,
   isActive,
+  trade,
 }: {
   disabled: boolean
   onClick: () => void
   isActive: boolean
+  trade?: InterfaceTrade
 }) {
   return (
     <Button
@@ -87,7 +91,7 @@ export default function MenuButton({
       data-testid="open-settings-dialog-button"
       aria-label={t`Transaction Settings`}
     >
-      <ButtonContent />
+      <ButtonContent trade={trade} />
     </Button>
   )
 }

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -152,7 +152,12 @@ export default function SettingsTab({
 
   return (
     <Menu ref={node}>
-      <MenuButton disabled={!isChainSupported || chainId !== connectedChainId} isActive={isOpen} onClick={toggleMenu} />
+      <MenuButton
+        disabled={!isChainSupported || chainId !== connectedChainId}
+        isActive={isOpen}
+        onClick={toggleMenu}
+        trade={trade}
+      />
       {isOpenDesktop && <MenuFlyout>{Settings}</MenuFlyout>}
       {isOpenMobile && (
         <Portal>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

if the loaded trade is X, don't show the slippage UI next to the menu button. the slippage setting is not relevant for X trades.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2934/remove-slippage-indicator-when-using-uniswapx


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
 see linear ticket

### After
<img width="655" alt="Screenshot 2023-10-10 at 10 53 30 AM" src="https://github.com/Uniswap/interface/assets/66155195/d6af1432-1184-4722-9231-81a831616308">
<img width="655" alt="Screenshot 2023-10-10 at 10 53 35 AM" src="https://github.com/Uniswap/interface/assets/66155195/79e85662-ef7f-4e1e-b130-331aae6fed09">

