### PR TITLE
fix: MenuItem without line wrap

### DIFF
--- a/apps/web/src/components/NavBar/index.tsx
+++ b/apps/web/src/components/NavBar/index.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
+import clsx, { ClassValue } from 'clsx'
 import { useAccountDrawer } from 'components/AccountDrawer'
 import { UniIcon } from 'components/Logo/UniIcon'
 import Web3Status from 'components/Web3Status'
@@ -34,16 +35,17 @@ const Nav = styled.nav`
 interface MenuItemProps {
   href: string
   id?: NavLinkProps['id']
+  className?: ClassValue
   isActive?: boolean
   children: ReactNode
   dataTestId?: string
 }
 
-const MenuItem = ({ href, dataTestId, id, isActive, children }: MenuItemProps) => {
+const MenuItem = ({ href, dataTestId, id, className, isActive, children }: MenuItemProps) => {
   return (
     <NavLink
       to={href}
-      className={isActive ? styles.activeMenuItem : styles.menuItem}
+      className={clsx(isActive ? styles.activeMenuItem : styles.menuItem, className)}
       id={id}
       style={{ textDecoration: 'none' }}
       data-testid={dataTestId}
@@ -83,11 +85,9 @@ export const PageTabs = () => {
           <Trans>NFTs</Trans>
         </MenuItem>
       )}
-      <Box display={{ sm: 'flex', lg: 'none', xxl: 'flex' }} width="full">
-        <MenuItem href="/pools" dataTestId="pool-nav-link" isActive={isPoolActive}>
-          <Trans>Pools</Trans>
-        </MenuItem>
-      </Box>
+      <MenuItem href="/pools" className={styles.pools} dataTestId="pool-nav-link" isActive={isPoolActive}>
+        <Trans>Pools</Trans>
+      </MenuItem>
       <Box marginY="4">
         <MenuDropdown />
       </Box>

--- a/apps/web/src/components/NavBar/style.css.ts
+++ b/apps/web/src/components/NavBar/style.css.ts
@@ -77,6 +77,7 @@ const baseMenuItem = style([
   {
     lineHeight: '22px',
     textDecoration: 'none',
+    whiteSpace: 'nowrap',
     ':hover': {
       background: vars.color.lightGrayOverlay,
     },
@@ -95,5 +96,11 @@ export const activeMenuItem = style([
   sprinkles({
     color: 'neutral1',
     background: 'none',
+  }),
+])
+
+export const pools = style([
+  sprinkles({
+    display: { sm: 'flex', lg: 'none', xxl: 'flex' },
   }),
 ])


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Do not wrap menu items, #6265 is fixed too.


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| ![CleanShot 2023-11-27 at 16 51 37@2x](https://github.com/Uniswap/interface/assets/21138718/f2e1b273-7a1f-4f7a-a9dd-48e670b965c4) | ![CleanShot 2023-11-27 at 16 53 10@2x](https://github.com/Uniswap/interface/assets/21138718/a37e87fe-a619-4c87-a580-0c29faf01a20) |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| ![CleanShot 2023-11-27 at 16 52 46@2x](https://github.com/Uniswap/interface/assets/21138718/9c2f5bd0-56df-4d86-8866-2d9b8a00d905)  | ![CleanShot 2023-11-27 at 16 53 35@2x](https://github.com/Uniswap/interface/assets/21138718/ddf6f418-de0d-4d5d-a281-52565a00410b) |


### Reproducing the error
1. set language to 简体中文






