### PR TITLE
test: updatea e2e tests after X rollout

### DIFF
--- a/cypress/e2e/swap/uniswapx.test.ts
+++ b/cypress/e2e/swap/uniswapx.test.ts
@@ -46,7 +46,7 @@ describe('UniswapX Toggle', () => {
   beforeEach(() => {
     stubNonPriceQuoteWith(QuoteWhereUniswapXIsBetter)
     cy.visit(`/swap/?inputCurrency=${USDC_MAINNET.address}&outputCurrency=${DAI.address}`, {
-      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: false }],
+      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: true }],
     })
   })
 
@@ -55,38 +55,8 @@ describe('UniswapX Toggle', () => {
     cy.get('#swap-currency-input .token-amount-input').type('300')
     cy.wait('@quote')
 
-    // UniswapX UI should not be visible
-    cy.get(getTestSelector('gas-estimate-uniswapx-icon')).should('not.exist')
-
-    // Opt-in to UniswapX
-    cy.contains('Try it now').click()
-
     // UniswapX UI should be visible
     cy.get(getTestSelector('gas-estimate-uniswapx-icon')).should('exist')
-  })
-
-  it('prompts opt-in if UniswapX is better', () => {
-    // Setup a swap
-    cy.get('#swap-currency-input .token-amount-input').type('300')
-    cy.wait('@quote')
-
-    // UniswapX should not display in gas estimate row before opt-in
-    cy.get(getTestSelector('gas-estimate-uniswapx-icon')).should('not.exist')
-
-    // UniswapX mustache should be visible
-    cy.contains('Try it now').click()
-
-    // Opt-in dialog should now be hidden
-    cy.contains('Try it now').should('not.be.visible')
-
-    // UniswapX should display in gas estimate row
-    cy.get(getTestSelector('gas-estimate-uniswapx-icon')).should('exist')
-
-    // Opt-in dialog should not reappear if user manually toggles UniswapX off
-    cy.get(getTestSelector('open-settings-dialog-button')).click()
-    cy.get(getTestSelector('toggle-uniswap-x-button')).click()
-    cy.get(getTestSelector('open-settings-dialog-button')).click()
-    cy.contains('Try it now').should('not.be.visible')
   })
 })
 
@@ -100,7 +70,7 @@ describe('UniswapX Orders', () => {
 
     cy.hardhat().then((hardhat) => hardhat.fund(hardhat.wallet, CurrencyAmount.fromRawAmount(USDC_MAINNET, 3e8)))
     cy.visit(`/swap/?inputCurrency=${USDC_MAINNET.address}&outputCurrency=${DAI.address}`, {
-      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: false }],
+      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: true }],
     })
   })
 
@@ -108,8 +78,6 @@ describe('UniswapX Orders', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('300')
     cy.wait('@quote')
-
-    cy.contains('Try it now').click()
 
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
@@ -130,8 +98,6 @@ describe('UniswapX Orders', () => {
     cy.get('#swap-currency-output .token-amount-input').type('300')
     cy.wait('@quote')
 
-    cy.contains('Try it now').click()
-
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
     cy.contains('Confirm swap').click()
@@ -151,8 +117,6 @@ describe('UniswapX Orders', () => {
     cy.get('#swap-currency-input .token-amount-input').type('300')
     cy.wait('@quote')
 
-    cy.contains('Try it now').click()
-
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
     cy.contains('Confirm swap').click()
@@ -168,8 +132,6 @@ describe('UniswapX Orders', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('300')
     cy.wait('@quote')
-
-    cy.contains('Try it now').click()
 
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
@@ -198,7 +160,7 @@ describe('UniswapX Eth Input', () => {
     stubSwapTxReceipt()
 
     cy.visit(`/swap/?inputCurrency=ETH&outputCurrency=${DAI.address}`, {
-      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: false }],
+      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: true }],
     })
   })
 
@@ -207,7 +169,6 @@ describe('UniswapX Eth Input', () => {
     cy.get('#swap-currency-input .token-amount-input').type('1')
 
     cy.wait('@quote')
-    cy.contains('Try it now').click()
 
     // Prompt ETH wrap to use for order
     cy.get('#swap-button').click()
@@ -240,8 +201,6 @@ describe('UniswapX Eth Input', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('1')
     cy.wait('@quote')
-
-    cy.contains('Try it now').click()
 
     // Prompt ETH wrap and confirm
     cy.get('#swap-button').click()
@@ -289,14 +248,13 @@ describe('UniswapX activity history', () => {
       await hardhat.fund(hardhat.wallet, CurrencyAmount.fromRawAmount(USDC_MAINNET, 3e8))
     })
     cy.visit(`/swap/?inputCurrency=${USDC_MAINNET.address}&outputCurrency=${DAI.address}`, {
-      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: false }],
+      featureFlags: [{ name: FeatureFlag.uniswapXDefaultEnabled, value: true }],
     })
   })
 
   it('can view UniswapX order status progress in activity', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('300')
-    cy.contains('Try it now').click()
 
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
@@ -324,7 +282,6 @@ describe('UniswapX activity history', () => {
   it('can view UniswapX order status progress in activity upon expiry', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('300')
-    cy.contains('Try it now').click()
 
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
@@ -351,7 +308,6 @@ describe('UniswapX activity history', () => {
   it('deduplicates remote vs local uniswapx orders', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('300')
-    cy.contains('Try it now').click()
 
     // Submit uniswapx order signature
     cy.get('#swap-button').click()
@@ -383,7 +339,6 @@ describe('UniswapX activity history', () => {
   it('balances should refetch after uniswapx swap', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('300')
-    cy.contains('Try it now').click()
 
     const gqlSpy = cy.spy().as('gqlSpy')
     cy.intercept(/graphql/, (req) => {


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

updates our e2e tests to *enable* unsiwapX by default since that's the behavior in prod now. 
