### PR TITLE
fix: update USDC address on Celo Alfajores testnet

### DIFF
--- a/apps/web/src/constants/routing.ts
+++ b/apps/web/src/constants/routing.ts
@@ -26,7 +26,8 @@ import {
   USDC_AVALANCHE,
   USDC_BASE,
   USDC_BSC,
-  USDC_CELO,
+  USDC_CELO_ALFAJ0RES_NATIVE,
+  USDC_CELO_NATIVE,
   USDC_MAINNET,
   USDC_OPTIMISM,
   USDC_OPTIMISM_GOERLI,
@@ -142,13 +143,16 @@ export const COMMON_BASES: ChainCurrencyList = {
     WETH_POLYGON_MUMBAI,
   ].map(buildCurrencyInfo),
 
-  [ChainId.CELO]: [nativeOnChain(ChainId.CELO), CEUR_CELO, CUSD_CELO, PORTAL_ETH_CELO, USDC_CELO, WBTC_CELO].map(
+  [ChainId.CELO]: [nativeOnChain(ChainId.CELO), CEUR_CELO, CUSD_CELO, PORTAL_ETH_CELO, USDC_CELO_NATIVE, WBTC_CELO].map(
     buildCurrencyInfo
   ),
 
-  [ChainId.CELO_ALFAJORES]: [nativeOnChain(ChainId.CELO_ALFAJORES), CUSD_CELO_ALFAJORES, CEUR_CELO_ALFAJORES].map(
-    buildCurrencyInfo
-  ),
+  [ChainId.CELO_ALFAJORES]: [
+    nativeOnChain(ChainId.CELO_ALFAJORES),
+    CUSD_CELO_ALFAJORES,
+    CEUR_CELO_ALFAJORES,
+    USDC_CELO_ALFAJ0RES_NATIVE,
+  ].map(buildCurrencyInfo),
 
   [ChainId.BNB]: [nativeOnChain(ChainId.BNB), DAI_BSC, USDC_BSC, USDT_BSC, ETH_BSC, BTC_BSC, BUSD_BSC].map(
     buildCurrencyInfo

--- a/apps/web/src/constants/tokens.ts
+++ b/apps/web/src/constants/tokens.ts
@@ -61,7 +61,14 @@ export const USDC_POLYGON_MUMBAI = new Token(
   'USDC',
   'USD Coin'
 )
-export const USDC_CELO = new Token(ChainId.CELO, '0xceba9300f2b948710d2653dd7b07f33a8b32118c', 6, 'USDC', 'USD Coin')
+export const USDC_CELO_NATIVE = new Token(ChainId.CELO, '0xcebA9300f2b948710d2653dD7B07f33A8B32118C', 6, 'USDC', 'USDC')
+export const USDC_CELO_ALFAJ0RES_NATIVE = new Token(
+  ChainId.CELO_ALFAJORES,
+  '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+  6,
+  'USDC',
+  'USDC CELO Testnet'
+)
 export const USDC_BASE = new Token(ChainId.BASE, '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', 6, 'USDC', 'USD Coin')
 
 export const DAI = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'Dai Stablecoin')
@@ -478,8 +485,8 @@ export const TOKEN_SHORTHANDS: { [shorthand: string]: { [chainId in ChainId]?: s
     [ChainId.POLYGON_MUMBAI]: USDC_POLYGON_MUMBAI.address,
     [ChainId.BNB]: USDC_BSC.address,
     [ChainId.BASE]: USDC_BASE.address,
-    [ChainId.CELO]: USDC_CELO.address,
-    [ChainId.CELO_ALFAJORES]: USDC_CELO.address,
+    [ChainId.CELO]: USDC_CELO_NATIVE.address,
+    [ChainId.CELO_ALFAJORES]: USDC_CELO_ALFAJ0RES_NATIVE.address,
     [ChainId.GOERLI]: USDC_GOERLI.address,
     [ChainId.SEPOLIA]: USDC_SEPOLIA.address,
     [ChainId.AVALANCHE]: USDC_AVALANCHE.address,
@@ -496,8 +503,8 @@ const STABLECOINS: { [chainId in ChainId]: Token[] } = {
   [ChainId.POLYGON_MUMBAI]: [USDC_POLYGON_MUMBAI],
   [ChainId.BNB]: [USDC_BSC],
   [ChainId.BASE]: [USDC_BASE],
-  [ChainId.CELO]: [USDC_CELO],
-  [ChainId.CELO_ALFAJORES]: [USDC_CELO],
+  [ChainId.CELO]: [USDC_CELO_NATIVE],
+  [ChainId.CELO_ALFAJORES]: [USDC_CELO_ALFAJ0RES_NATIVE],
   [ChainId.GOERLI]: [USDC_GOERLI],
   [ChainId.SEPOLIA]: [USDC_SEPOLIA],
   [ChainId.AVALANCHE]: [USDC_AVALANCHE],


### PR DESCRIPTION
Currently, the USDC address specified for Celo Alfajores testnet is incorrect.

https://github.com/Uniswap/interface/blob/1ffb97086790de08b503311e85306223e9427c8b/apps/web/src/constants/tokens.ts#L481-L482

The correct USDC addresses are:

1. Celo (mainnet): [`0xcebA93...`](https://celoscan.io/address/0xcebA9300f2b948710d2653dD7B07f33A8B32118C)
2. Celo Alfajores (testnet): [`0x2F25de...`](https://alfajores.celoscan.io/address/0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B)

```diff
- [ChainId.CELO_ALFAJORES]: USDC_CELO.address,
+ [ChainId.CELO_ALFAJORES]: USDC_CELO_ALFAJ0RES_NATIVE.address,
```

```diff
  export const USDC_CELO_NATIVE = new Token(ChainId.CELO, '0xcebA9300f2b948710d2653dD7B07f33A8B32118C', 6, 'USDC', 'USDC')
+ export const USDC_CELO_ALFAJ0RES_NATIVE = new Token(
+  ChainId.CELO_ALFAJORES,
+  '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+  6,
+  'USDC',
+  'USDC CELO Testnet'
+ )
```