### PR TITLE
fix: add space to migrateV2 link

### DIFF
--- a/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -400,7 +400,7 @@ function V2PairMigration({
         {chainId && migrator && (
           <ExternalLink href={getExplorerLink(chainId, migrator.address, ExplorerDataType.ADDRESS)}>
             <ThemedText.DeprecatedBlue display="inline">
-              <Trans>Uniswap migration contract↗</Trans>
+              <Trans>Uniswap migration contract</Trans> ↗
             </ThemedText.DeprecatedBlue>
           </ExternalLink>
         )}


### PR DESCRIPTION
Knocking out ticket https://linear.app/uniswap/issue/WEB-3039/hey-there-is-a-missing-space-in-the-migrate-v2-liquidity-page