### PR TITLE
feat: add spam toggle to mini portfolio

### DIFF
--- a/src/components/AccountDrawer/HideSpamToggle.tsx
+++ b/src/components/AccountDrawer/HideSpamToggle.tsx
@@ -1,0 +1,19 @@
+import { t } from '@lingui/macro'
+import { useAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+
+import { SettingsToggle } from './SettingsToggle'
+
+export const hideSpamAtom = atomWithStorage<boolean>('hideSmallBalances', true)
+
+export function HideSpamToggle() {
+  const [hideSpam, updateHideSpam] = useAtom(hideSpamAtom)
+
+  return (
+    <SettingsToggle
+      title={t`Hide unknown tokens & NFTs`}
+      isActive={hideSpam}
+      toggle={() => void updateHideSpam((value) => !value)}
+    />
+  )
+}

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/ActivityRow.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/ActivityRow.tsx
@@ -43,8 +43,9 @@ function StatusIndicator({ activity: { status, timestamp } }: { activity: Activi
 }
 
 export function ActivityRow({ activity }: { activity: Activity }) {
-  const { chainId, title, descriptor, logos, otherAccount, currencies, hash, prefixIconSrc, offchainOrderStatus } =
-    activity
+  const { chainId, title, descriptor, logos, otherAccount, currencies, hash, prefixIconSrc } = activity
+  const { offchainOrderStatus, isSpam } = activity
+
   const openOffchainActivityModal = useOpenOffchainActivityModal()
 
   const { ENSName } = useENSName(otherAccount)
@@ -58,6 +59,8 @@ export function ActivityRow({ activity }: { activity: Activity }) {
 
     window.open(getExplorerLink(chainId, hash, ExplorerDataType.TRANSACTION), '_blank')
   }, [offchainOrderStatus, chainId, hash, openOffchainActivityModal])
+
+  if (isSpam) return null
 
   return (
     <TraceEvent

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/__snapshots__/parseRemote.test.tsx.snap
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/__snapshots__/parseRemote.test.tsx.snap
@@ -37,7 +37,7 @@ Object {
   "descriptor": "1 SomeCollectionName from ",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
-  "isSpam": undefined,
+  "isSpam": false,
   "logos": Array [
     "imageUrl",
   ],

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/__snapshots__/parseRemote.test.tsx.snap
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/__snapshots__/parseRemote.test.tsx.snap
@@ -6,6 +6,7 @@ Object {
   "descriptor": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [],
   "nonce": 12345,
   "status": "CONFIRMED",
@@ -20,6 +21,7 @@ Object {
   "descriptor": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [],
   "nonce": 12345,
   "status": "CONFIRMED",
@@ -35,6 +37,7 @@ Object {
   "descriptor": "1 SomeCollectionName from ",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": undefined,
   "logos": Array [
     "imageUrl",
   ],
@@ -52,6 +55,7 @@ Object {
   "descriptor": "1 SomeCollectionName",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "imageUrl",
   ],
@@ -132,6 +136,7 @@ Object {
   "descriptor": "100 ETH for 100 WETH",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "https://token-icons.s3.amazonaws.com/eth.png",
     "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
@@ -162,6 +167,7 @@ Object {
   "descriptor": "100 WETH for 100",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "moonpay.svg",
   ],
@@ -178,6 +184,7 @@ Object {
   "descriptor": "1 SomeCollectionName",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "imageUrl",
   ],
@@ -207,6 +214,7 @@ Object {
   "descriptor": "100 WETH from ",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "logoUrl",
   ],
@@ -248,6 +256,7 @@ Object {
   "descriptor": "100 WETH and 100 DAI",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "logoUrl",
     "logoUrl",
@@ -278,6 +287,7 @@ Object {
   "descriptor": "100 DAI to ",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "logoUrl",
   ],
@@ -319,6 +329,7 @@ Object {
   "descriptor": "100 DAI for 100 WETH",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "logoUrl",
   ],
@@ -359,6 +370,7 @@ Object {
   "descriptor": "100 DAI for 100 WETH",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "logoUrl",
   ],
@@ -389,6 +401,7 @@ Object {
   "descriptor": "DAI",
   "from": "0x50EC05ADe8280758E2077fcBC08D878D4aef79C3",
   "hash": "someHash",
+  "isSpam": false,
   "logos": Array [
     "logoUrl",
   ],

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/types.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/types.ts
@@ -19,6 +19,7 @@ export type Activity = {
   nonce?: number | null
   prefixIconSrc?: string
   cancelled?: boolean
+  isSpam?: boolean
 }
 
 export type ActivityMap = { [id: string]: Activity | undefined }

--- a/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
+++ b/src/components/AccountDrawer/MiniPortfolio/Tokens/index.tsx
@@ -1,5 +1,6 @@
 import { BrowserEvent, InterfaceElementName, SharedEventName } from '@uniswap/analytics-events'
 import { TraceEvent } from 'analytics'
+import { hideSpamAtom } from 'components/AccountDrawer/HideSpamToggle'
 import { useCachedPortfolioBalancesQuery } from 'components/PrefetchBalancesWrapper/PrefetchBalancesWrapper'
 import Row from 'components/Row'
 import { DeltaArrow } from 'components/Tokens/TokenDetails/Delta'
@@ -24,6 +25,7 @@ import PortfolioRow, { PortfolioSkeleton, PortfolioTabWrapper } from '../Portfol
 export default function Tokens({ account }: { account: string }) {
   const toggleWalletDrawer = useToggleAccountDrawer()
   const hideSmallBalances = useAtomValue(hideSmallBalancesAtom)
+  const hideSpam = useAtomValue(hideSpamAtom)
   const [showHiddenTokens, setShowHiddenTokens] = useState(false)
 
   const { data } = useCachedPortfolioBalancesQuery({ account })
@@ -31,8 +33,8 @@ export default function Tokens({ account }: { account: string }) {
   const tokenBalances = data?.portfolios?.[0].tokenBalances as TokenBalance[] | undefined
 
   const { visibleTokens, hiddenTokens } = useMemo(
-    () => splitHiddenTokens(tokenBalances ?? [], { hideSmallBalances }),
-    [hideSmallBalances, tokenBalances]
+    () => splitHiddenTokens(tokenBalances ?? [], { hideSmallBalances, hideSpam }),
+    [hideSmallBalances, tokenBalances, hideSpam]
   )
 
   if (!data) {

--- a/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/src/components/AccountDrawer/SettingsMenu.tsx
@@ -13,6 +13,7 @@ import ThemeToggle from 'theme/components/ThemeToggle'
 
 import { AnalyticsToggle } from './AnalyticsToggle'
 import { GitVersionRow } from './GitVersionRow'
+import { HideSpamToggle } from './HideSpamToggle'
 import { LanguageMenuItems } from './LanguageMenu'
 import { SlideOutMenu } from './SlideOutMenu'
 import { SmallBalanceToggle } from './SmallBalanceToggle'
@@ -91,6 +92,7 @@ export default function SettingsMenu({
           <ToggleWrapper currencyConversionEnabled={currencyConversionEnabled}>
             <ThemeToggle />
             <SmallBalanceToggle />
+            <HideSpamToggle />
             <AnalyticsToggle />
             <TestnetsToggle />
           </ToggleWrapper>

--- a/src/graphql/data/activity.graphql
+++ b/src/graphql/data/activity.graphql
@@ -1,6 +1,7 @@
 fragment NFTAssetParts on NftAsset {
   id
   name
+  isSpam
   nftContract {
     id
     chain

--- a/src/utils/splitHiddenTokens.test.tsx
+++ b/src/utils/splitHiddenTokens.test.tsx
@@ -120,9 +120,7 @@ const tokens: TokenBalance[] = [
 
 describe('splitHiddenTokens', () => {
   it('splits spam tokens into hidden but keeps small balances if hideSmallBalances = false', () => {
-    const { visibleTokens, hiddenTokens } = splitHiddenTokens(tokens, {
-      hideSmallBalances: false,
-    })
+    const { visibleTokens, hiddenTokens } = splitHiddenTokens(tokens, { hideSmallBalances: false })
 
     expect(hiddenTokens.length).toBe(1)
     expect(hiddenTokens[0].id).toBe('spam')
@@ -130,6 +128,19 @@ describe('splitHiddenTokens', () => {
     expect(visibleTokens.length).toBe(4)
     expect(visibleTokens[0].id).toBe('low-balance-native')
     expect(visibleTokens[1].id).toBe('low-balance-nonnative')
+    expect(visibleTokens[2].id).toBe('valid')
+    expect(visibleTokens[3].id).toBe('undefined-value')
+  })
+
+  it('splits small balance tokens into hidden but keeps small balances if hideSpam = false', () => {
+    const { visibleTokens, hiddenTokens } = splitHiddenTokens(tokens, { hideSpam: false })
+
+    expect(hiddenTokens.length).toBe(1)
+    expect(hiddenTokens[0].id).toBe('low-balance-nonnative')
+
+    expect(visibleTokens.length).toBe(4)
+    expect(visibleTokens[0].id).toBe('low-balance-native')
+    expect(visibleTokens[1].id).toBe('spam')
     expect(visibleTokens[2].id).toBe('valid')
     expect(visibleTokens[3].id).toBe('undefined-value')
   })


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
adds spam toggle, in parity w/ the uniswap wallet's settings. the spam toggle affects token balances and activity history, allowing us to add multi-chain activity history next, as it prevents i.e. spammy token receive tx's on polygon from filling up activity feed. 

Refactors splitHiddenTokens for simplicity/readability

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-3160/add-multichain-gql-activity-history

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

|    Before    |   After    |
| ------------ | ------------ |
| <img width="393" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/6c27336a-f610-4bdc-8da5-dab96bf655f3"> | <img width="394" alt="image" src="https://github.com/Uniswap/interface/assets/39385577/0c78e4d4-1ed5-4b6e-9495-049cedd896ee"> |