### PR TITLE
fix: update uniwallet wc link

### DIFF
--- a/src/connection/WalletConnectV2.ts
+++ b/src/connection/WalletConnectV2.ts
@@ -86,7 +86,7 @@ export class UniwalletConnect extends WalletConnectV2 {
       if (isIOS) {
         // Using window.location.href to open the deep link ensures smooth navigation and leverages OS handling for installed apps,
         // avoiding potential popup blockers or inconsistent behavior associated with window.open
-        window.location.href = `https://uniswap.org/app/wc?uri=${encodeURIComponent(uri)}`
+        window.location.href = `uniswap://wc?uri=${encodeURIComponent(uri)}`
       }
     })
   }

--- a/src/connection/WalletConnectV2.ts
+++ b/src/connection/WalletConnectV2.ts
@@ -78,14 +78,15 @@ export class UniwalletConnect extends WalletConnectV2 {
 
     this.events.on(URI_AVAILABLE, (uri) => {
       if (!uri) return
+
       // Emits custom wallet connect code, parseable by the Uniswap Wallet
-      this.events.emit(UniwalletConnect.UNI_URI_AVAILABLE, `hello_uniwallet:${uri}`)
+      this.events.emit(UniwalletConnect.UNI_URI_AVAILABLE, `https://uniswap.org/app/wc?uri=${uri}`)
 
       // Opens deeplink to Uniswap Wallet if on iOS
       if (isIOS) {
         // Using window.location.href to open the deep link ensures smooth navigation and leverages OS handling for installed apps,
         // avoiding potential popup blockers or inconsistent behavior associated with window.open
-        window.location.href = `uniswap://wc?uri=${encodeURIComponent(uri)}`
+        window.location.href = `https://uniswap.org/app/wc?uri=${encodeURIComponent(uri)}`
       }
     })
   }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
!! this should not be merged until uniwallet v1.15 is released !!

just updates the WalletConnect URI schema as requested by the mobile team. see the slack message below for details. according to that message, this new schema will result in the behavior:

* If the user doesn't have the wallet app, it opens the URL in the browser, which has the link to download the app.
* If the user has the wallet installed and reads the QR code with the camera app, it'll launch the app and show the WalletConnect sheet (after the fix above is live).
* If the user reads from the wallet's scan screen, it'll show the WalletConnect sheet (after the fix above is live).

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2982/update-the-url-for-wc-scan
_Slack thread:_ https://uniswapteam.slack.com/archives/C03JG5E8N4B/p1696948339018599?thread_ts=1695999340.625809&cid=C03JG5E8N4B



## Test plan


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] @brnunes  tested this URL schema and ensured it behaves as outlined above


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->

* macbook +  iPhone 13 to test the above flows
