### PR TITLE
refactor: clean up getExplorerLink helper fn

### DIFF
--- a/src/utils/getExplorerLink.ts
+++ b/src/utils/getExplorerLink.ts
@@ -4,6 +4,8 @@ const BLOCK_EXPLORER_PREFIXES: { [chainId: number]: string } = {
   [ChainId.MAINNET]: 'https://etherscan.io',
   [ChainId.GOERLI]: 'https://goerli.etherscan.io',
   [ChainId.SEPOLIA]: 'https://sepolia.etherscan.io',
+  [ChainId.ARBITRUM_ONE]: 'https://arbiscan.io',
+  [ChainId.ARBITRUM_GOERLI]: 'https://goerli.arbiscan.io',
   [ChainId.OPTIMISM]: 'https://optimistic.etherscan.io',
   [ChainId.OPTIMISM_GOERLI]: 'https://goerli-optimism.etherscan.io',
   [ChainId.POLYGON]: 'https://polygonscan.com',
@@ -29,34 +31,6 @@ export enum ExplorerDataType {
  * @param type the type of the data
  */
 export function getExplorerLink(chainId: number, data: string, type: ExplorerDataType): string {
-  if (chainId === ChainId.ARBITRUM_ONE) {
-    switch (type) {
-      case ExplorerDataType.TRANSACTION:
-        return `https://arbiscan.io/tx/${data}`
-      case ExplorerDataType.ADDRESS:
-      case ExplorerDataType.TOKEN:
-        return `https://arbiscan.io/address/${data}`
-      case ExplorerDataType.BLOCK:
-        return `https://arbiscan.io/block/${data}`
-      default:
-        return `https://arbiscan.io/`
-    }
-  }
-
-  if (chainId === ChainId.ARBITRUM_GOERLI) {
-    switch (type) {
-      case ExplorerDataType.TRANSACTION:
-        return `https://goerli.arbiscan.io/tx/${data}`
-      case ExplorerDataType.ADDRESS:
-      case ExplorerDataType.TOKEN:
-        return `https://goerli.arbiscan.io/address/${data}`
-      case ExplorerDataType.BLOCK:
-        return `https://goerli.arbiscan.io/block/${data}`
-      default:
-        return `https://goerli.arbiscan.io/`
-    }
-  }
-
   const prefix = BLOCK_EXPLORER_PREFIXES[chainId] ?? 'https://etherscan.io'
 
   switch (type) {
@@ -67,9 +41,6 @@ export function getExplorerLink(chainId: number, data: string, type: ExplorerDat
       return `${prefix}/token/${data}`
 
     case ExplorerDataType.BLOCK:
-      if (chainId === ChainId.OPTIMISM || chainId === ChainId.OPTIMISM_GOERLI) {
-        return `${prefix}/tx/${data}`
-      }
       return `${prefix}/block/${data}`
 
     case ExplorerDataType.ADDRESS:


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- getExplorerLink had a syntactical split between arbitrum and the rest of the chains which seems like a no longer needed artifact as arbiscan follows the same format as the rest of the explorers
  - This led to the explorer link on TDPs for arbitrum tokens to go to the contract address explorer instead of the token address explorer
  - proof of token routing https://arbiscan.io/token/0x912ce59144191c1204e64559fe8253a0e49e6548
- there was also a bug with the explorer link for optimism block numbers that this fixes. you can see this by tapping on the bottom right Polling interval when on Optimism on this branch vs on main
![Screenshot 2023-11-01 at 12 53 45 PM](https://github.com/Uniswap/interface/assets/11512321/4c1a8e7e-b3d6-4ff9-85ac-71ceb303e057)
  - OP block explorer https://optimistic.etherscan.io/block/111634636

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] Follow the explorer link for a token on Arbitrum
- [ ] Click on the Block number when on OP
