### PR TITLE
Adding check for __generated__ folder and creating it if needed

### DIFF
--- a/apps/web/scripts/compile-ajv-validators.js
+++ b/apps/web/scripts/compile-ajv-validators.js
@@ -6,15 +6,20 @@ const Ajv = require('ajv')
 const standaloneCode = require('ajv/dist/standalone').default
 const addFormats = require('ajv-formats')
 const schema = require('@uniswap/token-lists/dist/tokenlist.schema.json')
+const generated_path = path.join(__dirname, '../src/utils/__generated__')
+
+if (!fs.existsSync(generated_path)) {
+  fs.mkdirSync(generated_path, { recursive: true })
+}
 
 const tokenListAjv = new Ajv({ code: { source: true, esm: true } })
 addFormats(tokenListAjv)
 const validateTokenList = tokenListAjv.compile(schema)
 let tokenListModuleCode = standaloneCode(tokenListAjv, validateTokenList)
-fs.writeFileSync(path.join(__dirname, '../src/utils/__generated__/validateTokenList.js'), tokenListModuleCode)
+fs.writeFileSync(generated_path + '/validateTokenList.js', tokenListModuleCode)
 
 const tokensAjv = new Ajv({ code: { source: true, esm: true } })
 addFormats(tokensAjv)
 const validateTokens = tokensAjv.compile({ ...schema, required: ['tokens'] })
 let tokensModuleCode = standaloneCode(tokensAjv, validateTokens)
-fs.writeFileSync(path.join(__dirname, '../src/utils/__generated__/validateTokens.js'), tokensModuleCode)
+fs.writeFileSync(generated_path + '/validateTokens.js', tokensModuleCode)


### PR DESCRIPTION
Running `yarn g:prepare` on freshly cloned repo fails due to missing `__generated__` folder.  Added check if folder exists and creating it if it does not. 

Multiple people has run into this judging be issues I found eg:
`https://github.com/Uniswap/interface/discussions/7718`

Took me 15 min to figure out. Everyone who clones repo will run into it. Let's save peoples time. 

🖖