### PR TITLE
fix(web): Implement enhanced account dropdown ux

### DIFF
--- a/apps/web/src/components/AccountDrawer/index.tsx
+++ b/apps/web/src/components/AccountDrawer/index.tsx
@@ -107,7 +107,6 @@ const SideDrawerContainer = styled(Flex, {
   },
 })
 
-
 type AccountDrawerProps = {
   isOpen: boolean
   onClose: () => void


### PR DESCRIPTION
## Summary
  Updated AccountDrawer to use a modal-style darkened background overlay (Scrim) instead of a close
   button, matching the pattern used by other modals in the app. Users can now close the drawer by
  clicking anywhere outside it.

 ## Changes
 - Added Scrim component for darkened background overlay
  - Removed the close button with chevron icon
  - Fixed z-index layering to ensure drawer appears above the background
  - Implemented click-outside-to-close functionality

## Before

https://github.com/user-attachments/assets/8a3f5840-5db8-4174-a8d3-d76a029d4b1c

## After

https://github.com/user-attachments/assets/84affdef-0fc8-4bff-89e4-2a1388a95940