### PR TITLE
fix: replace @ts-expect-error with proper type assertion in finalizeTransaction

### DIFF
--- a/packages/wallet/src/features/transactions/executeTransaction/services/TransactionRepository/transactionRepositoryImplRedux.ts
+++ b/packages/wallet/src/features/transactions/executeTransaction/services/TransactionRepository/transactionRepositoryImplRedux.ts
@@ -6,6 +6,7 @@ import { AddressTransactionsSelector } from 'uniswap/src/features/transactions/s
 import { transactionActions } from 'uniswap/src/features/transactions/slice'
 import { isClassic } from 'uniswap/src/features/transactions/swap/utils/routing'
 import {
+  type FinalizedTransactionStatus,
   type OnChainTransactionDetails,
   type TransactionDetails,
   TransactionStatus,
@@ -105,8 +106,7 @@ function createSagaTransactionRepository(ctx: TransactionRepositoryReduxContext)
     return put(
       ctx.actions.finalizeTransaction({
         ...input.transaction,
-        // @ts-expect-error - TODO: fix this
-        status: input.status,
+        status: input.status as FinalizedTransactionStatus,
       }),
     )
   }


### PR DESCRIPTION
Replace unsafe @ts-expect-error with proper type assertion to FinalizedTransactionStatus. This eliminates technical debt, improves type safety, and removes the TODO comment while maintaining runtime correctness since only final transaction statuses are passed to this method.