### PR TITLE
fix(rwa): display Ondo tokenized stocks with .on suffix

### DIFF
--- a/packages/uniswap/src/data/rest/rwa/formatIssuerDisplaySymbol.test.ts
+++ b/packages/uniswap/src/data/rest/rwa/formatIssuerDisplaySymbol.test.ts
@@ -2,7 +2,7 @@ import { formatIssuerDisplaySymbol, formatIssuerLabel } from 'uniswap/src/data/r
 
 describe('formatIssuerDisplaySymbol', () => {
   it('composes ondo suffix', () => {
-    expect(formatIssuerDisplaySymbol({ baseSymbol: 'TSLA', issuer: 'ondo', apiSymbol: 'TSLAON' })).toBe('TSLA.o')
+    expect(formatIssuerDisplaySymbol({ baseSymbol: 'TSLA', issuer: 'ondo', apiSymbol: 'TSLAON' })).toBe('TSLA.on')
   })
 
   it('falls back to api symbol for unknown issuers', () => {

--- a/packages/uniswap/src/data/rest/rwa/formatIssuerDisplaySymbol.ts
+++ b/packages/uniswap/src/data/rest/rwa/formatIssuerDisplaySymbol.ts
@@ -1,6 +1,6 @@
-/** Maps issuer slug → display suffix (e.g. ondo → `.o` for `TSLA.o`). */
+/** Maps issuer slug → display suffix (e.g. ondo → `.on` for `TSLA.on`). */
 const ISSUER_DISPLAY_SUFFIX: Record<string, string> = {
-  ondo: 'o',
+  ondo: 'on',
   backed: 'b',
   superstate: 's',
   xstocks: 'x',


### PR DESCRIPTION
## Summary

On the explore stocks views, Ondo tokenized stocks render as `TSLA.o` / `AAPL.o`. The issuer display map abbreviates Ondo to a single-letter `o` suffix:

```ts
// packages/uniswap/src/data/rest/rwa/formatIssuerDisplaySymbol.ts
const ISSUER_DISPLAY_SUFFIX: Record<string, string> = {
  ondo: 'o',
  ...
}
```

But Ondo's tokens use an **`on` suffix in their actual on-chain ERC-20 symbol** — verified on mainnet:

- Oracle: `ORCLon` ([0x8a23…33e1e](https://etherscan.io/token/0x8a23c6baadb88512b30475c83df6a63881e33e1e))
- Apple `AAPLon`, Tesla `TSLAon`, NVIDIA `NVDAon`, etc.

This also matches the token page (which shows `ORCLon`) and Ondo's own published token list. The single-letter `.o` is the odd one out.

## Change

Map `ondo` to `on` so the displayed symbol reads `TSLA.on`, matching the on-chain symbol and Ondo's branding. Other issuers are unchanged.

This is also consistent with the rest of the RWA test suite, where Ondo fixtures already use `TSLA.on` (e.g. `rwaMatch.test.ts`, `useIsRWAGeoBlocked.test.ts`, `useLogRWATokenDetailsViewed.test.ts`).

## Test

Updated `formatIssuerDisplaySymbol.test.ts` to assert `TSLA.on`.