### PR TITLE
fix: position X opt in tooltip on TDP

### DIFF
--- a/src/pages/Swap/UniswapXOptIn.tsx
+++ b/src/pages/Swap/UniswapXOptIn.tsx
@@ -17,6 +17,7 @@ import {
 import { formatCommonPropertiesForTrade } from 'lib/utils/analytics'
 import { PropsWithChildren, useEffect, useRef, useState } from 'react'
 import { X } from 'react-feather'
+import { useLocation } from 'react-router-dom'
 import { Text } from 'rebass'
 import { useAppDispatch } from 'state/hooks'
 import { RouterPreference } from 'state/routing/types'
@@ -73,6 +74,7 @@ const OptInContents = ({
   const dispatch = useAppDispatch()
   const [showYoureIn, setShowYoureIn] = useState(false)
   const isVisible = isOnClassic
+  const location = useLocation()
 
   // adding this as we need to mount and then set shouldAnimate = true after it mounts to avoid a flicker on initial mount
   const [shouldAnimate, setShouldAnimate] = useState(false)
@@ -115,7 +117,7 @@ const OptInContents = ({
 
   const containerRef = useRef<HTMLDivElement>()
 
-  if (isSmall) {
+  if (isSmall || location.pathname.includes('/tokens/')) {
     return (
       <SwapOptInSmallContainer ref={containerRef as any} visible={isVisible} shouldAnimate={shouldAnimate}>
         <SwapMustache>


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

UniswapX opt-in modal was rendering off-screen on the TDP. this fix just uses the small screen layout to avoid the issue on that page.

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2964/token-details-page-is-rendering-the-uniswapx-modal-off-the-right-edge


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### After
<img width="1429" alt="Screenshot 2023-10-13 at 9 16 12 AM" src="https://github.com/Uniswap/interface/assets/66155195/bb20fb3c-6b99-4567-986b-1ec18e392b2c">



### Before
<img width="1429" alt="Screenshot 2023-10-13 at 9 21 54 AM" src="https://github.com/Uniswap/interface/assets/66155195/1f8c798e-455f-48ca-9ae6-b15969dc4d6d">

