### PR TITLE
fix: reset token selections when  changing chains on /add

### DIFF
--- a/cypress/e2e/add-liquidity.test.ts
+++ b/cypress/e2e/add-liquidity.test.ts
@@ -16,7 +16,7 @@ describe('Add Liquidity', () => {
     cy.contains('0.05% fee tier')
   })
 
-  it.only('clears the token selection when chain changes', () => {
+  it('clears the token selection when chain changes', () => {
     cy.visit('/add/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/ETH/500')
     cy.get('#add-liquidity-input-tokena .token-symbol-container').should('contain.text', 'UNI')
     cy.get('#add-liquidity-input-tokenb .token-symbol-container').should('contain.text', 'ETH')

--- a/cypress/e2e/add-liquidity.test.ts
+++ b/cypress/e2e/add-liquidity.test.ts
@@ -16,6 +16,16 @@ describe('Add Liquidity', () => {
     cy.contains('0.05% fee tier')
   })
 
+  it.only('clears the token selection when chain changes', () => {
+    cy.visit('/add/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/ETH/500')
+    cy.get('#add-liquidity-input-tokena .token-symbol-container').should('contain.text', 'UNI')
+    cy.get('#add-liquidity-input-tokenb .token-symbol-container').should('contain.text', 'ETH')
+    cy.get('[data-testid="chain-selector"]').last().click()
+    cy.contains('Polygon').click()
+    cy.get('#add-liquidity-input-tokenb .token-symbol-container').should('contain.text', 'ETH')
+    cy.get('#add-liquidity-input-tokena .token-symbol-container').should('not.contain.text', 'UNI')
+  })
+
   it('does not crash if token is duplicated', () => {
     cy.visit('/add/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984')
     cy.get('#add-liquidity-input-tokena .token-symbol-container').should('contain.text', 'UNI')

--- a/src/components/Pools/PoolDetails/PoolDetailsHeader.test.tsx
+++ b/src/components/Pools/PoolDetails/PoolDetailsHeader.test.tsx
@@ -1,9 +1,36 @@
 import userEvent from '@testing-library/user-event'
+import store from 'state'
+import { addSerializedToken } from 'state/user/reducer'
 import { act, render, screen } from 'test-utils/render'
 
 import { PoolDetailsHeader } from './PoolDetailsHeader'
 
 describe('PoolDetailsHeader', () => {
+  beforeEach(() => {
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+      })
+    )
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          symbol: 'WETH',
+          name: 'Wrapped Ether',
+          decimals: 18,
+        },
+      })
+    )
+  })
+
   const mockProps = {
     chainId: 1,
     poolAddress: '0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640',

--- a/src/components/Pools/PoolDetails/PoolDetailsLink.test.tsx
+++ b/src/components/Pools/PoolDetails/PoolDetailsLink.test.tsx
@@ -1,11 +1,38 @@
 import { ChainId } from '@uniswap/sdk-core'
 import { USDC_MAINNET } from 'constants/tokens'
+import store from 'state'
+import { addSerializedToken } from 'state/user/reducer'
 import { usdcWethPoolAddress, validPoolToken0, validPoolToken1 } from 'test-utils/pools/fixtures'
 import { render, screen } from 'test-utils/render'
 
 import { PoolDetailsLink } from './PoolDetailsLink'
 
 describe('PoolDetailsHeader', () => {
+  beforeEach(() => {
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+      })
+    )
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          symbol: 'WETH',
+          name: 'Wrapped Ether',
+          decimals: 18,
+        },
+      })
+    )
+  })
+
   it('renders link for pool address', async () => {
     const { asFragment } = render(
       <PoolDetailsLink

--- a/src/components/Pools/PoolDetails/PoolDetailsStats.test.tsx
+++ b/src/components/Pools/PoolDetails/PoolDetailsStats.test.tsx
@@ -1,4 +1,6 @@
 import { enableNetConnect } from 'nock'
+import store from 'state'
+import { addSerializedToken } from 'state/user/reducer'
 import { validPoolDataResponse } from 'test-utils/pools/fixtures'
 import { act, render, screen } from 'test-utils/render'
 import { BREAKPOINTS } from 'theme'
@@ -15,6 +17,28 @@ describe('PoolDetailsStats', () => {
   beforeEach(() => {
     // Enable network connections for retrieving token logos
     enableNetConnect()
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+      })
+    )
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          symbol: 'WETH',
+          name: 'Wrapped Ether',
+          decimals: 18,
+        },
+      })
+    )
   })
 
   it('renders stats text correctly', async () => {

--- a/src/components/Pools/PoolDetails/PoolDetailsStatsButtons.test.tsx
+++ b/src/components/Pools/PoolDetails/PoolDetailsStatsButtons.test.tsx
@@ -1,5 +1,7 @@
 import userEvent from '@testing-library/user-event'
 import useMultiChainPositions from 'components/AccountDrawer/MiniPortfolio/Pools/useMultiChainPositions'
+import store from 'state'
+import { addSerializedToken } from 'state/user/reducer'
 import { mocked } from 'test-utils/mocked'
 import { useMultiChainPositionsReturnValue, validPoolToken0, validPoolToken1 } from 'test-utils/pools/fixtures'
 import { act, render, screen } from 'test-utils/render'
@@ -24,6 +26,28 @@ describe('PoolDetailsStatsButton', () => {
 
   beforeEach(() => {
     mocked(useMultiChainPositions).mockReturnValue(useMultiChainPositionsReturnValue)
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+      })
+    )
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          symbol: 'WETH',
+          name: 'Wrapped Ether',
+          decimals: 18,
+        },
+      })
+    )
   })
 
   it('loading skeleton shown correctly', () => {

--- a/src/components/Pools/PoolDetails/__snapshots__/PoolDetailsLink.test.tsx.snap
+++ b/src/components/Pools/PoolDetails/__snapshots__/PoolDetailsLink.test.tsx.snap
@@ -541,7 +541,7 @@ exports[`PoolDetailsHeader renders link for token address 1`] = `
           class="c5"
         >
           <img
-            alt="UNKNOWN logo"
+            alt="USDC logo"
             class="c6"
             loading="lazy"
             src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"

--- a/src/components/Pools/PoolDetails/__snapshots__/PoolDetailsStats.test.tsx.snap
+++ b/src/components/Pools/PoolDetails/__snapshots__/PoolDetailsStats.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`PoolDetailsStats pool balance chart not visible on mobile 1`] = `
               class="c10"
             >
               <img
-                alt="UNKNOWN logo"
+                alt="USDC logo"
                 class="c11"
                 loading="lazy"
                 src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"

--- a/src/lib/hooks/useCurrency.ts
+++ b/src/lib/hooks/useCurrency.ts
@@ -68,9 +68,12 @@ export function useTokenFromActiveNetwork(tokenAddress: string | undefined): Tok
     // If the token is on another chain, we cannot fetch it on-chain, and it is invalid.
     if (typeof tokenAddress !== 'string' || !isSupportedChain(chainId) || !formattedAddress) return undefined
     if (isLoading || !chainId) return null
+    if (!decimals?.result?.[0] && parsedSymbol === UNKNOWN_TOKEN_SYMBOL && parsedName === UNKNOWN_TOKEN_NAME) {
+      return undefined
+    }
 
     return new Token(chainId, formattedAddress, parsedDecimals, parsedSymbol, parsedName)
-  }, [chainId, tokenAddress, formattedAddress, isLoading, parsedDecimals, parsedSymbol, parsedName])
+  }, [tokenAddress, chainId, formattedAddress, isLoading, decimals?.result, parsedDecimals, parsedSymbol, parsedName])
 }
 
 type TokenMap = { [address: string]: Token }

--- a/src/pages/PoolDetails/__snapshots__/index.test.tsx.snap
+++ b/src/pages/PoolDetails/__snapshots__/index.test.tsx.snap
@@ -2087,7 +2087,7 @@ exports[`PoolDetailsPage pool header is displayed when data is received from the
                   class="c71"
                 >
                   <img
-                    alt="UNKNOWN logo"
+                    alt="USDC logo"
                     class="c72"
                     loading="lazy"
                     src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"

--- a/src/pages/PoolDetails/index.test.tsx
+++ b/src/pages/PoolDetails/index.test.tsx
@@ -1,5 +1,7 @@
 import { usePoolData } from 'graphql/thegraph/PoolData'
 import Router from 'react-router-dom'
+import store from 'state'
+import { addSerializedToken } from 'state/user/reducer'
 import { mocked } from 'test-utils/mocked'
 import { validParams, validPoolDataResponse } from 'test-utils/pools/fixtures'
 import { render, screen, waitFor } from 'test-utils/render'
@@ -23,6 +25,28 @@ describe('PoolDetailsPage', () => {
   beforeEach(() => {
     jest.spyOn(Router, 'useParams').mockReturnValue(validParams)
     mocked(usePoolData).mockReturnValue(validPoolDataResponse)
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+      })
+    )
+    store.dispatch(
+      addSerializedToken({
+        serializedToken: {
+          chainId: 1,
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          symbol: 'WETH',
+          name: 'Wrapped Ether',
+          decimals: 18,
+        },
+      })
+    )
   })
 
   it('not found page displayed when given no poolAddress', () => {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes an issue on the `/add` page where token selections from the previous chain persist to the new chain, and are displayed as "UNKNOWN" ...

my fix here is to disallow any "unknown" tokens since they likely don't exist. an "unknown" token is one where we couldn't get valid decimals/name/symbol from the onchain call.

the token state on this page is actually managed via the URL route and is actually hard to change. (i tried using react router to reset the state in many different ways, but couldn't get it working). 
we might want to consider moving away from URL-based state management on this page at some point, but i wanted to submit this simpler fix as a short term solution.



<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-3014/if-you-change-network-in-create-position-it-doesnt-clear-input
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before


https://github.com/Uniswap/interface/assets/66155195/4593daaa-fb4b-47a9-89b3-bf39f929eef2



### After


https://github.com/Uniswap/interface/assets/66155195/9415c53c-3c7c-4c8f-b183-7db3825c1a2d



## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. go to /add/ETH page
2. select tokens
3. change chain
4. notice that the tokens are "unknown" on new chain

