### PR TITLE
fix: return 404 status for undefined routes

### DIFF
--- a/functions/[[index]].ts
+++ b/functions/[[index]].ts
@@ -21,7 +21,7 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
   try {
     const content = new HTMLRewriter().on('head', new MetaTagInjector(data, request)).transform(await res).body
     return new Response(content, {
-      status: doesMatchPath(requestURL.pathname) || requestURL.toString().includes('.') ? 200 : 404,
+      status: doesMatchPath(requestURL.pathname) || requestURL.pathname.includes('.') ? 200 : 404,
     })
   } catch (e) {
     return res

--- a/functions/[[index]].ts
+++ b/functions/[[index]].ts
@@ -1,8 +1,16 @@
 /* eslint-disable import/no-unused-modules */
+import { paths } from '../src/pages/paths'
 import { MetaTagInjector } from './components/metaTagInjector'
 
+function doesMatchPath(path: string): boolean {
+  const regexPaths = paths.map((p) => '^' + p.replace(/:[^/]+/g, '[^/]+').replace(/\*/g, '.*') + '$')
+
+  return regexPaths.some((regex) => new RegExp(regex).test(path))
+}
+
 export const onRequest: PagesFunction = async ({ request, next }) => {
-  const imageUri = new URL(request.url).origin + '/images/1200x630_Rich_Link_Preview_Image.png'
+  const requestURL = new URL(request.url)
+  const imageUri = requestURL.origin + '/images/1200x630_Rich_Link_Preview_Image.png'
   const data = {
     title: 'Uniswap Interface',
     image: imageUri,
@@ -11,7 +19,10 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
   }
   const res = next()
   try {
-    return new HTMLRewriter().on('head', new MetaTagInjector(data, request)).transform(await res)
+    const content = new HTMLRewriter().on('head', new MetaTagInjector(data, request)).transform(await res).body
+    return new Response(content, {
+      status: doesMatchPath(requestURL.pathname) || requestURL.toString().includes('.') ? 200 : 404,
+    })
   } catch (e) {
     return res
   }

--- a/src/pages/paths.test.ts
+++ b/src/pages/paths.test.ts
@@ -1,0 +1,13 @@
+import { paths } from './paths'
+import { routes } from './RouteDefinitions'
+
+describe('Paths', () => {
+  it('should have every path in the app RouteDefinitions', () => {
+    const appPaths: string[] = routes.map((routeDef) => routeDef.path)
+    appPaths.forEach((path) => {
+      // We don't want to expose these fallback routes to the Cloudflare function.
+      if (path === '*' || path === '/not-found') return
+      expect(paths).toContain(path)
+    })
+  })
+})

--- a/src/pages/paths.ts
+++ b/src/pages/paths.ts
@@ -1,0 +1,38 @@
+// This is just an array of the app's defined paths that can be used in our Cloudflare Functions.
+// Do not add any imports to this file.
+// The array is kept up to date via the tests in src/pages/paths.test.ts
+
+export const paths = [
+  '/',
+  '/explore',
+  '/explore',
+  '/explore/tokens/:chainName/:tokenAddress',
+  '/tokens',
+  '/tokens/:chainName',
+  '/tokens/:chainName/:tokenAddress',
+  'explore/pools/:chainName/:poolAddress',
+  '/vote/*',
+  '/create-proposal',
+  '/send',
+  '/swap',
+  '/pool/v2/find',
+  '/pool/v2',
+  '/pool',
+  '/pool/:tokenId',
+  '/pools/v2/find',
+  '/pools/v2',
+  '/pools',
+  '/pools/:tokenId',
+  '/add/v2',
+  '/add',
+  '/increase',
+  '/remove/v2/:currencyIdA/:currencyIdB',
+  '/remove/:tokenId',
+  '/migrate/v2',
+  '/migrate/v2/:address',
+  '/nfts',
+  '/nfts/asset/:contractAddress/:tokenId',
+  '/nfts/profile',
+  '/nfts/collection/:contractAddress',
+  '/nfts/collection/:contractAddress/activity',
+]


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

add a check in our catch-all CF function for the validity of the requested route. The response data and  app behavior should not change, but if we notice that the request is for a route that the app doesn't handle, we set the status code to 404.


<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-3152/404-pages-should-be-404s

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->

i tested this by running `yarn start:cloud` and making requests to the URL with valid and invalid routes. I verified that the undefined routes receive a 404 in return but all the page assets still load correctly.



### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [x] Unit test
