### PR TITLE
feat: Remove logging whole error object for analytics

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -104,7 +104,6 @@ export function useUniversalRouterSwapCallback(
             ...analyticsContext,
             client_block_number: blockNumber,
             tx,
-            error: gasError,
             isAutoSlippage,
           })
           console.warn(gasError)


### PR DESCRIPTION
## Description
We weren't using this `error` field, and it was logging every individual object property as a separate field, so let's remove it from logging here.

