### PR TITLE
chore: revert cache skip

### DIFF
--- a/cypress/e2e/mini-portfolio/accounts.test.ts
+++ b/cypress/e2e/mini-portfolio/accounts.test.ts
@@ -59,10 +59,9 @@ describe('Mini Portfolio account drawer', () => {
     cy.get(getTestSelector('mini-portfolio-navbar')).contains('NFTs').click()
     cy.get(getTestSelector('mini-portfolio-page')).contains('I Got Plenty')
 
-    // Skip this for now, someone sent test account an NFT on block 17445713 that causes this test to fail
-    // cy.intercept(/graphql/, { fixture: 'mini-portfolio/pools.json' })
-    // cy.get(getTestSelector('mini-portfolio-navbar')).contains('Pools').click()
-    // cy.get(getTestSelector('mini-portfolio-page')).contains('No pools yet')
+    cy.intercept(/graphql/, { fixture: 'mini-portfolio/pools.json' })
+    cy.get(getTestSelector('mini-portfolio-navbar')).contains('Pools').click()
+    cy.get(getTestSelector('mini-portfolio-page')).contains('No pools yet')
 
     cy.intercept(/graphql/, { fixture: 'mini-portfolio/full_activity.json' })
     cy.get(getTestSelector('mini-portfolio-navbar')).contains('Activity').click()

--- a/cypress/e2e/swap/errors.test.ts
+++ b/cypress/e2e/swap/errors.test.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { CurrencyAmount } from '@uniswap/sdk-core'
-import { FeatureFlag } from 'featureFlags'
 
 import { DEFAULT_DEADLINE_FROM_NOW } from '../../../src/constants/misc'
 import { DAI, USDC_MAINNET } from '../../../src/constants/tokens'
@@ -64,9 +63,7 @@ describe('Swap errors', () => {
   })
 
   it('slippage failure', () => {
-    cy.visit(`/swap?inputCurrency=${USDC_MAINNET.address}&outputCurrency=${DAI.address}`, {
-      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: false }],
-    })
+    cy.visit(`/swap?inputCurrency=${USDC_MAINNET.address}&outputCurrency=${DAI.address}`)
     cy.hardhat({ automine: false }).then(async (hardhat) => {
       await hardhat.fund(hardhat.wallet, CurrencyAmount.fromRawAmount(USDC_MAINNET, 500e6))
       await hardhat.mine()
@@ -89,7 +86,6 @@ describe('Swap errors', () => {
       cy.get(getTestSelector('open-settings-dialog-button')).click()
       cy.get(getTestSelector('max-slippage-settings')).click()
       cy.get(getTestSelector('slippage-input')).clear().type('0.01')
-      cy.get(getTestSelector('toggle-uniswap-x-button')).click() // turn off uniswapx
       cy.get('body').click('topRight') // close modal
       cy.get(getTestSelector('slippage-input')).should('not.exist')
 

--- a/cypress/e2e/swap/fees.test.ts
+++ b/cypress/e2e/swap/fees.test.ts
@@ -4,7 +4,7 @@ import { FeatureFlag } from 'featureFlags'
 import { USDC_MAINNET } from '../../../src/constants/tokens'
 import { getBalance, getTestSelector } from '../../utils'
 
-describe.skip('Swap with fees', () => {
+describe('Swap with fees', () => {
   describe('Classic swaps', () => {
     beforeEach(() => {
       cy.visit('/swap', { featureFlags: [{ name: FeatureFlag.feesEnabled, value: true }] })

--- a/cypress/e2e/swap/uniswapx.test.ts
+++ b/cypress/e2e/swap/uniswapx.test.ts
@@ -24,8 +24,7 @@ function stubSwapTxReceipt() {
   })
 }
 
-// TODO: FIX THESE TESTS where we should NOT stub for pricing requests
-describe.skip('UniswapX Toggle', () => {
+describe('UniswapX Toggle', () => {
   beforeEach(() => {
     cy.intercept(QuoteEndpoint, { fixture: QuoteWhereUniswapXIsBetter })
     cy.visit(`/swap/?inputCurrency=${USDC_MAINNET.address}&outputCurrency=${DAI.address}`, {
@@ -71,7 +70,7 @@ describe.skip('UniswapX Toggle', () => {
   })
 })
 
-describe.skip('UniswapX Orders', () => {
+describe('UniswapX Orders', () => {
   beforeEach(() => {
     cy.intercept(QuoteEndpoint, { fixture: QuoteWhereUniswapXIsBetter })
     cy.intercept(OrderSubmissionEndpoint, { fixture: 'uniswapx/orderResponse.json' })
@@ -156,7 +155,7 @@ describe.skip('UniswapX Orders', () => {
   })
 })
 
-describe.skip('UniswapX Eth Input', () => {
+describe('UniswapX Eth Input', () => {
   beforeEach(() => {
     cy.intercept(QuoteEndpoint, { fixture: QuoteWithEthInput })
     cy.intercept(OrderSubmissionEndpoint, { fixture: 'uniswapx/orderResponse.json' })
@@ -246,7 +245,7 @@ describe.skip('UniswapX Eth Input', () => {
   })
 })
 
-describe.skip('UniswapX activity history', () => {
+describe('UniswapX activity history', () => {
   beforeEach(() => {
     cy.intercept(QuoteEndpoint, { fixture: QuoteWhereUniswapXIsBetter })
     cy.intercept(OrderSubmissionEndpoint, { fixture: 'uniswapx/orderResponse.json' })

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -13,8 +13,7 @@ const forkingConfig = {
 const forks = {
   [ChainId.MAINNET]: {
     url: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-    // Temporarily hardcoding this to fix e2e tests as we investigate source of swap tests failing on older blocknumbers
-    blockNumber: 18537387,
+    blockNumber: UNIVERSAL_ROUTER_CREATION_BLOCK(ChainId.MAINNET),
     ...forkingConfig,
   },
   [ChainId.POLYGON]: {

--- a/src/hooks/useAccountRiskCheck.ts
+++ b/src/hooks/useAccountRiskCheck.ts
@@ -1,3 +1,4 @@
+import ms from 'ms'
 import { useEffect } from 'react'
 import { ApplicationModal, setOpenModal } from 'state/application/reducer'
 import { useAppDispatch } from 'state/hooks'
@@ -6,23 +7,34 @@ export default function useAccountRiskCheck(account: string | null | undefined) 
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    if (!account) return
-
-    // TODO: add back local browser cacheing (revisit 11/13/2023)
-    const headers = new Headers({ 'Content-Type': 'application/json' })
-    fetch('https://api.uniswap.org/v1/screen', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ address: account }),
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.block) {
-          dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
+    if (account) {
+      const riskCheckLocalStorageKey = `risk-check-${account}`
+      const now = Date.now()
+      try {
+        // Check local browser cache
+        const storedTime = localStorage.getItem(riskCheckLocalStorageKey)
+        const checkExpirationTime = storedTime ? parseInt(storedTime) : now - 1
+        if (checkExpirationTime < Date.now()) {
+          const headers = new Headers({ 'Content-Type': 'application/json' })
+          fetch('https://api.uniswap.org/v1/screen', {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ address: account }),
+          })
+            .then((res) => res.json())
+            .then((data) => {
+              if (data.block) {
+                dispatch(setOpenModal(ApplicationModal.BLOCKED_ACCOUNT))
+              }
+            })
+            .catch(() => {
+              dispatch(setOpenModal(null))
+            })
         }
-      })
-      .catch(() => {
-        dispatch(setOpenModal(null))
-      })
+      } finally {
+        // Set item to have 1 day local cache storage
+        localStorage.setItem(riskCheckLocalStorageKey, (now + ms(`1d`)).toString())
+      }
+    }
   }, [account, dispatch])
 }


### PR DESCRIPTION
Since the upstream bug is fixed we can revert to the old cache behavior, as upstream will correctly report address taint in the initial case now. 

https://app.amplitude.com/analytics/uniswap/dashboard/fjl04nu

![image](https://github.com/Uniswap/interface/assets/5773490/87f7912e-11c6-4dab-9e98-7c59538ae564)

The current setup sets us up for an extremely expensive contract overrun. 

