### PR TITLE
fix: Autofocus 'You pay' field when Swap navigation item clicked

### DIFF
--- a/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
+++ b/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
@@ -242,6 +242,7 @@ interface SwapCurrencyInputPanelProps {
     onDisabledClick?: () => void
     disabledTooltipBody?: ReactNode
   }
+  autoFocus?: boolean
 }
 
 const SwapCurrencyInputPanel = forwardRef<HTMLInputElement, SwapCurrencyInputPanelProps>(
@@ -269,6 +270,7 @@ const SwapCurrencyInputPanel = forwardRef<HTMLInputElement, SwapCurrencyInputPan
       disabled = false,
       numericalInputSettings,
       label,
+      autoFocus,
       ...rest
     },
     ref
@@ -323,6 +325,7 @@ const SwapCurrencyInputPanel = forwardRef<HTMLInputElement, SwapCurrencyInputPan
                   $loading={loading}
                   id={id}
                   ref={ref}
+                  autoFocus={autoFocus}
                 />
               </div>
             )}

--- a/src/components/NumericalInput/index.tsx
+++ b/src/components/NumericalInput/index.tsx
@@ -56,10 +56,11 @@ interface InputProps extends Omit<React.HTMLProps<HTMLInputElement>, 'ref' | 'on
   fontSize?: string
   align?: 'right' | 'left'
   prependSymbol?: string
+  autoFocus?: boolean
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ value, onUserInput, placeholder, prependSymbol, ...rest }: InputProps, ref) => {
+  ({ value, onUserInput, placeholder, prependSymbol, autoFocus, ...rest }: InputProps, ref) => {
     const { formatterLocale } = useFormatterLocales()
 
     const enforcer = (nextUserInput: string) => {
@@ -106,6 +107,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         minLength={1}
         maxLength={79}
         spellCheck="false"
+        autoFocus={autoFocus}
       />
     )
   }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -658,6 +658,7 @@ export function Swap({
               id={InterfaceSectionName.CURRENCY_INPUT_PANEL}
               loading={independentField === Field.OUTPUT && routeIsSyncing}
               ref={inputCurrencyNumericalInputRef}
+              autoFocus
             />
           </Trace>
         </SwapSection>


### PR DESCRIPTION
## Description

There's a very high likelihood the user intends to use those swap inputs due to clicking the Swap navigation item.  To improve the speed with which a user can go from navigation to executing a swap, this PR autofocuses the "You pay" field immediately after clicking the "Swap" navigation item.

## Screen capture

https://github.com/Uniswap/interface/assets/46655/36aea2fc-d6d3-41a1-8483-8e242720d4dd

## Test plan

1. Click the "Swap" navigation item
2. See the cursor in the "You pay" input
3. Immediately be able to start typing your "you pay" number

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
