### PR TITLE
fix: hide modal upon keyboard blur

### DIFF
--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -12,7 +12,7 @@ export function useOnClickOutside<T extends HTMLElement>(
   }, [handler])
 
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
+    const handleClickOutside = (e: MouseEvent | KeyboardEvent) => {
       const nodeClicked = node.current?.contains(e.target as Node)
       const ignoredNodeClicked = ignoredNodes.reduce(
         (reducer, val) => reducer || !!val.current?.contains(e.target as Node),
@@ -27,9 +27,11 @@ export function useOnClickOutside<T extends HTMLElement>(
     }
 
     document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keyup', handleClickOutside)
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keyup', handleClickOutside)
     }
   }, [node, ignoredNodes])
 }


### PR DESCRIPTION
## Description
This change mimics the `mousedown` event of `Modal`s, extending the same functionality to blurring the `Modal` via tabbing out of the first or last element via the keyboard `tab` key.  With this PR, if you tab off of the first or last item of a given modal, the modal is closed, just clicking outside the `Modal` would.

## Test plan

1. Click the top bar's "..." item
2. Continuously press `[tab]`
3. When tabbing off the last item, the modal will close
4. Click the top bar's "..." item
5. Press `shit-tab` to bail out of the first item, see the modal close

## Visual


https://github.com/Uniswap/interface/assets/46655/c00fd817-4402-41f0-a6d9-01c39caf024f



### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
