### PR TITLE
fix: display chart when tickCurrent is zero

### DIFF
--- a/src/hooks/usePoolTickData.ts
+++ b/src/hooks/usePoolTickData.ts
@@ -28,7 +28,9 @@ export interface TickProcessed {
 const REFRESH_FREQUENCY = { blocksPerFetch: 2 }
 
 const getActiveTick = (tickCurrent: number | undefined, feeAmount: FeeAmount | undefined) =>
-  tickCurrent && feeAmount ? Math.floor(tickCurrent / TICK_SPACINGS[feeAmount]) * TICK_SPACINGS[feeAmount] : undefined
+  tickCurrent !== undefined && feeAmount
+    ? Math.floor(tickCurrent / TICK_SPACINGS[feeAmount]) * TICK_SPACINGS[feeAmount]
+    : undefined
 
 const bitmapIndex = (tick: number, tickSpacing: number) => {
   return Math.floor(tick / tickSpacing / 256)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Updated the getActiveTick condition to recognize 0 as an acceptable tickAmount.
This state can occur frequently when stable pools have a currentTick of zero.

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
![Screenshot from 2023-10-26 12-51-45](https://github.com/Uniswap/interface/assets/71703830/f82b7eb8-dbdb-4dc7-ac8f-baf371b357fa)

### After
![Screenshot from 2023-10-26 12-51-22](https://github.com/Uniswap/interface/assets/71703830/06ea842d-e72a-4987-abde-b22e47b71e02)

