### PR TITLE
fix: remove sitemap step from ci

### DIFF
--- a/.github/workflows/1-main-to-staging.yml
+++ b/.github/workflows/1-main-to-staging.yml
@@ -67,12 +67,6 @@ jobs:
           echo '* @uniswap/web-admins' > CODEOWNERS
           git add CODEOWNERS
           git commit -m 'ci: add global CODEOWNERS'
-      
-      - name: Update sitemap
-        run: |
-          yarn sitemap:generate
-          git add public/sitemap.xml
-          git commit -m 'ci: update sitemap'
 
       - name: Git push
         run: |


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

failing action: https://github.com/Uniswap/interface/actions/runs/6512256939/job/17689537081

the dependencies aren't installed in this CI action, so we can't rely on xml2js ? reverting now to unblock release and will follow up with a fix
