### PR TITLE
Adjust price for decimals when comparing to 1

### DIFF
--- a/apps/web/src/components/PositionListItem/index.tsx
+++ b/apps/web/src/components/PositionListItem/index.tsx
@@ -146,7 +146,7 @@ export function getPriceOrderingFromPositionForUI(position?: Position): {
   }
 
   // if both prices are below 1, invert
-  if (position.token0PriceUpper.lessThan(1)) {
+  if (position.token0PriceUpper.adjustedForDecimals.lessThan(1)) {
     return {
       priceLower: position.token0PriceUpper.invert(),
       priceUpper: position.token0PriceLower.invert(),


### PR DESCRIPTION
In the position list component, when checking if the price should be inverted for display purposes, the check is done on the (unadjusted) price which can lead to confusion/inconsistencies.

For example, a pool with a token0 with 2 decimals and a token1 with 6 decimals will be displayed differently than a pool with a token0 with 6 decimals and a token1 with 6 decimals, even though they have the same adjusted price below 1 (the first pool will fail the check and return an (unadjusted) price above 1).