### PR TITLE
fix: prevent SecurityError from external hash fragments on landing page

### DIFF
--- a/apps/web/src/pages/RouteDefinitions.tsx
+++ b/apps/web/src/pages/RouteDefinitions.tsx
@@ -129,7 +129,15 @@ export const routes: RouteDefinition[] = [
     getTitle: () => StaticTitlesAndDescriptions.UniswapTitle,
     getDescription: () => StaticTitlesAndDescriptions.SwapDescription,
     getElement: (args) => {
-      return args.browserRouterEnabled && args.hash ? <Navigate to={args.hash.replace('#', '')} replace /> : <Landing />
+      if (args.browserRouterEnabled && args.hash) {
+        const path = args.hash.replace('#', '')
+        // Only redirect to internal paths starting with a single '/' to prevent
+        // protocol-relative URLs (e.g. //example.org) from causing SecurityErrors.
+        if (path.startsWith('/') && !path.startsWith('//')) {
+          return <Navigate to={path} replace />
+        }
+      }
+      return <Landing />
     },
   }),
   createRouteDefinition({


### PR DESCRIPTION
When a URL like app.uniswap.org/#//example.org is opened, stripping the '#' leaves '//example.org' which React Router passes to history.replaceState. The browser rejects protocol-relative URLs from a different origin, throwing a SecurityError and showing the error overlay.

Only redirect when the resulting path starts with a single '/', which preserves all valid legacy hash routes like #/swap while ignoring external-looking fragments.

Fixes #7979