### PR TITLE
Fix: compile-ajv-validator's directory issue

### DIFF
--- a/apps/web/scripts/compile-ajv-validators.js
+++ b/apps/web/scripts/compile-ajv-validators.js
@@ -6,15 +6,19 @@ const Ajv = require('ajv')
 const standaloneCode = require('ajv/dist/standalone').default
 const addFormats = require('ajv-formats')
 const schema = require('@uniswap/token-lists/dist/tokenlist.schema.json')
+const outputDir = path.join(__dirname, '../src/utils/__generated__')
+
+// ensure the directory exists
+fs.mkdirSync(outputDir, { recursive: true })
 
 const tokenListAjv = new Ajv({ code: { source: true, esm: true } })
 addFormats(tokenListAjv)
 const validateTokenList = tokenListAjv.compile(schema)
 let tokenListModuleCode = standaloneCode(tokenListAjv, validateTokenList)
-fs.writeFileSync(path.join(__dirname, '../src/utils/__generated__/validateTokenList.js'), tokenListModuleCode)
+fs.writeFileSync(path.join(outputDir, 'validateTokenList.js'), tokenListModuleCode)
 
 const tokensAjv = new Ajv({ code: { source: true, esm: true } })
 addFormats(tokensAjv)
 const validateTokens = tokensAjv.compile({ ...schema, required: ['tokens'] })
 let tokensModuleCode = standaloneCode(tokensAjv, validateTokens)
-fs.writeFileSync(path.join(__dirname, '../src/utils/__generated__/validateTokens.js'), tokensModuleCode)
+fs.writeFileSync(path.join(outputDir, 'validateTokens.js'), tokensModuleCode)


### PR DESCRIPTION
**Error while running the command "yarn":-**
@uniswap/interface:ajv: node:internal/fs/utils:356
@uniswap/interface:ajv:     throw err;
@uniswap/interface:ajv:     ^
@uniswap/interface:ajv: 
@uniswap/interface:ajv: Error: ENOENT: no such file or directory, open '/------/interface/apps/web/src/utils/__generated__/validateTokenList.js'
@uniswap/interface:ajv:     at Object.openSync (node:fs:596:3)
@uniswap/interface:ajv:     at Object.writeFileSync (node:fs:2322:35)
@uniswap/interface:ajv:     at Object.<anonymous> (/------/interface/apps/web/scripts/compile-ajv-validators.js:14:4)
@uniswap/interface:ajv:     at Module._compile (node:internal/modules/cjs/loader:1364:14)
@uniswap/interface:ajv:     at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
@uniswap/interface:ajv:     at Module.load (node:internal/modules/cjs/loader:1203:32)
@uniswap/interface:ajv:     at Module._load (node:internal/modules/cjs/loader:1019:12)
@uniswap/interface:ajv:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
@uniswap/interface:ajv:     at node:internal/main/run_main_module:28:49 {
@uniswap/interface:ajv:   errno: -2,
@uniswap/interface:ajv:   syscall: 'open',
@uniswap/interface:ajv:   code: 'ENOENT',
@uniswap/interface:ajv:   path: '/-------/interface/apps/web/src/utils/__generated__/validateTokenList.js'

**Fix:-**
auto created and ensured the directory exists before joining the path