### PR TITLE
fix: android banner DownloadButton onClick should not propagate up

### DIFF
--- a/src/components/Banner/AndroidAnnouncementBanner/index.tsx
+++ b/src/components/Banner/AndroidAnnouncementBanner/index.tsx
@@ -48,10 +48,12 @@ export default function AndroidAnnouncementBanner() {
           <ThemedText.LabelMicro>
             <Trans>Available now - download from the Google Play Store today</Trans>
           </ThemedText.LabelMicro>
-          <DownloadButton onClick={(e) => {
-            e.stopPropagation() 
-            onClick()
-            }}>
+          <DownloadButton
+            onClick={(e) => {
+              e.stopPropagation()
+              onClick()
+            }}
+          >
             <Trans>Download now</Trans>
           </DownloadButton>
         </TextContainer>

--- a/src/components/Banner/AndroidAnnouncementBanner/index.tsx
+++ b/src/components/Banner/AndroidAnnouncementBanner/index.tsx
@@ -48,7 +48,10 @@ export default function AndroidAnnouncementBanner() {
           <ThemedText.LabelMicro>
             <Trans>Available now - download from the Google Play Store today</Trans>
           </ThemedText.LabelMicro>
-          <DownloadButton onClick={onClick}>
+          <DownloadButton onClick={(e) => {
+            e.stopPropagation() 
+            onClick()
+            }}>
             <Trans>Download now</Trans>
           </DownloadButton>
         </TextContainer>

--- a/src/utils/openDownloadApp.ts
+++ b/src/utils/openDownloadApp.ts
@@ -59,5 +59,7 @@ const openDownloadStore = (options: AnalyticsLinkOptions) => {
     element: options.element,
     appPlatform: options?.appPlatform,
   })
-  window.open(APP_DOWNLOAD_LINKS[options.element], /* target = */ options.linkTarget)
+  // window.open(APP_DOWNLOAD_LINKS[options.element], /* target = */ options.linkTarget)
+  window.open(APP_DOWNLOAD_LINKS[options.element])
+
 }

--- a/src/utils/openDownloadApp.ts
+++ b/src/utils/openDownloadApp.ts
@@ -59,7 +59,5 @@ const openDownloadStore = (options: AnalyticsLinkOptions) => {
     element: options.element,
     appPlatform: options?.appPlatform,
   })
-  // window.open(APP_DOWNLOAD_LINKS[options.element], /* target = */ options.linkTarget)
-  window.open(APP_DOWNLOAD_LINKS[options.element])
-
+  window.open(APP_DOWNLOAD_LINKS[options.element], /* target = */ options.linkTarget)
 }


### PR DESCRIPTION
DownloadButton, which is nested in TextContainer, is bubbling up its onClick to the textcontainer - causing problems. Need to prevent event from bubbling up to parent TextContainer.