### PR TITLE
fix: display currencyBase symbol at the lower price

### DIFF
--- a/apps/web/src/pages/Pool/PositionPage.tsx
+++ b/apps/web/src/pages/Pool/PositionPage.tsx
@@ -1024,7 +1024,7 @@ function PositionPageContent() {
 
                       {inRange && (
                         <Text fontSize={11} color="$neutral3">
-                          <Trans i18nKey="pool.position.100" />
+                          <Trans i18nKey="pool.position.100.at" values={{ symbol: currencyBase?.symbol }} />
                         </Text>
                       )}
                     </AutoColumn>


### PR DESCRIPTION
Using `pool.position.100.at` instead of `pool.position.100` for lower tick's card