### PR TITLE
[BUG FIX] Preserve single-sided deposit amounts from URL parameters

### DIFF
--- a/apps/web/src/components/Liquidity/Deposit.tsx
+++ b/apps/web/src/components/Liquidity/Deposit.tsx
@@ -128,9 +128,15 @@ export const DepositStep = () => {
 
   useEffect(() => {
     if (deposit1Disabled) {
-      setDepositState({ exactField: PositionField.TOKEN0, exactAmounts: {} })
+      setDepositState((prev) => ({
+        exactField: PositionField.TOKEN0,
+        exactAmounts: { [PositionField.TOKEN0]: prev.exactAmounts[PositionField.TOKEN0] || '' },
+      }))
     } else if (deposit0Disabled) {
-      setDepositState({ exactField: PositionField.TOKEN1, exactAmounts: {} })
+      setDepositState((prev) => ({
+        exactField: PositionField.TOKEN1,
+        exactAmounts: { [PositionField.TOKEN1]: prev.exactAmounts[PositionField.TOKEN1] || '' },
+      }))
     }
   }, [deposit0Disabled, deposit1Disabled, setDepositState])
 


### PR DESCRIPTION
**BUG**

Copying the URL for `positions/create/` into a new tab does not correctly populate token amounts for single-sided LP positions. 

**REPO STEPS**

Entering pool info the URL is 
```
https://app.uniswap.org/positions/create/v3?currencyA=NATIVE&currencyB=0x754704Bc059F8C67012fEd69BC8A327a5aafb603&chain=monad&fee={%22feeAmount%22:3000,%22tickSpacing%22:60,%22isDynamic%22:false}&hook=undefined&priceRangeState={%22priceInverted%22:false,%22fullRange%22:false,%22minPrice%22:%220.023720627%22,%22maxPrice%22:%220.03260054%22,%22initialPrice%22:%22%22,%22inputMode%22:%22price%22}&depositState={%22exactField%22:%22TOKEN0%22,%22exactAmounts%22:{%22TOKEN0%22:%222%22}}&step=1
```
and UI
<img width="1115" height="1465" alt="Screenshot 2026-02-25 at 4 22 58 PM" src="https://github.com/user-attachments/assets/5a93f1f2-8ae2-4b38-989d-ffaac6c0c65c" />

However in a new tab the URL after loading becomes 
```
https://app.uniswap.org/positions/create/v3?currencyA=NATIVE&currencyB=0x754704Bc059F8C67012fEd69BC8A327a5aafb603&chain=monad&fee={%22feeAmount%22:3000,%22tickSpacing%22:60,%22isDynamic%22:false}&hook=undefined&priceRangeState={%22priceInverted%22:false,%22fullRange%22:false,%22minPrice%22:%220.023720627%22,%22maxPrice%22:%220.03260054%22,%22initialPrice%22:%22%22,%22inputMode%22:%22price%22}&depositState={%22exactField%22:%22TOKEN0%22,%22exactAmounts%22:{}}&step=1
```
and UI loads as 
<img width="1108" height="1470" alt="Screenshot 2026-02-25 at 4 25 29 PM" src="https://github.com/user-attachments/assets/093b122c-465d-4f72-8c55-35123d3caf21" />
Notice the token amount is 0. 

**TESTING**

I ran into some problems on my local machine. Something in the UI thinks this will be a new pool 
<img width="1106" height="832" alt="Screenshot 2026-02-25 at 4 20 04 PM" src="https://github.com/user-attachments/assets/16d3cfb9-a60b-43cd-8e20-135cc79bc3b6" />

<img width="1106" height="1446" alt="Screenshot 2026-02-25 at 4 33 08 PM" src="https://github.com/user-attachments/assets/c3410795-912b-4b28-b71c-072e36d1c2c6" />


However the URL appears to be what I expect
```
http://localhost:3000/positions/create/v3?currencyA=NATIVE&currencyB=0x754704Bc059F8C67012fEd69BC8A327a5aafb603&chain=monad&fee={%22feeAmount%22:3000,%22tickSpacing%22:60,%22isDynamic%22:false}&hook=undefined&priceRangeState={%22priceInverted%22:false,%22fullRange%22:false,%22minPrice%22:%220.023720627%22,%22maxPrice%22:%220.03260054%22,%22initialPrice%22:%22%22,%22inputMode%22:%22price%22}&depositState={%22exactField%22:%22TOKEN0%22,%22exactAmounts%22:{%22TOKEN0%22:%222%22}}&step=1
```

If you could advise on how to get around this 'new pool' flag I could test more thoroughly. 
