### PR TITLE
refactor: allow missing input for useSwapTaxes

### DIFF
--- a/src/hooks/useSwapTaxes.ts
+++ b/src/hooks/useSwapTaxes.ts
@@ -69,7 +69,7 @@ async function getSwapTaxes(
   return { inputTax, outputTax }
 }
 
-export function useSwapTaxes(inputTokenAddress: string | undefined, outputTokenAddress: string | undefined) {
+export function useSwapTaxes(inputTokenAddress?: string, outputTokenAddress?: string) {
   const fotDetector = useFeeOnTransferDetectorContract()
   const [{ inputTax, outputTax }, setTaxes] = useState({ inputTax: ZERO_PERCENT, outputTax: ZERO_PERCENT })
   const { chainId } = useWeb3React()


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- If you try to use `useSwapTaxes` with only an `inputTokenAddress` you'll currently need to include a secondary argument of just `undefined`. This update allows you to not need that second argument.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture
<img width="545" alt="Screenshot 2023-10-19 at 11 49 33 AM" src="https://github.com/Uniswap/interface/assets/11512321/ee662a89-9bc8-42c9-854a-50601680f039">
<img width="524" alt="Screenshot 2023-10-19 at 11 49 41 AM" src="https://github.com/Uniswap/interface/assets/11512321/e26b4f00-11b6-47fb-b895-4865e0e975f7">
<img width="503" alt="Screenshot 2023-10-19 at 11 52 18 AM" src="https://github.com/Uniswap/interface/assets/11512321/71a47ff7-3bbd-4f7f-a154-6f0d837c8066">



## Test plan


### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Tested that fee UX is the same on prod for a swap with 2 FOT, 1 FOT, and 0 FOT
