### PR TITLE
feat: use useUSDPrice hook for calculating token usd value for auto slippage

### DIFF
--- a/src/hooks/useAutoSlippageTolerance.ts
+++ b/src/hooks/useAutoSlippageTolerance.ts
@@ -108,7 +108,7 @@ export default function useClassicAutoSlippageTolerance(trade?: ClassicTrade): P
     if (outputDollarValue && dollarCostToUse) {
       // optimize for highest possible slippage without getting MEV'd
       // so set slippage % such that the difference between expected amount out and minimum amount out < gas fee to sandwich the trade
-      const fraction = dollarCostToUse.asFraction.divide(outputDollarValue)
+      const fraction = dollarCostToUse.asFraction.divide(outputDollarValue.asFraction)
       const result = new Percent(fraction.numerator, fraction.denominator)
       if (result.greaterThan(MAX_AUTO_SLIPPAGE_TOLERANCE)) {
         return MAX_AUTO_SLIPPAGE_TOLERANCE


### PR DESCRIPTION
## Description
We already call useUSDPrice in the Swap flow, so this would use a cached value instead of needing fetch a new routing-api request 

## Screen capture
(observe that theyre still the same)
### After
|    Before (on app.uniswap.org)    |   After   |
| ------------ | ----------- |
|<img width="545" alt="image" src="https://github.com/Uniswap/interface/assets/59578595/99d6d8aa-60e6-4d62-99c4-7b9e825a5198">|<img width="529" alt="image" src="https://github.com/Uniswap/interface/assets/59578595/514ec9b3-6467-40a9-9a28-7d5e7c7b0b01">|


