### PR TITLE
fix: fix sitemaps routes test

### DIFF
--- a/src/pages/routes.test.ts
+++ b/src/pages/routes.test.ts
@@ -12,7 +12,7 @@ describe('Routes', () => {
     const sitemapPaths: string[] = sitemap.urlset.url.map((url: any) => new URL(url['$'].loc).pathname)
 
     sitemapPaths
-      .filter((p) => !p.includes(':') && !p.includes('*') && !p.includes('not-found'))
+      .filter((p) => !p.includes('/0x'))
       .forEach((path: string) => {
         expect(pathNames).toContain(path)
       })

--- a/src/pages/routes.test.ts
+++ b/src/pages/routes.test.ts
@@ -9,12 +9,12 @@ describe('Routes', () => {
     const contents = fs.readFileSync('./public/sitemap.xml', 'utf8')
     const sitemap = await parseStringPromise(contents)
 
-    const sitemapPaths = sitemap.urlset.url.map((url: any) => new URL(url['$'].loc).pathname)
+    const sitemapPaths: string[] = sitemap.urlset.url.map((url: any) => new URL(url['$'].loc).pathname)
 
-    pathNames
+    sitemapPaths
       .filter((p) => !p.includes(':') && !p.includes('*') && !p.includes('not-found'))
       .forEach((path: string) => {
-        expect(sitemapPaths).toContain(path)
+        expect(pathNames).toContain(path)
       })
   })
 


### PR DESCRIPTION
sitemap URLs should exist as Router paths - should test that routerPaths contain each sitemap URL, not vice versa

Context: we are adding Router paths that aren't publicly-available yet