### PR TITLE
fix: disable showing approve cost for arbitrum

### DIFF
--- a/src/state/routing/gas.ts
+++ b/src/state/routing/gas.ts
@@ -1,5 +1,5 @@
 import { MaxUint256, PERMIT2_ADDRESS } from '@uniswap/permit2-sdk'
-import { Currency } from '@uniswap/sdk-core'
+import { ChainId, Currency } from '@uniswap/sdk-core'
 import ERC20_ABI from 'abis/erc20.json'
 import { Erc20, Weth } from 'abis/types'
 import WETH_ABI from 'abis/weth.json'
@@ -25,6 +25,12 @@ export async function getApproveInfo(
 
   // If any of these arguments aren't provided, then we cannot generate approval cost info
   if (!account || !usdCostPerGas) return { needsApprove: false }
+
+  // routing-api under estimates gas for Arbitrum swaps so it inflates cost per gas by a lot
+  // so disable showing approves for Arbitrum until routing-api gives more accurate gas estimates
+  if (currency.chainId === ChainId.ARBITRUM_ONE || currency.chainId === ChainId.ARBITRUM_GOERLI) {
+    return { needsApprove: false }
+  }
 
   const provider = DEPRECATED_RPC_PROVIDERS[currency.chainId as SupportedInterfaceChain]
   const tokenContract = getContract(currency.address, ERC20_ABI, provider) as Erc20


### PR DESCRIPTION
## Description
We are way off for gas estimates for Arbitrum approvals, so disable until we fix

## Screen capture

|    Before    |   After    |
| ------------ | ------------ |
| <img width="533" alt="image" src="https://github.com/Uniswap/interface/assets/59578595/fb6b9308-de46-404c-824b-e201f5cc78f0"> | <img width="692" alt="image" src="https://github.com/Uniswap/interface/assets/59578595/c501ddce-9cf9-4df8-a234-4010640159bd"> |


