### PR TITLE
build: upgrade cypress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,9 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4]
     steps:
+      # cypress/base:18.16 images are missing openssl and ca-certificates, but they should be used to match .nvmrc.
+      # See https://github.com/cypress-io/cypress-docker-images/issues/803#issuecomment-1451083809.
+      - run: apt-get update && apt-get install -y --no-install-recommends ca-certificates
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,17 +125,11 @@ jobs:
   cypress-test-matrix:
     needs: [build, cypress-rerun]
     runs-on: ubuntu-latest
-    container:
-      image: cypress/base:18.16.0 # matches .nvmrc
-      options: --shm-size 2gb
     strategy:
       fail-fast: false
       matrix:
         containers: [1, 2, 3, 4]
     steps:
-      # cypress/base:18.16 images are missing openssl and ca-certificates, but they should be used to match .nvmrc.
-      # See https://github.com/cypress-io/cypress-docker-images/issues/803#issuecomment-1451083809.
-      - run: apt-get update && apt-get install -y --no-install-recommends ca-certificates
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,9 @@ jobs:
   cypress-test-matrix:
     needs: [build, cypress-rerun]
     runs-on: ubuntu-latest
+    container:
+      image: cypress/base:18.16.0 # matches .nvmrc
+      options: --shm-size 2gb
     strategy:
       fail-fast: false
       matrix:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   chromeWebSecurity: false,
   experimentalMemoryManagement: true, // better memory management, see https://github.com/cypress-io/cypress/pull/25462
   retries: { runMode: process.env.CYPRESS_RETRIES ? +process.env.CYPRESS_RETRIES : 2 },
-  video: false, // GH provides 2 CPUs, and cypress video eats one up, see https://github.com/cypress-io/cypress/issues/20468#issuecomment-1307608025
   e2e: {
     async setupNodeEvents(on, config) {
       await setupHardhatEvents(on, config)

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import { setupHardhatEvents } from 'cypress-hardhat'
 export default defineConfig({
   projectId: 'yp82ef',
   defaultCommandTimeout: 24000, // 2x average block time
+  requestTimeout: 12000, // average block time
   chromeWebSecurity: false,
   experimentalMemoryManagement: true, // better memory management, see https://github.com/cypress-io/cypress/pull/25462
   retries: { runMode: process.env.CYPRESS_RETRIES ? +process.env.CYPRESS_RETRIES : 2 },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "browser-cache-mock": "^0.1.7",
     "buffer": "^6.0.3",
     "concurrently": "^8.0.1",
-    "cypress": "12.12.0",
+    "cypress": "^13.3.1",
     "cypress-hardhat": "^2.5.0",
     "env-cmd": "^10.1.0",
     "eslint": "^7.11.0",

--- a/src/components/Logo/AssetLogo.tsx
+++ b/src/components/Logo/AssetLogo.tsx
@@ -79,6 +79,7 @@ export default function AssetLogo({
             onLoad={() => void setImgLoaded(true)}
             onError={nextSrc}
             imgLoaded={imgLoaded}
+            loading="lazy"
           />
         </LogoImageWrapper>
       ) : (

--- a/src/components/SearchModal/__snapshots__/CommonBases.test.tsx.snap
+++ b/src/components/SearchModal/__snapshots__/CommonBases.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`CommonBases renders without crashing 1`] = `
           <img
             alt="ETH logo"
             class="c6"
+            loading="lazy"
             src="ethereum-logo.png"
           />
         </div>
@@ -130,6 +131,7 @@ exports[`CommonBases renders without crashing 1`] = `
           <img
             alt="DAI logo"
             class="c6"
+            loading="lazy"
             src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
           />
         </div>
@@ -155,6 +157,7 @@ exports[`CommonBases renders without crashing 1`] = `
           <img
             alt="USDC logo"
             class="c6"
+            loading="lazy"
             src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
           />
         </div>
@@ -180,6 +183,7 @@ exports[`CommonBases renders without crashing 1`] = `
           <img
             alt="USDT logo"
             class="c6"
+            loading="lazy"
             src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
           />
         </div>
@@ -205,6 +209,7 @@ exports[`CommonBases renders without crashing 1`] = `
           <img
             alt="WBTC logo"
             class="c6"
+            loading="lazy"
             src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
           />
         </div>
@@ -230,6 +235,7 @@ exports[`CommonBases renders without crashing 1`] = `
           <img
             alt="WETH logo"
             class="c6"
+            loading="lazy"
             src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
           />
         </div>

--- a/src/components/swap/__snapshots__/SwapLineItem.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapLineItem.test.tsx.snap
@@ -2762,6 +2762,7 @@ exports[`SwapLineItem.tsx exact input 1`] = `
                       <img
                         alt="ABC logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                       />
                     </div>
@@ -2828,6 +2829,7 @@ exports[`SwapLineItem.tsx exact input 1`] = `
                                       <img
                                         alt="DEF logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                                       />
                                     </div>
@@ -2846,6 +2848,7 @@ exports[`SwapLineItem.tsx exact input 1`] = `
                                       <img
                                         alt="ABC logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                                       />
                                     </div>
@@ -2887,6 +2890,7 @@ exports[`SwapLineItem.tsx exact input 1`] = `
                       <img
                         alt="DEF logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                       />
                     </div>
@@ -4429,6 +4433,7 @@ exports[`SwapLineItem.tsx exact input api 1`] = `
                       <img
                         alt="ABC logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                       />
                     </div>
@@ -4495,6 +4500,7 @@ exports[`SwapLineItem.tsx exact input api 1`] = `
                                       <img
                                         alt="DEF logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                                       />
                                     </div>
@@ -4513,6 +4519,7 @@ exports[`SwapLineItem.tsx exact input api 1`] = `
                                       <img
                                         alt="ABC logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                                       />
                                     </div>
@@ -4554,6 +4561,7 @@ exports[`SwapLineItem.tsx exact input api 1`] = `
                       <img
                         alt="DEF logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                       />
                     </div>
@@ -6096,6 +6104,7 @@ exports[`SwapLineItem.tsx exact output 1`] = `
                       <img
                         alt="ABC logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                       />
                     </div>
@@ -6162,6 +6171,7 @@ exports[`SwapLineItem.tsx exact output 1`] = `
                                       <img
                                         alt="GHI logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000003/logo.png"
                                       />
                                     </div>
@@ -6180,6 +6190,7 @@ exports[`SwapLineItem.tsx exact output 1`] = `
                                       <img
                                         alt="ABC logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                                       />
                                     </div>
@@ -6221,6 +6232,7 @@ exports[`SwapLineItem.tsx exact output 1`] = `
                       <img
                         alt="GHI logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000003/logo.png"
                       />
                     </div>
@@ -7971,6 +7983,7 @@ exports[`SwapLineItem.tsx fee on buy 1`] = `
                       <img
                         alt="ABC logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                       />
                     </div>
@@ -8037,6 +8050,7 @@ exports[`SwapLineItem.tsx fee on buy 1`] = `
                                       <img
                                         alt="DEF logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                                       />
                                     </div>
@@ -8055,6 +8069,7 @@ exports[`SwapLineItem.tsx fee on buy 1`] = `
                                       <img
                                         alt="ABC logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                                       />
                                     </div>
@@ -8096,6 +8111,7 @@ exports[`SwapLineItem.tsx fee on buy 1`] = `
                       <img
                         alt="DEF logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                       />
                     </div>
@@ -9846,6 +9862,7 @@ exports[`SwapLineItem.tsx fee on sell 1`] = `
                       <img
                         alt="ABC logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                       />
                     </div>
@@ -9912,6 +9929,7 @@ exports[`SwapLineItem.tsx fee on sell 1`] = `
                                       <img
                                         alt="DEF logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                                       />
                                     </div>
@@ -9930,6 +9948,7 @@ exports[`SwapLineItem.tsx fee on sell 1`] = `
                                       <img
                                         alt="ABC logo"
                                         class="c15"
+                                        loading="lazy"
                                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
                                       />
                                     </div>
@@ -9971,6 +9990,7 @@ exports[`SwapLineItem.tsx fee on sell 1`] = `
                       <img
                         alt="DEF logo"
                         class="c15"
+                        loading="lazy"
                         src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
                       />
                     </div>

--- a/src/components/swap/__snapshots__/SwapModalHeader.test.tsx.snap
+++ b/src/components/swap/__snapshots__/SwapModalHeader.test.tsx.snap
@@ -165,6 +165,7 @@ exports[`SwapModalHeader.tsx matches base snapshot, test trade exact input 1`] =
             <img
               alt="ABC logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
             />
           </div>
@@ -213,6 +214,7 @@ exports[`SwapModalHeader.tsx matches base snapshot, test trade exact input 1`] =
             <img
               alt="DEF logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
             />
           </div>
@@ -388,6 +390,7 @@ exports[`SwapModalHeader.tsx renders ETH input token for an ETH input UniswapX s
             <img
               alt="ETH logo"
               class="c12"
+              loading="lazy"
               src="ethereum-logo.png"
             />
           </div>
@@ -436,6 +439,7 @@ exports[`SwapModalHeader.tsx renders ETH input token for an ETH input UniswapX s
             <img
               alt="DEF logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
             />
           </div>
@@ -611,6 +615,7 @@ exports[`SwapModalHeader.tsx renders preview trades with loading states 1`] = `
             <img
               alt="DEF logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
             />
           </div>
@@ -659,6 +664,7 @@ exports[`SwapModalHeader.tsx renders preview trades with loading states 1`] = `
             <img
               alt="DEF logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000002/logo.png"
             />
           </div>
@@ -834,6 +840,7 @@ exports[`SwapModalHeader.tsx test trade exact output, no recipient 1`] = `
             <img
               alt="ABC logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000001/logo.png"
             />
           </div>
@@ -882,6 +889,7 @@ exports[`SwapModalHeader.tsx test trade exact output, no recipient 1`] = `
             <img
               alt="GHI logo"
               class="c12"
+              loading="lazy"
               src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x0000000000000000000000000000000000000003/logo.png"
             />
           </div>

--- a/src/pages/Landing/__snapshots__/index.test.tsx.snap
+++ b/src/pages/Landing/__snapshots__/index.test.tsx.snap
@@ -1902,6 +1902,7 @@ exports[`disable nft on landing page does not render nft information and card 1`
                                       <img
                                         alt="ETH logo"
                                         class="c35"
+                                        loading="lazy"
                                         src="ethereum-logo.png"
                                       />
                                     </div>
@@ -4548,6 +4549,7 @@ exports[`disable nft on landing page renders nft information and card 1`] = `
                                       <img
                                         alt="ETH logo"
                                         class="c35"
+                                        loading="lazy"
                                         src="ethereum-logo.png"
                                       />
                                     </div>

--- a/src/pages/PoolDetails/__snapshots__/PoolDetailsStats.test.tsx.snap
+++ b/src/pages/PoolDetails/__snapshots__/PoolDetailsStats.test.tsx.snap
@@ -255,6 +255,7 @@ exports[`PoolDetailsStats pool balance chart not visible on mobile 1`] = `
               <img
                 alt="UNKNOWN logo"
                 class="c11"
+                loading="lazy"
                 src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
               />
             </div>
@@ -274,6 +275,7 @@ exports[`PoolDetailsStats pool balance chart not visible on mobile 1`] = `
               <img
                 alt="WETH logo"
                 class="c11"
+                loading="lazy"
                 src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
               />
             </div>

--- a/src/pages/PoolDetails/__snapshots__/index.test.tsx.snap
+++ b/src/pages/PoolDetails/__snapshots__/index.test.tsx.snap
@@ -911,6 +911,7 @@ exports[`PoolDetailsPage pool header is displayed when data is received from the
                 <img
                   alt="UNKNOWN logo"
                   class="c40"
+                  loading="lazy"
                   src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
                 />
               </div>
@@ -985,6 +986,7 @@ exports[`PoolDetailsPage pool header is displayed when data is received from the
                 <img
                   alt="WETH logo"
                   class="c40"
+                  loading="lazy"
                   src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
                 />
               </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,6 +1592,30 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
+"@cypress/request@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.1.tgz#72d7d5425236a2413bd3d8bb66d02d9dc3168960"
+  integrity sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    http-signature "~1.3.6"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    performance-now "^2.1.0"
+    qs "6.10.4"
+    safe-buffer "^5.1.2"
+    tough-cookie "^4.1.3"
+    tunnel-agent "^0.6.0"
+    uuid "^8.3.2"
+
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -5635,10 +5659,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^14.14.31":
-  version "14.17.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.13.tgz#392ba5c51b1550ee3c38082cf1e59b3144f06871"
-  integrity sha512-OqG3iSnFg3cnJLsSRyhriILdDfBOwGty0fmnalbsPdYKbDgK6TI9On/36lzO/1bcaeEkg9OGD2wYLjx8t5MZNQ==
+"@types/node@*", "@types/node@^18.17.5":
+  version "18.18.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.5.tgz#afc0fd975df946d6e1add5bbf98264225b212244"
+  integrity sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==
 
 "@types/node@^10.12.18":
   version "10.17.60"
@@ -5654,6 +5678,11 @@
   version "13.13.52"
   resolved "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz"
   integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
+
+"@types/node@^14.14.31":
+  version "14.17.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.13.tgz#392ba5c51b1550ee3c38082cf1e59b3144f06871"
+  integrity sha512-OqG3iSnFg3cnJLsSRyhriILdDfBOwGty0fmnalbsPdYKbDgK6TI9On/36lzO/1bcaeEkg9OGD2wYLjx8t5MZNQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -9610,14 +9639,14 @@ cypress-hardhat@^2.5.0:
     "@uniswap/sdk-core" ">= 3"
     "@uniswap/universal-router-sdk" "^1.5.4"
 
-cypress@*, cypress@12.12.0:
-  version "12.12.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.12.0.tgz#0da622a34c970d8699ca6562d8e905ed7ce33c77"
-  integrity sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==
+cypress@*, cypress@^13.3.1:
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.3.1.tgz#d72f922e167891574c7773d07ac64d7114e11d49"
+  integrity sha512-g4mJLZxYN+UAF2LMy3Znd4LBnUmS59Vynd81VES59RdW48Yt+QtR2cush3melOoVNz0PPbADpWr8DcUx6mif8Q==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
+    "@types/node" "^18.17.5"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
@@ -9650,9 +9679,10 @@ cypress@*, cypress@12.12.0:
     minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -17311,6 +17341,13 @@ qrcode@1.5.3:
     pngjs "^5.0.0"
     yargs "^15.3.1"
 
+qs@6.10.4:
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.4.tgz#6a3003755add91c0ec9eacdc5f878b034e73f9e7"
+  integrity sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -17344,6 +17381,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2, queue-microtask@^1.2.3:
   version "1.2.3"
@@ -19736,14 +19778,15 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tough-cookie@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
-  integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
+tough-cookie@^4.0.0, tough-cookie@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
     psl "^1.1.33"
     punycode "^2.1.1"
-    universalify "^0.1.2"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -20166,6 +20209,11 @@ universalify@^0.1.0, universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -20247,6 +20295,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
## Description

Upgrades Cypress to v13. Cypress v13 has two (potentially large) performance improvements that we'd like to take advantage of:

- Video has been replaced with Test Replay.
  Video *had* slowed our tests, so it was disabled at the cost of debuggability of CI tests.
  Enabling Test Replay will gain debuggability at little performance cost.
- Websocket commands have been replaced with CDP (Chrome DevTools Protocol) to drive Chromium.

Test Replay still seems to slow down the tests, to the point where the plugin (Hardhat) does not always resolve in time. To fix this, this PR also improves memory usage in two ways to avoid contention between Hardhat and Cypress:

- Lazy loads `AssetLogo` images.
  This is a net win for users as well, as they'll no longer preload every single currency in the selector.
- Explicitly sets shared memory to 2gb for the cypress test container.

_Relevant docs:_ https://docs.cypress.io/guides/references/changelog#13-0-0

## Test plan

### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [X] Unit test N/A
- [X] Integration/E2E test
