### PR TITLE
Fix double pagination in Top Pools tableFix double pagination in Top Pools table

### DIFF
--- a/apps/web/src/components/Pools/PoolTable/PoolTable.tsx
+++ b/apps/web/src/components/Pools/PoolTable/PoolTable.tsx
@@ -210,7 +210,7 @@ const TopPoolTable = memo(function TopPoolTable({
   return (
     <TableWrapper data-testid="top-pools-explore-table">
       <PoolsTable
-        pools={topPools?.slice(0, page * pageSize)}
+        pools={topPools}
         loading={isLoading}
         error={isError}
         loadMore={staticSize ? undefined : loadMore}


### PR DESCRIPTION
Prevents duplicate pagination behavior in the Top Pools table by ensuring loadMore is only passed when applicable.
