### PR TITLE
feat: add progress_indicator_v2 flag

### DIFF
--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -8,13 +8,13 @@ import { useInfoLiveViewsFlag } from 'featureFlags/flags/infoLiveViews'
 import { useInfoPoolPageFlag } from 'featureFlags/flags/infoPoolPage'
 import { useInfoTDPFlag } from 'featureFlags/flags/infoTDP'
 import { useMultichainUXFlag } from 'featureFlags/flags/multichainUx'
+import { useProgressIndicatorV2Flag } from 'featureFlags/flags/progressIndicatorV2'
 import { useQuickRouteMainnetFlag } from 'featureFlags/flags/quickRouteMainnet'
 import { TraceJsonRpcVariant, useTraceJsonRpcFlag } from 'featureFlags/flags/traceJsonRpc'
 import { useUniswapXDefaultEnabledFlag } from 'featureFlags/flags/uniswapXDefault'
 import { useUniswapXEthOutputFlag } from 'featureFlags/flags/uniswapXEthOutput'
 import { useUniswapXExactOutputFlag } from 'featureFlags/flags/uniswapXExactOutput'
 import { useUniswapXSyntheticQuoteFlag } from 'featureFlags/flags/uniswapXUseSyntheticQuote'
-import { useProgressIndicatorV2 } from 'featureFlags/flags/useProgressIndicatorV2'
 import { useUpdateAtom } from 'jotai/utils'
 import { Children, PropsWithChildren, ReactElement, ReactNode, useCallback, useState } from 'react'
 import { X } from 'react-feather'
@@ -258,7 +258,7 @@ export default function FeatureFlagModal() {
         />
         <FeatureFlagOption
           variant={BaseVariant}
-          value={useProgressIndicatorV2()}
+          value={useProgressIndicatorV2Flag()}
           featureFlag={FeatureFlag.progressIndicatorV2}
           label="Refreshed swap progress indicator"
         />

--- a/src/components/FeatureFlagModal/FeatureFlagModal.tsx
+++ b/src/components/FeatureFlagModal/FeatureFlagModal.tsx
@@ -14,6 +14,7 @@ import { useUniswapXDefaultEnabledFlag } from 'featureFlags/flags/uniswapXDefaul
 import { useUniswapXEthOutputFlag } from 'featureFlags/flags/uniswapXEthOutput'
 import { useUniswapXExactOutputFlag } from 'featureFlags/flags/uniswapXExactOutput'
 import { useUniswapXSyntheticQuoteFlag } from 'featureFlags/flags/uniswapXUseSyntheticQuote'
+import { useProgressIndicatorV2 } from 'featureFlags/flags/useProgressIndicatorV2'
 import { useUpdateAtom } from 'jotai/utils'
 import { Children, PropsWithChildren, ReactElement, ReactNode, useCallback, useState } from 'react'
 import { X } from 'react-feather'
@@ -254,6 +255,12 @@ export default function FeatureFlagModal() {
           value={useFotAdjustmentsFlag()}
           featureFlag={FeatureFlag.fotAdjustedmentsEnabled}
           label="Enable fee-on-transfer UI and slippage adjustments"
+        />
+        <FeatureFlagOption
+          variant={BaseVariant}
+          value={useProgressIndicatorV2()}
+          featureFlag={FeatureFlag.progressIndicatorV2}
+          label="Refreshed swap progress indicator"
         />
         <FeatureFlagGroup name="Quick routes">
           <FeatureFlagOption

--- a/src/featureFlags/flags/progressIndicatorV2.ts
+++ b/src/featureFlags/flags/progressIndicatorV2.ts
@@ -1,5 +1,5 @@
 import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
 
-export function useProgressIndicatorV2(): BaseVariant {
+export function useProgressIndicatorV2Flag(): BaseVariant {
   return useBaseFlag(FeatureFlag.progressIndicatorV2)
 }

--- a/src/featureFlags/flags/useProgressIndicatorV2.ts
+++ b/src/featureFlags/flags/useProgressIndicatorV2.ts
@@ -1,0 +1,5 @@
+import { BaseVariant, FeatureFlag, useBaseFlag } from '../index'
+
+export function useProgressIndicatorV2(): BaseVariant {
+  return useBaseFlag(FeatureFlag.progressIndicatorV2)
+}

--- a/src/featureFlags/index.tsx
+++ b/src/featureFlags/index.tsx
@@ -21,6 +21,7 @@ export enum FeatureFlag {
   infoLiveViews = 'info_live_views',
   uniswapXDefaultEnabled = 'uniswapx_default_enabled',
   quickRouteMainnet = 'enable_quick_route_mainnet',
+  progressIndicatorV2 = 'progress_indicator_v2',
 }
 
 interface FeatureFlagsContextType {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description

- Adds a statsig feature flag to gate the new progress indicator on the swap flow
- https://console.statsig.com/5M2TFMQiHkbY9RML95FAEa/gates/progress_indicator_v2

Why use a feature flag for this?
- There are several parts of this new UX, which are most logical / impactful when bundled together
- This allows us to break up the changes into smaller PRs, making reviews easier and more thorough
- This modifies a core product experience, hence the ability to roll back the changes in case of error is vital

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2764/[swaptober]-progress-indicator-v2
_Relevant docs:_ https://www.figma.com/file/JX7QWhOXvVJEm0sY5IfFoW/Time-to-Swap?type=design&node-id=993-56975&mode=dev

<!-- Delete this section if your change does not affect UI. -->
## Screen capture
<img width="557" alt="Screenshot 2023-10-11 at 11 49 06 AM" src="https://github.com/Uniswap/interface/assets/18626088/3b262e90-23d8-45fd-9533-d401899028cc">