### PR TITLE
fix: dont show USD price difference for wraps

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -355,13 +355,13 @@ export function Swap({
   const preTaxFiatValueTradeOutput = useUSDPrice(trade?.outputAmount)
   const [stablecoinPriceImpact, preTaxStablecoinPriceImpact] = useMemo(
     () =>
-      routeIsSyncing || !isClassicTrade(trade)
+      routeIsSyncing || !isClassicTrade(trade) || showWrap
         ? [undefined, undefined]
         : [
             computeFiatValuePriceImpact(fiatValueTradeInput.data, fiatValueTradeOutput.data),
             computeFiatValuePriceImpact(fiatValueTradeInput.data, preTaxFiatValueTradeOutput.data),
           ],
-    [fiatValueTradeInput, fiatValueTradeOutput, preTaxFiatValueTradeOutput, routeIsSyncing, trade]
+    [fiatValueTradeInput, fiatValueTradeOutput, preTaxFiatValueTradeOutput, routeIsSyncing, trade, showWrap]
   )
 
   const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useSwapActionHandlers(dispatch)


### PR DESCRIPTION
## Description
There's may still be a cached `trade` when the swap input becomes a wrap, so don't show the USD price difference in that case.

## Screen capture


https://github.com/Uniswap/interface/assets/59578595/d35d50cb-b6e4-4382-9b74-f8ce4d029822






