### PR TITLE
fix: use a different ipfs gateway

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -1,6 +1,6 @@
-export const UNI_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
-export const UNI_EXTENDED_LIST = 'https://gateway.ipfs.io/ipns/extendedtokens.uniswap.org'
-const UNI_UNSUPPORTED_LIST = 'https://gateway.ipfs.io/ipns/unsupportedtokens.uniswap.org'
+export const UNI_LIST = 'https://cloudflare-ipfs.com/ipns/tokens.uniswap.org'
+export const UNI_EXTENDED_LIST = 'https://cloudflare-ipfs.com/ipns/extendedtokens.uniswap.org'
+const UNI_UNSUPPORTED_LIST = 'https://cloudflare-ipfs.com/ipns/unsupportedtokens.uniswap.org'
 const AAVE_LIST = 'tokenlist.aave.eth'
 const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
 // TODO(WEB-2282): Re-enable CMC list once we have a better solution for handling large lists.


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

replaces the ipfs gateway url to cloudflare's. this should help us get around the `ERR_CERT_COMMON_NAME_INVALID` error that we were sometimes getting

<!-- Delete inapplicable lines: -->
_Slack thread:_ https://uniswapteam.slack.com/archives/C047U65H422/p1697472005682969

## Test plan

test that the new URL is successfully fetched, on the preview URL

<img width="635" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/78cd64c6-ec86-4f57-aea5-79212168ca05">
