### PR TITLE
fix: use correct arb subgraph endpoint

### DIFF
--- a/src/graphql/thegraph/apollo.ts
+++ b/src/graphql/thegraph/apollo.ts
@@ -5,7 +5,7 @@ import store from '../../state/index'
 
 const CHAIN_SUBGRAPH_URL: Record<number, string> = {
   [ChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3?source=uniswap',
-  [ChainId.ARBITRUM_ONE]: 'https://thegraph.com/hosted-service/subgraph/ianlapham/uniswap-arbitrum-one?source=uniswap',
+  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-arbitrum-one?source=uniswap',
   [ChainId.OPTIMISM]: 'https://api.thegraph.com/subgraphs/name/ianlapham/optimism-post-regenesis?source=uniswap',
   [ChainId.POLYGON]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-polygon?source=uniswap',
   [ChainId.CELO]: 'https://api.thegraph.com/subgraphs/name/jesse-sawa/uniswap-celo?source=uniswap',

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -6,13 +6,11 @@ import {
   ENS_REGISTRAR_ADDRESSES,
   MULTICALL_ADDRESSES,
   NONFUNGIBLE_POSITION_MANAGER_ADDRESSES,
-  TICK_LENS_ADDRESSES,
   V2_ROUTER_ADDRESS,
   V3_MIGRATOR_ADDRESSES,
 } from '@uniswap/sdk-core'
 import IUniswapV2PairJson from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import IUniswapV2Router02Json from '@uniswap/v2-periphery/build/IUniswapV2Router02.json'
-import TickLensJson from '@uniswap/v3-periphery/artifacts/contracts/lens/TickLens.sol/TickLens.json'
 import UniswapInterfaceMulticallJson from '@uniswap/v3-periphery/artifacts/contracts/lens/UniswapInterfaceMulticall.sol/UniswapInterfaceMulticall.json'
 import NonfungiblePositionManagerJson from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
 import V3MigratorJson from '@uniswap/v3-periphery/artifacts/contracts/V3Migrator.sol/V3Migrator.json'
@@ -32,13 +30,12 @@ import { DEPRECATED_RPC_PROVIDERS, RPC_PROVIDERS } from 'constants/providers'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { useFallbackProviderEnabled } from 'featureFlags/flags/fallbackProvider'
 import { useEffect, useMemo } from 'react'
-import { NonfungiblePositionManager, TickLens, UniswapInterfaceMulticall } from 'types/v3'
+import { NonfungiblePositionManager, UniswapInterfaceMulticall } from 'types/v3'
 import { V3Migrator } from 'types/v3/V3Migrator'
 import { getContract } from 'utils'
 
 const { abi: IUniswapV2PairABI } = IUniswapV2PairJson
 const { abi: IUniswapV2Router02ABI } = IUniswapV2Router02Json
-const { abi: TickLensABI } = TickLensJson
 const { abi: MulticallABI } = UniswapInterfaceMulticallJson
 const { abi: NFTPositionManagerABI } = NonfungiblePositionManagerJson
 const { abi: V2MigratorABI } = V3MigratorJson
@@ -170,10 +167,4 @@ export function useV3NFTPositionManagerContract(withSignerIfPossible?: boolean):
     }
   }, [account, chainId, contract, withSignerIfPossible])
   return contract
-}
-
-export function useTickLens(): TickLens | null {
-  const { chainId } = useWeb3React()
-  const address = chainId ? TICK_LENS_ADDRESSES[chainId] : undefined
-  return useContract(address, TickLensABI) as TickLens | null
 }

--- a/src/hooks/usePoolTickData.ts
+++ b/src/hooks/usePoolTickData.ts
@@ -1,21 +1,17 @@
-import { ChainId, Currency, V3_CORE_FACTORY_ADDRESSES } from '@uniswap/sdk-core'
-import { FeeAmount, nearestUsableTick, Pool, TICK_SPACINGS, tickToPrice } from '@uniswap/v3-sdk'
+import { Currency, V3_CORE_FACTORY_ADDRESSES } from '@uniswap/sdk-core'
+import { FeeAmount, Pool, TICK_SPACINGS, tickToPrice } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
-import { ZERO_ADDRESS } from 'constants/misc'
 import { useAllV3TicksQuery } from 'graphql/thegraph/__generated__/types-and-hooks'
 import { TickData, Ticks } from 'graphql/thegraph/AllV3TicksQuery'
 import { apolloClient } from 'graphql/thegraph/apollo'
 import JSBI from 'jsbi'
-import { useSingleContractMultipleData } from 'lib/hooks/multicall'
 import ms from 'ms'
 import { useEffect, useMemo, useState } from 'react'
 import computeSurroundingTicks from 'utils/computeSurroundingTicks'
 
-import { useTickLens } from './useContract'
 import { PoolState, usePool } from './usePools'
 
 const PRICE_FIXED_DIGITS = 8
-const CHAIN_IDS_MISSING_SUBGRAPH_DATA = [ChainId.ARBITRUM_ONE, ChainId.ARBITRUM_GOERLI]
 
 // Tick with fields parsed to JSBIs, and active liquidity computed.
 export interface TickProcessed {
@@ -25,117 +21,8 @@ export interface TickProcessed {
   price0: string
 }
 
-const REFRESH_FREQUENCY = { blocksPerFetch: 2 }
-
 const getActiveTick = (tickCurrent: number | undefined, feeAmount: FeeAmount | undefined) =>
   tickCurrent && feeAmount ? Math.floor(tickCurrent / TICK_SPACINGS[feeAmount]) * TICK_SPACINGS[feeAmount] : undefined
-
-const bitmapIndex = (tick: number, tickSpacing: number) => {
-  return Math.floor(tick / tickSpacing / 256)
-}
-
-function useTicksFromTickLens(
-  currencyA: Currency | undefined,
-  currencyB: Currency | undefined,
-  feeAmount: FeeAmount | undefined,
-  numSurroundingTicks: number | undefined = 125
-) {
-  const [tickDataLatestSynced, setTickDataLatestSynced] = useState<TickData[]>([])
-
-  const [poolState, pool] = usePool(currencyA, currencyB, feeAmount)
-
-  const tickSpacing = feeAmount && TICK_SPACINGS[feeAmount]
-
-  // Find nearest valid tick for pool in case tick is not initialized.
-  const activeTick = pool?.tickCurrent && tickSpacing ? nearestUsableTick(pool?.tickCurrent, tickSpacing) : undefined
-
-  const { chainId } = useWeb3React()
-
-  const poolAddress =
-    currencyA && currencyB && feeAmount && poolState === PoolState.EXISTS
-      ? Pool.getAddress(
-          currencyA?.wrapped,
-          currencyB?.wrapped,
-          feeAmount,
-          undefined,
-          chainId ? V3_CORE_FACTORY_ADDRESSES[chainId] : undefined
-        )
-      : undefined
-
-  // it is also possible to grab all tick data but it is extremely slow
-  // bitmapIndex(nearestUsableTick(TickMath.MIN_TICK, tickSpacing), tickSpacing)
-  const minIndex = useMemo(
-    () =>
-      tickSpacing && activeTick ? bitmapIndex(activeTick - numSurroundingTicks * tickSpacing, tickSpacing) : undefined,
-    [tickSpacing, activeTick, numSurroundingTicks]
-  )
-
-  const maxIndex = useMemo(
-    () =>
-      tickSpacing && activeTick ? bitmapIndex(activeTick + numSurroundingTicks * tickSpacing, tickSpacing) : undefined,
-    [tickSpacing, activeTick, numSurroundingTicks]
-  )
-
-  const tickLensArgs: [string, number][] = useMemo(
-    () =>
-      maxIndex && minIndex && poolAddress && poolAddress !== ZERO_ADDRESS
-        ? new Array(maxIndex - minIndex + 1)
-            .fill(0)
-            .map((_, i) => i + minIndex)
-            .map((wordIndex) => [poolAddress, wordIndex])
-        : [],
-    [minIndex, maxIndex, poolAddress]
-  )
-
-  const tickLens = useTickLens()
-  const callStates = useSingleContractMultipleData(
-    tickLensArgs.length > 0 ? tickLens : undefined,
-    'getPopulatedTicksInWord',
-    tickLensArgs,
-    REFRESH_FREQUENCY
-  )
-
-  const isError = useMemo(() => callStates.some(({ error }) => error), [callStates])
-  const isLoading = useMemo(() => callStates.some(({ loading }) => loading), [callStates])
-  const IsSyncing = useMemo(() => callStates.some(({ syncing }) => syncing), [callStates])
-  const isValid = useMemo(() => callStates.some(({ valid }) => valid), [callStates])
-
-  const tickData: TickData[] = useMemo(
-    () =>
-      callStates
-        .map(({ result }) => result?.populatedTicks)
-        .reduce(
-          (accumulator, current) => [
-            ...accumulator,
-            ...(current?.map((tickData: TickData) => {
-              return {
-                tick: tickData.tick,
-                liquidityNet: JSBI.BigInt(tickData.liquidityNet),
-              }
-            }) ?? []),
-          ],
-          []
-        ),
-    [callStates]
-  )
-
-  // reset on input change
-  useEffect(() => {
-    setTickDataLatestSynced([])
-  }, [currencyA, currencyB, feeAmount])
-
-  // return the latest synced tickData even if we are still loading the newest data
-  useEffect(() => {
-    if (!IsSyncing && !isLoading && !isError && isValid) {
-      setTickDataLatestSynced(tickData.sort((a, b) => a.tick - b.tick))
-    }
-  }, [isError, isLoading, IsSyncing, tickData, isValid])
-
-  return useMemo(
-    () => ({ isLoading, IsSyncing, isError, isValid, tickData: tickDataLatestSynced }),
-    [isLoading, IsSyncing, isError, isValid, tickDataLatestSynced]
-  )
-}
 
 function useTicksFromSubgraph(
   currencyA: Currency | undefined,
@@ -174,17 +61,9 @@ function useAllV3Ticks(
   error: unknown
   ticks?: TickData[]
 } {
-  const useSubgraph = currencyA ? !CHAIN_IDS_MISSING_SUBGRAPH_DATA.includes(currencyA.chainId) : true
-
-  const tickLensTickData = useTicksFromTickLens(!useSubgraph ? currencyA : undefined, currencyB, feeAmount)
-
   const [skipNumber, setSkipNumber] = useState(0)
   const [subgraphTickData, setSubgraphTickData] = useState<Ticks>([])
-  const {
-    data,
-    error,
-    loading: isLoading,
-  } = useTicksFromSubgraph(useSubgraph ? currencyA : undefined, currencyB, feeAmount, skipNumber)
+  const { data, error, loading: isLoading } = useTicksFromSubgraph(currencyA, currencyB, feeAmount, skipNumber)
 
   useEffect(() => {
     if (data?.ticks.length) {
@@ -196,11 +75,9 @@ function useAllV3Ticks(
   }, [data?.ticks])
 
   return {
-    isLoading: useSubgraph
-      ? isLoading || data?.ticks.length === MAX_THE_GRAPH_TICK_FETCH_VALUE
-      : tickLensTickData.isLoading,
-    error: useSubgraph ? error : tickLensTickData.isError,
-    ticks: useSubgraph ? subgraphTickData : tickLensTickData.tickData,
+    isLoading: isLoading || data?.ticks.length === MAX_THE_GRAPH_TICK_FETCH_VALUE,
+    error,
+    ticks: subgraphTickData,
   }
 }
 


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

fixes a typo causing the arbitrum subgraph to not work

<!-- Delete inapplicable lines: -->
_Linear ticket:_ https://linear.app/uniswap/issue/WEB-3083/redeploy-the-arbitrum-subgraphs-again


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1.  load up the Add Liquidity page, enter inputs and note that the tick data graph isn't populating

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [x] the tick data chart works now

