### PR TITLE
fix(api): remove strict 130-char signature length regex to support EIP-1271 smart account signatures (#8008)

### DIFF
--- a/packages/api/src/clients/trading/api.json
+++ b/packages/api/src/clients/trading/api.json
@@ -7647,8 +7647,7 @@
               },
               "signature": {
                 "type": "string",
-                "description": "The signature for a message signing step.",
-                "pattern": "^0x[a-fA-F0-9]{130}$"
+                "description": "The signature for a message signing step."
               }
             }
           }


### PR DESCRIPTION
## 📝 Overview & Problem
This PR resolves [Issue #8008](https://github.com/Uniswap/interface/issues/8008), where users leveraging Smart Contract Wallets (e.g., Safe, Ambire, Argent, Biconomy) encounter client-side and OpenAPI schema validation errors when signing transaction steps or placing Limit Orders/UniswapX trades:
```json
{
    "detail": "\"signature\" with value \"0xf0640...\" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{130}$/",
    "errorCode": "VALIDATION_ERROR"
}