### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open source repository for all Uniswap front end interfaces maintained by Uni
 
 ## Socials / Contact
 
-- Twitter: [@Uniswap](https://twitter.com/Uniswap)
+- Twitter: [@Uniswap](https://x.com/Uniswap)
 - Reddit: [/r/Uniswap](https://www.reddit.com/r/Uniswap/)
 - Email: [contact@uniswap.org](mailto:contact@uniswap.org)
 - Discord: [Uniswap](https://discord.gg/FCfyBSbCU5)

--- a/apps/mobile/src/features/externalProfile/ProfileHeader.tsx
+++ b/apps/mobile/src/features/externalProfile/ProfileHeader.tsx
@@ -116,7 +116,7 @@ export const ProfileHeader = memo(function ProfileHeader({ address }: ProfileHea
 
   const onPressTwitter = useCallback(async () => {
     if (twitter) {
-      await openUri(`https://twitter.com/${twitter}`)
+      await openUri(`https://x.com/${twitter}`)
     }
   }, [twitter])
 

--- a/apps/web/functions/explore/tokens/token.test.ts
+++ b/apps/web/functions/explore/tokens/token.test.ts
@@ -48,7 +48,7 @@ test.each(tokens)('should inject metadata for valid tokens', async (token) => {
   )
   expect(body).toContain(`<meta property="twitter:image" content="${token.image}" data-rh="true">`)
   expect(body).toContain(
-    `<meta property="twitter:image:alt" content="Get ${token.tokenData.symbol} on Uniswap" data-rh="true">`,
+    `<meta property=":image:alt" content="Get ${token.tokenData.symbol} on Uniswap" data-rh="true">`,
   )
 })
 

--- a/apps/web/src/components/Tokens/TokenDetails/ShareButton.tsx
+++ b/apps/web/src/components/Tokens/TokenDetails/ShareButton.tsx
@@ -38,7 +38,7 @@ export function openShareTweetWindow(name: string) {
   const positionX = (window.screen.width - TWITTER_WIDTH) / 2
   const positionY = (window.screen.height - TWITTER_HEIGHT) / 2
   window.open(
-    `https://twitter.com/intent/tweet?text=Check%20out%20${name}%20${currentLocation}%20via%20@Uniswap`,
+    `https://x.com/intent/tweet?text=Check%20out%20${name}%20${currentLocation}%20via%20@Uniswap`,
     'newwindow',
     `left=${positionX}, top=${positionY}, width=${TWITTER_WIDTH}, height=${TWITTER_HEIGHT}`,
   )

--- a/apps/web/src/nft/components/collection/CollectionStats.tsx
+++ b/apps/web/src/nft/components/collection/CollectionStats.tsx
@@ -110,7 +110,7 @@ const MobileSocialsPopover = ({
             </MobileSocialsIcon>
           ) : null}
           {collectionStats.twitterUrl ? (
-            <MobileSocialsIcon href={'https://twitter.com/' + collectionStats.twitterUrl}>
+            <MobileSocialsIcon href={'https://x.com/' + collectionStats.twitterUrl}>
               <Box margin="auto" paddingTop="6">
                 <TwitterIcon
                   fill={themeVars.colors.neutral2}
@@ -198,7 +198,7 @@ const CollectionName = ({
             </SocialsIcon>
           ) : null}
           {collectionStats.twitterUrl ? (
-            <SocialsIcon href={'https://twitter.com/' + collectionStats.twitterUrl}>
+            <SocialsIcon href={'https://x.com/' + collectionStats.twitterUrl}>
               <TwitterIcon
                 fill={themeVars.colors.neutral2}
                 color={themeVars.colors.neutral2}

--- a/apps/web/src/nft/components/details/AssetDetails.tsx
+++ b/apps/web/src/nft/components/details/AssetDetails.tsx
@@ -437,7 +437,7 @@ export const AssetDetails = ({ asset, collection }: AssetDetailsProps) => {
           </DescriptionText>
           <SocialsContainer>
             {collection.externalUrl && <Resource name="Website" link={`${collection.externalUrl}`} />}
-            {collection.twitterUrl && <Resource name="Twitter" link={`https://twitter.com/${collection.twitterUrl}`} />}
+            {collection.twitterUrl && <Resource name="Twitter" link={`https://x.com/${collection.twitterUrl}`} />}
             {collection.discordUrl && <Resource name="Discord" link={collection.discordUrl} />}
           </SocialsContainer>
         </>

--- a/apps/web/src/nft/utils/asset.tsx
+++ b/apps/web/src/nft/utils/asset.tsx
@@ -76,7 +76,7 @@ export const getMarketplaceIcon = (marketplace: string, size: string | number = 
 }
 
 export const generateTweetForAsset = (asset: GenieAsset): string => {
-  return `https://twitter.com/intent/tweet?text=Check%20out%20${
+  return `https://x.com/intent/tweet?text=Check%20out%20${
     asset.name ? encodeURIComponent(asset.name) : `${asset.collectionName}%20%23${asset.tokenId}`
   }%20(${asset.collectionName})%20https://app.uniswap.org/nfts/asset/${asset.address}/${asset.tokenId}%20via%20@uniswap`
 }
@@ -87,7 +87,7 @@ export const generateTweetForPurchase = (assets: UpdatedGenieAsset[], txHashUrl:
   const tweetText = `I just purchased ${
     multipleCollections ? `${assets.length} NFTs` : `${assets.length} ${assets[0].collectionName ?? 'NFT'}`
   } with @Uniswap 🦄\n\nhttps://app.uniswap.org/nfts/${collectionUrl}\n${txHashUrl}`
-  return `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`
+  return `https://x.com/intent/tweet?text=${encodeURIComponent(tweetText)}`
 }
 
 function getMinListingPrice(listings: Listing[]): number {
@@ -122,5 +122,5 @@ export const generateTweetForList = (assets: WalletAsset[]): string => {
         } items on @Uniswap at https://app.uniswap.org/nfts/profile\n\nCollections: ${mapAssetsToCollections(assets)
           .map(({ collection, items }) => `${collection} ${items.map((item) => item).join(', ')}`)
           .join(', ')} \n\nMarketplaces: ${assets[0].marketplaces?.map((market) => market.name).join(', ')}`
-  return `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`
+  return `https://x.com/intent/tweet?text=${encodeURIComponent(tweetText)}`
 }

--- a/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
+++ b/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
@@ -143,7 +143,7 @@ export function NewsletterEtc() {
             </SquareCard>
             <RectCard
               group="card"
-              href="https://twitter.com/Uniswap/"
+              href="https://x.com/Uniswap/"
               target="_blank"
               rel="noopener noreferrer"
               backgroundColor="$accent2"

--- a/packages/wallet/src/utils/linking.ts
+++ b/packages/wallet/src/utils/linking.ts
@@ -79,5 +79,5 @@ export function getTokenUrl(currencyId: string, addMobileUTMTags: boolean = fals
 }
 
 export function getTwitterLink(twitterName: string): string {
-  return `https://twitter.com/${twitterName}`
+  return `https://x.com/${twitterName}`
 }


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.