### PR TITLE
fix: remove bridge usdc arbitrum

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.test.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.test.tsx
@@ -1,5 +1,5 @@
 import { ChainId } from '@uniswap/sdk-core'
-import { BRIDGED_USDC_ARBITRUM, DAI, DAI_ARBITRUM_ONE, USDC_MAINNET } from 'constants/tokens'
+import { DAI, DAI_ARBITRUM_ONE, USDC_ARBITRUM, USDC_MAINNET } from 'constants/tokens'
 import { render } from 'test-utils/render'
 
 import { PortfolioLogo } from './PortfolioLogo'
@@ -12,7 +12,7 @@ describe('PortfolioLogo', () => {
 
   it('renders with L2 icon', () => {
     const { container } = render(
-      <PortfolioLogo chainId={ChainId.ARBITRUM_ONE} currencies={[DAI_ARBITRUM_ONE, BRIDGED_USDC_ARBITRUM]} />
+      <PortfolioLogo chainId={ChainId.ARBITRUM_ONE} currencies={[DAI_ARBITRUM_ONE, USDC_ARBITRUM]} />
     )
     expect(container).toMatchSnapshot()
   })

--- a/src/components/AccountDrawer/MiniPortfolio/__snapshots__/PortfolioLogo.test.tsx.snap
+++ b/src/components/AccountDrawer/MiniPortfolio/__snapshots__/PortfolioLogo.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`PortfolioLogo renders with L2 icon 1`] = `
       />
       <img
         class="c2"
-        src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/arbitrum/assets/0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8/logo.png"
+        src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/arbitrum/assets/0xaf88d065e77c8cC2239327C5EDb3A432268e5831/logo.png"
       />
     </div>
     <div

--- a/src/components/FiatOnrampModal/utils.ts
+++ b/src/components/FiatOnrampModal/utils.ts
@@ -1,6 +1,5 @@
 import { ChainId, WETH9 } from '@uniswap/sdk-core'
 import {
-  BRIDGED_USDC_ARBITRUM,
   MATIC,
   USDC_ARBITRUM,
   USDC_MAINNET,
@@ -34,7 +33,6 @@ const CURRENCY_CODES: {
   },
   [Chain.Arbitrum]: {
     [USDC_ARBITRUM.address.toLowerCase()]: 'usdc_arbitrum',
-    [BRIDGED_USDC_ARBITRUM.address.toLowerCase()]: 'usdc_arbitrum',
     native: 'eth_arbitrum',
   },
   [Chain.Optimism]: {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -31,13 +31,6 @@ const USDC_OPTIMISM_GOERLI = new Token(
   'USDC',
   'USD//C'
 )
-export const BRIDGED_USDC_ARBITRUM = new Token(
-  ChainId.ARBITRUM_ONE,
-  '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
-  6,
-  'USDC',
-  'USD//C'
-)
 export const USDC_ARBITRUM = new Token(
   ChainId.ARBITRUM_ONE,
   '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
@@ -468,7 +461,7 @@ export function getSwapCurrencyId(currency: Currency): string {
 export const TOKEN_SHORTHANDS: { [shorthand: string]: { [chainId in ChainId]?: string } } = {
   USDC: {
     [ChainId.MAINNET]: USDC_MAINNET.address,
-    [ChainId.ARBITRUM_ONE]: BRIDGED_USDC_ARBITRUM.address,
+    [ChainId.ARBITRUM_ONE]: USDC_ARBITRUM.address,
     [ChainId.ARBITRUM_GOERLI]: USDC_ARBITRUM_GOERLI.address,
     [ChainId.OPTIMISM]: USDC_OPTIMISM.address,
     [ChainId.OPTIMISM_GOERLI]: USDC_OPTIMISM_GOERLI.address,

--- a/src/hooks/useStablecoinPrice.ts
+++ b/src/hooks/useStablecoinPrice.ts
@@ -6,9 +6,9 @@ import { INTERNAL_ROUTER_PREFERENCE_PRICE } from 'state/routing/types'
 import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
 
 import {
-  BRIDGED_USDC_ARBITRUM,
   CUSD_CELO,
   DAI_OPTIMISM,
+  USDC_ARBITRUM,
   USDC_AVALANCHE,
   USDC_MAINNET,
   USDC_POLYGON,
@@ -19,7 +19,7 @@ import {
 // The amount is large enough to filter low liquidity pairs.
 const STABLECOIN_AMOUNT_OUT: { [chainId: number]: CurrencyAmount<Token> } = {
   [ChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC_MAINNET, 100_000e6),
-  [ChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(BRIDGED_USDC_ARBITRUM, 10_000e6),
+  [ChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC_ARBITRUM, 10_000e6),
   [ChainId.OPTIMISM]: CurrencyAmount.fromRawAmount(DAI_OPTIMISM, 10_000e18),
   [ChainId.POLYGON]: CurrencyAmount.fromRawAmount(USDC_POLYGON, 10_000e6),
   [ChainId.CELO]: CurrencyAmount.fromRawAmount(CUSD_CELO, 10_000e18),


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

moonpay will no longer support bridged USDC on arbitrum, which means we don't have a reason to keep this token in the codebase anymore

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C047U65H422/p1697038790829849

