### PR TITLE
fix: hide invalid nft collections with 0 items from search bar

### DIFF
--- a/src/graphql/data/nft/CollectionSearch.ts
+++ b/src/graphql/data/nft/CollectionSearch.ts
@@ -82,9 +82,11 @@ export function useCollectionSearch(queryOrAddress: string): useCollectionSearch
   const isName = !isAddress(queryOrAddress.toLowerCase())
   const queryResult = useCollectionQuerySearch(queryOrAddress, /* skip= */ !isName)
   const addressResult = useCollection(queryOrAddress, /* skip= */ isName)
+  const invalidCollectionAddress =
+    blocklistedCollections.includes(queryOrAddress) || !addressResult.data.stats?.total_supply
   return isName
     ? queryResult
-    : blocklistedCollections.includes(queryOrAddress)
+    : invalidCollectionAddress
     ? { data: [], loading: false }
     : { data: [addressResult.data], loading: addressResult.loading }
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- `nftCollections` query with an invalid address, such as an erc20 address, is returning a mostly null object which is being shown in the searchBar suggestions
- BE team has been notified but in the interim we can make a quick UX fix to hide nft address search results with 0 items

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-3068/when-you-paste-in-a-token-address-it-creates-a-dummy-nft-collection
_Slack thread:_ https://uniswapteam.slack.com/archives/C04QKTF9T35/p1699376536927179


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
![Screenshot 2023-11-07 at 9 09 45 AM](https://github.com/Uniswap/interface/assets/11512321/9b76dc1b-8df3-41f6-b6ac-389eb5413016)



### After
![Screenshot 2023-11-07 at 9 09 38 AM](https://github.com/Uniswap/interface/assets/11512321/45a4203a-cc68-4d4c-81bb-634826604d9c)