### PR TITLE
fix: fixing ugly scrollbar

### DIFF
--- a/src/components/Tokens/TokenTable/NetworkFilter.tsx
+++ b/src/components/Tokens/TokenTable/NetworkFilter.tsx
@@ -57,7 +57,7 @@ const MenuTimeFlyout = styled.span<{ isInfoExplorePageEnabled: boolean }>`
   background-color: ${({ theme }) => theme.surface1};
   box-shadow: ${({ theme }) => theme.deprecated_deepShadow};
   border: 0.5px solid ${({ theme }) => theme.surface3};
-  border-radius: 12px;
+  border-radius: 12px 0px 0px 12px;
   padding: 8px;
   display: flex;
   flex-direction: column;
@@ -65,6 +65,20 @@ const MenuTimeFlyout = styled.span<{ isInfoExplorePageEnabled: boolean }>`
   position: absolute;
   top: 48px;
   z-index: 100;
+
+  scrollbar-width: thin;
+  scrollbar-color: ${({ theme }) => `${theme.surface3} transparent`};
+
+  // safari and chrome scrollbar styling
+  ::-webkit-scrollbar {
+    background: transparent;
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.surface3};
+    border-radius: 8px;
+  }
 
   ${({ isInfoExplorePageEnabled }) =>
     isInfoExplorePageEnabled


### PR DESCRIPTION
* scrollbar ugly -> scrollbar not ugly
* changed border radius because thats currently how it is displayed in the app and there is no good way on gods green earth to add a margin to the side of a webkit scrollbar

Before (Chrome):
![Screen Shot 2023-11-01 at 1 54 06 PM](https://github.com/Uniswap/interface/assets/9094792/5fe2df9b-2409-420d-a9f3-9eb0c8da866b)

Before (Firefox):
![Screen Shot 2023-11-01 at 1 51 26 PM](https://github.com/Uniswap/interface/assets/9094792/4eedd9ee-eebd-4f44-8903-cb50ca1f44d5)

After (Firefox):
![Screen Shot 2023-11-01 at 1 51 16 PM](https://github.com/Uniswap/interface/assets/9094792/8edb0b1d-8d0d-45dd-a26f-09a77e2a132f)

After (Chrome):
![Screen Shot 2023-11-01 at 1 51 10 PM](https://github.com/Uniswap/interface/assets/9094792/c1c7d896-e361-460a-805c-4574abc737a5)

After (Safari):
![Screen Shot 2023-11-01 at 1 50 55 PM](https://github.com/Uniswap/interface/assets/9094792/24d63db0-bc82-49b0-b6be-7b0839cfa717)

