### PR TITLE
fix: only change input currency to weth after eth wrap completes for uniswapx eth input trades

### DIFF
--- a/cypress/e2e/swap/uniswapx.test.ts
+++ b/cypress/e2e/swap/uniswapx.test.ts
@@ -197,7 +197,7 @@ describe('UniswapX Eth Input', () => {
     cy.contains('Swapped')
   })
 
-  it('switches swap input to WETH after wrap', () => {
+  it('keeps ETH as the input currency before wrap completes', () => {
     // Setup a swap
     cy.get('#swap-currency-input .token-amount-input').type('1')
     cy.wait('@quote')
@@ -209,6 +209,19 @@ describe('UniswapX Eth Input', () => {
 
     // Close review modal before wrap is confirmed on chain
     cy.get(getTestSelector('confirmation-close-icon')).click()
+    // Confirm ETH is still the input token before wrap succeeds
+    cy.contains('ETH')
+  })
+
+  it('switches swap input to WETH after wrap', () => {
+    // Setup a swap
+    cy.get('#swap-currency-input .token-amount-input').type('1')
+    cy.wait('@quote')
+
+    // Prompt ETH wrap and confirm
+    cy.get('#swap-button').click()
+    cy.contains('Confirm swap').click()
+    cy.wait('@eth_sendRawTransaction')
     cy.hardhat().then((hardhat) => hardhat.mine())
 
     // Confirm wrap is successful and WETH is now input token

--- a/cypress/e2e/swap/uniswapx.test.ts
+++ b/cypress/e2e/swap/uniswapx.test.ts
@@ -228,10 +228,6 @@ describe('UniswapX Eth Input', () => {
     cy.contains('Wrapped')
     cy.contains('WETH')
 
-    // Reopen review modal and continue swap
-    cy.get('#swap-button').click()
-    cy.contains('Confirm swap').click()
-
     // Approve WETH spend
     cy.wait('@eth_sendRawTransaction')
     cy.hardhat().then((hardhat) => hardhat.mine())
@@ -246,6 +242,11 @@ describe('UniswapX Eth Input', () => {
 
     // Verify swap success
     cy.contains('Swapped')
+
+    // Close modal
+    cy.get(getTestSelector('confirmation-close-icon')).click()
+    // The input currency should now be WETH
+    cy.contains('WETH')
   })
 })
 

--- a/src/components/swap/ConfirmSwapModal.tsx
+++ b/src/components/swap/ConfirmSwapModal.tsx
@@ -133,9 +133,6 @@ function useConfirmModalState({
           onWrap?.()
             .then((wrapTxHash) => {
               setWrapTxHash(wrapTxHash)
-              // After the wrap has succeeded, reset the input currency to be WETH
-              // because the trade will be on WETH -> token
-              onCurrencySelection(Field.INPUT, trade.inputAmount.currency)
               sendAnalyticsEvent(InterfaceEventName.WRAP_TOKEN_TXN_SUBMITTED, {
                 chain_id: chainId,
                 token_symbol: maximumAmountIn?.currency.symbol,
@@ -183,7 +180,6 @@ function useConfirmModalState({
       onWrap,
       trace,
       trade,
-      onCurrencySelection,
     ]
   )
 
@@ -200,10 +196,20 @@ function useConfirmModalState({
   useEffect(() => {
     // If the wrapping step finished, trigger the next step (allowance or swap).
     if (wrapConfirmed && !prevWrapConfirmed) {
+      // After the wrap has succeeded, reset the input currency to be WETH
+      // because the trade will be on WETH -> token
+      onCurrencySelection(Field.INPUT, trade.inputAmount.currency)
       // moves on to either approve WETH or to swap submission
       performStep(pendingModalSteps[1])
     }
-  }, [pendingModalSteps, performStep, prevWrapConfirmed, wrapConfirmed])
+  }, [
+    pendingModalSteps,
+    performStep,
+    prevWrapConfirmed,
+    wrapConfirmed,
+    onCurrencySelection,
+    trade.inputAmount.currency,
+  ])
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Description
This fixes it an issue where the input currency would request WETH trades and would revert to classic swaps bcuz not enough user balance yet :)



https://github.com/Uniswap/interface/assets/59578595/531e2482-ad2d-44ad-8c2b-0401f5854ab3



### QA (ie manual testing)
- Try a small ETH input swap (larger amounts will always remain as UniswapX because of some tricky technical reasons.. DM me for more info)


### Automated testing
manually tested
added e2e test