### PR TITLE
fix: preserve large approval amounts

### DIFF
--- a/apps/web/src/state/sagas/transactions/approvalAmount.ts
+++ b/apps/web/src/state/sagas/transactions/approvalAmount.ts
@@ -1,0 +1,4 @@
+/** Parse a decimal approval amount without losing precision for large token balances. */
+export function getRequiredApprovalAmount(amount: string): bigint {
+  return BigInt(amount)
+}

--- a/apps/web/src/state/sagas/transactions/utils.test.ts
+++ b/apps/web/src/state/sagas/transactions/utils.test.ts
@@ -1,11 +1,20 @@
 import { runSaga } from 'redux-saga'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { addTransaction } from 'uniswap/src/features/transactions/slice'
+import { getRequiredApprovalAmount } from '~/state/sagas/transactions/approvalAmount'
 import type { HandleOnChainStepParams, OnChainTransactionStep } from 'uniswap/src/features/transactions/steps/types'
 import { TransactionStepType } from 'uniswap/src/features/transactions/steps/types'
 import { TransactionType } from 'uniswap/src/features/transactions/types/transactionDetails'
 
 const mockSendTransaction = vi.fn()
+
+describe('getRequiredApprovalAmount', () => {
+  it('preserves large decimal approval amounts exactly', () => {
+    const amount = '10000000000000000000000000000000000000000000000001'
+
+    expect(getRequiredApprovalAmount(amount)).toBe(BigInt(amount))
+  })
+})
 
 vi.mock('wagmi/actions', () => ({
   getConnectorClient: vi.fn().mockResolvedValue({}),

--- a/apps/web/src/state/sagas/transactions/utils.ts
+++ b/apps/web/src/state/sagas/transactions/utils.ts
@@ -69,6 +69,7 @@ import type { TransactionTypeInfo } from 'uniswap/src/features/transactions/type
 import { getInterfaceTransaction, isInterfaceTransaction } from 'uniswap/src/features/transactions/types/utils'
 import { areAddressesEqual } from 'uniswap/src/utils/addresses'
 import { parseERC20ApproveCalldata } from 'uniswap/src/utils/approvals'
+import { getRequiredApprovalAmount } from '~/state/sagas/transactions/approvalAmount'
 import { currencyId } from 'uniswap/src/utils/currencyId'
 import { interruptTransactionFlow } from 'uniswap/src/utils/saga'
 import { logger } from 'utilities/src/logger/logger'
@@ -420,7 +421,7 @@ function getPermitTransactionInfo(approvalStep: Permit2TransactionStep): Permit2
 }
 
 function checkApprovalAmount(data: string, step: TokenApprovalTransactionStep | TokenRevocationTransactionStep) {
-  const requiredAmount = BigInt(`0x${parseInt(step.amount, 10).toString(16)}`)
+  const requiredAmount = getRequiredApprovalAmount(step.amount)
   const submitted = parseERC20ApproveCalldata(data)
   const approvedAmount = submitted.amount.toString(10)
 


### PR DESCRIPTION
## Summary

Preserve large ERC-20 approval amounts exactly when checking submitted approval transactions.

## Problem

The approval checker converted the decimal amount with `parseInt` before converting it back to `bigint`. JavaScript numbers cannot represent many raw token amounts exactly, so large approvals could be rounded and compared against the wrong required amount.

## Fix

Parse the decimal string directly with `BigInt`, using a small pure helper that can be tested independently.

## Validation

- Added a regression test with a 50-digit approval amount.
- Ran the transaction saga utility tests: 3 tests passed.
