### PR TITLE
chore(datadog-cloud): mark internal Pulumi packages as private to prevent dependency confusion

### DIFF
--- a/packages/datadog-cloud/dashboards/package.json
+++ b/packages/datadog-cloud/dashboards/package.json
@@ -1,5 +1,6 @@
 {
   "name": "datadog-dashboards-universe",
+  "private": true,
   "version": "1.0.0",
   "description": "Datadog dashboards for Universe services",
   "main": "index.ts",

--- a/packages/datadog-cloud/package.json
+++ b/packages/datadog-cloud/package.json
@@ -1,5 +1,6 @@
 {
   "name": "datadog-cloud-universe",
+  "private": true,
   "version": "1.0.0",
   "description": "Datadog monitors and dashboards for Universe services",
   "main": "index.ts",


### PR DESCRIPTION
## Summary
Marks 2 internal `package.json` file(s) as `"private": true` to close a dependency-confusion attack class.

## Background

[Cantina finding #677](https://cantina.xyz/code/f9df94db-c7b1-434b-bb06-d1360abdd1be/findings/677) identified two internal package names in `interface` (`datadog-cloud-universe`, `datadog-dashboards-universe`) that were unscoped and not marked `"private": true`, creating dependency-confusion exposure: if any tooling ever fell back from workspace resolution to the public npm registry for these names, an attacker who registered the name first would achieve arbitrary code execution in the install context (developer laptops or CI runners).

A sweep across the rest of the Uniswap orgs' local-checkout repos found the same vulnerability shape in 2 `package.json` file(s) here, plus dozens more across `backend`, `unichain`, and others (separate PRs). Several internal Uniswap package names across the org are already registered to **third-party accounts** on public npm — including `ai-agents`, `cloudflare`, `data-api`, `mission-control`, `notification-service`, `liquidity`, and `websockets` — meaning the dependency-confusion target is currently *live*, not theoretical.

## What changed

- `packages/datadog-cloud/package.json` (`datadog-cloud-universe`)
- `packages/datadog-cloud/dashboards/package.json` (`datadog-dashboards-universe`)

These are the literal files named in Cantina finding #677.

The fix is purely defensive: `npm` / `bun` refuse to publish a package marked `private`, and the resolver's behavior is unchanged for any consumer that already uses workspace or lockfile resolution. No behavior change is expected for builds, tests, deploys, or developer workflows.

## Test plan

- [x] All edited files still parse as valid JSON (verified locally)
- [x] `"private": true` set on each
- [ ] CI passes with no lockfile or workspace-config churn

## Session context

- **Why this scope:** Per your direction, opening one PR per repo with `Uniswap/security` tagged so the security team can sign off on the closing of the class without surprise.
- **What was deliberately skipped:** `apps/mobile/src/{"name":"src"}` Metro module-resolution markers (not a dep-confusion vector — bundlers don't resolve `src` from npm), and `cypress-hardhat` (intentionally published under `uniswap-labs-service-account`).
- **Deeper convention fix:** The backend cookiecutter template at `scripts/ecsServiceTemplate/T_SERVICE_NAME/infra/package.json` is included in the backend PR so future generated services start private-by-default. Universe's Nx generator already does the right thing.
- **Out of scope here:** A CI lint that fails on any new unscoped + non-private `package.json` would prevent regression entirely; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
