### PR TITLE
Kvara/addingHinkalRDNS

### DIFF
--- a/apps/web/src/components/WalletModal/PendingWalletConnectionModal/state.ts
+++ b/apps/web/src/components/WalletModal/PendingWalletConnectionModal/state.ts
@@ -3,7 +3,10 @@ import { atomWithStorage } from 'jotai/utils'
 import { CONNECTION_PROVIDER_IDS } from 'uniswap/src/constants/web3'
 
 /** Wallets that require separate user consent for EVM vs SVM connections (currently just MetaMask). */
-const SEPARATE_PROMPT_WALLET_IDS = new Set<string>([CONNECTION_PROVIDER_IDS.METAMASK_RDNS])
+const SEPARATE_PROMPT_WALLET_IDS = new Set<string>([
+  CONNECTION_PROVIDER_IDS.METAMASK_RDNS,
+  CONNECTION_PROVIDER_IDS.HINKAL_RDNS,
+])
 
 export function getWalletRequiresSeparatePrompt(walletId: string) {
   return SEPARATE_PROMPT_WALLET_IDS.has(walletId)

--- a/packages/uniswap/src/constants/web3.ts
+++ b/packages/uniswap/src/constants/web3.ts
@@ -11,6 +11,7 @@ export const CONNECTION_PROVIDER_IDS = {
   BINANCE_WALLET_CONNECTOR_ID: 'wallet.binance.com',
   BINANCE_WALLET_RDNS: 'com.binance.wallet',
   PORTO_CONNECTOR_ID: 'xyz.ithaca.porto',
+  HINKAL_RDNS: 'pro.hinkal',
   MOCK_CONNECTOR_ID: 'mock',
 } as const
 


### PR DESCRIPTION
When connecting Hinkal to Uniswap, users were experiencing a double wallet permission popup during the connection flow. This happens because Hinkal, similar to MetaMask, requires separate user consent for EVM and SVM connections. However, Hinkal was not previously included in the SEPARATE_PROMPT_WALLET_IDS set, so the interface treated it as a wallet that supports a unified approval flow.

As a result, the modal logic triggered multiple connection requests, leading to two permission popups being shown to the user. This creates a confusing UX and does not align with how Hinkal’s connection model is designed to operate.

By adding HINKAL_RDNS (pro.hinkal) to SEPARATE_PROMPT_WALLET_IDS, the interface now correctly recognizes that Hinkal requires separate consent handling. This aligns its behavior with MetaMask’s existing logic and prevents redundant connection prompts.

This is a minimal, additive change that fixes the double popup issue while keeping the current wallet connection architecture intact.