### PR TITLE
Typo Update README.md

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -18,4 +18,4 @@ Shared code for wallet functionality and larger UI components.
 
 ## `utilities`
 
-Shared utility functionality used across app applications. Should not import any other packages or applications.
+Shared utility functionality used across applications. Should not import any other packages or applications.


### PR DESCRIPTION
<img width="810" alt="Снимок экрана 2024-11-10 в 15 44 06" src="https://github.com/user-attachments/assets/11a65433-ce64-40e5-8fb4-505f3b4e07d9">

"Shared utility functionality used across app applications."

The word "**app**" is redundant here, and it should be corrected to:

"Shared utility functionality used across applications."

Corrected.