### PR TITLE
don't request undefined background image if there is no background image

### DIFF
--- a/apps/web/src/components/About/Card.tsx
+++ b/apps/web/src/components/About/Card.tsx
@@ -15,7 +15,9 @@ const StyledCard = styled.div<{ $isDarkMode: boolean; $backgroundImgSrc?: string
   background: ${({ $isDarkMode, $backgroundImgSrc, $type, theme }) =>
     $isDarkMode
       ? `${theme.surface2} ${$backgroundImgSrc ? ` url(${$backgroundImgSrc})` : ''}`
-      : `${$type === CardType.Primary ? 'white' : theme.surface2} url(${$backgroundImgSrc})`};
+      : `${$type === CardType.Primary ? 'white' : theme.surface2} ${
+        $backgroundImgSrc ? ` url(${$backgroundImgSrc})` : ''
+      }`};
   background-size: auto 100%;
   background-position: right;
   background-repeat: no-repeat;


### PR DESCRIPTION
When accessing the frontpage of the interface, the interface queries an image at path `/undefined`. This results an error in the console. This removes this unnecessary query