### PR TITLE
Promise

### DIFF
--- a/apps/web/src/connection/EmbeddedWalletConnector.ts
+++ b/apps/web/src/connection/EmbeddedWalletConnector.ts
@@ -127,12 +127,10 @@ export function embeddedWallet(_parameters: EmbeddedWalletParameters = {}) {
       }
 
       try {
-        await Promise.all([
-          provider.request({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId }],
-          }),
-        ])
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId }],
+        })
         return chain
       } catch (err) {
         const error = err as RpcError


### PR DESCRIPTION
Promise.all is unnecessary here because only a single promise is being passed.
It's not a critical issue, but it's better to avoid this pattern as it can be misleading — it may suggest that multiple promises are involved.