### PR TITLE
chore: converting useStablecoinPrice to useUsdPrice in autoslippage

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -11,7 +11,8 @@ import { useMemo } from 'react'
 import { ClassicTrade } from 'state/routing/types'
 
 import useGasPrice from './useGasPrice'
-import useStablecoinPrice, { useStablecoinAmountFromFiatValue, useStablecoinValue } from './useStablecoinPrice'
+import { useStablecoinAmountFromFiatValue, useStablecoinValue } from './useStablecoinPrice'
+import { useUSDPrice } from './useUSDPrice'
 
 const DEFAULT_AUTO_SLIPPAGE = new Percent(5, 1000) // 0.5%
 
@@ -77,30 +78,31 @@ export default function useClassicAutoSlippageTolerance(trade?: ClassicTrade): P
   const { chainId } = useWeb3React()
   const onL2 = chainId && L2_CHAIN_IDS.includes(chainId)
   const outputDollarValue = useStablecoinValue(trade?.outputAmount)
-  const nativeGasPrice = useGasPrice()
 
+  const nativeGasPrice = useGasPrice()
   const gasEstimate = guesstimateGas(trade)
   const gasEstimateUSD = useStablecoinAmountFromFiatValue(trade?.gasUseEstimateUSD) ?? null
   const nativeCurrency = useNativeCurrency(chainId)
-  const nativeCurrencyPrice = useStablecoinPrice((trade && nativeCurrency) ?? undefined)
+
+  const nativeGasCost =
+    nativeGasPrice && typeof gasEstimate === 'number'
+      ? JSBI.multiply(nativeGasPrice, JSBI.BigInt(gasEstimate))
+      : undefined
+  const gasCostUSD = useUSDPrice(
+    trade && nativeCurrency && nativeGasCost ? CurrencyAmount.fromRawAmount(nativeCurrency, nativeGasCost) : undefined
+  )
+  const gasCostStablecoinAmount = useStablecoinAmountFromFiatValue(gasCostUSD.data)
 
   return useMemo(() => {
     if (!trade || onL2) return DEFAULT_AUTO_SLIPPAGE
-
-    const nativeGasCost =
-      nativeGasPrice && typeof gasEstimate === 'number'
-        ? JSBI.multiply(nativeGasPrice, JSBI.BigInt(gasEstimate))
-        : undefined
-    const dollarGasCost =
-      nativeCurrency && nativeGasCost && nativeCurrencyPrice
-        ? nativeCurrencyPrice.quote(CurrencyAmount.fromRawAmount(nativeCurrency, nativeGasCost))
-        : undefined
 
     // if valid estimate from api and using api trade, use gas estimate from api
     // NOTE - dont use gas estimate for L2s yet - need to verify accuracy
     // if not, use local heuristic
     const dollarCostToUse =
-      chainId && SUPPORTED_GAS_ESTIMATE_CHAIN_IDS.includes(chainId) && gasEstimateUSD ? gasEstimateUSD : dollarGasCost
+      chainId && SUPPORTED_GAS_ESTIMATE_CHAIN_IDS.includes(chainId) && gasEstimateUSD
+        ? gasEstimateUSD
+        : gasCostStablecoinAmount
 
     if (outputDollarValue && dollarCostToUse) {
       // optimize for highest possible slippage without getting MEV'd
@@ -119,15 +121,5 @@ export default function useClassicAutoSlippageTolerance(trade?: ClassicTrade): P
     }
 
     return DEFAULT_AUTO_SLIPPAGE
-  }, [
-    trade,
-    onL2,
-    nativeGasPrice,
-    gasEstimate,
-    nativeCurrency,
-    nativeCurrencyPrice,
-    chainId,
-    gasEstimateUSD,
-    outputDollarValue,
-  ])
+  }, [trade, onL2, chainId, gasEstimateUSD, gasCostStablecoinAmount, outputDollarValue])
 }


### PR DESCRIPTION
* implements tina's idea to reuse the same routing-api result from the previous useUsdPrice call as explained in slack here: https://uniswapteam.slack.com/archives/C047U65H422/p1698868768687079