### PR TITLE
fix(Settings): dont hide deadline settings on L2s

### DIFF
--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -118,7 +118,7 @@ export default function SettingsTab({
   hideRoutingSettings?: boolean
 }) {
   const { chainId: connectedChainId } = useWeb3React()
-  const showDeadlineSettings = Boolean(chainId && !L2_CHAIN_IDS.includes(chainId))
+  const showDeadlineSettings = Boolean(chainId)
   const node = useRef<HTMLDivElement | null>(null)
   const isOpen = useModalIsOpen(ApplicationModal.SETTINGS)
 


### PR DESCRIPTION
5 minute deadline on L2 makes it really difficult to get LP transactions through on multisigs even when all signers are present at the same time.