### PR TITLE
fix: very large USDT amounts break UI

### DIFF
--- a/src/components/NumericalInput/index.tsx
+++ b/src/components/NumericalInput/index.tsx
@@ -104,7 +104,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         pattern="^[0-9]*[.,]?[0-9]*$"
         placeholder={placeholder || '0'}
         minLength={1}
-        maxLength={79}
+        maxLength={50}
         spellCheck="false"
       />
     )


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
fixes #7509 

The problem might be coming from how the uniswap sdk handles conversion of very big values with the quote method. It doesn't only occur in usdt, but usdc and wbtc as well. I chose 50 as the limit because wbtc breaks the UI when input length reaches early 50s.

A snapshot test fails on changing this. As a new contributor, I am not sure if the test itself would need to be altered by me or core maintainers, please feel free to make changes



<!-- Delete inapplicable lines: -->


<!-- Delete this section if your change is not a bug fix. -->

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
Go to swap
Select USDT, USDC or WBC as your token
Fill the text box with numbers
The error does not occur because the limit is never reached


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test N/A
- [x] Integration/E2E test N/A
