### PR TITLE
fix: portfolioLogo alignment

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.tsx
@@ -36,7 +36,9 @@ const DoubleLogoContainer = styled.div`
   }
 `
 
-const StyledLogoParentContainer = styled.div`
+const LogoContainer = styled.div`
+  display: flex;
+  align-items: center;
   position: relative;
   top: 0;
   left: 0;
@@ -57,9 +59,9 @@ const CircleLogoImage = styled.img<{ size: string }>`
 const L2LogoContainer = styled.div`
   border-radius: ${getDefaultBorderRadius(16)}px;
   height: 16px;
-  left: 60%;
+  left: 70%;
   position: absolute;
-  top: 60%;
+  top: 70%;
   outline: 2px solid ${({ theme }) => theme.surface1};
   width: 16px;
   display: flex;
@@ -155,10 +157,10 @@ function SquareL2Logo({ chainId }: { chainId: ChainId }) {
  */
 export function PortfolioLogo(props: PortfolioLogoProps) {
   return (
-    <StyledLogoParentContainer style={props.style}>
+    <LogoContainer style={props.style}>
       {getLogo(props)}
       <SquareL2Logo chainId={props.chainId} />
-    </StyledLogoParentContainer>
+    </LogoContainer>
   )
 }
 

--- a/src/components/AccountDrawer/MiniPortfolio/__snapshots__/PortfolioLogo.test.tsx.snap
+++ b/src/components/AccountDrawer/MiniPortfolio/__snapshots__/PortfolioLogo.test.tsx.snap
@@ -32,6 +32,14 @@ exports[`PortfolioLogo renders with L2 icon 1`] = `
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   position: relative;
   top: 0;
   left: 0;
@@ -46,9 +54,9 @@ exports[`PortfolioLogo renders with L2 icon 1`] = `
 .c3 {
   border-radius: 4px;
   height: 16px;
-  left: 60%;
+  left: 70%;
   position: absolute;
-  top: 60%;
+  top: 70%;
   outline: 2px solid #FFFFFF;
   width: 16px;
   display: -webkit-box;
@@ -150,6 +158,14 @@ exports[`PortfolioLogo renders without L2 icon 1`] = `
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   position: relative;
   top: 0;
   left: 0;

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -114,7 +114,7 @@ const ClickableContent = styled.div<{ gap?: number }>`
   cursor: pointer;
 `
 const ClickableName = styled(ClickableContent)`
-  gap: 12px;
+  gap: 14px;
   max-width: 100%;
 `
 const StyledHeaderRow = styled(StyledTokenRow)`

--- a/src/components/Tokens/TokenTable/__snapshots__/TokenRow.test.tsx.snap
+++ b/src/components/Tokens/TokenTable/__snapshots__/TokenRow.test.tsx.snap
@@ -3,6 +3,14 @@
 exports[`LoadedRow.tsx renders a row 1`] = `
 <DocumentFragment>
   .c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   position: relative;
   top: 0;
   left: 0;
@@ -94,7 +102,7 @@ exports[`LoadedRow.tsx renders a row 1`] = `
 }
 
 .c6 {
-  gap: 12px;
+  gap: 14px;
   max-width: 100%;
 }
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-3047/token-table-icon-and-text-misaligned


<!-- Delete this section if your change does not affect UI. -->
## Screen capture


|    Before    |   After    |
| ------------ | ------------ |
| <img width="284" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/db118f45-707e-45f7-81bf-9a2f11b3caa8"> | <img width="282" alt="Screenshot 2023-11-14 at 2 05 45 PM" src="https://github.com/Uniswap/interface/assets/39385577/66b43146-2e97-4aa2-93fa-a02b82c8c28a"> |

(logo is align w/ text now, l2 icon is slightly further right & down, and gap is slightly increase to account for l2 icon changes)