### PR TITLE
Update ForceUpgradeModal link in README to current GitHub location

### DIFF
--- a/packages/wallet/src/features/forceUpgrade/README.md
+++ b/packages/wallet/src/features/forceUpgrade/README.md
@@ -25,4 +25,4 @@ force_upgrade: {
 
 ## UI
 
-[ForceUpgradeModal](https://github.com/Uniswap/universe/blob/main/apps/mobile/src/components/forceUpgrade/ForceUpgradeModal.tsx)
+[ForceUpgradeModal](https://github.com/Uniswap/interface/blob/main/apps/mobile/src/components/forceUpgrade/ForceUpgradeModal.tsx)


### PR DESCRIPTION
Replaced the outdated link to ForceUpgradeModal in the README with the correct, up-to-date URL pointing to the component in the Uniswap/interface repository. This ensures that documentation references the actual source code location and prevents confusion for developers.