### PR TITLE
fix: Make Swap to / from toggle keyboard accessible

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -69,10 +69,13 @@ import { useIsDarkMode } from '../../theme/components/ThemeToggle'
 import { OutputTaxTooltipBody } from './TaxTooltipBody'
 import { UniswapXOptIn } from './UniswapXOptIn'
 
-export const ArrowContainer = styled.div`
+export const ArrowContainer = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
 
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Description
At present the down/up-arrow button to switch the "You pay" and "You receive" value is not keyboard accessible.  Simply switching to using a `button` element, with some helpful CSS, makes this element more accessible.

## Screen capture

https://github.com/Uniswap/interface/assets/46655/a61871d2-8c48-4cb4-9880-62dcf1e41f9e

### QA (ie manual testing)

1.  Open the Swaps page
2. Tab until you get to the Down/Up toggle
3. Press enter a bunch
4. See the values change

#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
