### PR TITLE
fix(web): support numeric chain IDs in URL params

### DIFF
--- a/apps/web/src/utils/params/chainParams.test.ts
+++ b/apps/web/src/utils/params/chainParams.test.ts
@@ -1,6 +1,12 @@
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { toGraphQLChain } from 'uniswap/src/features/chains/utils'
-import { getChainIdFromBackendChain, getChainIdFromChainUrlParam, getChainUrlParam } from '~/utils/params/chainParams'
+import { CurrencyField } from 'uniswap/src/types/currency'
+import {
+  getChainIdFromBackendChain,
+  getChainIdFromChainUrlParam,
+  getChainUrlParam,
+  getParsedChainId,
+} from '~/utils/params/chainParams'
 
 describe('getChainFromChainUrlParam', () => {
   it('should return true for valid chain slug', () => {
@@ -18,9 +24,37 @@ describe('getChainFromChainUrlParam', () => {
     expect(getChainIdFromChainUrlParam(invalidChainName)).toBe(undefined)
   })
 
+  it('should return the chain for a valid numeric chain ID', () => {
+    expect(getChainIdFromChainUrlParam(String(UniverseChainId.Base))).toBe(UniverseChainId.Base)
+  })
+
+  it('should return undefined for an unknown numeric chain ID', () => {
+    expect(getChainIdFromChainUrlParam('999999999')).toBeUndefined()
+  })
+
   it('should return false for a misconfigured chain slug', () => {
     const invalidChainName = 'eThErEuM'
     expect(getChainIdFromChainUrlParam(invalidChainName)).toBe(undefined)
+  })
+})
+
+describe('getParsedChainId', () => {
+  it('should parse a chain interface name', () => {
+    expect(getParsedChainId({ chain: 'base' })).toBe(UniverseChainId.Base)
+  })
+
+  it('should parse a numeric chain ID', () => {
+    expect(getParsedChainId({ chain: String(UniverseChainId.Base) })).toBe(UniverseChainId.Base)
+  })
+
+  it('should parse a numeric output chain ID', () => {
+    expect(getParsedChainId({ outputChain: String(UniverseChainId.ArbitrumOne) }, CurrencyField.OUTPUT)).toBe(
+      UniverseChainId.ArbitrumOne,
+    )
+  })
+
+  it('should not parse a non-canonical numeric value', () => {
+    expect(getParsedChainId({ chain: `0${UniverseChainId.Base}` })).toBeUndefined()
   })
 })
 

--- a/apps/web/src/utils/params/chainParams.ts
+++ b/apps/web/src/utils/params/chainParams.ts
@@ -5,6 +5,12 @@ import { getChainInfo, UNIVERSE_CHAIN_INFO } from 'uniswap/src/features/chains/c
 import { GqlChainId, UniverseChainId } from 'uniswap/src/features/chains/types'
 import { CurrencyField } from 'uniswap/src/types/currency'
 
+type ChainInfo = (typeof UNIVERSE_CHAIN_INFO)[keyof typeof UNIVERSE_CHAIN_INFO]
+
+function getChainIdFromParam(value: string, matchesName: (chain: ChainInfo) => boolean): UniverseChainId | undefined {
+  return Object.values(UNIVERSE_CHAIN_INFO).find((chain) => matchesName(chain) || String(chain.id) === value)?.id
+}
+
 // i.e. ?chain=mainnet -> ethereum
 export function searchParamToBackendName(interfaceName: string | null): string | undefined {
   if (interfaceName === null) {
@@ -16,12 +22,12 @@ export function searchParamToBackendName(interfaceName: string | null): string |
 }
 
 export function isChainUrlParam(str: string): boolean {
-  return !!str && Object.values(UNIVERSE_CHAIN_INFO).some((chain) => chain.urlParam === str)
+  return !!str && getChainIdFromChainUrlParam(str) !== undefined
 }
 
 export function getChainIdFromChainUrlParam(chainUrlParam?: string): UniverseChainId | undefined {
   return chainUrlParam !== undefined
-    ? Object.values(UNIVERSE_CHAIN_INFO).find((chain) => chainUrlParam === chain.urlParam)?.id
+    ? getChainIdFromParam(chainUrlParam, (chain) => chainUrlParam === chain.urlParam)
     : undefined
 }
 
@@ -50,6 +56,5 @@ export function getParsedChainId(
     return undefined
   }
 
-  const chainInfo = Object.values(UNIVERSE_CHAIN_INFO).find((i) => i.interfaceName === chain)
-  return chainInfo?.id
+  return getChainIdFromParam(chain, (chainInfo) => chainInfo.interfaceName === chain)
 }

--- a/apps/web/src/utils/params/chainQueryParam.test.ts
+++ b/apps/web/src/utils/params/chainQueryParam.test.ts
@@ -19,6 +19,14 @@ describe('getChainFilterFromSearchParams', () => {
     })
   })
 
+  it('returns parsed chain for a numeric chain ID', () => {
+    const params = new URLSearchParams(`${CHAIN_SEARCH_PARAM}=${UniverseChainId.Base}`)
+    expect(getChainFilterFromSearchParams(params)).toEqual({
+      chainUrlParam: String(UniverseChainId.Base),
+      chainId: UniverseChainId.Base,
+    })
+  })
+
   it('returns empty when param missing', () => {
     expect(getChainFilterFromSearchParams(new URLSearchParams())).toEqual({})
   })
@@ -60,6 +68,11 @@ describe('getTDPChainSearchParam', () => {
 
   it('returns parsed chain when a valid chain slug is present', () => {
     const params = new URLSearchParams(`${CHAIN_SEARCH_PARAM}=base`)
+    expect(getTDPChainSearchParam(params)).toEqual({ type: 'chain', chainId: UniverseChainId.Base })
+  })
+
+  it('returns parsed chain when a numeric chain ID is present', () => {
+    const params = new URLSearchParams(`${CHAIN_SEARCH_PARAM}=${UniverseChainId.Base}`)
     expect(getTDPChainSearchParam(params)).toEqual({ type: 'chain', chainId: UniverseChainId.Base })
   })
 


### PR DESCRIPTION
## Description

Adds support for numeric EIP-155 chain IDs in URL parameters while preserving the existing chain-name behavior.

For example, both of these now resolve to Base:

- `?chain=base`
- `?chain=8453`

Unknown and non-canonical numeric values remain invalid.

## Changes

- Accept configured numeric chain IDs in shared chain parameter parsing.
- Support numeric IDs for input and output swap chain parameters.
- Support numeric IDs in portfolio and token-detail chain query parsing.
- Add regression coverage for valid, unknown, and non-canonical numeric values.

## Test plan

- `chainParams.test.ts`
- `chainQueryParam.test.ts`
- 33 tests passed locally.

Closes #7992