### PR TITLE
feat: add splits rpc to connectSrc

### DIFF
--- a/apps/web/public/csp.json
+++ b/apps/web/public/csp.json
@@ -115,6 +115,7 @@
     "https://prodregistryv2.org",
     "https://cloudflare-dns.com",
     "https://beyondwickedmapping.org",
+    "https://*.splits.org",
     "wss://*.uniswap.org",
     "wss://relay.walletconnect.com",
     "wss://relay.walletconnect.org",


### PR DESCRIPTION
Whitelists [splits](https://splits.org/) RPC to enable communication with the [splits wallet](https://splits.org/teams/). The splits wallet is built on top of the porto SDK. You can find the the code for the splits extension [here](https://github.com/0xSplits/splits-connect).