### PR TITLE
fix: redux migration to flush german locale

### DIFF
--- a/src/state/migrations.test.ts
+++ b/src/state/migrations.test.ts
@@ -14,7 +14,7 @@ const defaultState = {
   user: {},
   _persist: {
     rehydrated: true,
-    version: 3,
+    version: 4,
   },
   application: {
     chainId: null,

--- a/src/state/migrations.ts
+++ b/src/state/migrations.ts
@@ -5,6 +5,7 @@ import { migration0 } from './migrations/0'
 import { migration1 } from './migrations/1'
 import { migration2 } from './migrations/2'
 import { migration3 } from './migrations/3'
+import { migration4 } from './migrations/4'
 import { legacyLocalStorageMigration } from './migrations/legacy'
 
 /**
@@ -21,6 +22,7 @@ export const migrations: MigrationManifest = {
   1: migration1,
   2: migration2,
   3: migration3,
+  4: migration4,
 }
 
 // We use a custom migration function for the initial state, because redux-persist

--- a/src/state/migrations/4.test.ts
+++ b/src/state/migrations/4.test.ts
@@ -1,4 +1,3 @@
-import { ChainId, Token } from '@uniswap/sdk-core'
 import { createMigrate } from 'redux-persist'
 import { RouterPreference } from 'state/routing/types'
 import { SlippageTolerance } from 'state/user/types'

--- a/src/state/migrations/4.test.ts
+++ b/src/state/migrations/4.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE } from 'constants/locales'
 import { createMigrate } from 'redux-persist'
 import { RouterPreference } from 'state/routing/types'
 import { SlippageTolerance } from 'state/user/types'
@@ -6,7 +7,6 @@ import { migration1 } from './1'
 import { migration2 } from './2'
 import { migration3 } from './3'
 import { migration4, PersistAppStateV4 } from './4'
-import { DEFAULT_LOCALE } from 'constants/locales'
 
 const previousState: PersistAppStateV4 = {
   user: {

--- a/src/state/migrations/4.test.ts
+++ b/src/state/migrations/4.test.ts
@@ -1,0 +1,47 @@
+import { ChainId, Token } from '@uniswap/sdk-core'
+import { createMigrate } from 'redux-persist'
+import { RouterPreference } from 'state/routing/types'
+import { SlippageTolerance } from 'state/user/types'
+
+import { migration1 } from './1'
+import { migration2 } from './2'
+import { migration3 } from './3'
+import { migration4, PersistAppStateV4 } from './4'
+import { DEFAULT_LOCALE } from 'constants/locales'
+
+const previousState: PersistAppStateV4 = {
+  user: {
+    userLocale: 'de-DE',
+    userRouterPreference: RouterPreference.API,
+    userHideClosedPositions: false,
+    userSlippageTolerance: SlippageTolerance.Auto,
+    userSlippageToleranceHasBeenMigratedToAuto: true,
+    userDeadline: 1800,
+    tokens: {},
+    pairs: {},
+    timestamp: Date.now(),
+    hideAndroidAnnouncementBanner: false,
+  },
+  _persist: {
+    version: 3,
+    rehydrated: true,
+  },
+}
+
+describe('migration to v4', () => {
+  it('should migrate users who currently have German as their set locale', async () => {
+    const migrator = createMigrate(
+      {
+        1: migration1,
+        2: migration2,
+        3: migration3,
+        4: migration4,
+      },
+      { debug: false }
+    )
+    const result: any = await migrator(previousState, 4)
+    expect(result.user.userLocale).toEqual(DEFAULT_LOCALE)
+
+    expect(result?._persist.version).toEqual(4)
+  })
+})

--- a/src/state/migrations/4.ts
+++ b/src/state/migrations/4.ts
@@ -1,0 +1,31 @@
+import { Token } from '@uniswap/sdk-core'
+import { ChainId } from '@uniswap/sdk-core'
+import { DEFAULT_LOCALE } from 'constants/locales'
+import { PersistState } from 'redux-persist'
+import { serializeToken } from 'state/user/hooks'
+import { UserState } from 'state/user/reducer'
+
+export type PersistAppStateV4 = {
+  _persist: PersistState
+} & { user?: UserState }
+
+/**
+ * Migration to set german locale to default locale, after
+ * the german locale was removed from supported locales.
+ */
+export const migration4 = (state: PersistAppStateV4 | undefined) => {
+  if (state?.user) {
+    if (state.user.userLocale === 'de-DE') {
+      state.user.userLocale = DEFAULT_LOCALE
+    }
+
+    return {
+      ...state,
+      _persist: {
+        ...state._persist,
+        version: 4,
+      },
+    }
+  }
+  return state
+}

--- a/src/state/migrations/4.ts
+++ b/src/state/migrations/4.ts
@@ -1,8 +1,5 @@
-import { Token } from '@uniswap/sdk-core'
-import { ChainId } from '@uniswap/sdk-core'
 import { DEFAULT_LOCALE } from 'constants/locales'
 import { PersistState } from 'redux-persist'
-import { serializeToken } from 'state/user/hooks'
 import { UserState } from 'state/user/reducer'
 
 export type PersistAppStateV4 = {

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -44,7 +44,7 @@ export type AppState = ReturnType<typeof appReducer>
 
 const persistConfig: PersistConfig<AppState> = {
   key: 'interface',
-  version: 3, // see migrations.ts for more details about this version
+  version: 4, // see migrations.ts for more details about this version
   storage: localForage.createInstance({
     name: 'redux',
   }),


### PR DESCRIPTION
* we removed German from supported locales so we need to flush redux locale storage for users that have German set as their preferred language