### PR TITLE
fix: change default tx deadline to 10m

### DIFF
--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -5,7 +5,7 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 // TODO(WEB-1984): Convert the deadline to minutes and remove unecessary conversions from
 // seconds to minutes in the codebase.
-// 30 minutes, denominated in seconds
+// 10 minutes, denominated in seconds
 export const DEFAULT_DEADLINE_FROM_NOW = 60 * 10
 export const L2_DEADLINE_FROM_NOW = 60 * 5
 

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -6,7 +6,7 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 // TODO(WEB-1984): Convert the deadline to minutes and remove unecessary conversions from
 // seconds to minutes in the codebase.
 // 30 minutes, denominated in seconds
-export const DEFAULT_DEADLINE_FROM_NOW = 60 * 30
+export const DEFAULT_DEADLINE_FROM_NOW = 60 * 10
 export const L2_DEADLINE_FROM_NOW = 60 * 5
 
 // transaction popup dismisal amounts

--- a/src/state/migrations.test.ts
+++ b/src/state/migrations.test.ts
@@ -13,7 +13,7 @@ const defaultState = {
   user: {},
   _persist: {
     rehydrated: true,
-    version: 0,
+    version: 1,
   },
   application: {
     chainId: null,

--- a/src/state/migrations.ts
+++ b/src/state/migrations.ts
@@ -2,19 +2,21 @@ import { createMigrate, MigrationManifest, PersistedState, PersistMigrate } from
 import { MigrationConfig } from 'redux-persist/es/createMigrate'
 
 import { migration0 } from './migrations/0'
+import { migration1 } from './migrations/1'
 import { legacyLocalStorageMigration } from './migrations/legacy'
 
 /**
  * These run once per state re-hydration when a version mismatch is detected.
  * Keep them as lightweight as possible.
  *
- * Migration functions should not assume that any value exists in localStorage previously,
- * because a user may be visiting the site for the first time or have cleared their localStorage.
+ * Migration functions should not assume that any value exists in the persisted data previously,
+ * because a user may be visiting the site for the first time or have cleared their data.
  */
 
 // The target version number is the key
 export const migrations: MigrationManifest = {
   0: migration0,
+  1: migration1,
 }
 
 // We use a custom migration function for the initial state, because redux-persist

--- a/src/state/migrations/1.test.ts
+++ b/src/state/migrations/1.test.ts
@@ -1,0 +1,50 @@
+import { RouterPreference } from 'state/routing/types'
+import { UserState } from 'state/user/reducer'
+import { SlippageTolerance } from 'state/user/types'
+
+import { migration1, PersistAppStateV1 } from './1'
+
+const previousState: PersistAppStateV1 = {
+  user: {
+    userLocale: null,
+    userRouterPreference: RouterPreference.API,
+    userHideClosedPositions: false,
+    userSlippageTolerance: SlippageTolerance.Auto,
+    userSlippageToleranceHasBeenMigratedToAuto: true,
+    userDeadline: 1800,
+    tokens: {},
+    pairs: {},
+    timestamp: Date.now(),
+    hideBaseWalletBanner: false,
+  },
+  _persist: {
+    version: 0,
+    rehydrated: true,
+  },
+}
+
+describe('migration to v1', () => {
+  it('should migrate the default deadline', () => {
+    const result = migration1(previousState)
+    expect(result?.user?.userDeadline).toEqual(600)
+  })
+
+  it('should not migrate a non-default value', () => {
+    const result = migration1({
+      ...previousState,
+      user: {
+        ...previousState.user,
+        userDeadline: 300,
+      } as UserState,
+    })
+    expect(result?.user?.userDeadline).toEqual(300)
+  })
+
+  it('should not migrate if user state is not set', () => {
+    const result = migration1({
+      ...previousState,
+      user: undefined,
+    })
+    expect(result?.user?.userDeadline).toBeUndefined()
+  })
+})

--- a/src/state/migrations/1.ts
+++ b/src/state/migrations/1.ts
@@ -2,7 +2,7 @@ import { DEFAULT_DEADLINE_FROM_NOW } from 'constants/misc'
 import { PersistState } from 'redux-persist'
 import { UserState } from 'state/user/reducer'
 
-type PersistAppStateV1 = {
+export type PersistAppStateV1 = {
   _persist: PersistState
 } & { user?: UserState }
 

--- a/src/state/migrations/1.ts
+++ b/src/state/migrations/1.ts
@@ -18,6 +18,10 @@ export const migration1 = (state: PersistAppStateV1 | undefined) => {
         ...state.user,
         userDeadline: DEFAULT_DEADLINE_FROM_NOW,
       },
+      _persist: {
+        ...state._persist,
+        version: 1,
+      },
     }
   }
   return state

--- a/src/state/migrations/1.ts
+++ b/src/state/migrations/1.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_DEADLINE_FROM_NOW } from 'constants/misc'
+import { PersistState } from 'redux-persist'
+import { UserState } from 'state/user/reducer'
+
+type PersistAppStateV1 = {
+  _persist: PersistState
+} & { user?: UserState }
+
+/**
+ * Migration to change the default user deadline from 30 minutes to 10 minutes.
+ * We only migrate if the saved deadline is the old default.
+ */
+export const migration1 = (state: PersistAppStateV1 | undefined) => {
+  if (state?.user && state.user?.userDeadline === 1800) {
+    return {
+      ...state,
+      user: {
+        ...state.user,
+        userDeadline: DEFAULT_DEADLINE_FROM_NOW,
+      },
+    }
+  }
+  return state
+}

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -44,7 +44,7 @@ export type AppState = ReturnType<typeof appReducer>
 
 const persistConfig: PersistConfig<AppState> = {
   key: 'interface',
-  version: 0, // see migrations.ts for more details about this version
+  version: 1, // see migrations.ts for more details about this version
   storage: localForage.createInstance({
     name: 'redux',
   }),


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

updates the default deadline from 30 minutes (1800 seconds) to 10 minutes (600 seconds). this includes changing the constant value used to seed the default state, but also includes a migration for all users who had the old default value persisted. 


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2938/30m-feels-high-for-classic-swaps-xinwan-and-austinadams-can-weigh-in
_Relevant docs:_ https://www.notion.so/Redux-migrations-in-interface-30aca899626a4ac4af7b070f92ce976d


<!-- Delete this section if your change does not affect UI. -->


## Test plan


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] manually loaded the app and verified that `user.userDeadline` had the new default value saved in my IndexedDB



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
