### PR TITLE
Fix for Uniswap #2648: Sets price in price bar to match the execution price

### DIFF
--- a/apps/web/src/components/swap/TradePrice.tsx
+++ b/apps/web/src/components/swap/TradePrice.tsx
@@ -33,7 +33,7 @@ export default function TradePrice({ price }: TradePriceProps) {
   const [showInverted, setShowInverted] = useState<boolean>(false)
 
   const { baseCurrency, quoteCurrency } = price
-  const { data: usdPrice } = useUSDPrice(tryParseCurrencyAmount('1', showInverted ? baseCurrency : quoteCurrency))
+  const { data: usdPrice } = useUSDPrice(tryParseCurrencyAmount('1',  showInverted ? quoteCurrency : baseCurrency))
 
   const formattedPrice = useMemo(() => {
     try {
@@ -49,6 +49,10 @@ export default function TradePrice({ price }: TradePriceProps) {
 
   const text = `${'1 ' + labelInverted + ' = ' + formattedPrice ?? '-'} ${label}`
 
+  const executionPrice = usdPrice ? 
+    (Number(formattedPrice) * usdPrice)
+    : 0;
+
   return (
     <StyledPriceContainer
       onClick={(e) => {
@@ -63,7 +67,7 @@ export default function TradePrice({ price }: TradePriceProps) {
           <Trans>
             (
             {formatNumber({
-              input: usdPrice,
+              input: executionPrice,
               type: NumberType.FiatTokenPrice,
             })}
             )


### PR DESCRIPTION
This PR makes it so that the price in the price bar matched the execution price, not the price of 1 base, as shown below. 

![Uniswap exec price issue](https://github.com/Uniswap/interface/assets/41202834/5e3007e0-b011-4109-88ce-01323fedfa35)

Above we see 1 ETH = 20.2571 DAI, which is ~$20.27. Before, the price shown was the price of 1 ETH.


Also, on a side note, I experienced an issue while trying to run this locally. After cloning down the repo and running yarn install and yarn web start at the project's root, I got the below error:

![uniswap running issues](https://github.com/Uniswap/interface/assets/41202834/c8ff2c1d-eb62-49c6-bd9e-5a920254298e)

I was able to X it out in the browser and continue working, but just a heads up.