### PR TITLE
fix: pod version command

### DIFF
--- a/scripts/local-version-check.sh
+++ b/scripts/local-version-check.sh
@@ -26,7 +26,7 @@ localRubyVersion=$(echo "$localRubyOutput" | awk '/ruby/ {print $2}')
 check "ruby" $localRubyVersion "3.2.2"
 
 # Check cocoapods version
-localPodVersion="$(cd apps/mobile && bundle exec pod --version cd ../..)"
+localPodVersion="$(cd apps/mobile && bundle exec pod --version)"
 check "pod" $localPodVersion "1.14.3"
 
 echo "All versions match!"


### PR DESCRIPTION
the `cd ../..` slipped into the same line with `bundle exec pod --version`, breaking the command.
cleaned it up so it runs as intended.
