### PR TITLE
fix: support zero-decimal auction tokens in FDV sorting

### DIFF
--- a/apps/web/src/features/Toucan/Auction/BidForm/BidReviewModal/useBidReviewData.ts
+++ b/apps/web/src/features/Toucan/Auction/BidForm/BidReviewModal/useBidReviewData.ts
@@ -219,7 +219,7 @@ export function useBidReviewData({
 
   // Calculate Max FDV (totalSupply * maxPrice) in bid token
   const maxFdvData = useMemo(() => {
-    if (!preparedBid || !totalSupply || !auctionTokenDecimals || fallbackBidTokenDecimals === undefined) {
+    if (!preparedBid || !totalSupply || auctionTokenDecimals === undefined || fallbackBidTokenDecimals === undefined) {
       return { formatted: undefined, fiatFormatted: undefined, preciseFormatted: undefined }
     }
 

--- a/apps/web/src/features/Toucan/Auction/utils/fixedPointFdv.ts
+++ b/apps/web/src/features/Toucan/Auction/utils/fixedPointFdv.ts
@@ -32,7 +32,7 @@ export function computeFdvBidTokenRaw({
   totalSupplyRaw: string | bigint
   auctionTokenDecimals?: number
 }): bigint {
-  if (!auctionTokenDecimals) {
+  if (auctionTokenDecimals === undefined) {
     return 0n
   }
 

--- a/apps/web/src/features/Toucan/hooks/useTopAuctions/useTopAuctions.test.ts
+++ b/apps/web/src/features/Toucan/hooks/useTopAuctions/useTopAuctions.test.ts
@@ -64,6 +64,14 @@ describe('auctionCommittedVolumeComparator', () => {
     expect(auctionCommittedVolumeComparator(fiveTokens, oneToken)).toBeLessThan(0)
   })
 
+  it('supports zero-decimal bid tokens in the fallback volume sort', () => {
+    const oneToken = createEnrichedAuction({ totalBidVolume: '1', currencyTokenDecimals: 0 })
+    const fiveTokens = createEnrichedAuction({ totalBidVolume: '5', currencyTokenDecimals: 0 })
+
+    expect(auctionCommittedVolumeComparator(oneToken, fiveTokens)).toBeGreaterThan(0)
+    expect(auctionCommittedVolumeComparator(fiveTokens, oneToken)).toBeLessThan(0)
+  })
+
   it('uses the bid-token fallback when only one side has USD', () => {
     // Mixed case: one row has USD, the other does not — USD is not comparable cross-row,
     // so both fall back to bid-token amounts.

--- a/apps/web/src/features/Toucan/hooks/useTopAuctions/useTopAuctions.ts
+++ b/apps/web/src/features/Toucan/hooks/useTopAuctions/useTopAuctions.ts
@@ -47,7 +47,7 @@ export function compareDescendingMissingLast(a: number | undefined, b: number | 
 }
 
 function getBidTokenVolume(auction: EnrichedAuction['auction']): number | undefined {
-  if (!auction?.totalBidVolume || !auction.currencyTokenDecimals) {
+  if (!auction?.totalBidVolume || auction.currencyTokenDecimals === undefined) {
     return undefined
   }
   return approximateNumberFromRaw({ raw: BigInt(auction.totalBidVolume), decimals: auction.currencyTokenDecimals })

--- a/apps/web/src/features/Toucan/utils/computeProjectedFdv.ts
+++ b/apps/web/src/features/Toucan/utils/computeProjectedFdv.ts
@@ -102,7 +102,7 @@ export function computeProjectedFdvTableValue({
     }
 
     // For active auctions (or completed without market price), use clearing price
-    if (!bidTokenDecimals || !bidTokenSymbol) {
+    if (bidTokenDecimals === undefined || !bidTokenSymbol) {
       return fallback
     }
 

--- a/apps/web/src/pages/Explore/tables/Auctions/TopAuctionsTable.test.ts
+++ b/apps/web/src/pages/Explore/tables/Auctions/TopAuctionsTable.test.ts
@@ -313,6 +313,20 @@ describe('top auctions table sorting', () => {
       expect(sorted.map((auction) => auction.id)).toEqual(['high-fdv-raw', 'mid-fdv-raw', 'low-fdv-raw', 'no-fdv-data'])
     })
 
+    it('supports zero-decimal bid tokens when falling back to bid-token FDV', () => {
+      const lowFdvRaw = createAuctionTableValue({ id: 'low-fdv-raw', fdvRaw: 1n, currencyTokenDecimals: 0 })
+      const highFdvRaw = createAuctionTableValue({ id: 'high-fdv-raw', fdvRaw: 5n, currencyTokenDecimals: 0 })
+      const midFdvRaw = createAuctionTableValue({ id: 'mid-fdv-raw', fdvRaw: 3n, currencyTokenDecimals: 0 })
+
+      const sorted = sortAuctions({
+        auctions: [lowFdvRaw, highFdvRaw, midFdvRaw],
+        sortMethod: AuctionSortField.FDV,
+        sortAscending: false,
+      })
+
+      expect(sorted.map((auction) => auction.id)).toEqual(['high-fdv-raw', 'mid-fdv-raw', 'low-fdv-raw'])
+    })
+
     it('reverses order when ascending', () => {
       const sorted = sortAuctions({
         auctions: [midFdvUsd, lowFdvUsd, highFdvUsd],

--- a/apps/web/src/pages/Explore/tables/Auctions/TopAuctionsTable.tsx
+++ b/apps/web/src/pages/Explore/tables/Auctions/TopAuctionsTable.tsx
@@ -69,7 +69,7 @@ export interface SortableTopAuctionTableValue {
 /** FDV in bid-token units; `raw` 0n means "no data" (see computeProjectedFdvTableValue fallback). */
 function getFdvBidTokenValue({ auction, projectedFdv }: SortableTopAuctionTableValue): number | undefined {
   const decimals = auction.auction?.currencyTokenDecimals
-  if (projectedFdv.raw === 0n || !decimals) {
+  if (projectedFdv.raw === 0n || decimals === undefined) {
     return undefined
   }
   return approximateNumberFromRaw({ raw: projectedFdv.raw, decimals })


### PR DESCRIPTION
## Summary

Auction FDV sorting incorrectly treats valid zero-decimal bid tokens as missing data.

## Cause and effect

The comparator used a truthiness check for `currencyTokenDecimals`. Since `0` is a valid ERC-20 decimals value, auctions using indivisible tokens were excluded from bid-token FDV sorting and could remain in their original order.

## Fix

Check explicitly for `undefined` so `decimals = 0` is passed to the existing raw-value conversion logic. No other sorting behavior is changed.

## Validation

- Added a regression test covering descending FDV sorting for zero-decimal bid tokens.
- Ran `TopAuctionsTable.test.ts`: 17 tests passed.
