### PR TITLE
fix: resolve duplicate pools in Explore page Pools list

### DIFF
--- a/apps/web/src/pages/Explore/tables/Pools/PoolTable.tsx
+++ b/apps/web/src/pages/Explore/tables/Pools/PoolTable.tsx
@@ -204,7 +204,7 @@ const TopPoolTable = memo(function TopPoolTable({
   const effectiveLoadMore = backendLoadMore ?? clientLoadMore
   const displayedPools = backendLoadMore
     ? topPools // Backend pagination: use all fetched pools
-    : topPools?.slice(0, page * pageSize) // Client-side: slice by page
+    : topPools?.slice(0, (page + 1) * pageSize) // Client-side: slice by page (page is 0-indexed)
 
   return (
     <TableWrapper data-testid="top-pools-explore-table">


### PR DESCRIPTION
Fixes issue #7984 where pools were displayed twice in the Pools list.

The issue was caused by incorrect client-side pagination logic. The page variable is 0-indexed, but the slice calculation was using 'page * pageSize' which resulted in displaying accumulated pools from previous pages.

Changed slice calculation from 'page * pageSize' to '(page + 1) * pageSize' to correctly display only the pools for the current page.