### PR TITLE
Fix typo Update README.md

### DIFF
--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -51,7 +51,7 @@ E2E tests should remain as close as possible to production, but sometimes mockin
 
 Only mocking entire files is supported at the moment, so you may need to reorganize functions. To mock a file, create a new one with the same name and extension `mock.ts` (e.g. `AnimatedHeader.ts` -> `AnimatedHeader.mock.ts`) in the same directory. The metro bundler will override any file that has a `mock.ts` equivalent in Detox runs.
 
-Android native views based on jetpack compose and libraries utilizing long-running asynchronouse background processes like sentry are not supported by detox currently. Imports mocking is unfortunatelly not supported by detox yet. If such problems occur, the entire component using problematic library needs to be mocked or a component exposing only targeted library needs to be created and then it can be mocked, precisely replacing only targeted library.
+Android native views based on jetpack compose and libraries utilizing long-running asynchronouse background processes like sentry are not supported by detox currently. Imports mocking is unfortunately not supported by detox yet. If such problems occur, the entire component using problematic library needs to be mocked or a component exposing only targeted library needs to be created and then it can be mocked, precisely replacing only targeted library.
 
 To mock a component for specific platform follow this pattern:
 iOS: `AnimatedHeader.ts` -> `AnimatedHeader.ios.mock.ts`


### PR DESCRIPTION
# Fix Typo in README.md

## Summary of Changes
- Corrected a typo: "unfortunatelly" to "unfortunately" in the `apps/mobile/e2e/README.md` file for improved clarity and accuracy.

---

## Additional Notes
This is a minor documentation update and does not affect the functionality of the project.  
Please review and merge at your convenience. Thank you! 😊
