### PR TITLE
fix: merge portfolio tokens w/ default token list in Currency Selector

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { t, Trans } from '@lingui/macro'
 import { InterfaceEventName, InterfaceModalName } from '@uniswap/analytics-events'
-import { Currency, Token } from '@uniswap/sdk-core'
+import { ChainId, Currency, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { Trace } from 'analytics'
 import { useCachedPortfolioBalancesQuery } from 'components/PrefetchBalancesWrapper/PrefetchBalancesWrapper'
@@ -76,9 +76,6 @@ export function CurrencySearch({
   const searchTokenIsAdded = useIsUserAddedToken(searchToken)
 
   const defaultTokens = useDefaultActiveTokens(chainId)
-  const filteredTokens: Token[] = useMemo(() => {
-    return Object.values(defaultTokens).filter(getTokenFilter(debouncedQuery))
-  }, [defaultTokens, debouncedQuery])
 
   const { data, loading: balancesAreLoading } = useCachedPortfolioBalancesQuery({ account })
   const balances: TokenBalances = useMemo(() => {
@@ -100,34 +97,57 @@ export function CurrencySearch({
     )
   }, [chainId, data?.portfolios])
 
-  const sortedTokens: Token[] = useMemo(
-    () =>
-      !balancesAreLoading
-        ? filteredTokens
-            .filter((token) => {
-              if (onlyShowCurrenciesWithBalance) {
-                return balances[token.address?.toLowerCase()]?.usdValue > 0
-              }
+  const sortedTokens: Token[] = useMemo(() => {
+    const portfolioTokens = data?.portfolios?.[0].tokenBalances
+      ?.map((tokenBalance) => {
+        if (!tokenBalance?.token?.chain || !tokenBalance.token?.address || !tokenBalance.token?.decimals) {
+          return undefined
+        }
+        return new Token(
+          supportedChainIdFromGQLChain(tokenBalance.token?.chain) ?? ChainId.MAINNET,
+          tokenBalance.token?.address,
+          tokenBalance.token?.decimals,
+          tokenBalance.token?.symbol,
+          tokenBalance.token?.name
+        )
+      })
+      .filter((token) => !!token) as Token[]
 
-              // If there is no query, filter out unselected user-added tokens with no balance.
-              if (!debouncedQuery && token instanceof UserAddedToken) {
-                if (selectedCurrency?.equals(token) || otherSelectedCurrency?.equals(token)) return true
-                return balances[token.address.toLowerCase()]?.usdValue > 0
-              }
-              return true
-            })
-            .sort(tokenComparator.bind(null, balances))
-        : filteredTokens,
-    [
-      balancesAreLoading,
-      filteredTokens,
-      balances,
-      onlyShowCurrenciesWithBalance,
-      debouncedQuery,
-      selectedCurrency,
-      otherSelectedCurrency,
-    ]
-  )
+    const filteredTokens = Object.values(defaultTokens)
+      .filter(getTokenFilter(debouncedQuery))
+      // Filter out tokens with balances so they aren't duplicated when we merge below.
+      .filter((token) => !(token.address?.toLowerCase() in balances))
+    const mergedTokens = [...(portfolioTokens ?? []), ...filteredTokens]
+
+    if (balancesAreLoading) {
+      return mergedTokens
+    }
+
+    return mergedTokens
+      .filter((token) => {
+        if (onlyShowCurrenciesWithBalance) {
+          return balances[token.address?.toLowerCase()]?.usdValue > 0
+        }
+
+        // If there is no query, filter out unselected user-added tokens with no balance.
+        if (!debouncedQuery && token instanceof UserAddedToken) {
+          if (selectedCurrency?.equals(token) || otherSelectedCurrency?.equals(token)) return true
+          return balances[token.address.toLowerCase()]?.usdValue > 0
+        }
+        return true
+      })
+      .sort(tokenComparator.bind(null, balances))
+  }, [
+    data,
+    defaultTokens,
+    debouncedQuery,
+    balancesAreLoading,
+    balances,
+    onlyShowCurrenciesWithBalance,
+    selectedCurrency,
+    otherSelectedCurrency,
+  ])
+
   const isLoading = Boolean(balancesAreLoading && !tokenLoaderTimerElapsed)
 
   const filteredSortedTokens = useSortTokensByQuery(debouncedQuery, sortedTokens)
@@ -205,7 +225,7 @@ export function CurrencySearch({
 
   // if no results on main list, show option to expand into inactive
   const filteredInactiveTokens = useSearchInactiveTokenLists(
-    !onlyShowCurrenciesWithBalance && (filteredTokens.length === 0 || (debouncedQuery.length > 2 && !isAddressSearch))
+    !onlyShowCurrenciesWithBalance && (sortedTokens.length === 0 || (debouncedQuery.length > 2 && !isAddressSearch))
       ? debouncedQuery
       : undefined
   )


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes a bug where we don't show a user's portfolio token (w/ balance) at the top of the token selector if it's neither on the default list or in the local user-added tokens store.

this solution just merges the portfolio tokens into the default list before the sorting step.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-2710/include-all-tokens-w-balances-in-token-selector


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
<img width="506" alt="image" src="https://github.com/Uniswap/interface/assets/66155195/68f139ec-a067-4a85-8d41-b037bd4ac76a">


### After
![image](https://github.com/Uniswap/interface/assets/66155195/54feffd3-b929-4749-b826-dd2c8129927c)



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. own a token that isn't on the default token list, and make sure it's not in your local "user-added tokens" store
  a. if you need to obtain one, swap for a random token on the app that isn't on the list, then just clear your user state
  b. to clear your user state, in devtools go to application > indexed DB > redux > keyvaluepairs and delete the `persist:interface` entry
2. note that the token doesn't appear at the top of the token selector currency list

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] performed the above steps and verified this fixes the issue

